### PR TITLE
Add grade distribution data for 2022–2024

### DIFF
--- a/documents/edu.uh.grade_distribution/Grade Distribution 2022-02 (Summer 2022).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2022-02 (Summer 2022).csv
@@ -1,2258 +1,2115 @@
 TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
-Summer 2022,COMM,1303,2,13385,Writing for Communicators,Lyn,Robyn,11,1,2,0,0,0,0,3.549
-Summer 2022,ACCT,2302,8,15312,Prin of Managerial Accounting,Newman,Michael Ray,12,5,6,0,0,0,1,3.247
-Summer 2022,PETR,8398,11,16578,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,3,0,0
-Summer 2022,CIVE,8598,22,17180,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,6,0,0
-Summer 2022,CIS,2332,1,15668,Info Tech Hdwr & Systems Sftwr,Peddoju,Suresh Kumar,19,0,0,0,0,0,0,3.965
-Summer 2022,MATH,1324,5,10738,Finite Math with Applications,Chang,James A,5,4,4,3,4,0,0,2.216
-Summer 2022,MATH,3321,1,10743,Engineering Mathematics,Etgen,Garret J,14,14,10,2,5,0,3,2.659
-Summer 2022,HRMA,3341,1,12371,Hospitality Managerial Acct,Ramirez,Arlene D,0,4,1,0,0,0,0,2.8
-Summer 2022,CUIN,3302,1,12612,Social Education,Thomas,Dustine J,24,0,0,0,1,0,1,3.84
-Summer 2022,ELCS,8361,1,15623,Public & Community Relations,Freelon,Rhoda,7,0,0,0,0,0,0,4
-Summer 2022,BIOE,8699,1,16425,Doctoral Dissertation,Mohan,Chandra,2,0,0,0,0,0,0,4
-Summer 2022,ECON,3334,1,13477,Intermediate Macroeconomics,Mcgregor,Ryan P,8,3,9,1,0,0,3,2.747
-Summer 2022,PHYS,2125,2,16202,University Physics Lab I,Maric,Sladjana,2,55,8,2,2,0,0,2.663
-Summer 2022,HDCS,2301,1,11134,Consumer Science,Stewart,Juliana Floriene,25,0,0,1,0,0,1,3.808
-Summer 2022,PSYC,6336,2,13137,Directed Rsch in Social Psyc,Neighbors,Clayton T,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8399,12,10952,Doctoral Dissertation,Harold,Michael P,0,0,0,0,0,6,0,0
-Summer 2022,LAW,5197,21,14197,Selected Topics,Lawrence,Jim E,0,0,0,0,0,4,0,0
-Summer 2022,PSYC,7399,8,16803,Masters Thesis,Cirino,Paul,1,0,0,0,0,0,0,4
-Summer 2022,SOCW,7391,1,11133,Field Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,8,0,0
-Summer 2022,MANA,8399,2,16519,Doctoral Dissertation,Vera,Dusya M,1,0,0,0,0,0,0,4
-Summer 2022,ELCS,6342,1,12530,Critical Issues in Higher Educ,Barnes,Yolanda Michelle,5,1,0,0,0,0,0,3.888
-Summer 2022,NURS,8336,1,16054,Advanced Synthesis Practicum,Joseph,Beena Roby,0,0,0,0,0,6,0,0
-Summer 2022,PHLS,8199,3,16644,Dissertation,Reitzel,Lorraine R,1,0,0,0,0,0,0,4
-Summer 2022,FINA,7361,1,12733,Risk Management,Hogan,Kenneth David,16,0,0,0,0,0,0,4
-Summer 2022,COMD,7381,1,11269,Medical SLP Seminar,Ivey,Michelle L,13,0,0,0,0,0,0,3.949
-Summer 2022,BIOE,8398,5,16405,Doctoral Research,Naash,Muna,0,0,0,0,0,5,0,0
-Summer 2022,PETR,6397,1,16268,Selected Topics,Mohamed,Mohamed Ibrahim,13,1,1,0,0,0,0,3.712
-Summer 2022,CUIN,8310,46,11789,Laboratory of Practice,McNeil,Sara G,4,0,0,0,0,0,0,4
-Summer 2022,LAW,5602,1,11992,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,0
-Summer 2022,LAW,6355,3,11602,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,1311,1,12444,Fundamentals of Chemistry,Czader,Arkadiusz,5,14,19,20,36,0,5,1.263
-Summer 2022,FINA,7374,1,12946,Midstream Energy Finance,Broxson,John Robert,36,0,0,0,0,0,0,3.991
-Summer 2022,COMM,4303,1,12362,Communication Law and Ethics,Bundage Juvane,Stephanie,18,0,0,0,0,0,0,4
-Summer 2022,TLIM,4341,31,12954,Production & Service Operation,Terrell,John Allen,11,8,1,0,0,0,0,3.418
-Summer 2022,SPEC,7341,1,12615,Assessment of Learning Diff,Hassett,Kristen Spring,8,0,0,0,0,0,1,3.959
-Summer 2022,CHEM,4340,1,15637,Research Methods,Ekeoba,Jacqueline Njideka,2,0,0,0,0,0,0,4
-Summer 2022,MANA,4355,1,11613,Selection and Staffing,Phillips,James S,7,19,4,2,0,0,0,2.938
-Summer 2022,CNST,3205,1,11787,Construction Safety Management,Hart,Lee J,24,3,0,0,0,0,0,3.889
-Summer 2022,PHYS,8698,11,16721,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,4,0,0
-Summer 2022,PHLS,8351,1,12201,Hist & Philosophy of Psyc Syst,Reyna,Ronda,31,0,0,0,0,0,0,4
-Summer 2022,PSYC,2301,5,11920,Introduction to Psychology,Capuozzo,Kristen Irene,9,4,1,1,0,0,0,3.4
-Summer 2022,MIS,4397,1,14491,Selected Topics in MIS,Messinger,Jacob Nelson,12,0,0,0,0,0,1,3.863
-Summer 2022,DIGM,3152,30,13441,Graphic Comm Output Lab,Dawson,Michael John,7,1,0,0,0,0,0,3.875
-Summer 2022,MATH,4378,1,10744,Advanced Linear Algebra II,Torok,Andrei S,4,3,5,3,1,0,0,2.231
-Summer 2022,ILAS,3150,1,16847,Internship Practicum,Connolly,Sally,6,2,1,0,1,0,0,3.2
-Summer 2022,COMD,7383,2,11628,Pediatric SLP Seminar,Ivey,Michelle L,9,0,0,0,0,0,0,3.963
-Summer 2022,COMD,7170,1,16968,Graduate Seminar in SLP,Cizek,Laura S,1,0,0,0,0,0,0,4
-Summer 2022,CHEM,6698,20,11627,Special Problems,Gilbertson,Scott R,0,0,0,0,0,4,0,0
-Summer 2022,PHYS,8698,24,16734,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,3,0,0
-Summer 2022,PHOP,6557,4,16400,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4
-Summer 2022,ACCT,4396,1,10521,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8398,8,16845,Doctoral Research,Chen,Ji,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,6393,1,12234,Practicum,Davis,Tiffany J,2,0,0,0,0,0,0,4
-Summer 2022,PHOP,8598,9,16654,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,6257,6,13106,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4
-Summer 2022,ECE,8498,21,16822,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,8698,3,16344,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8498,17,16815,Doctoral Research,Chen,Ji,0,0,0,0,0,4,0,0
-Summer 2022,ACCT,4380,1,15562,Contro & Sec Intern Fin Inform,Kahl,Keith E,2,0,0,0,0,0,0,4
-Summer 2022,ACCT,7396,2,13351,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8398,18,16418,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,0
-Summer 2022,SOCW,7397,17,17186,Selected Topics in Social Work,Mollhagen,Amber Mayo,1,0,0,0,0,0,0,4
-Summer 2022,KIN,3304,1,13466,Human Structure & Phys Perform,Breslin,Whitney L,10,23,7,2,0,0,1,2.992
-Summer 2022,HRMA,4343,1,11251,Financial Admin for Hosp.Ind.,Koh,Yoon,15,10,6,2,0,0,1,3.102
-Summer 2022,PHYS,1101,4,11158,College Physics I (lab),Maric,Sladjana,1,14,7,0,0,0,1,2.712
-Summer 2022,PSYC,3339,2,13480,Intro To Clinical Psychology,Zegel,Maya,37,3,0,1,1,0,1,3.754
-Summer 2022,PHYS,1101,5,12780,College Physics I (lab),Wood,Lowell T,2,7,4,1,0,0,1,2.714
-Summer 2022,ENTR,3310,4,13362,Entrepreneurship,Ortega,Carlos Alberto,78,15,4,0,0,0,0,3.685
-Summer 2022,HLT,3380,1,13584,Culture and Health,Kamdar-Sharif,Amber,42,5,3,0,0,0,0,3.688
-Summer 2022,COSC,8698,115,13292,Doctoral Research,Laszka,Aron,0,0,0,0,0,6,0,0
-Summer 2022,LAW,5228,2,12157,Judicial Externship I,Powers,William,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8699,1,16844,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,0
-Summer 2022,INDE,8398,1,11003,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,4,16548,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,0
-Summer 2022,ECE,6298,3,16863,Research,Li,Xingpeng,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,15,17077,Doctoral Research,Warner,Margaret,0,0,0,0,0,1,0,0
-Summer 2022,PEP,8350,1,17158,HHP Candidacy Project Research,Lee,Dong Hun,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,6398,11,16888,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,0,0,0
-Summer 2022,COSC,8399,127,17303,Doctoral Dissertation,Subhlok,Jaspal,0,0,0,0,0,1,0,0
-Summer 2022,PETR,8598,1,16509,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,7399,4,11942,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6398,9,12053,Independent Studies,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,0
-Summer 2022,NUTR,4333,1,11567,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,4,12,12,1,0,0,0,2.61
-Summer 2022,CHEM,1112,8,10866,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,7,2,0,0,0,2,3.166
-Summer 2022,PSYC,3301,5,13610,Intro Psych Stats,Saiyed,Amna Shabbir,34,4,0,0,0,0,1,3.877
-Summer 2022,MANA,3335,4,12671,Intro Org Behavior and Mgmt,Currie,Daniel David,100,19,8,0,0,0,8,3.691
-Summer 2022,BIOL,2101,4,11341,Anatomy & Physiology Lab I,Gill,Tejendra,2,17,1,0,2,0,1,2.653
-Summer 2022,MATH,2312,5,11626,Precalculus,Douglas,Casey,14,7,4,3,5,0,4,2.647
-Summer 2022,ACCT,2302,7,15311,Prin of Managerial Accounting,Newman,Michael Ray,11,6,0,0,0,0,1,3.666
-Summer 2022,LAW,5228,1,12156,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,6,0,0
-Summer 2022,GENB,7303,3,15341,Prof Accounting Communication,Newman,Michael Ray,10,2,0,0,0,0,0,3.888
-Summer 2022,ENGL,1302,13,13126,First Year Writing II,Downey,Carlton M,19,1,0,0,2,0,0,3.606
-Summer 2022,SPAN,4313,1,13672,Advanced Eng/Span Translation,Arboleda,Paola,6,7,2,0,0,0,1,3.245
-Summer 2022,CHEE,8398,11,10939,Doctoral Research,Orman,Mehmet,0,0,0,0,0,4,0,0
-Summer 2022,CHEM,8698,10,10713,Doctoral Research,Chen,Tai-Yen,0,0,0,0,0,3,0,0
-Summer 2022,HON,4398,1,16940,Independent Study,Cremins,Robert Paul,1,0,0,0,0,0,0,4
-Summer 2022,FORE,6398,1,11708,Special Problems in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4
-Summer 2022,MATH,8698,16,13227,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7384,1,11131,Field Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,11,0,0
-Summer 2022,BIOE,6343,1,13081,Global Healthcare,Akay,Yasemin M,14,0,0,0,0,0,0,3.882
-Summer 2022,DIGM,3354,30,11863,Video Production 1,Snyder,Philip Charles,11,6,2,2,3,0,0,2.723
-Summer 2022,ENGL,1302,10,13123,First Year Writing II,Rolater,Sara C,9,8,0,0,2,0,5,3.123
-Summer 2022,MANA,   6A83,2,13485,Strategic Analysis,Celly,Nikhil,13,1,0,0,0,0,0,3.929
-Summer 2022,ATP,7302,1,11781,Gen Med/Pharm 2-Pathophysiolog,Knoblauch,Mark Alan,14,1,0,0,0,0,0,3.933
-Summer 2022,CIS,2336,1,13509,Internet Application Developmt,Faiyaz,Sajida,8,7,7,0,0,0,1,3.09
-Summer 2022,PETR,8398,8,16505,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,3,0,0
-Summer 2022,COSC,4398,101,17190,Independent Study,Cheng,Albert M K,0,0,0,0,0,2,0,0
-Summer 2022,GENB,5303,1,11757,Prof Acct Communication,Newman,Michael Ray,1,3,1,0,0,0,0,3.132
-Summer 2022,MANA,7392,2,12892,Managerial Issues,Walker,William A,12,0,0,0,0,0,1,4
-Summer 2022,CUIN,7356,4,17282,Issues in Distance Education,Dogan,Bulent,1,0,0,0,0,0,0,4
-Summer 2022,SOCW,7397,4,17343,Selected Topics in Social Work,Gonzales,Shelley A,0,0,0,0,0,1,0,0
-Summer 2022,ACCT,5368,2,15320,Intermediate Accounting II,Sun,Xue,3,1,2,0,0,0,0,3.167
-Summer 2022,CIS,2334,1,12705,Information Systems Applicatns,Lendasse,Amaury,26,4,9,2,0,0,6,3.301
-Summer 2022,ACCT,2302,1,11572,Prin of Managerial Accounting,Weber,Catherine K,11,13,5,3,0,0,0,3.031
-Summer 2022,COSC,4377,301,13048,Intro To Computer Networks,Long,Kevin B,35,42,11,1,1,0,2,3.211
-Summer 2022,COMM,3353,2,11754,Information & Comm Tech I,Liu,Youmei,12,5,4,0,0,0,2,3.397
-Summer 2022,HLT,3301,2,13205,Health Behavior Theories,Bennett,Kristin C,19,1,0,0,1,0,0,3.746
-Summer 2022,CIS,2348,2,16031,Info Systems Appl Development,Ratner,Edward,6,4,8,5,2,0,0,2.214
-Summer 2022,COMM,2320,1,11248,Fundamentals Media Production,Crowe,Craig Warren,28,2,0,0,0,0,1,3.779
-Summer 2022,NUTR,4351,1,16199,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,25,14,9,2,3,0,2,2.932
-Summer 2022,PSYC,8399,15,12325,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,4,0,0
-Summer 2022,BIOE,8198,16,17364,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5229,2,12159,Judicial Externship II,Archer,Anna M,0,0,0,0,0,1,0,0
-Summer 2022,ENTR,3312,2,10526,Corporate Entrepreneurship,Karonika,John R,22,17,5,1,1,0,3,3.311
-Summer 2022,MANA,   6A25,1,11585,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,16,13,2,0,0,0,0,3.42
-Summer 2022,SOCW,7397,6,15662,Selected Topics in Social Work,Dettlaff,Alan J,14,0,0,0,0,0,0,4
-Summer 2022,ACCT,3368,4,15319,Intermediate Accounting II,Sun,Xue,6,12,7,1,1,0,0,2.753
-Summer 2022,ECON,3368,1,12118,Economics of Health Care,Zhivan,Natalia A.,9,11,9,5,4,0,0,2.421
-Summer 2022,IDNS,2197,2,16267,Top-Natrl Sci & Mth,Pattison,Donna,0,0,0,0,0,42,0,0
-Summer 2022,DIGM,1300,30,13439,Introduction to Digital Media,Waite,Jerry J,8,5,5,1,2,0,0,2.715
-Summer 2022,ENGL,2315,2,16112,Literature and Film,Sicinski,Michael J,14,9,1,0,1,0,0,3.334
-Summer 2022,PHAR,4280,1,10008,Med/Pt Safety & Informatics,Varkey,Divya A,105,1,0,2,0,0,0,3.935
-Summer 2022,KIN,4690,1,11242,Internship in Sport Admin 1,Walsh,David W,11,1,0,1,0,0,0,3.642
-Summer 2022,SPEC,6367,1,13435,Special Education for Leaders,McCormick,Marina,9,2,1,0,1,0,0,3.258
-Summer 2022,FINA,7323,1,12965,Applied Equity Fund Management,George,Thomas J,17,0,0,0,0,0,0,4
-Summer 2022,SOCW,7385,1,11154,Field Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,17,0,0
-Summer 2022,COMM,3353,1,11142,Information & Comm Tech I,Liu,Youmei,12,8,1,1,1,0,2,3.275
-Summer 2022,ENGL,1302,7,12460,First Year Writing II,Krajniak,Matthew J,7,8,4,2,2,0,1,2.696
-Summer 2022,NURS,6331,1,13543,Advanced Pharmacotherapy,Dwyer,Carol Ann,5,2,1,0,0,0,0,3.5
-Summer 2022,CHEE,8399,21,16266,Doctoral Dissertation,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,0
-Summer 2022,ACCT,5337,2,12904,Management Accounting,Serrato,Darlene Marie  Bohac,2,0,0,0,0,0,0,3.835
-Summer 2022,BIOL,6698,15,16947,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,2,0,0
-Summer 2022,HRD,4352,1,11729,Facilitation Strategies,Hampton,Elaine Denae,10,3,0,0,0,0,0,3.718
-Summer 2022,ECE,8298,17,16805,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,0
-Summer 2022,HRD,6396,1,11545,Internship in Human Res. Dev.,Shirmohammadi,Melika,3,0,0,0,0,0,0,4
-Summer 2022,FINA,3332,2,13138,Prin of Financial Management,Chisholm,Darla,2,1,1,0,0,0,1,3.25
-Summer 2022,POLS,3313,2,12199,Intro Internatl Relatns,Vardy,Ronald V,23,11,3,0,0,0,2,3.523
-Summer 2022,PHIL,1361,1,12178,Philosophy and the Arts,Drapela,Nick Gerard,6,2,5,1,2,0,1,2.48
-Summer 2022,MATH,5389,1,11333,Survey of Mathematics,Etgen,Garret J,6,6,0,0,0,0,0,3.583
-Summer 2022,CHEM,1111,9,11462,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,9,2,0,0,0,0,3.194
-Summer 2022,CHEE,8298,16,16297,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,0
-Summer 2022,PHAR,5217,1,12942,Pediatric Therapeutics,Rogers,Elizabeth Coyle,46,1,0,0,0,0,0,3.979
-Summer 2022,COMM,3361,1,12865,Advertising Copywriting,Clark,Thomas R,9,0,3,0,0,0,0,3.5
-Summer 2022,ECE,8298,3,16665,Doctoral Research,Yao,Yan,0,0,0,0,0,4,0,0
-Summer 2022,PHAR,5663,2,11130,Pharmacy Management,Truong,Mabel,5,0,0,0,0,0,0,4
-Summer 2022,PSYC,7397,4,16878,Selected Topics in Psychology,Harris,Gerald E,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8298,21,16302,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,0
-Summer 2022,ENGI,2304,8,13060,Technical Communications,Downey,Carlton M,12,1,0,0,0,0,2,3.948
-Summer 2022,LAW,5407,10,11597,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,2,0,0
-Summer 2022,CHEE,8398,15,11395,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,0
-Summer 2022,PHAR,5690,3,11715,Internal Medicine,Fernandez,Julianna M,2,0,0,0,0,0,0,4
-Summer 2022,SPEC,8365,1,13452,Admin-Supv Special Educ,Malechuk,Brian Edward,10,0,0,0,0,0,0,4
-Summer 2022,PHOP,6167,4,16647,Research Practicum A,Ritchey,Eric R,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8198,2,16450,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,0
-Summer 2022,COMD,7391,15,12551,Clinic in Speech Lang Disorder,Bolling,Kenyetta,1,0,0,0,0,0,0,3.67
-Summer 2022,HRD,6303,30,12911,Assessment & Evaluation in Hrd,White,Shironda,7,0,0,0,0,0,0,4
-Summer 2022,GEOL,8399,6,17069,Doctoral Dissertation,Brandon,Alan,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,12,16626,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8298,9,16676,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8399,28,10350,Doctoral Dissertation,Renshaw,Andrew,1,0,0,0,0,0,0,4
-Summer 2022,BIOL,8698,1,10112,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,6698,2,16582,Special Problems,Lekven,Arne,0,0,0,0,0,1,0,0
-Summer 2022,RELS,3337,1,13575,Theologies from the Margins,Pegoda,Andrew Joseph,3,2,1,0,2,0,1,2.459
-Summer 2022,CIVE,8198,10,16370,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,0
-Summer 2022,ECON,6693,1,11726,Master's Research Project,Zhivan,Natalia A.,4,0,0,0,0,0,0,4
-Summer 2022,COMM,4398,2,16976,Independent Study,Crowe,Craig Warren,3,0,0,0,0,0,0,4
-Summer 2022,LAW,6300,11,12331,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8399,21,16950,Doctoral Dissertation,Hoff,Kevin,0,0,0,0,0,3,0,0
-Summer 2022,MECE,8498,18,16983,Doctoral Research,Prosperetti,Andrea,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,7399,12,17112,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4
-Summer 2022,LAW,5110,1,10035,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,16,16818,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6157,8,16707,Research Practicum B,Porter,Jason,1,0,0,0,0,0,0,4
-Summer 2022,MATH,6398,9,10135,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,0
-Summer 2022,MATH,1324,3,13406,Finite Math with Applications,Caglar,Atife,5,13,9,12,12,0,1,1.745
-Summer 2022,GEOL,8398,2,16924,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,0,0,0
-Summer 2022,CHEM,2125,3,11381,Organic Chemistry Lab II,Zaitsev,Vladimir G,4,13,0,0,1,0,1,3.092
-Summer 2022,MECE,3338,1,13063,Dynamic & Control of Mech Syst,Hammami,Farah,2,12,13,2,0,0,0,2.437
-Summer 2022,ECE,8598,7,17119,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,8198,1,17281,Doctoral Research,Coulson-Thomas,Vivien J,0,0,0,0,0,0,0,0
-Summer 2022,BZAN,7320,1,10004,Bus Modeling For Comp Adv,Wiley,Briceon C,9,0,0,0,0,0,0,4
-Summer 2022,MATH,3333,1,12367,Intermediate Analysis,Kalantar,Mehrdad,4,9,1,0,2,0,3,2.771
-Summer 2022,COSC,6398,131,17258,Special Problems,Wu,Panruo,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,22,17057,Doctoral Research,Sun,Li,0,0,0,0,0,3,0,0
-Summer 2022,CIVE,7397,1,16142,Selected Topics,Vipulanandan,Cumaraswamy,9,1,0,0,0,0,0,3.933
-Summer 2022,THEA,6181,1,12229,Applying Method Des/Dramaturgy,Shimko,Robert B,11,0,0,0,0,0,0,4
-Summer 2022,BIOL,2102,3,11437,Anatomy & Physiology II (lab),Gill,Tejendra,5,9,3,2,3,0,1,2.53
-Summer 2022,GEOL,1103,4,13403,Physical Geology Lab,Sisson,Virginia B,5,2,1,0,0,0,1,3.5
-Summer 2022,MECE,8298,5,16554,Doctoral Research,Zhao,Bo,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8398,6,16703,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,0
-Summer 2022,MANA,4336,1,12166,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,5,11,5,0,2,0,1,2.696
-Summer 2022,CHEE,2331,2,12960,Chemical Processes,Kowal,Marsha Christine,2,3,1,0,0,0,0,3.057
-Summer 2022,CHEE,8298,12,16293,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,0
-Summer 2022,ECON,3332,1,10055,Intermediate Microeconomics,Sugiura,Ko,3,1,8,0,3,0,0,2.133
-Summer 2022,MANA,4353,1,13475,Mgmt Training and Career Devel,Bozeman,Dennis,34,8,6,2,0,0,0,3.526
-Summer 2022,SOCW,7397,3,13931,Selected Topics in Social Work,Lucas,Virginia,24,2,0,0,0,0,0,3.91
-Summer 2022,LAW,5120,1,13415,Texas Legal Research,Dykes,Christopher,7,10,0,0,0,0,0,3.392
-Summer 2022,DIGM,3351,30,11861,Individ Comm Processes,Waite,Jerry J,22,8,3,0,1,0,0,3.471
-Summer 2022,PHYS,8398,39,10457,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,0
-Summer 2022,LAW,6300,3,11600,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,0
-Summer 2022,BIOL,6698,4,16442,Special Problems,Mohan,Chandra,0,0,0,0,0,2,0,0
-Summer 2022,BTEC,6399,3,17372,Thesis,Iyer,Rupa S,0,0,0,0,0,0,0,0
-Summer 2022,PHYS,1101,5,12780,College Physics I (lab),Maric,Sladjana,2,7,4,1,0,0,1,2.714
-Summer 2022,PSYC,3325,2,12357,Psychology of Personality,Cano,Kiana Ellen,32,6,4,2,0,0,2,3.575
-Summer 2022,TLIM,4371,30,12933,Leading Change in the Wrkplace,Evans,Gerald S,20,8,0,0,0,0,0,3.679
-Summer 2022,BIOE,8399,5,16430,Doctoral Dissertation,Francis,Joseph Thachil,1,0,0,0,0,0,0,4
-Summer 2022,COMM,4357,1,15529,Intercultural Communication,Vaughn,Ginger Koto,16,3,0,0,0,0,1,3.877
-Summer 2022,SOCW,7325,3,13423,Assessment in SW Practice,Xu,Wen,25,0,0,0,0,0,0,3.974
-Summer 2022,BIOL,6698,1,16334,Special Problems,Chung,Sanghyuk,0,0,0,0,0,9,0,0
-Summer 2022,SOCW,7347,3,12910,SW Practice & Interv in School,Leger,Jan Ellen,12,1,1,0,0,0,0,3.739
-Summer 2022,ECE,8598,4,10995,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8698,127,13247,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6365,6,13364,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,0
-Summer 2022,PCOL,6498,6,17142,Special Problems,Trivedi PhD,Meghana,0,0,0,0,0,1,0,0
-Summer 2022,ECON,6693,1,11726,Master's Research Project,Boul,Ruxandra,4,0,0,0,0,0,0,4
-Summer 2022,HRMA,4352,1,13412,Hosp Organizational Behavior,Jarvis,Nathan Alexander,20,3,7,2,3,0,3,2.962
-Summer 2022,PSYC,2301,4,12119,Introduction to Psychology,Lipschutz,Rebecca Sara,36,18,1,1,1,0,1,3.48
-Summer 2022,SPAN,2312,1,10085,Intermediate Spanish II,Said White,Erika,14,4,1,0,0,0,1,3.719
-Summer 2022,CIVE,8598,17,16393,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,8399,19,16754,Doctoral Dissertation,Vujanovic,Anka Anna,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5500,1,12010,Government and Nonprofit Exter,Powers,William,0,0,0,0,0,3,0,0
-Summer 2022,GERM,3350,1,12843,20Th C Thru German Culture,Kleinheider,Julia D,5,2,1,0,2,0,1,2.734
-Summer 2022,PSYC,6352,5,16887,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,1,0,0
-Summer 2022,MANA,4355,2,13478,Selection and Staffing,Bozeman,Dennis,16,11,4,0,0,0,0,3.451
-Summer 2022,INDE,8398,3,13311,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1101,2,10450,College Physics I (lab),Maric,Sladjana,1,11,5,1,0,0,0,2.593
-Summer 2022,ARTS,3316,1,15643,Relief Printmaking,Nesbit,Tiffany Angel,13,0,0,0,0,0,0,3.949
-Summer 2022,PSYC,7399,10,16923,Masters Thesis,Hoff,Kevin,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7347,1,12879,SW Practice & Interv in School,Leger,Jan Ellen,4,8,1,0,0,0,0,3.282
-Summer 2022,LAW,5328,2,11593,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,4,0,0
-Summer 2022,COMD,7382,1,12704,CLD Issues in SLP,Ivey,Michelle L,5,0,0,0,0,0,0,4
-Summer 2022,PSYC,6365,1,13157,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,3,0,0,0,0,0,0,4
-Summer 2022,CUIN,7376,4,14229,New Tools Create Online Matls,Vyas,Anita,16,0,1,0,1,0,0,3.667
-Summer 2022,PSYC,6352,2,12017,Directed Rsch in I/O Psyc,Hoff,Kevin,0,0,0,0,0,3,0,0
-Summer 2022,THEA,6385,1,12227,Technical Direction/Shop Maint,Middents,Jonathan Mark,12,0,0,0,0,0,0,4
-Summer 2022,OPTO,5198,1,16249,Spec Prob Phys Optics,Piccolo,Marcus G,0,0,0,0,0,9,0,0
-Summer 2022,CHEE,6397,1,15498,Selected Topics,Kaushik,Krishna R,7,4,0,0,0,0,0,3.606
+Summer 2022,MIS,6341,1,10003,Information Systems,Silva,Leiser O,14,0,0,0,0,0,0,4.0
+Summer 2022,BZAN,7320,1,10004,Bus Modeling For Comp Adv,Wiley,Briceon C,9,0,0,0,0,0,0,4.0
 Summer 2022,CHEE,2332,1,10005,Chem Engr Thermodyn I,Fleischer,Miguel T,1,5,3,2,1,0,10,2.223
-Summer 2022,INDE,8398,2,13310,Doctoral Research,Lee,Tae Woo,0,0,0,0,0,1,0,0
-Summer 2022,MIS,   6A41,1,11587,Information Systems,Silva,Leiser O,40,4,0,0,0,0,0,3.917
-Summer 2022,IDNS,2197,2,16267,Top-Natrl Sci & Mth,Perepelitsa,Irina,0,0,0,0,0,42,0,0
-Summer 2022,DIGM,3353,31,15422,Visual Communications Tech,Dozier,Devin K,19,9,4,1,1,0,0,3.216
-Summer 2022,COSC,1437,301,12182,Introduction to Programming,Rincon Castro,Carlos Alberto,27,9,8,5,11,0,4,2.606
-Summer 2022,WGSS,2350,5,13510,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,2,0,0,1,0,1,3.782
-Summer 2022,BCHS,6498,4,17345,Special Problems,Widger,William R,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1101,3,10451,College Physics I (lab),Maric,Sladjana,2,8,5,0,0,0,2,2.8
-Summer 2022,PSYC,6336,1,13090,Directed Rsch in Social Psyc,Derrick,Jaye L,2,0,0,0,0,0,0,4
-Summer 2022,CHEM,1111,14,11520,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,7,1,0,0,0,0,3.378
-Summer 2022,COSC,8698,107,13267,Doctoral Research,Eick,Christoph F,0,0,0,0,0,2,0,0
-Summer 2022,PETR,8598,3,16511,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,0
-Summer 2022,CIVE,8198,3,16354,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,0
-Summer 2022,ELET,2300,1,16357,Introductn To C++ Programming,Montero Hernandez,Samuel Antonio,13,15,10,5,9,0,3,2.353
-Summer 2022,MIS,3370,1,12451,Info Systems Development Tools,Knighton,William B,7,11,6,3,4,0,1,2.452
-Summer 2022,SOC,3311,1,15629,Sociology of Law,Gallo,Joseph Ralph,26,11,12,0,1,0,0,3.22
-Summer 2022,CIVE,7399,2,17201,Master's Thesis,Louie,Stacey M,0,0,0,0,0,1,0,0
-Summer 2022,ECE,6198,2,16839,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8198,3,16454,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,4,0,0
-Summer 2022,MATH,6498,1,11076,Special Problems,Mang,Andreas,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1302,1,10831,College Physics II (lecture),Renshaw,Andrew,30,44,21,0,0,0,2,3.088
-Summer 2022,PHAR,5674,1,11112,Nutritional Support,Truong,Mabel,1,0,0,0,0,0,0,4
-Summer 2022,POLC,6391,1,12888,Public Policy Internship,Wong,Man Chiu,14,0,0,0,0,0,2,4
-Summer 2022,INDE,2333,2,16017,Engineering Statistics I,Wang,Yaping,34,52,18,1,1,0,0,3.129
-Summer 2022,MECE,3369,1,16153,Solid Mechanics,Wang,Jiawen,5,4,6,1,0,0,0,2.648
-Summer 2022,CUIN,7375,1,12861,Capstone for Literacy Educ,Hale,Margaret Ann,11,0,0,0,1,0,0,3.667
-Summer 2022,MECE,8498,14,16636,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,2,0,0
-Summer 2022,BIOL,6698,20,17087,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,3360,4,13669,Field Geology II,Weber,John,6,3,0,0,0,0,0,3.63
-Summer 2022,HLT,3306,1,16018,Environmental Health,Proctor,Robin Ann,53,6,1,0,2,0,1,3.689
-Summer 2022,CHEE,8398,5,10933,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,5,0,0
-Summer 2022,CUIN,8398,4,17316,Independent Study,Zhang,Jie,1,0,0,0,0,0,0,4
-Summer 2022,ACCT,7396,1,11678,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,6,0,0
-Summer 2022,BIOL,6698,5,16464,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,0
-Summer 2022,MIS,7397,1,14492,Selected Topics in MIS,Campbell,Phillip James,11,3,0,0,0,0,0,3.809
-Summer 2022,GEOL,8698,14,16988,Doctoral Research,Suppe,John,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,5397,1,15497,Selected Topics,Kaushik,Krishna R,2,3,0,0,0,0,0,3.466
-Summer 2022,PSYC,8199,2,17265,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,2123,3,10119,Organic Chemistry Lab I,Zaitsev,Vladimir G,6,9,1,0,0,0,1,3.313
-Summer 2022,FINA,4397,5,17100,Selected Topics in Finance,Goudie,Thomas Lawrence,4,0,0,0,0,0,0,4
-Summer 2022,ARTS,4398,2,16482,Independent Study,Parazette,Aaron,7,0,0,0,0,0,0,4
-Summer 2022,LAW,5514,1,11980,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,2,0,0
-Summer 2022,ECON,8699,6,17379,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,8399,3,16827,Doctoral Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,0
-Summer 2022,THEA,6184,1,12670,Applying Methods in Dir/Styles,Cook,Rena R,12,0,0,0,0,0,0,4
-Summer 2022,PSYC,8399,20,16882,Doctoral Dissertation,Damian,Rodica Ioana,1,0,0,0,0,0,0,4
-Summer 2022,INDE,8298,1,13304,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,0
-Summer 2022,ECE,8298,19,16811,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,6330,3,15615,Finance & School-Based Budgtng,Garcia-Velasquez,Erwin,12,0,0,0,0,0,0,4
-Summer 2022,AAS,6311,1,15431,Afr-Amer Soc & Phil Fndtns,Edwards,Crystal Latanya,5,1,1,0,0,0,0,3.336
-Summer 2022,BIOL,6355,1,13068,Introduction to Health Systems,Valier,Helen K,23,4,0,0,0,0,0,3.779
-Summer 2022,MECE,8198,1,16560,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,0
-Summer 2022,GEOL,7301,1,12839,Capstone Project,Van Nieuwenhuise,Donald S,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8598,12,16388,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,0
-Summer 2022,BIOE,8198,7,16493,Doctoral Research,Naash,Muna,0,0,0,0,0,5,0,0
-Summer 2022,MUSI,7399,1,17235,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,1,0,0
-Summer 2022,COMD,7391,18,13272,Clinic in Speech Lang Disorder,Maher,Lynn M,2,0,0,0,0,0,0,3.67
-Summer 2022,CUIN,8390,2,13031,Doctoral Thesis,Hutchison,Laveria F,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7397,7,15663,Selected Topics in Social Work,Ruiz,Ashley Brown,9,1,0,0,0,0,1,3.834
-Summer 2022,BIOE,8198,12,17115,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,0
-Summer 2022,CUIN,7356,1,14227,Issues in Distance Education,Dogan,Bulent,23,0,0,0,0,0,0,4
-Summer 2022,BCHS,8399,3,16338,Doctoral Dissertation,Widger,William R,0,0,0,0,0,1,0,0
-Summer 2022,KIN,4300,1,11588,Phys Activity Older Adults,Alastuey,Lisa L,16,13,5,4,4,0,2,2.684
-Summer 2022,CUIN,7356,3,14226,Issues in Distance Education,Dogan,Bulent,22,0,0,0,1,0,0,3.826
-Summer 2022,BIOL,1107,3,10575,Biology for Science Majors II,Hanke,Marc H,10,3,4,0,0,0,1,3.372
-Summer 2022,CHEE,2331,1,12959,Chemical Processes,Kowal,Marsha Christine,2,6,2,2,3,0,2,2.089
-Summer 2022,CIVE,8598,1,13354,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,0
-Summer 2022,HLT,1353,3,12171,Personal Health,Selzer,Lori Michele,17,10,1,2,1,0,1,3.28
-Summer 2022,ECON,4390,4,13449,Economics Internship,Saboury,Piruz,16,0,0,0,0,0,0,4
-Summer 2022,MIS,7397,2,15309,Selected Topics in MIS,Messinger,Jacob Nelson,7,2,0,0,0,0,0,3.741
-Summer 2022,HRMA,6191,1,12185,Project Development,Ramirez,Arlene D,0,0,0,0,0,8,0,0
-Summer 2022,THEA,6382,1,12200,Dramaturgy for H.S. Director,Shimko,Robert B,13,0,0,0,0,0,0,4
-Summer 2022,BIOL,8698,4,16628,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8698,106,13203,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5245,1,11138,Civil Practice Clinic II,McManus,Diane M,0,1,0,0,0,0,0,3.33
-Summer 2022,ECE,8399,10,16934,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4
+Summer 2022,CHEE,3321,1,10006,Analytical Methods Chem Engr,Malamataris,Nikolaos,4,1,4,0,0,0,1,2.963
+Summer 2022,PHAR,5493,1,10007,Introduction to Community IPPE,Hatfield,Catherine L,59,47,2,0,0,0,0,3.528
+Summer 2022,PHAR,4280,1,10008,Med/Pt Safety & Informatics,Varkey,Divya A,105,1,0,2,0,0,0,3.935
+Summer 2022,BIOE,8398,2,10009,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,3,0,
+Summer 2022,MANA,6398,1,10021,Research,Keller,Robert T,0,1,0,0,0,0,0,3.0
+Summer 2022,MARK,3336,1,10022,Introduction to Marketing,Zahn,William J,62,39,6,0,1,0,2,3.491
+Summer 2022,HLT,1353,1,10031,Personal Health,Rafique,Kiran Sajid,90,7,1,1,0,0,1,3.835
+Summer 2022,INDE,2333,1,10032,Engineering Statistics I,Wiggins,Nathanial David,21,9,1,0,0,0,0,3.485
+Summer 2022,LAW,5103,1,10033,Health Law Journal,Mantel,Jessica,0,0,0,0,0,0,0,
+Summer 2022,LAW,5110,1,10035,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2022,LAW,5210,1,10038,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2022,LAW,5410,1,10042,Law Review,Sanders,Joseph,0,0,0,0,0,2,0,
+Summer 2022,COMM,6398,4,10051,Special Problems,Vardeman,Jennifer E,1,0,0,0,0,0,0,4.0
+Summer 2022,ECON,3332,1,10055,Intermediate Microeconomics,Sugiura,Ko,3,1,8,0,3,0,0,2.133
+Summer 2022,ECON,8699,1,10064,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,4,0,
+Summer 2022,ECON,8699,3,10065,Doctoral Dissertation,Liu,Elaine Meichen,1,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,1301,1,10071,First Year Writing I,O'Bryan,Ann Patricia,13,2,1,0,5,0,0,2.857
 Summer 2022,SPAN,2311,1,10082,Intermediate Spanish I,Delgadillo,Maria Jose,3,9,9,0,3,0,0,2.306
-Summer 2022,MARK,7399,1,16131,MS Marketing Prof Project,Koch,Steven F.,4,1,0,0,0,0,0,3.866
-Summer 2022,MATH,1332,1,15473,Elem Mathematical Modeling,Hafeez,Shahinda,4,9,3,2,3,0,5,2.413
-Summer 2022,CHEM,8698,1,10705,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,3,0,0
-Summer 2022,BCHS,6698,4,16742,Special Problems,Wang,Yuhong,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,2344,3,12631,Cultural Psychology,Garcia,Jessica Leeann,26,17,5,1,7,0,0,2.941
-Summer 2022,ACCT,2302,2,10520,Prin of Managerial Accounting,Weber,Catherine K,8,11,10,2,2,0,2,2.706
-Summer 2022,ACCT,7385,1,11914,Fraud Examination,Ramey,Dan T,23,1,1,0,0,0,0,3.893
-Summer 2022,PHYS,1102,3,10834,College Physics II (lab),Wood,Lowell T,2,9,8,0,0,0,2,2.684
-Summer 2022,PETR,8198,9,16602,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,0
-Summer 2022,MECE,7399,1,17116,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,0
-Summer 2022,NUTR,6304,1,12644,Adv Nutr Counseling & Educ,Ledoux,Tracey A,7,3,0,0,0,0,2,3.535
-Summer 2022,LAW,6355,3,11602,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,0
-Summer 2022,ELCS,8312,2,13667,Lab of Practice-Res Meth Devel,Davis,Bradley,3,0,0,0,0,0,0,4
-Summer 2022,ENGL,1302,14,13363,First Year Writing II,Burns,William,12,5,3,0,2,0,2,3.091
-Summer 2022,LAW,6300,2,11599,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,5,0,0
-Summer 2022,CHEE,6198,1,17270,Research,Karim,Alamgir,0,0,0,0,0,1,0,0
-Summer 2022,PETR,8699,1,12581,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,0
-Summer 2022,LAW,7397,2,15555,Selected Topics,Morath,Sarah,5,7,0,0,0,0,0,3.389
-Summer 2022,HDFS,3350,1,11261,Observation and Assessment,Schroder,Kathleen Anne,36,6,0,1,0,0,1,3.668
-Summer 2022,NURS,4322,1,16048,Policy &Ethics in Prof Nursing,Quintana,Danielle,60,1,0,1,0,0,0,3.935
-Summer 2022,HDCS,4380,1,13523,Merchandising,Gatterson,Beverly,11,4,1,1,2,0,0,3.036
-Summer 2022,HDCS,4386,1,11732,Communication Strategies,Hitchman Sr,Cal M,5,6,2,1,0,0,0,3.048
-Summer 2022,POLS,4198,1,16192,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,7399,1,12820,Master's Thesis,Mo,Larry Yi-Lung,1,0,0,0,0,0,0,4
-Summer 2022,OPTO,6274,1,16256,Spec Contact Lens Workshops,Stafford Luman,Kristin Michele,0,0,0,0,0,20,0,0
-Summer 2022,CUIN,8310,45,11788,Laboratory of Practice,Hausmann,Robert Carl,4,0,0,0,0,0,0,4
-Summer 2022,LAW,5407,10,11597,Judicial Externship I,Powers,William,0,0,0,0,0,2,0,0
-Summer 2022,PETR,8399,5,12434,Doctoral Dissertation,Qin,Guan,0,0,0,0,0,1,0,0
-Summer 2022,IEEM,6360,1,13604,Data Analytics for Engr. Mgt,Chang,Feng-Chang Roger,60,12,0,0,0,0,1,3.778
-Summer 2022,OPTO,5298,2,16254,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,9,0,0
-Summer 2022,BIOL,6698,16,16973,Special Problems,McKeon,Frank D,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8399,16,11012,Doctoral Dissertation,Balakotaiah,Vemuri,0,0,0,0,0,1,0,0
-Summer 2022,ENTR,3310,3,12896,Entrepreneurship,Ortega,Carlos Alberto,79,18,1,1,0,0,0,3.721
-Summer 2022,ATP,6301,1,11775,Anatomy,Harrison,Layci,9,7,1,0,0,0,0,3.471
-Summer 2022,MIS,   6A41,3,11632,Information Systems,Silva,Leiser O,28,1,0,0,0,0,0,3.909
-Summer 2022,CHEM,3396,1,17421,Senior Research Project,Meen,James K,1,0,0,0,0,0,0,4
-Summer 2022,PCEU,8399,1,12582,Doctoral Dissertation,Liu,Xinli,1,0,0,0,0,0,0,4
-Summer 2022,ECE,8498,25,16933,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5228,2,12157,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,1,0,0
-Summer 2022,HIST,4398,1,17368,Independent Study,Young,Nancy Beck,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,3339,1,11921,Intro To Clinical Psychology,Szafranski,Derek D,61,8,2,0,0,0,4,3.771
-Summer 2022,GEOL,8698,4,16361,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,3301,6,13618,Intro Psych Stats,Vahedi,Meisam,53,4,1,0,0,0,1,3.879
-Summer 2022,MIS,4378,1,12034,Admin of Computer-Based MIS,Porra,Jaana,43,0,0,0,0,0,0,3.969
-Summer 2022,SOCW,6304,1,11571,Women's Issues,Aquino-Adriatico,Gabrielle,13,0,0,0,0,0,0,4
-Summer 2022,PHYS,1101,1,10449,College Physics I (lab),Wood,Lowell T,4,8,8,2,0,0,0,2.681
-Summer 2022,LAW,5206,4,12162,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,2,0,0
-Summer 2022,ECE,6598,2,17164,Research,Roysam,Badrinath,0,0,0,0,0,0,0,0
-Summer 2022,PETR,8399,4,12433,Doctoral Dissertation,Hathon,Lori A,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8399,24,10346,Doctoral Dissertation,Ordonez,Carlos,1,0,0,0,0,0,0,4
+Summer 2022,SPAN,2311,3,10084,Intermediate Spanish I,Cicerchia,Jose,15,5,3,0,1,0,1,3.293
+Summer 2022,SPAN,2312,1,10085,Intermediate Spanish II,Said White,Erika,14,4,1,0,0,0,1,3.719
 Summer 2022,SPAN,2307,1,10086,Span for Heritage Learners I,Milner,Allison L,5,9,3,1,2,0,0,2.75
-Summer 2022,LAW,5297,2,15590,Selected Topics,Lawrence,Jim E,1,2,0,0,0,1,0,2.5
-Summer 2022,MATH,8698,14,13225,Doctoral Research,Perepelitsa,Mikhail Antolyevic,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8398,9,10937,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,3301,1,12120,Intro Psych Stats,Pierce,Jace D,23,22,7,3,1,0,3,3.078
-Summer 2022,MIS,4477,1,11915,Network & Security Infrastruct,Messinger,Jacob Nelson,17,5,0,0,0,0,0,3.698
-Summer 2022,CIS,6397,1,16014,Selected Topics,Conklin,William A,10,1,2,0,0,0,0,3.615
-Summer 2022,CHEM,6698,11,10632,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8398,14,16414,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,6,0,0
-Summer 2022,COSC,8698,129,13293,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,0
-Summer 2022,COMM,1307,4,13384,Media and Society,Olson,Beth M,6,9,3,2,3,0,2,2.537
-Summer 2022,MECE,5388,1,12219,Intelligent Structural Systems,Song,Gangbing,6,22,5,0,0,0,5,3.09
-Summer 2022,COSC,4351,201,16194,Fundamentals of Software Engr,Hilford,Victoria,14,5,2,0,0,0,0,3.524
-Summer 2022,ECE,3155,2,13072,Electronics Laboratory,Ruchhoeft,Paul,7,3,1,0,0,0,0,3.605
-Summer 2022,COSC,8399,110,16953,Doctoral Dissertation,Gurkan,Deniz,1,0,0,0,0,0,0,4
-Summer 2022,ELCS,8695,8,16236,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,2,16539,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,2,0,0
-Summer 2022,BIOE,8298,1,16447,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,0
-Summer 2022,GOVT,2306,4,12650,US and Texas Const/Politics,Davis,Shelby,15,8,3,1,2,0,1,3.058
-Summer 2022,GEOL,8698,11,16965,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,7,0,0
-Summer 2022,CIVE,8198,22,17179,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,6,0,0
-Summer 2022,THEA,6284,1,12192,Program Management,Springfield,Travis,12,0,0,0,0,0,0,4
-Summer 2022,ELCS,8395,7,16659,Doctoral Thesis,Lopez,Ruth Maria,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,13,16629,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,0
-Summer 2022,HIST,8677,1,13149,Reading for Comps Exams,Golubev,Alexey Valeryevich,1,0,0,0,0,0,0,4
-Summer 2022,SCLT,4375,30,15489,Global Supply Chain,Velarde,Jose Manuel,18,6,12,0,3,0,0,2.872
-Summer 2022,ELCS,8395,3,16655,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6367,2,16702,Research Practicum A,Ritchey,Eric R,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5400,2,11596,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,6,0,0
-Summer 2022,CUIN,8398,3,17323,Independent Study,Hale,Margaret Ann,2,0,0,0,0,0,0,4
-Summer 2022,FINA,4323,1,16064,Investment & Mutual Fund Mgt,Blanchfield,Craig,34,11,6,0,1,0,0,3.487
-Summer 2022,MATH,6298,14,10745,Special Problems,Fitzgibbon,William E,0,0,0,0,0,11,0,0
-Summer 2022,THEA,6181,1,12229,Applying Method Des/Dramaturgy,Rigdon,Kevin L,11,0,0,0,0,0,0,4
-Summer 2022,ECE,8398,12,16860,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,0
-Summer 2022,PHYS,8698,6,16716,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,2,0,0
-Summer 2022,MUSI,2302,2,12221,Listening to Jazz,Marmolejo,Noe J,10,0,0,0,0,0,0,4
-Summer 2022,COMD,7391,12,11040,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,2,0,0,0,0,0,0,3.835
-Summer 2022,BIOL,2301,1,11434,Anatomy & Physiology I (lect),Wayne,Chad M,13,19,26,9,7,0,6,2.271
-Summer 2022,BTEC,1322,30,16025,Introduction to Biotechnology,Hosseinzadeh,Hemen,2,5,3,0,0,0,2,2.834
-Summer 2022,ACCT,3367,4,13507,Intermediate Accounting I,Kuruvilla,Mohan,8,7,11,4,3,0,5,2.464
-Summer 2022,BIOL,6698,10,16808,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,3,0,0
-Summer 2022,HON,4398,2,17195,Independent Study,Rhoden,Brenda,2,0,0,0,0,0,0,4
-Summer 2022,COSC,8698,117,13291,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,0
-Summer 2022,PSYC,7390,1,12012,Clin Neuropsychology Practicum,Woods,Steven Paul,4,0,0,0,0,0,0,4
-Summer 2022,MECE,8399,1,17221,Doctoral Dissertation,Wang,Su Su,0,0,0,0,0,0,0,0
-Summer 2022,OPTO,5250,1,16526,Seminar Scientific Investigatn,Frishman,Laura J,12,0,0,0,0,0,0,4
-Summer 2022,GEOL,8698,13,16987,Doctoral Research,Mann,Paul,0,0,0,0,0,3,0,0
-Summer 2022,ARCH,6397,1,15536,Sel Tpcs-Arc/Urbn Desgn,Diehl,Tom,2,1,1,0,0,0,0,3.333
-Summer 2022,PHCA,8199,5,17080,Doctoral Dissertation Defense,Chen,Hua,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,6398,2,11978,Independent Studies,Spitzmuller,Christiane,2,0,0,0,0,0,0,4
-Summer 2022,HDFS,2314,3,13245,Human Dev and Interventions,Schoger,Kimberly,29,3,5,0,1,0,0,3.501
-Summer 2022,CHEE,8399,13,10953,Doctoral Dissertation,Grabow,Lars C,1,0,0,0,0,2,0,1.333
-Summer 2022,CHEM,6698,18,10637,Special Problems,Comito,Robert Joseph,0,0,0,0,0,2,0,0
-Summer 2022,PHCA,8298,4,17073,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4
-Summer 2022,ENGL,7399,1,16174,Essay,Mazella,David S,1,0,0,0,0,0,0,4
-Summer 2022,PHLS,6397,1,17233,Selected Topics,Smedley,Diane,10,0,0,0,0,0,1,4
-Summer 2022,SPAN,1501,1,11291,Elementary Spanish I,Hernandez Vargas,Saul,11,5,0,1,1,0,4,3.333
-Summer 2022,MECE,8398,1,16630,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,0
-Summer 2022,MUSI,2302,1,16016,Listening to Jazz,Marmolejo,Noe J,15,0,0,0,1,0,0,3.75
-Summer 2022,CHEM,1112,15,12322,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,1,0,0,0,1,3.133
-Summer 2022,NURS,3634,1,13544,Clinical Nursing Practice II,Quintana,Danielle,54,8,1,0,0,0,0,3.857
-Summer 2022,SOCW,7397,1,13928,Selected Topics in Social Work,Lea III,Charles Herbert,11,0,0,0,0,0,0,4
-Summer 2022,PHLS,6335,3,13563,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,10,1,0,0,0,0,0,3.909
-Summer 2022,ECE,8498,24,16918,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8355,1,12632,Policy Pol & Gov of Education,Goree,Tonya,5,1,0,0,0,0,0,3.833
-Summer 2022,KIN,4398,3,17408,Independent Study,Cottingham,Michael,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,6457,4,16651,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8498,14,16311,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,0
-Summer 2022,PHCA,6398,1,16477,Special Problems,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4
-Summer 2022,COSC,8698,120,13278,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8399,5,11965,Doctoral Dissertation,Derrick,Jaye L,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8399,2,16463,Doctoral Dissertation,Lin,Chin-Yo,0,0,0,0,0,1,0,0
-Summer 2022,WGSS,2360,2,12700,Introduction to LGBT Studies,Stone,Lauren Michelle,14,4,4,2,0,0,0,3.278
-Summer 2022,ECE,8298,1,10983,Doctoral Research,Wolfe,John C,0,0,0,0,0,0,0,0
-Summer 2022,COMM,3326,1,12863,Graphics Applications,Economou-Clarke,Ann M,11,7,0,0,0,0,0,3.648
-Summer 2022,HDFS,3320,1,12208,Careers in HDFS,Jordan,Erica F,23,7,2,0,2,0,2,3.364
-Summer 2022,FINA,6335,1,15596,Managerial Finance,Wu,Guojun,0,0,0,0,0,0,0,0
-Summer 2022,SOCW,7354,1,15594,Spirituality and Aging,Bajic,Miljana,22,1,0,0,0,0,0,3.87
-Summer 2022,PHLA,7199,1,17256,Masters Thesis,Varkey,Divya A,0,0,0,0,0,1,0,0
-Summer 2022,PHCA,6298,2,17308,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4
-Summer 2022,SCLT,2362,31,12945,Intro To Logistics Technology,Chopra,Anuj,24,11,1,0,0,0,0,3.584
-Summer 2022,IRW,1300,1,12706,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,6,0,0
-Summer 2022,KIN,1352,3,11608,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,97,11,2,0,0,0,0,3.87
-Summer 2022,BCIS,1305,1,13462,Business Computer Applications,Felvegi,Emese,55,22,9,0,1,0,2,3.498
-Summer 2022,HIST,1377,6,17350,The U S To 1877,McDonald,Eric John,26,12,2,2,3,0,4,3.178
-Summer 2022,PHAR,5297,1,16085,Selected Topics in Pharmacy,Rosario,Natalie,26,15,2,0,0,0,0,3.558
-Summer 2022,MATH,1314,1,11135,College Algebra,Xhabli,Blerina,7,3,3,2,9,0,8,1.848
-Summer 2022,MANA,4346,2,17212,Leadership Development,Evans,Klavdia Markelova,9,0,0,0,0,0,0,4
-Summer 2022,MARK,   6A98,1,16402,Research,Habel,Johannes,1,0,0,0,0,0,0,4
-Summer 2022,INDE,8498,1,13315,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,0
-Summer 2022,ECE,8699,3,16849,Doctoral Dissertation,Shireen,Wajiha,0,0,0,0,0,0,0,0
-Summer 2022,PSYC,3325,3,12358,Psychology of Personality,Sutu,Andreea Emanuela,43,11,4,0,1,0,0,3.532
-Summer 2022,IEEM,6335,1,15614,Engr Mgmt of Organizations,Chang,Feng-Chang Roger,20,1,0,0,0,0,0,3.952
-Summer 2022,MECE,3363,1,13064,Intro To Fluid Mechanics,Love,Holley Carole,7,12,3,0,0,0,0,3.062
-Summer 2022,HON,3397,3,16239,Honors Selected Topics,Myrick,Keri D,5,0,0,0,0,0,0,3.934
-Summer 2022,ATP,7194,1,11777,Clinical Experience IV,Knoblauch,Mark Alan,8,5,0,0,0,0,0,3.615
-Summer 2022,BIOL,6698,2,16335,Special Problems,Zufall,Rebecca A,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8298,14,16682,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,0
-Summer 2022,IDNS,7099,3,17425,Degree Completion,Chu,Wei-Kan,0,0,0,0,0,1,0,0
-Summer 2022,COSC,6398,119,17360,Special Problems,Ordonez,Carlos,0,0,0,0,0,1,0,0
-Summer 2022,ACCT,5335,2,16019,Financial Statement Auditing,Kuruvilla,Mohan,0,1,1,0,0,0,0,2.665
-Summer 2022,PHOP,8498,1,13183,Doctoral Research,Berntsen,David A,1,0,0,0,0,0,0,4
-Summer 2022,BCHS,6698,11,16886,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8298,5,16484,Doctoral Research,Larin,Kirill,0,0,0,0,0,5,0,0
-Summer 2022,PHAR,5675,6,16220,Disease State Management,Rosario,Natalie,2,0,0,0,1,0,0,2.667
-Summer 2022,ACCT,5337,1,11152,Management Accounting,Serrato,Darlene Marie  Bohac,0,2,0,0,0,0,0,3
-Summer 2022,MECE,8498,21,17055,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8193,2,12505,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,12,0,0
-Summer 2022,NUTR,6311,1,12695,Capstone I,Haubrick,Kevin,3,0,0,0,1,0,0,2.835
-Summer 2022,PHLS,7327,2,15522,Counseling Children,Hurt,Kara Marie,5,0,0,0,0,0,0,4
-Summer 2022,ECE,6298,4,17204,Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,ENGL,8398,1,16524,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,18,16982,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,0
-Summer 2022,ECON,4390,2,10551,Economics Internship,Thornton,Rebecca Achee,2,0,0,0,0,0,0,4
-Summer 2022,MIS,3360,1,11456,Systems Analysis and Design,Porra,Jaana,38,1,0,0,0,0,0,3.924
-Summer 2022,OPTO,6274,1,16256,Spec Contact Lens Workshops,Logan,Anna-Kaye M,0,0,0,0,0,20,0,0
-Summer 2022,OPTO,6250,1,16257,Decision Making:Optometrc Prac,Quintero,Sam,0,0,0,0,0,14,0,0
-Summer 2022,BIOL,1107,2,10574,Biology for Science Majors II,Hanke,Marc H,8,7,3,0,1,0,0,3.14
-Summer 2022,ECON,2301,1,15429,Principles of Macroeconomics,Clarke,Christopher Arthur,7,23,16,6,12,0,2,2.104
-Summer 2022,KIN,3370,2,13467,Sport Facility Management,Pearson,Demetrius W,4,5,3,0,0,0,0,2.973
-Summer 2022,OPTO,8384,1,11097,Practice Management II,Davis,Mark K,21,9,0,0,0,0,0,3.612
-Summer 2022,NUTR,2332,2,13087,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,48,9,5,0,0,0,2,3.603
-Summer 2022,SOCW,8336,1,12183,Research Internship I,Berger Cardoso,Jodi A,8,0,0,0,0,0,0,4
-Summer 2022,HLT,3381,2,12926,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,19,2,1,1,0,0,1,3.624
-Summer 2022,PHAR,5694,1,11126,Pediatrics,Truong,Mabel,6,2,0,0,0,0,0,3.75
-Summer 2022,PSYC,8390,1,11945,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,3,0,0
-Summer 2022,ENGI,2304,12,15530,Technical Communications,Ellis,Kelly Ann,19,3,0,0,0,0,0,3.819
-Summer 2022,SOCW,8399,1,11137,Dissertation,Gearing,Robin Edward,0,0,0,0,0,0,0,0
-Summer 2022,EDUC,2301,1,12754,Intro to Special Populations,Hassett,Kristen Spring,26,9,1,0,1,0,0,3.577
-Summer 2022,GOVT,2305,4,12916,"US Govt: Congress,Pres & Crts",Alvarez,Robert D,20,4,1,0,0,0,1,3.786
-Summer 2022,COSC,2436,201,15682,Programming and Data Structure,Rizk,Nouhad J,12,12,18,0,12,0,9,2.186
-Summer 2022,ACCT,3377,2,12903,Cost Accounting,Serrato,Darlene Marie  Bohac,4,4,3,0,0,0,1,3.121
-Summer 2022,PETR,8398,9,16506,Doctoral Research,Qin,Guan,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8398,10,17313,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1102,1,10832,College Physics II (lab),Maric,Sladjana,2,7,9,0,0,0,0,2.648
-Summer 2022,SPEC,6353,1,12605,Technology in Special Pops,Goodrich,Elizabeth A,4,4,0,0,1,0,0,3.221
-Summer 2022,HRMA,6397,1,15514,Selected Topics,Legendre,Jungyoung Shin,18,0,0,0,0,0,0,3.982
-Summer 2022,POLS,4298,1,16193,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,0
-Summer 2022,PHAR,5680,1,11116,Oncology,Truong,Mabel,1,0,0,0,0,0,0,4
-Summer 2022,BIOL,2101,6,11676,Anatomy & Physiology Lab I,Gill,Tejendra,6,10,4,1,0,0,0,2.937
-Summer 2022,PHAR,5206,1,12940,Pharmacy and Geriatrics,Ordonez,Nancy D,21,24,2,0,0,0,0,3.404
-Summer 2022,HDFS,2314,1,12209,Human Dev and Interventions,Schoger,Kimberly,51,11,4,1,0,0,0,3.662
-Summer 2022,EDUC,2301,2,12755,Intro to Special Populations,Carp,Charlotte Lynn,17,5,1,2,0,0,1,3.414
-Summer 2022,MANA,   6A32,2,13484,Organizational Behavior & Mgt,Witt,Lawrence A,29,0,0,0,0,0,0,4
-Summer 2022,TLIM,3350,30,15355,Emergency Management Principle,Freedkin,Aaron Samuel,17,8,1,0,1,0,0,3.457
-Summer 2022,CNST,3155,1,12624,Const Materials & Testing,Meyer,Joseph Ray,13,12,5,0,0,0,0,3.267
-Summer 2022,PHYS,8399,17,10339,Doctoral Dissertation,Hosur,Pavan R,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,7,16558,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,3,0,0
-Summer 2022,MARK,7373,1,12190,Business to Business Marketing,Herman,Carl,20,2,0,0,0,0,0,3.864
-Summer 2022,ELCS,8399,4,13438,Doctoral Dissertation,Zou,Yali,0,0,0,0,0,1,0,0
-Summer 2022,PCOL,8698,1,16446,Doctoral Research,Trivedi PhD,Meghana,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,6698,4,10625,Special Problems,Teets,Thomas,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8298,11,17114,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,0
-Summer 2022,PCOL,6298,5,16620,Special Problems,Kumar,Ashok,0,0,0,0,0,0,0,0
-Summer 2022,SCLT,2380,30,11906,Distribution Channels,Hollis,Thomas Edward,17,2,2,0,0,0,0,3.683
-Summer 2022,SOCW,7378,1,12398,Integrated Behav Healthcare,Mohr,Gabriella A,24,3,0,0,0,0,0,3.901
-Summer 2022,HLT,4310,1,11900,Program Planning for Health,Markowitz,Eliz,17,8,4,1,2,0,1,3.136
-Summer 2022,DIGM,2357,30,12148,Content Strategy & Development,Alters,Monika Joanna,12,13,1,0,0,0,1,3.423
-Summer 2022,BCHS,8698,3,16766,Doctoral Research,Briggs,James M,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8298,8,16675,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,0
+Summer 2022,SPAN,8699,1,10095,Dissertation,Rivera Garza,Cristina,2,0,0,0,0,0,0,4.0
+Summer 2022,SPAN,8699,2,10096,Dissertation,Goodin-Mayeda,Carrie Elizabeth,0,0,0,0,0,1,0,
+Summer 2022,SPAN,8699,3,10097,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Summer 2022,ECON,2302,1,10098,Principles of Microeconomics,Melendez Lugo,Joel,22,20,16,5,4,0,3,2.668
 Summer 2022,BIOL,1106,1,10104,Biol for Science Majors I(Lab),Medrano,Ana I,19,3,1,0,0,0,1,3.768
-Summer 2022,PEP,8350,3,17167,HHP Candidacy Project Research,Park,Yoonjung,1,0,0,0,0,0,0,4
-Summer 2022,ELCS,8312,6,15606,Lab of Practice-Res Meth Devel,Lopez,Ruth Maria,1,1,0,0,0,0,0,3.5
+Summer 2022,BIOL,1106,2,10105,Biol for Science Majors I(Lab),Medrano,Ana I,16,2,0,0,0,0,0,3.761
+Summer 2022,BIOL,1106,3,10106,Biol for Science Majors I(Lab),Medrano,Ana I,14,2,1,0,0,0,0,3.726
+Summer 2022,BIOL,1106,4,10107,Biol for Science Majors I(Lab),Medrano,Ana I,22,1,1,0,0,0,0,3.834
+Summer 2022,BIOL,1306,1,10108,Biology for Science Majors I,Gifford,Jenifer Beth,26,32,22,15,10,0,1,2.486
+Summer 2022,BIOL,8698,1,10112,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2022,CHEM,1111,2,10114,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,1,0,1,0,1,3.048
+Summer 2022,CHEM,2123,1,10117,Organic Chemistry Lab I,Zaitsev,Vladimir G,7,3,6,0,1,0,0,2.844
+Summer 2022,CHEM,2123,2,10118,Organic Chemistry Lab I,Zaitsev,Vladimir G,4,8,3,0,0,0,2,3.111
+Summer 2022,CHEM,2123,3,10119,Organic Chemistry Lab I,Zaitsev,Vladimir G,6,9,1,0,0,0,1,3.313
+Summer 2022,MATH,1324,2,10121,Finite Math with Applications,Sosa,Moses,20,12,6,4,0,0,4,3.017
+Summer 2022,MATH,2413,3,10122,Calculus I,Sosa,Moses,32,14,20,12,18,0,22,2.285
+Summer 2022,MATH,4377,1,10125,Advanced Linear Algebra I,Haynes,Alan K,9,1,1,0,0,0,0,3.757
+Summer 2022,MATH,6398,9,10135,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Summer 2022,MATH,6398,11,10137,Special Problems,Haynes,Alan K,0,0,0,0,0,1,0,
+Summer 2022,MATH,8399,4,10173,Doctoral Dissertation,Cappanera,Loic,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,1301,1,10198,College Physics I (lecture),Cardoso Barato,Andre,41,26,28,4,1,0,9,3.013
+Summer 2022,PHYS,8398,14,10305,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8398,27,10317,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8399,5,10327,Doctoral Dissertation,Bellwied,Rene,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,8399,6,10328,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,2,0,
+Summer 2022,PHYS,8399,8,10330,Doctoral Dissertation,Cardoso Barato,Andre,1,0,0,0,0,1,0,4.0
+Summer 2022,PHYS,8399,17,10339,Doctoral Dissertation,Hosur,Pavan R,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8399,19,10341,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8399,24,10346,Doctoral Dissertation,Ordonez,Carlos,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,8399,27,10349,Doctoral Dissertation,Ren,Zhifeng,1,0,0,0,0,0,0,3.67
+Summer 2022,PHYS,8399,28,10350,Doctoral Dissertation,Renshaw,Andrew,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,1101,1,10449,College Physics I (lab),Wood,Lowell T,4,8,8,2,0,0,0,2.681
+Summer 2022,PHYS,1101,2,10450,College Physics I (lab),Wood,Lowell T,1,11,5,1,0,0,0,2.593
+Summer 2022,PHYS,1101,3,10451,College Physics I (lab),Wood,Lowell T,2,8,5,0,0,0,2,2.8
+Summer 2022,PHYS,8398,39,10457,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,
+Summer 2022,SCM,3301,1,10461,SCM Fundamentals,Khumawala,Basheer M,70,42,8,1,1,0,1,3.459
+Summer 2022,HLT,3301,1,10462,Health Behavior Theories,Bennett,Kristin C,50,3,2,0,2,0,0,3.708
+Summer 2022,SPAN,1501,5,10512,Elementary Spanish I,Miranda Moreno,Sujaila Abigail,2,2,5,1,5,0,1,1.557
+Summer 2022,SPAN,1502,1,10514,Elementary Spanish II,Monarrez Martinez,Sendy Patricia,16,3,1,2,3,0,1,3.027
+Summer 2022,SPAN,1502,3,10516,Elementary Spanish II,Ruffino,Gustavo,7,3,0,0,0,0,0,3.766
+Summer 2022,ACCT,2301,3,10519,Prin of Financial Accounting,Sykes,Mary Reeves,18,9,3,2,1,0,2,3.312
+Summer 2022,ACCT,2302,2,10520,Prin of Managerial Accounting,Weber,Catherine K,8,11,10,2,2,0,2,2.706
+Summer 2022,ACCT,4396,1,10521,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,2,0,
+Summer 2022,ENTR,3312,1,10525,Corporate Entrepreneurship,Karonika,John R,28,14,2,0,3,0,1,3.313
+Summer 2022,ENTR,3312,2,10526,Corporate Entrepreneurship,Karonika,John R,22,17,5,1,1,0,3,3.311
+Summer 2022,LAW,6318,2,10547,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,1,0,
+Summer 2022,LAW,6354,2,10548,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,1,0,
+Summer 2022,ECON,4390,2,10551,Economics Internship,Thornton,Rebecca Achee,2,0,0,0,0,0,0,4.0
+Summer 2022,SPAN,2312,6,10555,Intermediate Spanish II,Mejia Lara,Airy Sindik,11,9,3,1,0,0,0,3.25
+Summer 2022,SPAN,2312,12,10556,Intermediate Spanish II,Abend Van Dalen,Raquel Andreina de la Trinidad,10,7,3,0,1,0,0,3.222
+Summer 2022,SPAN,2308,1,10557,Span for Heritage Learners II,Martinez,Raquel,17,4,3,0,2,0,1,3.308
+Summer 2022,SPAN,8699,4,10566,Dissertation,Solino,Maria Elena,0,0,0,0,0,0,0,
+Summer 2022,ENGL,3328,1,10569,Masterpieces of British Lit II,Wood,Barry Albert,13,11,1,0,1,0,2,3.194
+Summer 2022,BIOL,1107,1,10573,Biology for Science Majors II,Hanke,Marc H,10,3,3,0,0,0,0,3.438
+Summer 2022,BIOL,1107,2,10574,Biology for Science Majors II,Hanke,Marc H,8,7,3,0,1,0,0,3.14
+Summer 2022,BIOL,1107,3,10575,Biology for Science Majors II,Hanke,Marc H,10,3,4,0,0,0,1,3.372
+Summer 2022,BIOL,1307,1,10577,Biology for Science Majors II,Farmer,Lisa M,11,10,14,9,1,0,2,2.525
+Summer 2022,CHEM,1112,1,10578,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,3,0,0,0,0,3.088
+Summer 2022,CHEM,6399,4,10602,Masters Thesis,Zastrow,Melissa L,1,0,0,0,0,0,0,3.67
+Summer 2022,CHEM,6399,5,10603,Masters Thesis,Cai,Chengzhi,0,1,0,0,0,0,0,3.0
+Summer 2022,CHEM,6698,1,10623,Special Problems,Do,Loi H,0,0,0,0,0,1,0,
+Summer 2022,CHEM,6698,2,10624,Special Problems,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Summer 2022,CHEM,6698,4,10625,Special Problems,Teets,Thomas,0,0,0,0,0,1,0,
+Summer 2022,CHEM,6698,5,10626,Special Problems,May,Jeremy A,0,0,0,0,0,4,0,
+Summer 2022,CHEM,6698,6,10627,Special Problems,Xu,Shoujun,0,0,0,0,0,3,0,
+Summer 2022,CHEM,6698,7,10628,Special Problems,Lee,T Randall,0,0,0,0,0,5,0,
+Summer 2022,CHEM,6698,9,10630,Special Problems,Bao,Jiming,0,0,0,0,0,2,0,
+Summer 2022,CHEM,6698,10,10631,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,3,0,
+Summer 2022,CHEM,6698,11,10632,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Summer 2022,CHEM,6698,13,10633,Special Problems,Zastrow,Melissa L,0,0,0,0,0,3,0,
+Summer 2022,CHEM,6698,14,10634,Special Problems,Bittner,Eric R,0,0,0,0,0,1,0,
+Summer 2022,CHEM,6698,15,10635,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Summer 2022,CHEM,6698,16,10636,Special Problems,Daugulis,Olafs,0,0,0,0,0,3,0,
+Summer 2022,CHEM,6698,18,10637,Special Problems,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Summer 2022,CHEM,6698,19,10638,Special Problems,Carrow,Bradley,0,0,0,0,0,5,0,
+Summer 2022,CHEM,8399,2,10691,Doctoral Dissertation,Lee,T Randall,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEM,8399,4,10692,Doctoral Dissertation,Harth,Eva M,3,0,0,0,0,0,0,4.0
+Summer 2022,CHEM,8399,6,10694,Doctoral Dissertation,Baldelli,Steve,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEM,8399,13,10700,Doctoral Dissertation,Guloy,Arnold M,0,0,0,0,0,1,0,
+Summer 2022,CHEM,8399,18,10704,Doctoral Dissertation,Brgoch,Jakoah,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEM,8698,1,10705,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,3,0,
+Summer 2022,CHEM,8698,2,10706,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,1,0,
+Summer 2022,CHEM,8698,4,10707,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,5,0,
+Summer 2022,CHEM,8698,5,10708,Doctoral Research,Lee,T Randall,0,0,0,0,0,4,0,
+Summer 2022,CHEM,8698,6,10709,Doctoral Research,Do,Loi H,0,0,0,0,0,2,0,
+Summer 2022,CHEM,8698,7,10710,Doctoral Research,May,Jeremy A,0,0,0,0,0,3,0,
+Summer 2022,CHEM,8698,9,10712,Doctoral Research,Teets,Thomas,0,0,0,0,0,6,0,
+Summer 2022,CHEM,8698,10,10713,Doctoral Research,Chen,Tai-Yen,0,0,0,0,0,3,0,
+Summer 2022,CHEM,8698,11,10714,Doctoral Research,Cuny,Gregory D,0,0,0,0,0,1,0,
+Summer 2022,CHEM,8698,13,10715,Doctoral Research,Cai,Chengzhi,0,0,0,0,0,2,0,
+Summer 2022,CHEM,8698,14,10716,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,3,0,
+Summer 2022,CHEM,8698,15,10717,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,2,0,
+Summer 2022,CHEM,8698,16,10718,Doctoral Research,Harth,Eva M,0,0,0,0,0,3,0,
+Summer 2022,CHEM,8698,18,10719,Doctoral Research,Guloy,Arnold M,0,0,0,0,0,1,0,
+Summer 2022,CHEM,8698,19,10720,Doctoral Research,Miljanic,Ognjen S,0,0,0,0,0,2,0,
+Summer 2022,CHEM,8699,2,10723,Doctoral Dissertation,Jacobson,Allan J,0,0,0,0,0,1,0,
+Summer 2022,MATH,1324,5,10738,Finite Math with Applications,Chang,James A,10,8,8,6,8,0,0,2.216
+Summer 2022,MATH,2312,4,10739,Precalculus,Caglar,Atife,14,18,12,0,4,0,2,2.792
+Summer 2022,MATH,2414,3,10740,Calculus II,Weber,Thomas Christian,9,12,7,7,5,0,6,2.243
+Summer 2022,MATH,3321,1,10743,Engineering Mathematics,Etgen,Garret J,14,14,10,2,5,0,3,2.659
+Summer 2022,MATH,4378,1,10744,Advanced Linear Algebra II,Torok,Andrei S,4,3,5,3,1,0,0,2.231
+Summer 2022,MATH,6298,14,10745,Special Problems,Fitzgibbon,William E,0,0,0,0,0,11,0,
+Summer 2022,MATH,6398,33,10757,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Summer 2022,MATH,8398,10,10803,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Summer 2022,PHYS,1302,1,10831,College Physics II (lecture),Renshaw,Andrew,30,44,21,0,0,0,2,3.088
+Summer 2022,PHYS,1102,1,10832,College Physics II (lab),Wood,Lowell T,2,7,9,0,0,0,0,2.648
+Summer 2022,PHYS,1102,2,10833,College Physics II (lab),Wood,Lowell T,0,8,4,0,0,0,2,2.694
+Summer 2022,PHYS,1102,3,10834,College Physics II (lab),Wood,Lowell T,2,9,8,0,0,0,2,2.684
+Summer 2022,CHEM,1112,7,10838,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,0,0,0,0,3.269
+Summer 2022,MARK,3337,1,10843,Professional Selling,Tueffert,Curt F,31,4,0,0,0,0,0,3.895
+Summer 2022,AAS,2320,2,10846,Intro To African American Stdy,Thompson,Kevin Bernard,29,3,2,0,0,0,1,3.804
+Summer 2022,CHEM,1112,8,10866,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,7,2,0,0,0,2,3.166
+Summer 2022,ARCH,6602,1,10868,Arch Design/Build Workshop,Peters,Patrick A,8,1,0,0,0,0,0,3.816
+Summer 2022,ACCT,3377,1,10871,Cost Accounting,Serrato,Darlene Marie  Bohac,5,5,2,0,1,0,0,3.076
+Summer 2022,ACCT,5331,1,10875,Federal Income Tax-Individual,Fernandez,Ramon,0,2,2,0,0,0,0,2.665
+Summer 2022,ACCT,5335,1,10876,Financial Statement Auditing,Kuruvilla,Mohan,4,5,2,1,0,0,0,3.055
+Summer 2022,ACCT,5367,1,10877,Intermediate Accounting I,Kuruvilla,Mohan,2,1,1,0,0,0,1,3.25
+Summer 2022,MANA,8399,1,10883,Doctoral Dissertation,Keller,Robert T,1,0,0,0,0,0,0,4.0
+Summer 2022,HDFS,4394,1,10886,Internship in HDFS,Conston,Toya,20,0,0,0,0,0,1,3.984
+Summer 2022,HLT,4392,1,10887,Field Work in Community Health,Solari Williams,Kayce D.,19,2,0,1,1,0,0,3.594
+Summer 2022,HLT,4393,1,10888,Field Work in Com Health,Solari Williams,Kayce D.,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8298,1,10924,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8298,2,10925,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,
+Summer 2022,CHEE,8298,4,10927,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8298,5,10928,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,1,10929,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,
+Summer 2022,CHEE,8398,2,10930,Doctoral Research,Harold,Michael P,0,0,0,0,0,5,0,
+Summer 2022,CHEE,8398,3,10931,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,
+Summer 2022,CHEE,8398,4,10932,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,5,10933,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,5,0,
+Summer 2022,CHEE,8398,6,10934,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,
+Summer 2022,CHEE,8398,7,10935,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,8,10936,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8398,9,10937,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,11,10939,Doctoral Research,Orman,Mehmet,0,0,0,0,0,4,0,
+Summer 2022,CHEE,8398,12,10940,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,3,0,
+Summer 2022,CHEE,8399,1,10941,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,4,10944,Doctoral Dissertation,Varadarajan,Navin,7,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,5,10945,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8399,6,10946,Doctoral Dissertation,Rimer,Jeffrey,0,0,0,0,0,5,0,
+Summer 2022,CHEE,8399,7,10947,Doctoral Dissertation,Palmer,Jeremy,3,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,8,10948,Doctoral Dissertation,Orman,Mehmet,4,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,10,10950,Doctoral Dissertation,Mountziaris,Triantafillos John,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,11,10951,Doctoral Dissertation,Karim,Alamgir,7,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,12,10952,Doctoral Dissertation,Harold,Michael P,0,0,0,0,0,6,0,
+Summer 2022,CHEE,8399,13,10953,Doctoral Dissertation,Grabow,Lars C,1,0,0,0,0,2,0,4.0
+Summer 2022,CHEE,8399,15,10955,Doctoral Dissertation,Conrad,Jacinta C,0,0,0,0,0,0,0,
+Summer 2022,CHEE,8498,1,10956,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8498,2,10957,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,
+Summer 2022,CHEE,8498,4,10959,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8498,5,10960,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8398,1,10969,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Summer 2022,ECE,6198,1,10970,Research,Chen,Ji,0,0,0,0,0,3,0,
+Summer 2022,ECE,6398,1,10971,Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,ECE,6598,1,10975,Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2022,ECE,8198,3,10978,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,
+Summer 2022,ECE,8198,4,10979,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,1,10983,Doctoral Research,Wolfe,John C,0,0,0,0,0,0,0,
+Summer 2022,ECE,8298,2,10984,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,4,0,
+Summer 2022,ECE,8398,1,10985,Doctoral Research,Jackson,David R,0,0,0,0,0,2,0,
+Summer 2022,ECE,8498,1,10990,Doctoral Research,Wolfe,John C,0,0,0,0,0,0,0,
+Summer 2022,ECE,8498,2,10991,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,4,0,
+Summer 2022,ECE,8598,3,10994,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,
+Summer 2022,ECE,8598,4,10995,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,INDE,6398,1,10998,Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Summer 2022,INDE,8398,1,11003,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8198,13,11010,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,13,11011,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,7,0,
+Summer 2022,CHEE,8399,16,11012,Doctoral Dissertation,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Summer 2022,HRMA,6360,1,11014,Graduate Directed Practicum,Back,KiJoon,18,0,0,0,0,0,0,3.982
+Summer 2022,LAW,5198,1,11015,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,3.67
+Summer 2022,LAW,5398,1,11017,Special Research and Writing,Vetter,Greg R,1,0,0,0,0,0,0,4.0
+Summer 2022,LAW,5419,1,11018,Consumer Law Clinic,Marquez,Ryan Michael,0,2,0,0,0,0,0,3.33
+Summer 2022,LAW,6349,1,11021,Consumer Law Clinic,Marquez,Ryan Michael,1,1,0,0,0,0,0,3.5
+Summer 2022,COMD,7391,2,11028,Clinic in Speech Lang Disorder,Chapman,Amanda,0,2,0,0,0,0,0,3.33
+Summer 2022,COMD,7391,3,11029,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,2,0,0,0,0,0,0,3.835
+Summer 2022,COMD,7391,4,11030,Clinic in Speech Lang Disorder,Degge,Mary Chistine,1,0,0,0,0,0,0,3.67
+Summer 2022,COMD,7391,6,11031,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,1,0,0,0,0,0,0,3.67
+Summer 2022,COMD,7391,7,11032,Clinic in Speech Lang Disorder,Ivey,Michelle L,2,0,0,0,0,0,0,3.67
+Summer 2022,COMD,7391,8,11033,Clinic in Speech Lang Disorder,Walker,Dionne A,1,1,0,0,0,0,0,3.665
+Summer 2022,COMD,7391,9,11034,Clinic in Speech Lang Disorder,Devore,Danielle R,2,0,0,0,0,0,0,3.67
+Summer 2022,COMM,4392,1,11036,Professional Internship,Ashley,Laura B,0,0,0,0,0,16,0,
+Summer 2022,COMD,7391,10,11039,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,1,1,0,0,0,0,0,3.665
+Summer 2022,COMD,7391,12,11040,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,2,0,0,0,0,0,0,3.835
+Summer 2022,MATH,1324,1,11057,Finite Math with Applications,Almus,Melahat,24,18,24,6,22,0,14,2.093
+Summer 2022,MATH,1325,1,11058,Calc for Bus & Social Sciences,Constante,Beatrice,14,20,4,4,4,0,4,2.725
+Summer 2022,MATH,2312,1,11059,Precalculus,Almus,Melahat,28,14,18,4,24,0,22,2.16
+Summer 2022,MATH,2413,1,11060,Calculus I,Perepelitsa,Irina,24,56,22,14,48,0,32,1.947
+Summer 2022,MATH,2414,1,11062,Calculus II,Xhabli,Blerina,31,15,13,4,23,0,10,2.295
+Summer 2022,MATH,6298,3,11065,Special Problems,Timofeyev,Ilya,0,0,0,0,0,4,0,
+Summer 2022,MATH,6398,5,11072,Special Problems,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Summer 2022,MATH,6498,1,11076,Special Problems,Mang,Andreas,0,0,0,0,0,1,0,
+Summer 2022,MATH,6498,4,11077,Special Problems,Timofeyev,Ilya,0,0,0,0,0,4,0,
+Summer 2022,MATH,6498,6,11078,Special Problems,Fitzgibbon,William E,0,0,0,0,0,10,0,
+Summer 2022,MATH,8399,1,11081,Doctoral Dissertation,Haynes,Alan K,1,0,0,0,0,0,0,4.0
+Summer 2022,MATH,8699,2,11083,Doctoral Dissertation,Josic,Kresimir,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,1340,1,11092,Earth Systems,Lytwyn,Jennifer N,26,52,44,16,14,0,10,2.414
+Summer 2022,OPTO,6251,1,11093,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,13,0,
+Summer 2022,OPTO,7150,1,11094,Developmental Optometry,Chandler,Moriah Adine,73,14,3,0,0,0,0,3.778
+Summer 2022,OPTO,7493,1,11095,General Clinic IIIA,Dempsey,Robert L.,0,0,0,0,0,85,0,
+Summer 2022,OPTO,8338,1,11096,Recent Developments/Round,Dempsey,Robert L.,16,16,0,0,0,0,0,3.418
+Summer 2022,OPTO,8384,1,11097,Practice Management II,Davis,Mark K,21,9,0,0,0,0,0,3.612
+Summer 2022,OPTO,8696,1,11098,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,29,0,
+Summer 2022,OPTO,8990,1,11099,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,58,0,
+Summer 2022,OPTO,8991,1,11100,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,51,0,
+Summer 2022,PHOP,6160,1,11101,Gen Sem Visual Sciences,Porter,Jason,18,0,0,0,0,1,0,4.0
+Summer 2022,PHOP,6372,1,11102,Experimental Quant in VS,Benoit,Julia S,5,9,0,0,0,0,0,3.357
+Summer 2022,PHAR,5642,1,11104,Emergency Medicine,Truong,Mabel,5,4,0,0,0,0,0,3.556
+Summer 2022,PHAR,5660,1,11106,Pharmaceutical Industry,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5664,1,11108,Legal & Regulatory Affairs,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5668,1,11109,Managed Care Pharmacy,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5670,1,11110,Community Pharmaceutical Care,Tolleson,Shane Russell,8,2,1,0,0,0,0,3.636
+Summer 2022,PHAR,5672,1,11111,Clinical Pharmaceutical Resch,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5674,1,11112,Nutritional Support,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5675,1,11113,Disease State Management,Tolleson,Shane Russell,14,2,0,0,0,0,0,3.875
+Summer 2022,PHAR,5678,1,11114,Transplant Therapeutics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5680,1,11116,Oncology,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5681,3,11118,Infectious Diseases,Garey,Kevin W,3,1,0,0,0,0,0,3.75
+Summer 2022,PHAR,5685,1,11119,Critical Care,Truong,Mabel,4,1,0,0,0,0,0,3.8
+Summer 2022,PHAR,5690,1,11121,Internal Medicine,Truong,Mabel,27,7,0,0,0,0,0,3.794
+Summer 2022,PHAR,5690,2,11122,Internal Medicine,Sherer,Jeffrey T,0,2,0,0,0,0,0,3.0
+Summer 2022,PHAR,5692,1,11124,Advanced Hospital Pharmacy,Truong,Mabel,35,3,0,0,0,0,0,3.921
+Summer 2022,PHAR,5693,1,11125,Advanced Community Pharmacy,Tolleson,Shane Russell,46,9,0,0,0,0,0,3.836
+Summer 2022,PHAR,5694,1,11126,Pediatrics,Truong,Mabel,6,2,0,0,0,0,0,3.75
+Summer 2022,PHAR,5695,1,11127,Geriatrics,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5663,2,11130,Pharmacy Management,Truong,Mabel,5,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7384,1,11131,Field Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,13,0,
+Summer 2022,SOCW,7388,1,11132,Field Practicum III Macro,Gonzales,Shelley A,0,0,0,0,0,3,0,
+Summer 2022,SOCW,7391,1,11133,Field Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,8,0,
+Summer 2022,HDCS,2301,1,11134,Consumer Science,Stewart,Juliana Floriene,25,0,0,1,0,0,1,3.808
+Summer 2022,MATH,1314,1,11135,College Algebra,Xhabli,Blerina,7,3,3,3,9,0,8,1.8
+Summer 2022,MATH,2415,5,11136,Calculus III,West,James David,6,0,7,7,11,0,3,1.398
+Summer 2022,SOCW,8399,1,11137,Dissertation,Gearing,Robin Edward,0,0,0,0,0,0,0,
+Summer 2022,LAW,5245,1,11138,Civil Practice Clinic II,Krasny,Frederick A,0,1,0,0,0,0,0,3.33
+Summer 2022,COMM,3353,1,11142,Information & Comm Tech I,Liu,Youmei,12,8,1,1,1,0,2,3.275
+Summer 2022,CHEE,8399,17,11144,Doctoral Dissertation,Economou,Demetre J,0,0,0,0,0,0,0,
+Summer 2022,MATH,8398,4,11145,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,
+Summer 2022,ACCT,5337,1,11152,Management Accounting,Serrato,Darlene Marie  Bohac,0,2,0,0,0,0,0,3.0
+Summer 2022,GOVT,2306,1,11153,US and Texas Const/Politics,Cole,Jeffrey Bryan,8,5,3,3,1,0,0,2.883
+Summer 2022,SOCW,7385,1,11154,Field Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,18,0,
+Summer 2022,SOCW,7389,1,11155,Field Practicum IV Macro,Gonzales,Shelley A,0,0,0,0,0,10,0,
+Summer 2022,COMM,3368,1,11156,Principles of Public Relations,Ashley,Laura B,22,2,1,0,0,0,0,3.787
+Summer 2022,ECON,3370,1,11157,Introduction To Econometrics,Boul,Ruxandra,8,8,6,2,3,0,4,2.58
+Summer 2022,PHYS,1101,4,11158,College Physics I (lab),Wood,Lowell T,1,14,7,0,0,0,1,2.712
+Summer 2022,PHYS,1102,4,11160,College Physics II (lab),Wood,Lowell T,4,7,8,1,0,0,0,2.601
+Summer 2022,KIN,4310,1,11239,Measurement Tech Human Perf,Thrasher,Timothy Adam,3,8,7,3,1,0,0,2.424
+Summer 2022,KIN,4345,1,11240,Econ and Finc Aspects of Sport,Lee,Dong Hun,11,12,0,0,0,0,0,3.478
+Summer 2022,KIN,4390,1,11241,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Summer 2022,KIN,4690,1,11242,Internship in Sport Admin 1,Walsh,David W,11,1,0,1,0,0,0,3.642
+Summer 2022,KIN,4691,1,11243,Internship in Sport Admin 2,Walsh,David W,9,2,1,0,0,0,0,3.584
+Summer 2022,KIN,4350,1,11244,Sport Marketing,Walsh,David W,9,32,22,6,2,0,1,2.577
+Summer 2022,NUTR,3334,1,11245,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,22,25,3,3,0,0,1,3.183
+Summer 2022,PEP,7393,1,11246,Internship & Practicum,Walsh,David W,2,0,0,0,0,0,0,4.0
+Summer 2022,COMM,2320,1,11248,Fundamentals Media Production,Crowe,Craig Warren,28,2,0,0,0,0,1,3.779
+Summer 2022,LAW,5283,1,11249,Mediation Externship,Willis,Tasha L,0,0,0,0,0,2,0,
+Summer 2022,LAW,5183,1,11250,Mediation Process,Willis,Tasha L,1,1,0,0,0,0,0,3.5
+Summer 2022,HRMA,4343,1,11251,Financial Admin for Hosp.Ind.,Koh,Yoon,15,10,6,2,0,0,1,3.102
+Summer 2022,KIN,4340,1,11252,Sport Governance,Walsh,David W,2,12,2,0,0,0,0,3.021
+Summer 2022,GOVT,2306,2,11254,US and Texas Const/Politics,Lopez-Hisijos,Lucia,20,1,0,0,2,0,0,3.566
+Summer 2022,GEOL,1303,1,11255,Physical Geology,Lytwyn,Jennifer N,24,40,27,21,12,0,10,2.363
+Summer 2022,ACCT,3367,1,11258,Intermediate Accounting I,Kuruvilla,Mohan,5,11,10,5,3,0,9,2.343
+Summer 2022,ENGL,1302,1,11259,First Year Writing II,Salome,Melanie Rebecca,8,8,5,0,1,0,2,2.94
+Summer 2022,GOVT,2305,1,11260,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,8,13,4,1,0,0,1,3.026
+Summer 2022,HDFS,3350,1,11261,Observation and Assessment,Schroder,Kathleen Anne,36,6,0,1,0,0,1,3.668
+Summer 2022,NUTR,3336,1,11267,Nutritional Pathophysiology,Haubrick,Kevin,23,18,4,1,0,0,1,3.305
+Summer 2022,COMD,7381,1,11269,Medical SLP Seminar,Ivey,Michelle L,13,0,0,0,0,0,0,3.949
+Summer 2022,SPAN,1501,1,11291,Elementary Spanish I,Hernandez Vargas,Saul,11,5,0,1,1,0,4,3.333
+Summer 2022,MATH,5389,1,11333,Survey of Mathematics,Etgen,Garret J,6,6,0,0,0,0,0,3.583
+Summer 2022,PHAR,5663,1,11334,Pharmacy Management,Tolleson,Shane Russell,4,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5683,1,11335,Cardiology,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7356,1,11336,Groups in Clinical Settings,OBryant,Michelle,23,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,2101,1,11338,Anatomy & Physiology Lab I,Gill,Tejendra,6,10,3,2,0,0,1,2.968
+Summer 2022,BIOL,2101,2,11339,Anatomy & Physiology Lab I,Gill,Tejendra,6,13,3,1,0,0,0,2.972
+Summer 2022,BIOL,2101,3,11340,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,2,2,3,0,1,2.546
+Summer 2022,BIOL,2101,4,11341,Anatomy & Physiology Lab I,Gill,Tejendra,2,17,1,0,1,0,2,2.779
+Summer 2022,BIOL,2101,5,11342,Anatomy & Physiology Lab I,Gill,Tejendra,5,7,3,1,3,0,0,2.526
+Summer 2022,HRMA,4132,1,11344,Bev Mgmt & Mktg Internship,Taylor,David C,3,0,0,0,0,0,0,4.0
+Summer 2022,KIN,1304,1,11345,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,190,26,7,2,3,0,4,3.773
+Summer 2022,PEP,6309,1,11346,Policies & Govt of Sport Org.,Hawkins,Billy J,12,0,0,0,0,0,0,3.973
+Summer 2022,ELET,3405,1,11349,Microprocessor Architecture,Soneja,Chandrayee,2,2,2,1,1,0,0,2.334
+Summer 2022,ENGL,1302,2,11355,First Year Writing II,Swensen,Russel,8,1,3,3,5,0,2,2.217
+Summer 2022,ENGL,1302,3,11356,First Year Writing II,Coleman,Quintin,4,7,6,1,4,0,3,2.258
+Summer 2022,PETR,6325,1,11357,Integrated Resrv Characterztn,Gonzalez,Reinaldo J,3,1,1,0,0,0,0,3.4
+Summer 2022,MECT,3342,1,11358,Elements of Plant Design,El Nahas,Medhat A,6,12,8,0,0,0,0,2.923
+Summer 2022,FINA,3332,1,11363,Prin of Financial Management,Chisholm,Darla,22,24,29,14,1,0,16,2.53
+Summer 2022,PUBL,6325,1,11368,Capstone Problem Project,Thurmond,James H,0,0,0,0,0,0,0,
+Summer 2022,PHAR,5675,2,11369,Disease State Management,Gee,Jodie Sue,3,0,0,0,0,0,0,4.0
+Summer 2022,MECE,3360,1,11378,Experimental Methods,Chen,Xuemei,11,4,4,1,1,0,1,3.064
+Summer 2022,CHEM,2125,3,11381,Organic Chemistry Lab II,Zaitsev,Vladimir G,4,13,0,0,0,0,2,3.274
+Summer 2022,MATH,8398,19,11383,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,15,11395,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2022,MATH,8398,21,11399,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8398,1,11413,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Summer 2022,HDFS,4393,2,11414,Internship in HDFS,Conston,Toya,16,3,0,1,0,0,1,3.7
+Summer 2022,PSYC,2319,2,11417,Intro to Social Psychology,Serrano Holden,Surizaday,45,7,3,0,0,0,0,3.776
+Summer 2022,BIOL,2301,1,11434,Anatomy & Physiology I (lect),Wayne,Chad M,13,19,26,9,6,0,7,2.302
+Summer 2022,BIOL,2102,1,11435,Anatomy & Physiology II (lab),Gill,Tejendra,2,4,3,1,2,0,1,2.168
+Summer 2022,BIOL,2102,2,11436,Anatomy & Physiology II (lab),Gill,Tejendra,4,10,2,3,0,0,1,2.772
+Summer 2022,BIOL,2102,3,11437,Anatomy & Physiology II (lab),Gill,Tejendra,5,9,3,2,3,0,1,2.53
+Summer 2022,BIOL,2102,4,11438,Anatomy & Physiology II (lab),Gill,Tejendra,6,8,5,4,0,0,1,2.667
+Summer 2022,BIOL,2302,1,11452,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,21,20,13,8,1,0,3,2.789
+Summer 2022,ACCT,2301,2,11453,Prin of Financial Accounting,Sykes,Mary Reeves,7,15,6,2,1,0,7,2.892
+Summer 2022,NUTR,3101,1,11455,Dietetics As a Profession,Scott,Claudia W,11,6,0,0,0,0,0,3.608
+Summer 2022,MIS,3360,1,11456,Systems Analysis and Design,Porra,Jaana,38,1,0,0,0,0,0,3.924
+Summer 2022,POLS,3310,1,11459,Intro to Political Theory,Lund,Peter S,7,3,1,0,3,0,2,2.739
+Summer 2022,ACCT,4332,1,11460,Corporate Taxation,Fernandez,Ramon,1,3,0,0,0,0,0,3.333
+Summer 2022,ACCT,7375,1,11461,Corporate Taxation,Fernandez,Ramon,4,9,0,0,0,0,0,3.435
+Summer 2022,CHEM,1111,9,11462,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,9,2,0,0,0,0,3.194
+Summer 2022,ENGL,1302,4,11469,First Year Writing II,Martiniuk,Jill,3,5,5,4,3,0,2,1.902
+Summer 2022,MARK,8399,1,11485,Doctoral Dissertation,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,8398,41,11501,Doctoral Research,Bittner,Eric R,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8399,45,11515,Doctoral Dissertation,Lubchenko,Vassiliy,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5644,1,11519,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,2,0,1,0,0,0,0,3.333
+Summer 2022,CHEM,1111,14,11520,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,7,1,0,0,0,0,3.378
+Summer 2022,COMD,6399,3,11527,Masters Thesis,Dial,Heather Raye,0,0,0,0,0,0,0,
+Summer 2022,POLS,7399,1,11533,Masters Thesis,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,1,0,
+Summer 2022,HRD,6396,1,11545,Internship in Human Res. Dev.,Shirmohammadi,Melika,3,0,0,0,0,0,0,4.0
+Summer 2022,HDCS,3303,1,11557,Retailing and Consumer Science,Rifai,Rana Ihsan,11,1,1,3,1,0,1,2.904
+Summer 2022,HDCS,3304,1,11558,Visual Merchandising,Stewart,Barbara L,0,7,4,2,1,0,0,2.191
+Summer 2022,HDCS,4375,1,11559,Strategies in E-Tailing,Kellough,James David,35,3,1,1,1,0,1,3.699
+Summer 2022,MATH,1342,1,11561,Elementary Statistical Methods,Wang,Wenshuang,18,26,20,16,40,0,6,1.656
+Summer 2022,MATH,2318,3,11562,Linear Algebra,Perepelitsa,Mikhail Antolyevic,13,8,7,3,4,0,4,2.648
+Summer 2022,STAT,3331,1,11563,Statistical Anal Bus Appl I,Wiley,Briceon C,33,39,31,8,3,0,3,2.761
+Summer 2022,NUTR,4333,1,11567,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,4,12,12,1,0,0,0,2.61
+Summer 2022,NUTR,4347,1,11568,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,2,7,1,1,1,0,0,2.502
+Summer 2022,MARK,4362,1,11569,Applied Buyer Behavior,Noriega,Jaime L,28,15,2,1,2,0,0,3.279
+Summer 2022,SOCW,6304,1,11571,Women's Issues,Aquino-Adriatico,Gabrielle Alanna,13,0,0,0,0,0,0,4.0
+Summer 2022,ACCT,2302,1,11572,Prin of Managerial Accounting,Weber,Catherine K,11,13,5,3,0,0,0,3.031
+Summer 2022,MANA,6A25,1,11585,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,16,13,2,0,0,0,0,3.42
+Summer 2022,MIS,6A41,1,11587,Information Systems,Silva,Leiser O,40,4,0,0,0,0,0,3.917
+Summer 2022,KIN,4300,1,11588,Phys Activity Older Adults,Alastuey,Lisa L,16,13,5,4,4,0,2,2.684
+Summer 2022,KIN,3350,1,11589,Psych Aspects Sport Exercise,Gray,Jon Phillip,50,4,2,0,0,0,2,3.839
+Summer 2022,INTB,3355,1,11590,Global Environment of Business,Miljanic,Andra Olivia,67,33,11,2,5,0,1,3.294
+Summer 2022,SGNL,1301,1,11591,Elementary Sign Language I,Brittain,Terrell,2,3,3,1,0,0,0,2.52
+Summer 2022,LAW,5328,1,11592,Judicial Externship I,Archer,Anna M,0,0,0,0,0,4,0,
+Summer 2022,LAW,5328,2,11593,Judicial Externship I,Archer,Anna M,0,0,0,0,0,4,0,
+Summer 2022,LAW,5400,2,11596,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,6,0,
+Summer 2022,LAW,5407,10,11597,Judicial Externship I,Archer,Anna M,0,0,0,0,0,2,0,
+Summer 2022,LAW,6300,2,11599,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,5,0,
+Summer 2022,LAW,6300,3,11600,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2022,LAW,6355,3,11602,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2022,LAW,5357,1,11603,Evidence,Gomez,Alissa R,11,17,0,0,0,7,0,3.334
+Summer 2022,CIS,3355,1,11604,Integrated Information Systems,Peddoju,Suresh Kumar,3,17,10,0,0,0,0,2.822
+Summer 2022,KIN,3306,2,11605,Physiology-Human Performance,Park,Yoonjung,5,9,7,8,4,0,4,2.101
+Summer 2022,ECE,3331,1,11606,Program Appl in Elec Comp Engr,Hebert,Thomas James,2,4,1,0,0,0,0,3.284
+Summer 2022,ECE,3337,1,11607,Signals and Systems Analysis,Hebert,Thomas James,5,7,3,0,0,0,1,3.111
+Summer 2022,KIN,1352,3,11608,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,97,11,2,0,0,0,0,3.87
+Summer 2022,KIN,1352,6,11609,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,97,10,2,0,0,0,0,3.875
+Summer 2022,MANA,4396,1,11610,Management Internship,Carlin,Barbara A,0,0,0,0,0,13,0,
+Summer 2022,MARK,4396,1,11611,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,27,0,
+Summer 2022,MAS,3340,1,11612,Mexican Amer Urban Communities,Pino,Diana,12,9,6,1,2,0,4,2.911
+Summer 2022,MANA,4355,1,11613,Selection and Staffing,Phillips,James S,7,19,4,2,0,0,0,2.938
+Summer 2022,ELCS,6332,1,11622,Student Develop/Student Affair,Messa,Emily Alice,8,0,0,0,0,0,1,4.0
+Summer 2022,PHCA,8199,1,11623,Doctoral Dissertation Defense,Thornton,James D,1,0,0,0,0,0,0,4.0
+Summer 2022,MATH,1324,6,11625,Finite Math with Applications,Caglar,Atife,36,8,14,6,2,0,2,3.081
+Summer 2022,MATH,2312,5,11626,Precalculus,Douglas,Casey,28,14,8,6,10,0,8,2.647
+Summer 2022,CHEM,6698,20,11627,Special Problems,Gilbertson,Scott R,0,0,0,0,0,4,0,
+Summer 2022,COMD,7383,2,11628,Pediatric SLP Seminar,Ivey,Michelle L,9,0,0,0,0,0,0,3.963
+Summer 2022,CHEM,6698,21,11629,Special Problems,Harth,Eva M,0,0,0,0,0,4,0,
+Summer 2022,HON,3301,1,11631,Readings in Medicine & Society,Reynolds,Aaron E,16,2,0,0,0,0,0,3.889
+Summer 2022,MIS,6A41,3,11632,Information Systems,Silva,Leiser O,28,1,0,0,0,0,0,3.909
+Summer 2022,CHEM,6698,23,11649,Special Problems,Chiang,Naihao,0,0,0,0,0,2,0,
+Summer 2022,MECE,3245,1,11656,Materials Science Laboratory,Hammami,Farah,13,13,3,0,1,0,1,3.288
+Summer 2022,PHCA,8298,1,11666,Doctoral Dissertation Research,Johnson,Michael L,2,0,0,0,0,0,0,4.0
+Summer 2022,PHIL,1321,2,11667,Logic I,Haaga,Curtis W,11,8,8,2,1,0,5,2.889
+Summer 2022,BIOL,2101,6,11676,Anatomy & Physiology Lab I,Gill,Tejendra,6,10,4,1,0,0,0,2.937
+Summer 2022,BIOL,2102,6,11677,Anatomy & Physiology II (lab),Gill,Tejendra,4,6,4,0,0,0,0,2.859
+Summer 2022,ACCT,7396,1,11678,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,6,0,
+Summer 2022,HIST,8699,1,11707,Doctoral Dissertation,Perales,Monica,0,0,0,0,0,1,0,
+Summer 2022,FORE,6398,1,11708,Special Problems in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5690,3,11715,Internal Medicine,Fernandez,Julianna M,2,0,0,0,0,0,0,4.0
+Summer 2022,ECON,6691,1,11725,Master's Internship,Rizvanoghlu,Islam,10,0,0,0,0,0,0,4.0
+Summer 2022,ECON,6693,1,11726,Master's Research Project,Boul,Ruxandra,4,0,0,0,0,0,0,4.0
+Summer 2022,HRD,4396,1,11727,Internship in HRD,Owens-Shepard,Toya,19,0,2,0,0,0,1,3.794
+Summer 2022,HRD,3340,1,11728,Principles of HRD,Hattier,Beth,18,7,1,0,0,0,0,3.59
+Summer 2022,HRD,4352,1,11729,Facilitation Strategies,Hampton,Elaine Denae,10,3,0,0,0,0,0,3.718
+Summer 2022,HRD,4344,1,11730,Designing E-Learning,Bennett,LaTasha,42,1,2,0,0,0,0,3.86
+Summer 2022,HDCS,3300,1,11731,Org Decisions,Hitchman Sr,Cal M,11,7,1,0,2,0,1,3.08
+Summer 2022,HDCS,4386,1,11732,Communication Strategies,Hitchman Sr,Cal M,5,6,2,1,0,0,0,3.048
+Summer 2022,HRMA,2160,1,11739,Professional Development,Dawson,Mary,27,6,0,0,0,0,0,3.808
+Summer 2022,FORE,6396,1,11740,Internship,Hines,Andrew Lewis,6,0,0,0,0,0,0,4.0
+Summer 2022,MANA,7346,1,11741,Global Human Resource Mgmt,Werner,Steve,12,0,0,0,0,0,0,4.0
+Summer 2022,MANA,6A25,2,11742,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,24,9,2,0,0,0,0,3.647
+Summer 2022,MANA,6A83,1,11743,Strategic Analysis,Celly,Nikhil,27,2,0,0,0,0,0,3.931
+Summer 2022,MATH,3339,3,11745,Statistics for the Sciences,Labate,Demetrio,8,3,6,3,4,0,3,2.278
+Summer 2022,DIGM,2352,30,11748,Digital Photography,Snyder,Philip Charles,12,0,2,0,2,0,1,3.147
+Summer 2022,BIOL,2120,1,11750,Microbiology for Non-Science,Knapp,Richard D,3,4,0,1,0,0,0,3.166
+Summer 2022,BIOL,2121,1,11751,Microbiology for Science Major,Knapp,Richard D,5,4,1,0,0,0,0,3.4
+Summer 2022,BIOL,2121,2,11752,Microbiology for Science Major,Knapp,Richard D,8,1,0,0,0,0,0,3.779
+Summer 2022,COMM,3353,2,11754,Information & Comm Tech I,Liu,Youmei,12,5,4,0,0,0,2,3.397
+Summer 2022,PUBL,6321,1,11755,Seminar in Urban Politics,Thurmond,James H,5,2,0,0,0,0,0,3.761
+Summer 2022,CUST,6370,1,11756,Cultural Found Amer Edu,Carales,Vincent D,9,2,0,0,2,0,1,3.155
+Summer 2022,GENB,5303,1,11757,Prof Acct Communication,Newman,Michael Ray,1,3,1,0,0,0,0,3.132
+Summer 2022,GENB,7303,1,11758,Prof Accounting Communication,Newman,Michael Ray,9,0,0,0,0,0,0,3.963
+Summer 2022,GOVT,2305,5,11759,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,9,5,4,1,0,0,2,3.088
+Summer 2022,NUTR,4312,1,11760,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,8,11,7,7,0,0,3,2.606
+Summer 2022,NUTR,4334,1,11761,Community Nutrition,Cepni,Aliye Beyza,31,43,12,5,5,0,2,2.883
+Summer 2022,SGNL,1302,1,11762,Elementary Sign Language II,Brittain,Robyn Michelle,10,9,0,0,1,0,0,3.334
+Summer 2022,MATH,1314,5,11764,College Algebra,Constante,Beatrice,8,5,1,3,2,0,2,2.685
+Summer 2022,MATH,1342,5,11765,Elementary Statistical Methods,Weber,Thomas Christian,38,18,12,0,2,0,6,3.267
+Summer 2022,SOCW,7323,1,11766,Organizatnl Behavior & Change,Mayer,Margaret,10,1,0,0,0,0,0,3.909
+Summer 2022,SCM,6A01,1,11767,SCM Concepts,Sahin,Funda,23,10,4,1,0,0,1,3.404
+Summer 2022,FINA,4320,1,11769,Investment Management,Doshi,Hitesh B,19,22,2,0,0,0,0,3.395
+Summer 2022,PHAR,5681,2,11770,Infectious Diseases,Truong,Mabel,8,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5645,1,11771,Pharmacy Informatics,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5646,1,11772,Medication Safety,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Summer 2022,ATP,6191,1,11774,Clinical Experience I,Harrison,Layci,17,0,0,0,0,0,0,4.0
+Summer 2022,ATP,6301,1,11775,Anatomy,Harrison,Layci,9,7,1,0,0,0,0,3.471
+Summer 2022,ATP,6302,1,11776,Emergency Care,Yellen,Joshua B,15,2,0,0,0,0,0,3.882
+Summer 2022,ATP,7194,1,11777,Clinical Experience IV,Knoblauch,Mark Alan,10,5,0,0,0,0,0,3.667
+Summer 2022,KIN,4190,1,11778,Sport Administration Seminar,Walsh,David W,11,1,0,0,0,0,0,3.889
+Summer 2022,ATP,7101,1,11779,"Head, Neck & Spine Eval Lab",Harrison,Layci,15,0,0,0,0,0,0,4.0
+Summer 2022,ATP,7301,1,11780,"Head, Neck & Spine Evaluation",Harrison,Layci,13,2,0,0,0,0,0,3.867
+Summer 2022,ATP,7302,1,11781,Gen Med/Pharm 2-Pathophysiolog,Knoblauch,Mark Alan,14,1,0,0,0,0,0,3.933
+Summer 2022,CUIN,7301,1,11782,CUIN Capstone Seminar,Brower,Samuel Richard,36,0,0,0,0,2,0,4.0
+Summer 2022,ENGL,1301,2,11783,First Year Writing I,Julian,Jennifer La'Vonne,19,3,0,2,0,0,0,3.598
+Summer 2022,CNST,3205,1,11787,Construction Safety Management,Hart,Lee J,24,3,0,0,0,0,0,3.889
+Summer 2022,CUIN,8310,45,11788,Laboratory of Practice,Hausmann,Robert Carl,4,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,8310,46,11789,Laboratory of Practice,McNeil,Sara G,4,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,8390,3,11791,Doctoral Thesis,Hausmann,Robert Carl,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6357,5,11794,Research Practicum B,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Summer 2022,ACCT,4331,1,11809,Federal Income Tax-Individual,Fernandez,Ramon,9,23,5,3,0,0,0,3.033
+Summer 2022,FINA,4396,1,11836,Finance Internship,Kumar,Praveen,0,0,0,0,0,48,1,
+Summer 2022,COMM,2311,1,11853,Writing for Print and Digital,Radcliffe Andre,Jennifer,10,9,0,0,1,0,0,3.284
+Summer 2022,COMM,4378,1,11858,Social Impact of Info Tech,Ashley,Laura B,11,2,2,0,1,0,0,3.334
+Summer 2022,DIGM,3351,30,11861,Individ Comm Processes,Waite,Jerry J,22,8,3,0,1,0,0,3.471
+Summer 2022,DIGM,3354,30,11863,Video Production 1,Snyder,Philip Charles,11,6,2,2,3,0,0,2.723
+Summer 2022,SCLT,3387,30,11892,Procurement,Elliott,Stephen Dwight,14,8,4,1,1,0,2,3.108
+Summer 2022,DIGM,1350,30,11893,Graphics for Digital Media,Beyl,Charles Eugene,8,8,0,0,0,0,3,3.418
+Summer 2022,DIGM,2353,30,11894,Page Layout and Design,De Vega,Jaime M,16,3,1,0,2,0,1,3.289
+Summer 2022,DIGM,3353,32,11896,Visual Communications Tech,Bravo,Gina C,36,0,0,2,0,0,0,3.816
+Summer 2022,HDFS,1300,1,11898,Dev of Contemporary Families,Jordan,Erica F,37,21,2,1,1,0,3,3.468
+Summer 2022,HLT,4310,1,11900,Program Planning for Health,Markowitz,Eliz,17,8,4,1,2,0,1,3.136
+Summer 2022,PSYC,3310,1,11901,Indstrl-Orgnztnl Psy,Van Egdom,Drake Alexander,33,9,12,1,3,0,0,3.229
+Summer 2022,PSYC,3325,1,11902,Psychology of Personality,Hotze,Mary Louise,45,12,0,0,2,0,1,3.633
+Summer 2022,MANA,7375,1,11903,Global Leadership,Vera,Dusya M,32,1,0,0,0,0,0,3.98
+Summer 2022,COMM,3383,1,11905,Non-linear Editing,Crowe,Craig Warren,13,1,1,0,0,0,1,3.822
+Summer 2022,SCLT,2380,30,11906,Distribution Channels,Hollis,Thomas Edward,17,2,2,0,0,0,0,3.683
+Summer 2022,ECE,3355,1,11907,Electronics,Ruchhoeft,Paul,6,3,2,4,0,0,0,2.755
+Summer 2022,SOCW,7368,1,11908,Trauma Treatment for Children,Amtsberg,Donna K.,24,0,0,0,0,0,0,4.0
 Summer 2022,MATH,3339,1,11911,Statistics for the Sciences,Poliak,Cathy Dawn,27,17,13,7,16,0,3,2.379
-Summer 2022,SOCW,7397,3,13931,Selected Topics in Social Work,Torres,Melissa Irene,24,2,0,0,0,0,0,3.91
+Summer 2022,GOVT,2306,10,11912,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,9,18,8,1,0,0,2,2.899
+Summer 2022,PSYC,3341,2,11913,Physiological Psychology,Matchanova,Anastasia,28,11,9,1,2,0,1,3.209
+Summer 2022,ACCT,7385,1,11914,Fraud Examination,Ramey,Dan T,23,1,1,0,0,0,0,3.893
+Summer 2022,MIS,4477,1,11915,Network & Security Infrastruct,Messinger,Jacob Nelson,17,5,0,0,0,0,0,3.698
+Summer 2022,WGSS,2350,2,11917,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,28,1,1,0,0,0,0,3.856
+Summer 2022,CUIN,8310,3,11918,Laboratory of Practice,Cooper,Jane McIntosh,4,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,2301,5,11920,Introduction to Psychology,Capuozzo,Kristen Irene,9,4,1,1,0,0,0,3.4
+Summer 2022,PSYC,3339,1,11921,Intro To Clinical Psychology,Szafranski,Derek D,61,8,2,0,0,0,4,3.771
+Summer 2022,MECE,2334,1,11923,Thermodynamics,Love,Holley Carole,5,16,11,2,0,0,3,2.696
+Summer 2022,NURS,3636,1,11925,Nur Process for Colabrtive Prc,Quintana,Danielle,8,54,0,1,0,0,0,3.095
+Summer 2022,HDFS,3318,1,11926,Human Ecol of Adult Developmt,Rab,Saira,43,3,0,0,0,0,0,3.913
+Summer 2022,NURS,3337,1,11929,Rdg/Interpreting Sci Lit,Phan,Huong Thi,35,26,0,1,0,0,0,3.532
+Summer 2022,RELS,3370,1,11930,The Bible and Modern Science,Ott,Aaron Frederick,4,3,3,3,1,0,0,2.429
+Summer 2022,PSYC,8121,1,11932,Clinical Psychology Internship,Vincent,John P,0,0,0,0,0,8,0,
+Summer 2022,PSYC,8399,1,11933,Doctoral Dissertation,Grigorenko,Elena L,2,0,0,0,0,1,0,4.0
+Summer 2022,PSYC,8699,1,11934,Doctoral Dissertation,Hoff,Kevin,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6392,1,11935,Intervention Practicum,Vincent,John P,0,0,0,0,0,7,0,
+Summer 2022,PSYC,7399,4,11942,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8399,2,11943,Doctoral Dissertation,Hernandez,Arturo E,2,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,8321,1,11944,Clinical Psyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8390,1,11945,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,3,0,
+Summer 2022,ENGL,3330,1,11947,Beg Creative Writing-Fiction,Stockwell,Patrick Edward,24,0,0,0,0,0,0,3.945
+Summer 2022,PSYC,8399,3,11948,Doctoral Dissertation,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8399,4,11949,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,7392,1,11950,Psychology Practicum,Fetterman,Adam Kent,4,0,0,0,0,0,0,4.0
+Summer 2022,ELED,3320,1,11952,Survey Literature Child Adol,Tyson,Eleanore S,18,2,0,0,0,0,1,3.851
+Summer 2022,PSYC,7399,5,11953,Masters Thesis,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8399,5,11965,Doctoral Dissertation,Derrick,Jaye L,0,0,0,0,0,1,0,
+Summer 2022,LAW,5603,1,11966,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,
+Summer 2022,CHEM,8399,20,11970,Doctoral Dissertation,Zastrow,Melissa L,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6398,2,11978,Independent Studies,Spitzmuller,Christiane,2,0,0,0,0,0,0,4.0
+Summer 2022,LAW,5514,1,11980,Judicial Externship I,Archer,Anna M,0,0,0,0,0,2,0,
+Summer 2022,PSYC,8399,7,11982,Doctoral Dissertation,Babcock,Julia,2,0,0,0,0,0,0,4.0
+Summer 2022,ACCT,4331,2,11986,Federal Income Tax-Individual,Fernandez,Ramon,1,18,6,0,0,0,0,2.892
+Summer 2022,MATH,8698,1,11988,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8399,9,11991,Doctoral Dissertation,Walker,Rheeda L,1,0,0,0,0,0,0,4.0
+Summer 2022,LAW,5602,1,11992,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2022,PSYC,8399,10,11993,Doctoral Dissertation,Spitzmuller,Christiane,2,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6352,1,11994,Directed Rsch in I/O Psyc,Spitzmuller,Christiane,5,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,7399,4,11998,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6398,5,12006,Independent Studies,Ng,Vincent,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8399,12,12007,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,
+Summer 2022,LAW,6500,1,12009,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2022,LAW,5500,1,12010,Government and Nonprofit Exter,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,
+Summer 2022,PSYC,7390,1,12012,Clin Neuropsychology Practicum,Woods,Steven Paul,4,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6398,6,12016,Independent Studies,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6352,2,12017,Directed Rsch in I/O Psyc,Hoff,Kevin,0,0,0,0,0,3,0,
+Summer 2022,MATH,8698,2,12026,Doctoral Research,Labate,Demetrio,0,0,0,0,0,7,0,
+Summer 2022,MIS,4378,1,12034,Admin of Computer-Based MIS,Porra,Jaana,43,0,0,0,0,0,0,3.969
+Summer 2022,MATH,8698,4,12050,Doctoral Research,Josic,Kresimir,0,0,0,0,0,2,0,
+Summer 2022,MATH,8698,5,12051,Doctoral Research,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6398,9,12053,Independent Studies,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Summer 2022,MATH,8698,6,12054,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,3,0,
+Summer 2022,HLT,4307,1,12059,Research and Eval in Health,Kamdar-Sharif,Amber,28,5,1,0,0,0,0,3.765
+Summer 2022,PSYC,6298,1,12060,Special Problems,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Summer 2022,WGSS,4360,1,12079,Capstone Internship Course,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,0,0,4.0
+Summer 2022,MATH,8698,7,12086,Doctoral Research,Onofrei,Daniel T,0,0,0,0,0,1,0,
+Summer 2022,MATH,8698,8,12087,Doctoral Research,Cappanera,Loic,0,0,0,0,0,1,0,
+Summer 2022,MATH,8698,9,12088,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,3,0,
+Summer 2022,ENGL,4390,1,12095,Professional Internship,Zentz,Lauren R,0,0,0,0,0,2,0,
+Summer 2022,PSYC,6398,10,12097,Independent Studies,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,7393,1,12098,Field Practicum in Psychology,Vincent,John P,0,0,0,0,0,10,0,
+Summer 2022,ECON,4390,3,12100,Economics Internship,Thornton,Rebecca Achee,17,2,0,0,0,0,0,3.895
+Summer 2022,KIN,3304,2,12101,Human Structure & Phys Perform,Breslin,Whitney L,5,15,10,1,0,0,1,2.785
+Summer 2022,MATH,8698,11,12104,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,2,0,
+Summer 2022,ENGL,1301,6,12106,First Year Writing I,Decarion,Andrew P,6,2,0,0,3,0,0,2.757
+Summer 2022,ECON,3368,1,12118,Economics of Health Care,Zhivan,Natalia A.,9,11,9,5,4,0,0,2.421
+Summer 2022,PSYC,2301,4,12119,Introduction to Psychology,Lipschutz,Rebecca Sara,36,18,1,1,1,0,1,3.48
+Summer 2022,PSYC,3301,1,12120,Intro Psych Stats,Pierce,Jace D,23,22,7,3,1,0,3,3.078
 Summer 2022,PSYC,3301,2,12121,Intro Psych Stats,Browne,Lindsay J,16,19,3,4,7,0,3,2.694
+Summer 2022,MATH,3325,1,12123,Transition to Advanced Math,Leger,Nicholas M,8,2,4,1,2,0,0,2.784
+Summer 2022,PHLS,8193,1,12124,Internship in Psychology,Allan,Blake A,0,0,0,0,0,7,0,
+Summer 2022,LAW,5424,1,12125,Death Penalty Clinic,Dow,David R,0,0,0,0,0,1,0,
+Summer 2022,LAW,5600,1,12127,Judicial Externship I,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2022,DIGM,3353,30,12145,Visual Communications Tech,Dozier,Devin K,27,4,2,2,1,0,0,3.482
+Summer 2022,DIGM,2357,30,12148,Content Strategy & Development,Alters,Monika Joanna,12,13,1,0,0,0,1,3.423
+Summer 2022,LAW,5385,1,12153,Introduction to the Laws of EU,Willis,Tasha L,2,8,0,0,0,0,0,3.398
+Summer 2022,LAW,5228,1,12156,Judicial Externship I,Archer,Anna M,0,0,0,0,0,6,0,
+Summer 2022,LAW,5228,2,12157,Judicial Externship I,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2022,LAW,5229,2,12159,Judicial Externship II,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2022,LAW,5203,1,12160,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,
+Summer 2022,LAW,5203,4,12161,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2022,LAW,5206,4,12162,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2022,TMTH,3360,1,12163,Applied Technical Statistics,Schroeder,Susan L,5,6,9,5,2,0,3,2.308
+Summer 2022,MANA,3335,1,12164,Intro Org Behavior and Mgmt,Currie,Daniel David,100,26,2,1,1,0,1,3.685
+Summer 2022,MANA,3335,2,12165,Intro Org Behavior and Mgmt,Salaiz,Ashley,38,5,5,1,0,0,0,3.633
+Summer 2022,MANA,4336,1,12166,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,5,11,5,0,2,0,1,2.696
+Summer 2022,SOCW,7326,1,12167,Disparities in Health,Torres,Isabel,15,8,0,0,0,0,0,3.667
+Summer 2022,SOCW,7365,1,12168,Crisis Intervention,Battle,Jennifer Alene,26,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7320,2,12169,Empowerment,Rabo,Amber L,19,1,0,0,0,0,1,3.917
+Summer 2022,SCLT,3381,30,12170,Industrial and Consumer Sales,Blount,James,15,4,0,0,0,0,1,3.703
+Summer 2022,HLT,1353,3,12171,Personal Health,Selzer,Lori Michele,17,10,1,2,1,0,1,3.28
+Summer 2022,HLT,2320,1,12172,Introduction to Public Health,Proctor,Robin Ann,67,10,2,2,1,0,1,3.663
+Summer 2022,HLT,3381,1,12173,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,58,10,2,2,0,0,1,3.681
+Summer 2022,ELCS,8191,1,12177,Special Field Projects,Shockley,Gerald,15,0,0,0,0,0,0,4.0
+Summer 2022,PHIL,1361,1,12178,Philosophy and the Arts,Drapela,Nick Gerard,6,2,5,1,2,0,1,2.48
+Summer 2022,PHIL,1361,2,12179,Philosophy and the Arts,Drapela,Nick Gerard,9,5,6,3,0,0,1,2.855
+Summer 2022,ECE,2202,1,12180,Circuit Analysis II,Shattuck,David P,2,8,3,4,2,0,1,2.263
+Summer 2022,COSC,1437,301,12182,Introduction to Programming,Rincon Castro,Carlos Alberto,27,9,8,5,11,0,4,2.606
+Summer 2022,SOCW,8336,1,12183,Research Internship I,Berger Cardoso,Jodi A,8,0,0,0,0,0,0,4.0
+Summer 2022,HDCS,1300,2,12184,Human Ecosystems & Tech Change,Gatterson,Beverly,22,7,0,0,1,0,3,3.545
+Summer 2022,HRMA,6191,1,12185,Project Development,Ramirez,Arlene D,0,0,0,0,0,8,0,
+Summer 2022,ENTR,4394,1,12188,RED Labs Accelerator,McCormick,Kelly,2,0,0,0,0,0,0,4.0
+Summer 2022,ENTR,7394,1,12189,RED Labs Accelerator,McCormick,Kelly,2,0,0,0,0,0,0,4.0
+Summer 2022,MARK,7373,1,12190,Business to Business Marketing,Herman,Carl,20,2,0,0,0,0,0,3.864
+Summer 2022,THEA,6284,1,12192,Program Management,Springfield,Travis,12,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6386,1,12193,Drama in Context,Shimko,Robert B,12,0,0,0,0,0,0,3.973
+Summer 2022,PSYC,4321,1,12195,Abnormal Psychology,Ridgely,Natalie,16,15,14,7,1,0,3,2.767
+Summer 2022,DANC,2303,1,12196,Introduction to Dance,Bobet,Jacqueline A,20,16,10,6,2,0,2,2.766
+Summer 2022,GOVT,2305,6,12198,"US Govt: Congress,Pres & Crts",Davis,Sharon M,11,13,9,3,0,0,1,2.926
+Summer 2022,POLS,3313,2,12199,Intro Internatl Relatns,Vardy,Ronald V,23,11,3,0,0,0,2,3.523
+Summer 2022,THEA,6382,1,12200,Dramaturgy for H.S. Director,Shimko,Robert B,13,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8351,1,12201,Hist & Philosophy of Psyc Syst,Reyna,Ronda,31,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8357,1,12202,Clinical Interventions,de Dios,Marcel A,4,0,0,0,0,0,0,3.918
+Summer 2022,PHLS,8364,1,12203,"Prof Prac Psy: Eth,Law,& Iss",Anderson,Jacqueline R,20,1,0,0,0,0,0,3.811
+Summer 2022,PHLS,8366,1,12204,"Assmt Child/Adol Aff, Beh, Per",Kahn,David Andrew,5,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8393,1,12205,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,9,0,
+Summer 2022,PHLS,8393,2,12206,Doctoral Practicum in Psy,Sohn McCormick,Anita Luisa,0,0,0,0,0,8,0,
+Summer 2022,HDFS,4316,1,12207,Dynamics of Family Relations,Rab,Saira,16,4,1,0,1,0,0,3.485
+Summer 2022,HDFS,3320,1,12208,Careers in HDFS,Jordan,Erica F,23,7,2,0,2,0,2,3.364
+Summer 2022,HDFS,2314,1,12209,Human Dev and Interventions,Schoger,Kimberly,51,11,4,1,0,0,0,3.662
+Summer 2022,MUSI,1117,1,12211,Aural Skills II,Garza,Paul Victor,10,1,6,0,3,0,1,2.618
+Summer 2022,MUSI,1312,1,12212,Music Theory II,Garza,Paul Victor,9,3,5,0,2,0,1,2.877
+Summer 2022,NUTR,2332,1,12214,Intro To Human Nutrition,Alastuey,Lisa L,21,22,17,4,2,0,3,2.753
+Summer 2022,MUSI,1182,1,12215,Group Piano II,Van Kekerix,Todd Evan,11,0,1,0,0,0,0,3.806
+Summer 2022,ECE,2201,1,12216,Circuit Analysis I,Shattuck,David P,7,9,14,6,6,0,1,2.127
+Summer 2022,GOVT,2306,50,12217,US and Texas Const/Politics,Cooper,Carol B,10,2,0,0,1,0,0,3.412
+Summer 2022,MECE,5388,1,12219,Intelligent Structural Systems,Song,Gangbing,6,22,5,0,0,0,5,3.08
+Summer 2022,MECE,3381,1,12220,Finite Elements for Mech Engr,Chen,Xuemei,17,21,15,3,3,0,3,2.813
+Summer 2022,MUSI,2302,2,12221,Listening to Jazz,Marmolejo,Noe J,10,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6280,1,12222,The teaching of Acting,Ferrarone,Jessica,13,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6281,1,12223,The teaching of Voice,Wetzel,Molly Elizabeth,13,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6381,1,12224,Scenic Des for H.S. Director,Rigdon,Kevin L,13,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6384,1,12225,Directing,Cook,Rena R,12,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6383,1,12226,Light/Cost Des for HS Director,Rigdon,Kevin L,12,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6385,1,12227,Technical Direction/Shop Maint,Middents,Jonathan Mark,12,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6180,1,12228,Applying Methods Acting/Voice,Ferrarone,Jessica,7,5,0,0,0,0,0,3.638
+Summer 2022,THEA,6181,1,12229,Applying Method Des/Dramaturgy,Rigdon,Kevin L,11,1,0,0,0,0,0,3.944
+Summer 2022,THEA,6182,1,12230,Applying Methods Light/Costume,Willson,Paige A,12,0,0,0,0,0,0,4.0
+Summer 2022,ARLD,6691,1,12231,Internship in Arts Organizatn,Luks Jacobs,Joel,1,0,0,0,0,0,0,4.0
+Summer 2022,GOVT,2305,2,12232,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,5,12,6,2,1,0,2,2.591
+Summer 2022,ENGL,3352,1,12233,19th Century American Fiction,Wood,Barry Albert,13,15,0,0,0,0,2,3.394
+Summer 2022,ELCS,6393,1,12234,Practicum,Davis,Tiffany J,2,0,0,0,0,0,0,4.0
+Summer 2022,MATH,2131,1,12235,Linear Alg Labs w/MATLAB,Ansari,Haseeb E,13,0,1,0,0,0,1,3.786
+Summer 2022,ELCS,6330,1,12238,Finance & School-Based Budgtng,Franklin,Delesa,12,3,0,0,0,0,0,3.822
+Summer 2022,ENGL,3301,1,12269,Intro To Literary Studies,Murray,Christopher Brean,16,3,1,0,0,0,0,3.618
+Summer 2022,PSYC,2301,3,12274,Introduction to Psychology,Shen,Shutian,37,14,3,0,2,0,0,3.524
+Summer 2022,INDE,4315,1,12277,Supply Chain Design Management,Wang,Yaping,6,8,3,0,0,0,0,3.235
+Summer 2022,PHAR,5696,5,12281,Ambulatory Care - Primary Care,Tolleson,Shane Russell,1,2,0,0,0,0,0,3.333
+Summer 2022,KIN,3305,2,12286,Sport Sociology,Graham,Marilynn Hadassah,70,18,4,1,0,0,6,3.631
+Summer 2022,PHOP,7399,1,12291,Masters Thesis,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,8190,1,12297,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Summer 2022,MATH,6315,1,12303,Masters Tutorial,Fu,Wenjiang,30,0,0,0,1,0,1,3.85
+Summer 2022,CHEM,1112,15,12322,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,1,0,0,0,1,3.133
+Summer 2022,PCOL,8399,1,12323,Doctoral Dissertation,McConnell,Bradley K,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,8399,15,12325,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,4,0,
+Summer 2022,PHAR,5686,2,12327,Psychiatry,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8399,3,12330,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Summer 2022,LAW,6300,11,12331,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,
+Summer 2022,POLS,8399,9,12333,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,8199,1,12334,Doctoral Dissertation,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,7399,5,12335,Masters Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Summer 2022,KIN,4398,1,12337,Independent Study,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,2344,2,12351,Cultural Psychology,Grigorenko,Elena L,7,7,4,3,6,0,6,2.21
+Summer 2022,PSYC,3350,2,12353,Intro to Cognitive Psychology,Anderson,Jill Annette,22,12,1,0,0,0,0,3.534
+Summer 2022,DIGM,2325,30,12354,Info Tech for Digital Media,Hargrove,Mark Stephen,9,6,2,0,3,0,0,2.9
+Summer 2022,PSYC,3325,2,12357,Psychology of Personality,Cano,Kiana Ellen,32,6,4,2,0,0,2,3.575
+Summer 2022,PSYC,3325,3,12358,Psychology of Personality,Sutu,Andreea Emanuela,43,11,4,0,1,0,0,3.532
+Summer 2022,PSYC,3350,1,12359,Intro to Cognitive Psychology,Santacroce,Lindsay,22,25,8,4,0,0,0,3.113
+Summer 2022,MANA,4330,1,12360,Intro to Strategic HR Mgt,Sebastijanovic,Marina,34,11,4,0,0,0,0,3.585
+Summer 2022,SOCW,7303,1,12361,Child Abuse and Neglect,Berger Cardoso,Jodi A,15,4,1,0,1,0,2,3.492
+Summer 2022,COMM,4303,1,12362,Communication Law and Ethics,Bundage Juvane,Stephanie,18,0,0,0,0,0,0,4.0
+Summer 2022,COMM,4365,2,12363,Digital PR and Advertising,Choi,Ho Joon,14,5,2,0,0,0,0,3.571
+Summer 2022,ELCS,8350,1,12364,Resource Management,Young,Yolanda Yvette,6,0,0,0,0,0,0,4.0
+Summer 2022,MATH,1314,2,12365,College Algebra,Chang,James A,7,5,2,0,0,0,7,3.31
+Summer 2022,MATH,2312,2,12366,Precalculus,May,Jennifer Ruhnow,16,12,4,2,6,0,2,2.75
+Summer 2022,MATH,3333,1,12367,Intermediate Analysis,Kalantar,Mehrdad,4,9,1,0,2,0,3,2.771
+Summer 2022,HRD,3351,1,12369,Instructional Design for HRD,Pereira-Leon,Maura Josefina,22,17,1,1,0,0,2,3.431
+Summer 2022,HRD,3350,30,12370,Workforce Diversity and Global,Polesello,Daiane,11,2,3,1,2,0,0,2.983
+Summer 2022,HRMA,3341,1,12371,Hospitality Managerial Acct,Ramirez,Arlene D,0,4,1,0,0,0,0,2.8
+Summer 2022,MATH,4389,3,12373,Survey of Undergraduate Math,Blecher,David P,5,3,4,1,0,0,1,2.872
+Summer 2022,NUTR,4352,1,12374,Child and Adolescent Nutrition,Vollrath,Kirstin,32,26,14,2,1,0,0,3.116
+Summer 2022,KIN,4360,1,12375,Adaptive Athletics Management,Cottingham,Michael,13,0,0,0,0,0,0,3.949
+Summer 2022,PHYS,2325,1,12376,University Physics I (lecture),Bassler,Kevin E,9,9,6,0,0,0,3,3.084
+Summer 2022,PHYS,2326,1,12378,University Physics II(lecture),Varghese,Oomman K,11,10,4,0,0,0,3,3.174
+Summer 2022,ENGI,2304,3,12380,Technical Communications,Anderson,Roshawnda M,19,2,2,0,1,0,0,3.556
+Summer 2022,ENGI,2304,6,12381,Technical Communications,Downey,Carlton M,12,2,1,0,2,0,0,3.333
+Summer 2022,POLS,3311,2,12386,Intro Compar Politics,Vardy,Ronald V,17,4,0,0,2,0,1,3.421
+Summer 2022,LAW,5303,1,12387,Criminal Law,Kaufman,Zachary Daniel,13,19,1,0,0,0,0,3.404
+Summer 2022,LAW,5378,1,12388,Statutory Interpretation & Rea,Bush,Darren,15,20,0,0,0,0,0,3.4
+Summer 2022,PHLS,6310,1,12389,Intro To Educ Research,Lee,Jungeun,25,3,1,0,0,0,0,3.816
+Summer 2022,MATH,2415,1,12393,Calculus III,Pan,Tsorng-Whay,5,3,4,0,2,0,1,2.643
+Summer 2022,SOCW,7340,1,12396,Clinical Practice with Child,Rivera,Jaime,20,2,1,1,0,0,0,3.571
+Summer 2022,SOCW,7371,1,12397,Trauma & SW,Amtsberg,Donna K.,27,0,0,0,0,0,0,3.988
+Summer 2022,SOCW,7378,1,12398,Integrated Behav Healthcare,Mohr,Gabriella A,24,3,0,0,0,0,0,3.901
+Summer 2022,INDE,7390,1,12399,Supply Chain Management,Keedy,Elias,10,15,2,0,0,0,0,3.357
+Summer 2022,AAS,2320,1,12401,Intro To African American Stdy,Lyons,Da' Vonte,22,7,6,1,0,0,0,3.416
+Summer 2022,PETR,8399,3,12432,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,2,0,
+Summer 2022,PETR,8399,4,12433,Doctoral Dissertation,Hathon,Lori A,0,0,0,0,0,1,0,
+Summer 2022,PETR,8399,5,12434,Doctoral Dissertation,Qin,Guan,0,0,0,0,0,1,0,
+Summer 2022,PETR,8399,7,12436,Doctoral Dissertation,Wong,George K,0,0,0,0,0,3,0,
+Summer 2022,PETR,8399,10,12439,Doctoral Dissertation,Sakhaee Pour,Ahmad,3,0,0,0,0,0,0,4.0
+Summer 2022,CHEM,1311,1,12444,Fundamentals of Chemistry,Czader,Arkadiusz,5,14,19,19,36,0,6,1.262
+Summer 2022,CHEM,1312,1,12445,Fundamentals of Chemistry 2,Czader,Arkadiusz,7,17,36,21,58,0,9,1.259
+Summer 2022,MECT,4372,1,12446,Materials Technology,Basaran,Burak,3,19,8,0,0,0,0,2.833
+Summer 2022,NURS,4216,1,12447,Perioperative Nursing,Quintana,Danielle,28,0,0,0,0,0,0,4.0
+Summer 2022,OPTO,6115,1,12449,Clinical Integration,Dempsey,Robert L.,0,0,0,0,0,45,0,
+Summer 2022,ENGL,3327,1,12450,Masterpieces of British Lit I,Long,Steven A.,19,3,2,1,1,0,2,3.462
+Summer 2022,MIS,3370,1,12451,Info Systems Development Tools,Knighton,William B,7,11,6,3,4,0,1,2.452
+Summer 2022,ENGL,2306,1,12452,Intro To Poetry,Loan,Leisa Marie,24,1,0,0,0,0,0,3.92
+Summer 2022,PSYC,7399,6,12453,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Summer 2022,DRAM,1310,1,12454,Introduction to Theatre,Young,Courtney Leigh,49,4,4,0,2,0,0,3.65
+Summer 2022,PSYC,8399,16,12455,Doctoral Dissertation,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Summer 2022,DRAM,1310,2,12456,Introduction to Theatre,Young,Courtney Leigh,41,7,3,1,3,0,3,3.431
+Summer 2022,ITEC,1301,1,12457,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,6,13,1,6,0,0,2,2.705
+Summer 2022,ENGL,1301,4,12459,First Year Writing I,Ely,Blaine,14,7,1,1,2,0,0,3.147
+Summer 2022,ENGL,1302,7,12460,First Year Writing II,Krajniak,Matthew J,7,8,4,2,2,0,1,2.696
+Summer 2022,PHLS,8193,2,12505,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,12,0,
+Summer 2022,PHOP,6257,2,12507,Research Practicum B,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6257,3,12508,Research Practicum B,Cheng,Han,0,0,0,0,0,1,0,
+Summer 2022,PHOP,8399,1,12509,Doctoral Dissertation,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Summer 2022,CNST,3185,1,12517,Construction Experience,Eldin,Neil N,22,9,2,6,6,0,3,2.778
+Summer 2022,PHAR,5675,4,12522,Disease State Management,De La Cruz,Austin Isaac,3,0,0,0,0,0,0,4.0
+Summer 2022,HRD,6354,1,12527,Facilitating Adult Group Proc.,Forney,Warren T,11,0,0,0,0,0,1,4.0
+Summer 2022,CHEM,1112,17,12528,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,2,0,0,0,1,3.166
+Summer 2022,ELCS,6342,1,12530,Critical Issues in Higher Educ,Barnes,Yolanda Michelle,5,1,0,0,0,0,0,3.888
+Summer 2022,MATH,8398,1,12540,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Summer 2022,PHCA,8199,2,12542,Doctoral Dissertation Defense,Johnson,Michael L,2,0,0,0,0,0,0,4.0
+Summer 2022,PHCA,8298,2,12543,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Summer 2022,COMD,7391,15,12551,Clinic in Speech Lang Disorder,Bolling,Kenyetta,1,0,0,0,0,0,0,3.67
+Summer 2022,POLS,4398,1,12562,Independent Study,Cross,Renee D,6,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,8399,17,12578,Doctoral Dissertation,Gallagher,Matthew Ward,1,0,0,0,0,2,0,4.0
+Summer 2022,PETR,8699,1,12581,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Summer 2022,PCEU,8399,1,12582,Doctoral Dissertation,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2022,CNST,3372,1,12586,Soil Mechanics & Foundations,Meyer,Joseph Ray,8,7,0,0,0,0,1,3.467
+Summer 2022,SPAN,3307,1,12601,Public Speaking in Spanish,Martinez,Jacqueline Aguilar,18,0,0,1,1,0,0,3.667
+Summer 2022,CHEM,1112,18,12602,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,1,2,2,0,1,2.6
+Summer 2022,SPEC,4353,1,12604,Technology in Special Pops,Goodrich,Elizabeth A,8,9,3,0,0,0,2,3.3
+Summer 2022,SPEC,6353,1,12605,Technology in Special Pops,Goodrich,Elizabeth A,4,4,0,0,1,0,0,3.221
+Summer 2022,SPEC,7391,1,12606,Collab Consulting & Coaching,Carp,Charlotte Lynn,21,2,0,0,0,0,0,3.87
+Summer 2022,MIS,4374,1,12607,Info Technology Project Mgmt,Campbell,Phillip James,15,12,2,0,0,0,1,3.391
+Summer 2022,HRMA,3352,1,12609,Human Resource Management,Guchait,Priyanko,17,6,1,1,0,0,0,3.494
+Summer 2022,HRMA,3361,1,12610,Hospitality Marketing,Johnson,Tucker A,20,1,4,0,0,0,1,3.587
+Summer 2022,CUIN,1350,1,12611,Mathematics for Teachers 1,Burris,Justin T,25,6,0,0,0,0,0,3.732
+Summer 2022,CUIN,3302,1,12612,Social Education,Thomas,Dustine J,24,0,0,0,1,0,1,3.84
+Summer 2022,SPEC,7341,1,12615,Assessment of Learning Diff,Hassett,Kristen Spring,8,0,0,0,0,0,1,3.959
+Summer 2022,SPEC,8360,1,12616,Instruct Probs in Special Pop,Kent,Shawn Christopher,8,0,0,0,0,0,0,3.959
+Summer 2022,MATH,1342,3,12619,Elementary Statistical Methods,Caputo,Matthew G,16,22,12,8,4,0,2,2.549
+Summer 2022,MATH,5341,1,12620,Mathematical Modeling,He,Jiwen,6,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,6293,1,12622,Field Practicum I - Foundation,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Summer 2022,SOCW,6294,1,12623,Field Practicum II,Gonzales,Shelley A,0,0,0,0,0,3,0,
+Summer 2022,CNST,3155,1,12624,Const Materials & Testing,Meyer,Joseph Ray,13,12,5,0,0,0,0,3.267
+Summer 2022,CNST,3331,1,12625,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,15,9,8,1,0,0,0,3.152
+Summer 2022,CNST,3355,1,12626,Strength of Construction Mtrls,Senouci,Ahmed,12,5,12,2,1,0,0,2.781
+Summer 2022,SOCW,7320,1,12627,Empowerment,Kalu,Sandra Renee,21,1,0,0,0,0,1,3.955
+Summer 2022,CNST,4302,1,12628,Construction Law and Ethics,Ducran,Denis George,2,7,3,0,0,0,0,2.862
+Summer 2022,HDFS,3300,1,12629,Educational Psychology,Conston,Toya,41,6,1,0,1,0,1,3.762
+Summer 2022,HDFS,3300,2,12630,Educational Psychology,Conston,Toya,36,10,3,1,0,0,0,3.594
+Summer 2022,PSYC,2344,3,12631,Cultural Psychology,Garcia,Jessica Leeann,26,17,5,1,7,0,0,2.941
+Summer 2022,ELCS,8355,1,12632,Policy Pol & Gov of Education,Goree,Tonya,5,1,0,0,0,0,0,3.833
+Summer 2022,EDRS,8382,1,12633,Statistical Analyses in Eductn,Davis,Bradley,4,0,0,0,0,0,0,4.0
+Summer 2022,NUTR,4346,1,12634,Research in Nutrition,Haubrick,Kevin,19,8,8,1,1,0,1,3.109
+Summer 2022,PHLS,6310,2,12635,Intro To Educ Research,Lee,Jungeun,7,1,0,0,0,0,0,3.875
+Summer 2022,MARK,7376,1,12636,Brand Management,Koch,Steven F.,30,0,0,0,0,0,0,4.0
+Summer 2022,MANA,7351,1,12637,Mgt of  Global Organizations,Keller,Robert T,11,6,0,0,0,0,0,3.647
+Summer 2022,MANA,4350,1,12638,International Management,Celly,Nikhil,30,4,2,0,0,0,0,3.75
+Summer 2022,POLS,3356,1,12639,Intro-Constitutionl Law,Abbott Jr,Kenneth Wayne,13,4,2,0,0,0,0,3.457
+Summer 2022,HRD,6358,30,12641,Global Human Resource Devel,Waight,Consuelo L,7,0,0,0,0,0,0,4.0
+Summer 2022,KIN,3360,1,12642,Professional Prep for Sp Admin,Pearson,Demetrius W,3,4,5,2,2,0,0,2.25
+Summer 2022,WCL,3366,2,12643,Latin American and Latino Film,Centeno,Daniel,11,10,6,2,0,0,1,2.966
+Summer 2022,NUTR,6304,1,12644,Adv Nutr Counseling & Educ,Ledoux,Tracey A,7,3,0,0,0,0,2,3.535
+Summer 2022,NUTR,6301,1,12645,Clinic Aspects of Nutr Support,Ferrell,Carla Denise,8,1,0,0,1,0,1,3.368
+Summer 2022,SOCW,7339,1,12646,Prof. Grant Writing for SW,Stagg,Helen Ruth,24,0,0,0,0,0,0,3.973
+Summer 2022,SOCW,7366,1,12647,Grief/Bereave Therapy,Rodgers,Beverly J,26,2,0,0,0,0,0,3.893
+Summer 2022,SOCW,7373,1,12648,Human Sexuality & Sw,Gracely,Jill Marie,25,1,0,0,0,0,0,3.962
+Summer 2022,COSC,6368,301,12649,Artificial Intelligence,Vilalta,Ricardo,41,19,0,0,0,0,0,3.551
+Summer 2022,GOVT,2306,4,12650,US and Texas Const/Politics,Davis,Shelby,15,8,3,1,2,0,1,3.058
+Summer 2022,LAW,6217,1,12653,Negotia & Creative Prblm Slvng,Block,Nathan Matthew,1,7,0,0,0,6,0,3.208
+Summer 2022,LAW,5299,19,12658,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Summer 2022,LAW,5299,17,12659,Special Problems,Vetter,Greg R,0,0,0,0,0,4,0,
+Summer 2022,ACCT,5331,2,12663,Federal Income Tax-Individual,Fernandez,Ramon,2,2,0,1,0,0,0,3.0
+Summer 2022,GOVT,2306,3,12668,US and Texas Const/Politics,Cole,Jeffrey Bryan,7,8,3,1,0,0,0,3.071
+Summer 2022,GOVT,2305,3,12669,"US Govt: Congress,Pres & Crts",Lothamer,Lucas J,18,8,3,1,1,0,1,3.291
+Summer 2022,THEA,6184,1,12670,Applying Methods in Dir/Styles,Cook,Rena R,12,0,0,0,0,0,0,4.0
+Summer 2022,MANA,3335,4,12671,Intro Org Behavior and Mgmt,Currie,Daniel David,100,19,8,0,0,0,8,3.691
+Summer 2022,THEA,6287,1,12672,Acting Styles,Noble,Adam S,12,0,0,0,0,0,0,4.0
+Summer 2022,COMM,1302,1,12673,Intro To Comm Theory,Lee,Jaesub,6,5,7,3,0,0,1,2.62
+Summer 2022,COMM,3360,1,12674,Principles of Strategic Comm,Choi,Ho Joon,16,4,0,2,1,0,0,3.348
+Summer 2022,COMM,4355,1,12675,Organizational Comm,Lee,Jaesub,12,2,1,0,1,0,0,3.438
+Summer 2022,PSYC,2319,3,12685,Intro to Social Psychology,Anderson,Jill Annette,10,12,12,3,3,0,2,2.46
+Summer 2022,SOCI,1301,1,12686,Introduction To Sociology,Adams,Jennifer Lauren,41,4,2,0,1,0,2,3.736
+Summer 2022,DANC,2303,2,12688,Introduction to Dance,Bobet,Jacqueline A,22,14,14,4,8,0,8,2.624
+Summer 2022,NURS,4220,1,12690,Clinical Decision Making,Obey,Faye B,7,10,0,0,0,0,0,3.412
+Summer 2022,SPAN,3375,2,12692,US Hispanic Culture & Civiliza,Cuesta,Mabel,11,5,0,0,1,0,1,3.412
+Summer 2022,CNST,4341,1,12693,Project Controls,Sulehri,Hassan,28,5,1,0,0,0,0,3.794
+Summer 2022,SPAN,3308,1,12694,Written Com-Hisp Herit Learner,Martinez,Jacqueline Aguilar,23,0,0,0,0,0,0,4.0
+Summer 2022,NUTR,6311,1,12695,Capstone I,Haubrick,Kevin,3,0,0,0,1,0,0,2.835
+Summer 2022,WGSS,3322,1,12699,Intersectionalities,De Los Reyes Heredia,Jose Guillermo,25,1,0,1,0,0,1,3.84
+Summer 2022,WGSS,2360,2,12700,Introduction to LGBT Studies,Stone,Lauren Michelle,14,4,4,2,0,0,0,3.278
+Summer 2022,SOCI,1301,4,12702,Introduction To Sociology,Nelson,Steven M,14,13,5,1,3,0,5,2.899
+Summer 2022,ENGL,8399,1,12703,Doctoral Dissertation,Tolliver,Cedric,1,0,0,0,0,0,0,4.0
+Summer 2022,COMD,7382,1,12704,CLD Issues in SLP,Ivey,Michelle L,5,0,0,0,0,0,0,4.0
+Summer 2022,CIS,2334,1,12705,Information Systems Applicatns,Lendasse,Amaury,26,4,9,2,0,0,6,3.301
+Summer 2022,IRW,1300,1,12706,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,6,0,
+Summer 2022,IRW,1300,2,12707,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,5,0,
+Summer 2022,DIGM,4396,30,12709,Internship in Digital Media,Waite,Jerry J,7,0,0,0,0,0,0,3.906
+Summer 2022,PHOP,6257,5,12730,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,8310,1,12732,Laboratory of Practice,Hutchison,Laveria F,8,0,0,0,0,0,0,4.0
+Summer 2022,FINA,7361,1,12733,Risk Management,Hogan,Kenneth David,16,0,0,0,0,0,0,4.0
+Summer 2022,EDUC,2301,1,12754,Intro to Special Populations,Hassett,Kristen Spring,26,9,1,0,1,0,0,3.577
+Summer 2022,EDUC,2301,2,12755,Intro to Special Populations,Carp,Charlotte Lynn,17,5,1,2,0,0,1,3.414
+Summer 2022,SPEC,4367,1,12756,Consultation and Coaching,Carp,Charlotte Lynn,19,4,0,0,0,0,0,3.754
+Summer 2022,ACCT,5332,1,12771,Corporate Taxation,Fernandez,Ramon,1,3,1,0,0,0,0,3.066
+Summer 2022,PHYS,1101,5,12780,College Physics I (lab),Wood,Lowell T,2,7,4,1,0,0,1,2.714
+Summer 2022,PHYS,1102,5,12781,College Physics II (lab),Wood,Lowell T,2,9,6,0,0,0,0,2.668
+Summer 2022,PSYC,6352,4,12790,Directed Rsch in I/O Psyc,Ng,Vincent,0,0,0,0,0,1,0,
+Summer 2022,CIVE,7399,1,12820,Master's Thesis,Mo,Larry Yi-Lung,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,3301,4,12823,Intro Psych Stats,Nguyen,My Viet Ha,7,14,9,5,8,0,8,2.201
+Summer 2022,BIOL,3396,1,12826,Senior Research Project,Lin,Chin-Yo,1,0,0,0,0,0,0,4.0
+Summer 2022,MATH,6398,1,12828,Special Problems,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Summer 2022,ELCS,6310,1,12832,Strategic Engagement,Davis,Kenneth D,16,0,0,0,0,0,0,3.979
+Summer 2022,POLS,8399,18,12833,Doctoral Dissertation,Shea,Patrick,0,0,0,0,0,1,0,
+Summer 2022,COMM,1307,1,12836,Media and Society,Olson,Beth M,3,4,3,2,1,0,0,2.436
+Summer 2022,COMM,1307,2,12837,Media and Society,Lyn,Robyn,25,4,2,1,1,0,2,3.545
+Summer 2022,COMM,1307,5,12838,Media and Society,Lyn,Robyn,5,1,2,0,0,0,0,3.416
+Summer 2022,GEOL,7301,1,12839,Capstone Project,Van Nieuwenhuise,Donald S,1,0,0,0,0,0,0,4.0
+Summer 2022,COMM,2311,5,12840,Writing for Print and Digital,Radcliffe Andre,Jennifer,13,4,2,1,0,0,0,3.384
+Summer 2022,COMM,2356,1,12842,Business & Professional Comm,Salisbury,Shelby,32,17,7,1,6,0,2,3.027
+Summer 2022,GERM,3350,1,12843,20Th C Thru German Culture,Kleinheider,Julia D,5,2,1,0,2,0,1,2.734
+Summer 2022,ELCS,8399,1,12844,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Summer 2022,PSYC,2301,6,12845,Introduction to Psychology,Orr,Michael F,4,4,5,2,3,0,3,2.296
+Summer 2022,PSYC,2305,1,12846,Intro to Methods in Psychology,Babalola,Olusegun Maria,28,23,3,1,6,0,3,2.995
+Summer 2022,PSYC,2344,1,12848,Cultural Psychology,Brooks,Jasmin R,22,13,9,2,10,0,1,2.672
+Summer 2022,PSYC,3341,3,12852,Physiological Psychology,Bodet III,Jean Philippe,36,15,6,2,1,0,0,3.444
+Summer 2022,PSYC,3341,4,12853,Physiological Psychology,Saiyed,Amna Shabbir,24,8,4,1,1,0,2,3.377
+Summer 2022,PSYC,3350,6,12855,Intro to Cognitive Psychology,Anderson,Jill Annette,23,14,1,0,0,0,0,3.466
+Summer 2022,PSYC,4321,3,12856,Abnormal Psychology,Gioia,Anthony,19,10,6,4,2,0,0,2.879
+Summer 2022,SPEC,6327,1,12857,Measurement Eval Research,Cole,Jana Belinda,18,0,1,0,1,0,0,3.634
+Summer 2022,ELCS,8371,1,12858,Legal Issues Sch District Levl,Causey,Ashley,5,1,0,0,0,0,0,3.778
+Summer 2022,CUIN,7375,1,12861,Capstone for Literacy Educ,Hale,Margaret Ann,11,0,0,0,1,0,0,3.667
+Summer 2022,COMM,3326,1,12863,Graphics Applications,Economou-Clarke,Ann M,11,7,0,0,0,0,0,3.648
+Summer 2022,COMM,3361,1,12865,Advertising Copywriting,Clark,Thomas R,9,0,3,0,0,0,0,3.5
+Summer 2022,SAER,8388,1,12867,Sem-Res Ed Ldshp Pol St,Davis,Tiffany J,17,3,0,0,0,0,0,3.867
+Summer 2022,PSYC,2305,9,12868,Intro to Methods in Psychology,Yoruk,Harun,34,13,8,1,1,0,1,3.392
+Summer 2022,PSYC,2305,11,12870,Intro to Methods in Psychology,Anderson,Jill Annette,17,21,4,1,0,0,0,3.217
+Summer 2022,PSYC,2319,4,12872,Intro to Social Psychology,Anderson,Jill Annette,6,17,15,3,2,0,0,2.473
+Summer 2022,KIN,4315,1,12873,Motor Learning and Control,Layne,Charles S,4,39,30,3,1,0,0,2.507
+Summer 2022,KIN,4370,1,12874,Exercise Testing,Markofski,Melissa,4,10,7,0,0,0,0,2.889
+Summer 2022,LAW,5339,1,12878,Trusts and Wills,Fagundes,Dave,5,8,1,0,0,12,0,3.191
+Summer 2022,SOCW,7347,1,12879,SW Practice & Interv in School,Leger,Jan Ellen,4,8,1,0,0,0,0,3.282
+Summer 2022,HRMA,4361,1,12881,Marketing Strategies,Taylor,David C,24,9,4,1,2,0,0,3.251
+Summer 2022,MATH,3321,3,12883,Engineering Mathematics,West,James David,4,8,7,4,9,0,4,1.74
+Summer 2022,MATH,3336,2,12884,Discrete Mathematics,Ru,Min,7,16,5,0,0,0,0,3.06
+Summer 2022,MATH,3363,1,12885,Introduction To Pde,Caglar,Atife,5,4,7,2,6,0,1,1.89
+Summer 2022,POLC,6391,1,12888,Public Policy Internship,Wong,Man Chiu,14,0,0,0,0,0,2,4.0
+Summer 2022,MANA,7392,2,12892,Managerial Issues,Walker,William A,12,0,0,0,0,0,1,4.0
+Summer 2022,MANA,4338,1,12893,Performance Management Systems,Bozeman,Dennis,17,16,10,4,0,0,2,3.056
+Summer 2022,MANA,4348,1,12894,Global Leadership,Walker,William A,15,1,1,0,0,0,0,3.804
+Summer 2022,SOCW,7371,2,12895,Trauma & SW,Olson,Lindamarie E,28,0,0,0,0,0,0,3.976
+Summer 2022,ENTR,3310,3,12896,Entrepreneurship,Ortega,Carlos Alberto,79,18,1,1,0,0,0,3.721
+Summer 2022,CIS,2348,1,12897,Info Systems Appl Development,Ratner,Edward,2,8,6,2,1,0,0,2.317
+Summer 2022,CIS,3347,1,12898,IS Infrastructure and Networks,Viseh,Mehran,10,7,18,0,1,0,0,2.713
+Summer 2022,COSC,3380,201,12899,Database Systems,Hilford,Victoria,60,27,2,0,0,0,1,3.581
+Summer 2022,COSC,4353,101,12900,Software Design,Singh,Raj Kumar,19,8,3,0,1,0,0,3.366
+Summer 2022,COSC,6353,101,12901,Software Design,Singh,Raj Kumar,23,2,0,0,0,0,1,3.88
+Summer 2022,ACCT,3377,2,12903,Cost Accounting,Serrato,Darlene Marie  Bohac,4,4,3,0,0,0,1,3.121
+Summer 2022,ACCT,5337,2,12904,Management Accounting,Serrato,Darlene Marie  Bohac,2,0,0,0,0,0,0,3.835
+Summer 2022,CHEM,2323,1,12905,Organic Chemistry I,Zaitsev,Vladimir G,10,8,14,25,31,0,11,1.307
+Summer 2022,ACCT,7378,1,12908,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,25,3,0,0,0,0,0,3.893
+Summer 2022,HDCS,1300,3,12909,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,35,4,2,1,2,0,1,3.538
+Summer 2022,SOCW,7347,3,12910,SW Practice & Interv in School,Leger,Jan Ellen,12,1,1,0,0,0,0,3.739
+Summer 2022,HRD,6303,30,12911,Assessment & Evaluation in Hrd,Alston,Carmen M,7,0,0,0,0,0,0,4.0
+Summer 2022,TECH,3365,1,12912,Appl of Discrete Mthds in Tech,Schroeder,Susan L,12,7,3,1,1,0,0,3.18
+Summer 2022,MATH,6386,1,12913,Big Data Analytics,Shastri,Dvijesh J,19,13,2,0,0,0,0,3.413
+Summer 2022,CNST,4315,1,12914,Steel Construction,Chang,Chi Chung,4,9,0,0,0,0,0,3.206
+Summer 2022,FINA,4328,1,12915,Principles of Personal Finance,Coleman,Alfred G,5,7,0,1,1,0,0,2.882
+Summer 2022,GOVT,2305,4,12916,"US Govt: Congress,Pres & Crts",Alvarez,Robert D,20,4,1,0,0,0,1,3.786
+Summer 2022,TLIM,3340,30,12917,Org Leadership & Supervision,Lattier,Gregory Jeff,27,5,3,1,3,0,3,3.299
+Summer 2022,TLIM,3345,1,12918,Human Resources in Technology,Mehring,Brian George,7,8,2,3,3,0,1,2.537
+Summer 2022,TLIM,3345,30,12919,Human Resources in Technology,Kirtley,Melinda Gayle,21,3,0,0,2,0,0,3.577
+Summer 2022,TLIM,3355,30,12920,Project Management Principles,Moore,George P,9,7,3,0,1,0,0,3.167
+Summer 2022,TLIM,3363,30,12921,Technical Communications,Tangeman,Anthony C,12,9,3,0,1,0,0,3.214
+Summer 2022,TLIM,3363,33,12922,Technical Communications,Tangeman,Anthony C,20,2,1,0,1,0,0,3.639
+Summer 2022,TLIM,3363,31,12923,Technical Communications,Piercy,Penelope Junker,13,7,5,1,1,0,1,3.062
+Summer 2022,TLIM,3363,34,12924,Technical Communications,Piercy,Penelope Junker,20,8,0,0,3,0,0,3.28
+Summer 2022,TLIM,3363,32,12925,Technical Communications,Peterson,Kathryn Marie,22,0,0,0,0,0,0,3.97
+Summer 2022,HLT,3381,2,12926,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,19,2,1,1,0,0,1,3.624
+Summer 2022,TLIM,4341,32,12927,Production & Service Operation,Chance,Michael Dean,11,6,3,1,0,0,0,3.191
+Summer 2022,TLIM,4341,30,12928,Production & Service Operation,Terrell,John Allen,22,9,3,0,1,0,0,3.401
+Summer 2022,TLIM,4342,31,12930,Quality Improvement Methods,O'Kelley,Donna K,7,17,4,1,1,0,0,2.922
+Summer 2022,TLIM,4342,32,12931,Quality Improvement Methods,O'Kelley,Donna K,5,10,4,1,1,0,0,2.825
+Summer 2022,TLIM,4342,30,12932,Quality Improvement Methods,Chance,Michael Dean,10,13,3,0,0,0,0,3.269
+Summer 2022,TLIM,4371,30,12933,Leading Change in the Wrkplace,Evans,Gerald S,20,8,0,0,0,0,0,3.679
+Summer 2022,TLIM,4372,30,12934,Proposal and Project Writing,Thomas,Jamie M,10,6,3,1,2,0,2,2.985
+Summer 2022,TLIM,4390,30,12935,Current Issues Ldshp & Innov,Mehring,Brian George,6,3,1,0,0,0,0,3.533
+Summer 2022,CHEM,1305,1,12936,Foundations of Chemistry,St Hill,Lydia Ruth,6,14,6,4,0,0,1,2.788
+Summer 2022,BIOL,1308,1,12938,Biology for Non-Science Majors,Ibrahim,Abdalla Zanouny,6,9,4,3,1,0,0,2.739
+Summer 2022,PHAR,5206,1,12940,Pharmacy and Geriatrics,Fernandez,Julianna M,21,24,2,0,0,0,0,3.404
+Summer 2022,PHAR,5207,1,12941,Herbal Medicine,Ruan,Ke-He,17,3,0,0,0,0,0,3.85
+Summer 2022,PHAR,5217,1,12942,Pediatric Therapeutics,Martinez,Brigetta,46,1,0,0,0,0,0,3.979
+Summer 2022,PHAR,5457,1,12943,Institutional IPPE,Hatfield,Catherine L,95,10,0,0,0,0,0,3.905
+Summer 2022,SCLT,3385,30,12944,Transport Economics and Policy,Poisler,Marco A,26,9,0,0,2,0,1,3.594
+Summer 2022,SCLT,2362,31,12945,Intro To Logistics Technology,Chopra,Anuj,24,11,1,0,0,0,0,3.584
+Summer 2022,FINA,7374,1,12946,Midstream Energy Finance,Broxson,John Robert,36,0,0,0,0,0,0,3.991
+Summer 2022,LAW,6347,1,12950,Secured Financing,Dole,Richard F,0,2,1,0,0,7,0,2.887
+Summer 2022,NURS,6338,1,12951,Advanced Pathophysiology,Reeve,Kathleen D,4,2,1,0,0,0,0,3.429
+Summer 2022,NUTR,4353,2,12952,Cultural Comp for Nutr Prof,Yoon,Cynthia Yursun,24,1,0,0,0,0,1,3.92
+Summer 2022,TLIM,3340,31,12953,Org Leadership & Supervision,Burns,Maria,27,1,0,0,0,0,2,3.929
+Summer 2022,TLIM,4341,31,12954,Production & Service Operation,Terrell,John Allen,11,8,1,0,0,0,0,3.418
+Summer 2022,ARTS,2356,2,12955,Fundamentals of Photo/DM,Hillerbrand,Stephan C,16,0,0,0,0,0,1,4.0
+Summer 2022,NUTR,6312,1,12956,Capstone II,Haubrick,Kevin,2,1,0,0,0,0,0,3.777
+Summer 2022,MUED,2342,1,12957,Music for Children,Bigwood,Cora Morgan,17,1,0,0,0,0,0,3.871
+Summer 2022,CHEE,2331,1,12959,Chemical Processes,Kowal,Marsha Christine,2,6,2,2,3,0,2,2.089
+Summer 2022,CHEE,2331,2,12960,Chemical Processes,Kowal,Marsha Christine,2,3,1,0,0,0,0,3.057
+Summer 2022,KIN,4302,1,12961,Fitness and Human Sexuality,Alastuey,Lisa L,7,15,12,5,2,0,2,2.431
+Summer 2022,FINA,7377,1,12962,Electric Power Markets,Gasca,Amparo Amy,21,5,0,0,0,0,0,3.693
+Summer 2022,FINA,4330,1,12964,Corporate Finance,Mai,Thien Anh Thu,15,9,10,1,0,0,3,3.133
+Summer 2022,FINA,7323,1,12965,Applied Equity Fund Management,George,Thomas J,17,0,0,0,0,0,0,4.0
+Summer 2022,RELS,2360,1,12966,Introduction to Buddhism,Huynh,Trung,4,2,1,0,0,0,0,3.429
+Summer 2022,SOCI,1301,3,12968,Introduction To Sociology,Nelson,Steven M,22,10,6,3,2,0,6,3.093
+Summer 2022,SCLT,4312,30,12969,Inventory & Materials Handling,Hu,Minxiang,11,10,3,1,1,0,0,3.052
+Summer 2022,SCLT,3376,30,12970,Global Trade Intermediaries,Blount,James,5,0,0,0,0,0,0,3.802
+Summer 2022,COSC,8398,120,12990,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Summer 2022,COSC,8398,125,12994,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Summer 2022,COSC,8398,127,12996,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,2,0,
+Summer 2022,COSC,8398,231,13029,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Summer 2022,ELCS,6301,1,13030,Leadership for Equity,Stewart,Cedric Benjamin,15,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,8390,2,13031,Doctoral Thesis,Hutchison,Laveria F,0,0,0,0,0,1,0,
+Summer 2022,PHIL,1301,1,13032,Intro To Philosophy,Haaga,Curtis W,24,12,3,0,1,0,1,3.45
+Summer 2022,NUTR,6307,1,13033,Community Nutrition Practice,Haubrick,Kevin,0,0,0,0,0,3,0,
+Summer 2022,GEOL,3355,1,13039,Field Geology I,Kalakay,Thomas J,4,4,1,0,0,0,0,3.297
+Summer 2022,GEOL,3360,3,13041,Field Geology II,Murphy,Michael,6,3,0,0,0,0,0,3.483
+Summer 2022,COSC,4377,301,13048,Intro To Computer Networks,Long,Kevin B,35,42,11,1,1,0,2,3.211
+Summer 2022,COSC,3337,201,13049,Data Science I,Rizk,Nouhad J,7,21,8,2,1,0,0,2.769
+Summer 2022,COMM,3370,1,13050,History of Cinema,Houk,Keith R,18,11,1,0,0,0,2,3.556
+Summer 2022,ENGL,2305,1,13053,Intro To Fiction,Presswood,Phillip Hilliard,19,4,1,0,0,0,0,3.778
+Summer 2022,NUTR,6308,1,13055,Clinical Nutrition Practice I,Haubrick,Kevin,0,0,0,0,0,1,0,
+Summer 2022,COSC,3340,201,13056,Intro. to Automata and Comp.,Leiss,Ernst L,4,10,8,4,0,0,1,2.627
+Summer 2022,ENGI,1331,3,13057,Computing for Engineers,Luna Singh,Jennifer Austin,8,9,7,3,2,0,8,2.632
+Summer 2022,ENGI,2304,7,13059,Technical Communications,Wilson,Chad A,17,4,0,0,3,0,0,3.292
+Summer 2022,ENGI,2304,8,13060,Technical Communications,Downey,Carlton M,12,1,0,0,0,0,2,3.948
+Summer 2022,MECE,3336,1,13062,Mechanics II,Wang,Jiawen,6,8,10,4,0,0,5,2.513
+Summer 2022,MECE,3338,1,13063,Dynamic & Control of Mech Syst,Hammami,Farah,2,12,13,2,0,0,0,2.437
+Summer 2022,MECE,3363,1,13064,Intro To Fluid Mechanics,Love,Holley Carole,7,12,3,0,0,0,0,3.062
+Summer 2022,COSC,6309,201,13067,Intro Automata & Computability,Leiss,Ernst L,0,2,0,0,0,0,0,3.0
+Summer 2022,BIOL,6355,1,13068,Introduction to Health Systems,Valier,Helen K,23,4,0,0,0,0,0,3.779
+Summer 2022,HIST,1377,1,13070,The U S To 1877,Clavin,Matthew J,19,76,23,2,5,0,5,2.829
+Summer 2022,ECE,3155,2,13072,Electronics Laboratory,Ruchhoeft,Paul,7,3,1,0,0,0,0,3.605
+Summer 2022,BIOE,5319,1,13076,Intro to Global Healthcare,Akay PhD,Metin,6,3,0,0,0,0,0,3.667
+Summer 2022,ECON,3320,1,13077,Intro to Econ Data Analysis,Melendez Lugo,Joel,8,12,8,1,2,0,1,2.742
+Summer 2022,OPTO,6115,2,13078,Clinical Integration,Dempsey,Robert L.,0,0,0,0,0,42,0,
+Summer 2022,BIOE,4303,1,13079,Biomaterials,Abidian,Mohammad Reza,4,1,0,0,0,0,0,3.668
+Summer 2022,BIOE,6303,1,13080,Biomaterials,Abidian,Mohammad Reza,7,2,0,0,1,0,0,3.4
+Summer 2022,BIOE,6343,1,13081,Global Healthcare,Akay PhD,Metin,14,0,0,0,0,0,0,3.882
+Summer 2022,WGSS,2350,1,13084,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,24,4,1,1,0,0,0,3.667
+Summer 2022,WGSS,2360,1,13085,Introduction to LGBT Studies,Stone,Lauren Michelle,11,5,1,1,1,0,0,3.263
+Summer 2022,WGSS,3321,1,13086,Gender in Transnational Persp,Al-Sowayel,Dina,17,3,2,0,1,0,1,3.507
+Summer 2022,NUTR,2332,2,13087,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,48,9,5,0,0,0,2,3.603
+Summer 2022,NUTR,2332,3,13088,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,22,9,11,0,0,0,1,3.207
+Summer 2022,PSYC,6336,1,13090,Directed Rsch in Social Psyc,Derrick,Jaye L,2,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6393,3,13091,Clinical Research Practicum,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6359,1,13099,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6257,6,13106,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6257,8,13108,Research Practicum B,Ostrin,Lisa,2,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6257,10,13111,Research Practicum B,Bergmanson,Jan Pg,1,0,0,0,0,0,0,4.0
+Summer 2022,ATP,6303,1,13119,Gen Med/Pharm 1 -System & Eval,Knoblauch,Mark Alan,9,5,3,0,0,0,0,3.353
+Summer 2022,ENGL,1302,10,13123,First Year Writing II,Rolater,Sara C,9,8,0,0,2,0,5,3.123
+Summer 2022,ENGL,1302,11,13124,First Year Writing II,Rolater,Sara C,9,8,0,1,3,0,3,2.842
+Summer 2022,ENGL,1302,12,13125,First Year Writing II,Downey,Carlton M,20,2,0,0,2,0,1,3.583
+Summer 2022,ENGL,1302,13,13126,First Year Writing II,Downey,Carlton M,19,1,0,0,2,0,0,3.606
+Summer 2022,ENGL,2315,1,13129,Literature and Film,Pegoda,Andrew Joseph,6,7,3,0,2,0,6,2.925
+Summer 2022,MARK,3339,1,13132,Marketing Strategy & Planning,Lish,Alan D,22,9,1,0,0,0,0,3.605
+Summer 2022,PSYC,6336,2,13137,Directed Rsch in Social Psyc,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Summer 2022,FINA,3332,2,13138,Prin of Financial Management,Chisholm,Darla,2,1,1,0,0,0,1,3.25
+Summer 2022,HIST,8699,2,13139,Doctoral Dissertation,Schafer Jr,James A,0,0,0,0,0,1,0,
+Summer 2022,HIST,8699,3,13140,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,0,0,
+Summer 2022,HIST,8677,1,13149,Reading for Comps Exams,Golubev,Alexey Valeryevich,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,8598,4,13153,Doctoral Research,Coates,Daniel R,2,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6365,1,13157,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,3,0,0,0,0,0,0,4.0
+Summer 2022,INAR,3360,1,13163,Human Factors in Interior Arch,Vos,Gordon A,3,2,0,0,0,0,0,3.6
+Summer 2022,INDS,3360,1,13164,Human Factors,Vos,Gordon A,2,0,0,0,0,0,0,3.835
+Summer 2022,PHYS,1101,6,13165,College Physics I (lab),Wood,Lowell T,2,9,6,0,0,0,1,2.881
+Summer 2022,PHYS,1102,6,13166,College Physics II (lab),Wood,Lowell T,2,13,3,1,1,0,0,2.684
+Summer 2022,PHOP,6567,1,13167,Research Practicum A,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Summer 2022,SCM,4311,1,13169,Project Management,Wayhan,Victor Brian,73,32,5,1,0,0,4,3.592
+Summer 2022,PHOP,6567,6,13177,Research Practicum A,Patel,Nimesh Bhikhu,2,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,8498,1,13183,Doctoral Research,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,8399,3,13184,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,1,0,
+Summer 2022,MATH,3339,2,13185,Statistics for the Sciences,Wang,Wenshuang,32,12,12,8,17,0,4,2.399
+Summer 2022,ENGL,8399,4,13186,Doctoral Dissertation,Shepley,Nathan,0,0,0,0,0,0,0,
+Summer 2022,PSYC,6365,2,13187,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6365,3,13192,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6198,3,13193,Spec Prob-Physio Optics,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,6336,3,13196,Directed Rsch in Social Psyc,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Summer 2022,COSC,8698,122,13200,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,3,0,
+Summer 2022,COSC,8698,106,13203,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,
+Summer 2022,HLT,3301,2,13205,Health Behavior Theories,Bennett,Kristin C,19,1,0,0,1,0,0,3.746
+Summer 2022,COSC,8698,128,13207,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,3,0,
+Summer 2022,HLT,3325,1,13209,Medical Terminology,Bloom,Joel A,91,6,1,1,0,0,0,3.832
+Summer 2022,HLT,3325,2,13210,Medical Terminology,Bloom,Joel A,32,4,0,0,0,0,0,3.861
+Summer 2022,HLT,3325,3,13211,Medical Terminology,Burk,Kelly Ann,71,4,3,0,0,0,1,3.783
+Summer 2022,HLT,1353,2,13214,Personal Health,Rafique,Kiran Sajid,89,7,0,0,2,0,0,3.793
+Summer 2022,SPAN,1501,3,13215,Elementary Spanish I,Molinete,Julio Antonio,7,2,0,0,0,0,0,3.594
+Summer 2022,SPAN,1502,5,13217,Elementary Spanish II,Pueyo Castan,Josefa,2,12,6,1,4,0,1,2.174
+Summer 2022,SPAN,2311,4,13219,Intermediate Spanish I,Benalcazar Astudillo,Diana Salome,10,5,3,0,1,0,1,3.106
+Summer 2022,MATH,6308,1,13221,Advanced Linear Algebra I,Haynes,Alan K,2,0,0,0,0,0,0,4.0
+Summer 2022,MATH,8698,14,13225,Doctoral Research,Perepelitsa,Mikhail Antolyevic,0,0,0,0,0,1,0,
+Summer 2022,MATH,8698,15,13226,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Summer 2022,MATH,8698,16,13227,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,
+Summer 2022,PHCA,8199,3,13231,Doctoral Dissertation Defense,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Summer 2022,MATH,8698,10,13238,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,3,0,
+Summer 2022,MATH,8698,12,13239,Doctoral Research,Nicol,Matthew J.,0,0,0,0,0,1,0,
+Summer 2022,COSC,8698,102,13242,Doctoral Research,Chen,Guoning,0,0,0,0,0,4,0,
+Summer 2022,HDFS,4316,2,13244,Dynamics of Family Relations,Rab,Saira,29,3,2,1,3,0,1,3.378
+Summer 2022,HDFS,2314,3,13245,Human Dev and Interventions,Schoger,Kimberly,29,3,4,0,1,0,1,3.541
+Summer 2022,COSC,8698,127,13247,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Summer 2022,COSC,8698,114,13252,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,3,0,
+Summer 2022,ENGL,8698,1,13260,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,3,0,
+Summer 2022,COSC,8698,112,13261,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Summer 2022,COSC,8698,107,13267,Doctoral Research,Eick,Christoph F,0,0,0,0,0,2,0,
+Summer 2022,COMD,7391,11,13269,Clinic in Speech Lang Disorder,Jacobson,Shannon,1,0,0,0,0,0,0,4.0
+Summer 2022,COMD,7391,16,13270,Clinic in Speech Lang Disorder,Cizek,Laura S,2,0,0,0,0,0,0,3.835
+Summer 2022,COMD,7391,17,13271,Clinic in Speech Lang Disorder,Ross,Byron L,2,0,0,0,0,0,0,4.0
+Summer 2022,COMD,7391,18,13272,Clinic in Speech Lang Disorder,Maher,Lynn M,2,0,0,0,0,0,0,3.67
+Summer 2022,COMD,7391,1,13275,Clinic in Speech Lang Disorder,Sims,Frankie B,1,1,0,0,0,0,0,3.665
+Summer 2022,COSC,8698,120,13278,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Summer 2022,COSC,8698,125,13279,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6365,4,13282,Dir Rsch in Dev Cog Beh Neuro,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Summer 2022,COSC,8698,109,13283,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Summer 2022,PHOP,8398,2,13285,Doctoral Research,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Summer 2022,ECON,8699,5,13287,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,1,0,
+Summer 2022,COSC,8698,117,13291,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,
+Summer 2022,COSC,8698,115,13292,Doctoral Research,Laszka,Aron,0,0,0,0,0,6,0,
+Summer 2022,COSC,8698,129,13293,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6365,5,13294,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,1,0,
+Summer 2022,COMM,1303,1,13296,Writing for Communicators,Lyn,Robyn,20,12,7,0,1,0,0,3.234
+Summer 2022,INDE,8298,1,13304,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,
+Summer 2022,INDE,8398,2,13310,Doctoral Research,Lee,Tae Woo,0,0,0,0,0,1,0,
+Summer 2022,INDE,8398,3,13311,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Summer 2022,INDE,8398,6,13314,Doctoral Research,Peng PhD,Jiming Ouyang,0,0,0,0,0,1,0,
+Summer 2022,INDE,8498,1,13315,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,
+Summer 2022,INDE,8598,7,13324,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,2,0,
+Summer 2022,INDE,8399,7,13326,Doctoral Dissertation,Lin PhD,Ying,1,0,0,0,0,0,0,4.0
+Summer 2022,INDE,8699,3,13328,Doctoral Dissertation,Lee,Tae Woo,1,0,0,0,0,0,0,4.0
+Summer 2022,WGSS,2350,3,13339,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,2,0,0,1,0,0,3.75
+Summer 2022,MARK,3337,2,13346,Professional Selling,Suki,Yara D,28,3,0,0,0,0,0,3.85
+Summer 2022,MANA,4347,1,13350,Ethics and Corp Soc Respon.,Salaiz,Ashley,28,15,4,1,0,0,0,3.41
+Summer 2022,ACCT,7396,2,13351,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,1,13352,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,1,13354,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2022,WGSS,2350,4,13358,Intro To Women's Studies,Martinez,Itzel Areli,25,4,0,0,0,0,0,3.862
+Summer 2022,ENTR,3310,4,13362,Entrepreneurship,Ortega,Carlos Alberto,78,15,4,0,0,0,0,3.685
+Summer 2022,ENGL,1302,14,13363,First Year Writing II,Burns,William,12,6,3,0,1,0,2,3.243
+Summer 2022,PSYC,6365,6,13364,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Summer 2022,INDE,8198,7,13367,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,2,0,
+Summer 2022,CUIN,7392,1,13369,Internship,Gronseth,Susie L B,2,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,8399,2,13373,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,0,0,
+Summer 2022,COMM,1307,4,13384,Media and Society,Olson,Beth M,6,9,3,2,3,0,2,2.537
+Summer 2022,COMM,1303,2,13385,Writing for Communicators,Lyn,Robyn,11,1,2,0,0,0,0,3.549
+Summer 2022,COMM,2327,1,13387,Introduction to Screen Writing,Vaughan,Thomas Michael,11,6,1,0,0,0,0,3.446
+Summer 2022,COMM,3317,2,13388,Multimedia Journalism,Smith,Camilo Hannibal,9,2,2,0,0,0,1,3.564
+Summer 2022,COMM,3328,1,13389,Intro to Sports Production,Freedman,Michael,10,3,2,0,1,0,0,3.292
+Summer 2022,COMM,3300,1,13390,Health Communication,Yamasaki,Jill S,42,15,1,0,2,0,1,3.567
+Summer 2022,COMM,3369,2,13392,Strategic Comm. Writing,Belton,Stephanie,16,3,0,0,0,0,1,3.755
+Summer 2022,COMM,3380,1,13394,Electronic Field Production,Crowe,Craig Warren,10,4,0,0,0,0,0,3.502
+Summer 2022,COMM,4303,3,13397,Communication Law and Ethics,Dulin,Matthew D,13,23,5,3,2,0,1,2.87
+Summer 2022,COMM,4354,1,13398,Organizational Crisis Comm.,Uhrick,Jan,3,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,1103,4,13403,Physical Geology Lab,Hauptvogel,Daniel William,5,2,1,0,0,0,1,3.5
+Summer 2022,GEOL,3355,2,13404,Field Geology I,Lindline,Jennifer,5,4,0,0,0,0,0,3.519
+Summer 2022,MATH,3336,1,13405,Discrete Mathematics,Papadakis,Emanuel Ioannis,8,7,5,0,2,0,1,2.909
+Summer 2022,MATH,1324,3,13406,Finite Math with Applications,Caglar,Atife,10,26,18,24,24,0,2,1.745
+Summer 2022,MATH,1342,2,13407,Elementary Statistical Methods,Weber,Thomas Christian,20,14,12,2,8,0,2,2.643
+Summer 2022,MATH,5383,1,13408,Number Theory,Ru,Min,5,5,0,0,0,0,0,3.467
+Summer 2022,BIOL,6352,1,13410,Molecular Mech Disease,Lin,Chin-Yo,18,9,0,0,0,0,0,3.654
+Summer 2022,HRMA,4352,1,13412,Hosp Organizational Behavior,Jarvis,Nathan Alexander,20,3,7,2,3,0,3,2.962
+Summer 2022,HRMA,4360,1,13413,Hospitality Internship,Shepherd,Ashley,27,0,0,0,0,0,1,4.0
+Summer 2022,LAW,6220,1,13414,Trademark Prosecution,Hunt,Lee Burton,3,8,0,0,0,0,0,3.303
+Summer 2022,LAW,5120,1,13415,Texas Legal Research,Dykes,Christopher,7,10,0,0,0,0,0,3.392
+Summer 2022,SOCW,7376,1,13420,Social Work-LGBTQ Communities,Keo,Bec Sokha,9,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7325,1,13421,Assessment in SW Practice,Borja,Sharon G,22,3,2,0,0,0,1,3.655
+Summer 2022,SOCW,7325,2,13422,Assessment in SW Practice,Fernandez,Jason,22,0,0,0,0,0,0,3.985
+Summer 2022,SOCW,7325,3,13423,Assessment in SW Practice,Xu,Wen,25,0,0,0,0,0,0,3.974
+Summer 2022,ACCT,3366,2,13424,Financial Reporting Frameworks,Parthasarathy,Kiran M,15,10,6,6,1,0,9,2.894
+Summer 2022,HIST,4379,1,13426,Sex and Violence in Old South,Deyle,Steven H,15,15,2,1,2,0,0,3.152
+Summer 2022,CUIN,4375,1,13427,Classroom Management,Thompson,Alan M,17,1,0,0,0,0,0,3.908
+Summer 2022,INDE,6321,1,13430,System Safety Engineering,Schulze,Lawrence John Henry,1,2,0,0,0,0,0,3.333
+Summer 2022,ELCS,6330,2,13434,Finance & School-Based Budgtng,Merricks,Michelle Fernandez,13,1,0,0,0,0,0,3.929
+Summer 2022,SPEC,6367,1,13435,Special Education for Leaders,McCormick,Marina,9,2,1,0,1,0,0,3.258
+Summer 2022,SPEC,6367,2,13436,Special Education for Leaders,Hill,Deena Clair,9,0,0,0,0,0,0,4.0
+Summer 2022,DIGM,1350,31,13437,Graphics for Digital Media,Pittman,Natalie,4,7,5,1,4,0,1,2.113
+Summer 2022,ELCS,8399,4,13438,Doctoral Dissertation,Zou,Yali,0,0,0,0,0,1,0,
+Summer 2022,DIGM,1300,30,13439,Introduction to Digital Media,Waite,Jerry J,8,5,5,1,2,0,0,2.715
+Summer 2022,DIGM,1376,30,13440,User Experience (UX)Principles,Showers,April Marie,16,7,5,6,1,0,1,2.857
+Summer 2022,DIGM,3152,30,13441,Graphic Comm Output Lab,Dawson,Michael John,7,1,0,0,0,0,0,3.875
+Summer 2022,LAW,5200,1,13442,Depositions,Chung,Jennifer,4,6,0,0,0,0,0,3.367
+Summer 2022,TLIM,3360,30,13446,Law & Ethics-Tech & Innovation,Soliz,Rudy,30,0,1,0,1,0,1,3.813
+Summer 2022,TLIM,3340,32,13447,Org Leadership & Supervision,Evans,Gerald S,32,3,0,0,0,0,0,3.886
+Summer 2022,ECON,4390,4,13449,Economics Internship,Pinto,Pablo M,16,0,0,0,0,0,0,4.0
+Summer 2022,SPEC,7394,1,13450,Diagnostician Internship I,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Summer 2022,ELCS,8330,1,13451,Statistical Analyses,Pettersson Cobb,Jennifer,8,1,1,0,0,0,0,3.7
+Summer 2022,SPEC,8365,1,13452,Admin-Supv Special Educ,Malechuk,Brian Edward,10,0,0,0,0,0,0,4.0
+Summer 2022,SPEC,8391,2,13453,Leadership Coaching,McCormick,Marina,13,2,0,0,0,0,0,3.757
+Summer 2022,ECON,2302,2,13457,Principles of Microeconomics,Le,Hoanh Yen Thi,4,2,3,1,0,0,0,2.867
+Summer 2022,ECON,2302,3,13459,Principles of Microeconomics,Hadah,Hussain,6,9,2,1,0,0,1,3.129
+Summer 2022,BCIS,1305,1,13462,Business Computer Applications,Felvegi,Emese,55,22,9,0,1,0,2,3.498
+Summer 2022,BUSI,3300,1,13464,Intro to Personal Finance,Harvey,Danny,44,0,1,0,3,0,0,3.708
+Summer 2022,BUSI,3300,3,13465,Intro to Personal Finance,Munchbach,Jim,42,5,1,0,1,0,1,3.722
+Summer 2022,KIN,3304,1,13466,Human Structure & Phys Perform,Breslin,Whitney L,10,23,7,2,0,0,1,2.992
+Summer 2022,KIN,3370,2,13467,Sport Facility Management,Pearson,Demetrius W,4,5,3,0,0,0,0,2.973
+Summer 2022,BUSI,2305,1,13468,Business Statistics,Wiley,Briceon C,42,60,94,48,26,0,52,2.153
+Summer 2022,ECON,2301,2,13469,Principles of Macroeconomics,Biju,Nabila Rahman,9,13,12,1,0,0,1,2.867
+Summer 2022,PEP,7308,2,13470,Sports Facility Administration,Pearson,Demetrius W,5,1,0,0,0,0,0,3.778
+Summer 2022,ECON,2301,3,13471,Principles of Macroeconomics,Loaeza Albino,Eva Davinia,2,3,4,0,0,0,0,2.631
+Summer 2022,MANA,4336,2,13473,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,14,16,4,1,0,0,3,3.191
+Summer 2022,MANA,4346,1,13474,Leadership Development,Evans,Klavdia Markelova,42,2,3,0,0,0,1,3.83
+Summer 2022,MANA,4353,1,13475,Mgmt Training and Career Devel,Bozeman,Dennis,34,8,6,2,0,0,0,3.526
+Summer 2022,ECON,3334,1,13477,Intermediate Macroeconomics,Mcgregor,Ryan P,8,3,9,1,0,0,3,2.747
+Summer 2022,MANA,4355,2,13478,Selection and Staffing,Bozeman,Dennis,16,11,4,0,0,0,0,3.451
+Summer 2022,PSYC,3339,2,13480,Intro To Clinical Psychology,Zegel,Maya,37,3,0,1,1,0,1,3.754
+Summer 2022,MANA,6A25,3,13483,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,5,2,0,0,0,0,0,3.714
+Summer 2022,MANA,6A32,2,13484,Organizational Behavior & Mgt,Witt,Lawrence A,29,0,0,0,0,0,0,4.0
+Summer 2022,MANA,6A83,2,13485,Strategic Analysis,Celly,Nikhil,13,1,0,0,0,0,0,3.929
+Summer 2022,MANA,7380,1,13486,People Analytics,Abbott,Jeanna L,35,1,0,0,0,0,0,3.945
+Summer 2022,FINA,7364,1,13487,Intl Bus & Political Risk Mgt,Miljanic,Andra Olivia,17,4,0,0,0,0,0,3.747
+Summer 2022,MANA,7354,1,13488,Cultrl Issues in Global Mgt,Sebastijanovic,Marina,30,6,0,0,0,0,0,3.843
+Summer 2022,BUSI,1301,1,13491,Business Principles,Thompson,Joseph Lee,96,13,4,0,3,0,3,3.69
+Summer 2022,PSYC,2308,2,13492,Child Development,Trent,Erika S,35,14,4,5,1,0,0,3.294
+Summer 2022,BIOE,4349,1,13502,Biomedical Microdevices,Majd,Sheereen,2,0,0,0,0,0,0,3.835
+Summer 2022,BIOE,6349,1,13503,Biomedical Microdevices,Majd,Sheereen,7,0,0,0,1,0,0,3.376
+Summer 2022,WGSS,2360,3,13504,Introduction to LGBT Studies,Pegoda,Andrew Joseph,10,7,2,1,1,0,0,3.19
+Summer 2022,KIN,4310,2,13505,Measurement Tech Human Perf,Parikh,Pranav J,35,8,2,0,0,0,0,3.719
+Summer 2022,ACCT,3367,4,13507,Intermediate Accounting I,Kuruvilla,Mohan,8,7,11,4,3,0,5,2.464
+Summer 2022,CIS,2336,1,13509,Internet Application Developmt,Faiyaz,Sajida,8,7,7,0,0,0,1,3.09
+Summer 2022,WGSS,2350,5,13510,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,2,0,0,1,0,1,3.782
+Summer 2022,WGSS,2350,6,13511,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,13,1,1,0,0,0,1,3.778
+Summer 2022,ACCT,4335,4,13512,Financial Statement Auditing,Kuruvilla,Mohan,7,7,7,3,1,0,0,2.68
+Summer 2022,AAS,2330,1,13516,Black Liberation Theology,Mitchell,Joshua,14,5,3,0,0,0,1,3.44
+Summer 2022,HDCS,1300,4,13519,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,15,2,1,1,3,0,1,3.091
+Summer 2022,HDCS,4302,1,13521,Apparel Analysis,Gatterson,Beverly,19,7,0,0,1,0,0,3.507
+Summer 2022,HDCS,4380,1,13523,Merchandising,Gatterson,Beverly,11,4,1,1,2,0,0,3.036
+Summer 2022,MANA,7340,1,13524,Management of High Tech Org.,Keller,Robert T,21,6,0,0,0,0,1,3.704
+Summer 2022,ENGI,1331,4,13525,Computing for Engineers,Luna Singh,Jennifer Austin,11,6,6,1,1,0,4,3.053
+Summer 2022,CNST,3351,1,13529,Construction Estimating II,Sulehri,Hassan,21,13,0,0,0,0,0,3.618
+Summer 2022,FINA,7361,2,13530,Risk Management,Hogan,Kenneth David,18,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,4361,1,13531,Second Language Methodology,Burgess Monroy,Miguel,19,1,0,0,0,0,0,3.95
+Summer 2022,INDS,2355,1,13534,Design History I,Williams,Celeste,7,0,0,0,0,0,0,3.953
+Summer 2022,INDS,2355,2,13535,Design History I,Williams,Celeste,13,1,0,0,0,0,0,3.881
+Summer 2022,NURS,6321,1,13542,Leadership Practicum,Brohard,Cheryl L,9,0,0,0,0,0,0,4.0
+Summer 2022,NURS,6331,1,13543,Advanced Pharmacotherapy,Dwyer,Carol Ann,5,2,1,0,0,0,0,3.5
+Summer 2022,NURS,3634,1,13544,Clinical Nursing Practice II,Quintana,Danielle,54,9,0,0,0,0,0,3.857
+Summer 2022,NURS,4218,1,13545,Emergency Nursing,Edwards-Maddox,Shermel Vinese,22,0,0,0,0,0,0,4.0
+Summer 2022,ARTS,2316,1,13553,Fundamentals of Painting,Alderson,Saran,14,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,3331,1,13557,Beg Creative Writing-Poetry,Rattner,Nicholas,18,1,0,0,0,0,0,3.93
+Summer 2022,PHLS,6335,4,13560,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,8,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,6335,1,13561,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,10,1,0,0,0,0,0,3.939
+Summer 2022,PHLS,6335,2,13562,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,11,0,0,0,0,0,0,3.97
+Summer 2022,PHLS,6335,3,13563,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,10,1,0,0,0,0,0,3.909
+Summer 2022,ELED,4320,1,13564,Social Studies Ele Sch,Ford,Haley Michelle Grimland,22,0,1,1,1,0,0,3.653
+Summer 2022,RELS,2310,1,13573,Bible and Western Culture I,Allen,Paul J,12,0,0,0,0,0,0,3.945
+Summer 2022,RELS,3337,1,13575,Theologies from the Margins,Pegoda,Andrew Joseph,3,2,1,0,2,0,1,2.459
+Summer 2022,MECE,6387,1,13580,Intelligent Structural Systems,Song,Gangbing,5,7,5,0,0,0,2,3.078
+Summer 2022,TLIM,3330,30,13582,Innovation Principles,Feriante,Chris,1,6,5,0,13,0,2,1.32
+Summer 2022,HLT,3380,1,13584,Culture and Health,Kamdar-Sharif,Amber,42,5,3,0,0,0,0,3.688
+Summer 2022,HLT,4302,1,13585,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,29,9,3,0,0,0,1,3.586
+Summer 2022,HLT,4392,2,13587,Field Work in Community Health,Solari Williams,Kayce D.,0,1,1,0,0,0,0,2.5
+Summer 2022,INDE,6336,1,13590,Reliability Engineering,Keedy,Elias,9,4,1,0,1,0,0,3.311
+Summer 2022,TLIM,3371,30,13591,Budgeting and Financial Princ,Burns,Maria,16,0,0,0,0,0,3,4.0
+Summer 2022,BUSI,4350,1,13593,Business Law and Ethics,Williams,John M,189,49,6,3,2,0,0,3.63
+Summer 2022,BUSI,4350,3,13595,Business Law and Ethics,Williams,John M,13,2,0,0,0,0,0,3.889
+Summer 2022,BUSI,4396,1,13597,Business Internship,Hopkins,Troy D,0,0,0,0,0,79,0,
+Summer 2022,IEEM,6360,1,13604,Data Analytics for Engr. Mgt,Chang,Feng-Chang Roger,60,12,0,0,0,0,1,3.778
+Summer 2022,SPEC,6367,3,13606,Special Education for Leaders,Malechuk,Brian Edward,14,0,0,0,0,0,0,4.0
+Summer 2022,ARCH,6303,3,13607,Visual Studies III,Logan,Jason,5,4,0,0,0,0,0,3.629
+Summer 2022,PSYC,3301,5,13610,Intro Psych Stats,Saiyed,Amna Shabbir,34,4,0,0,0,0,1,3.877
+Summer 2022,BUSI,4350,5,13612,Business Law and Ethics,Williams,John M,38,5,2,1,0,0,0,3.71
+Summer 2022,ELET,1401,1,13614,Circuit Theory and Lab II,Moges,Mequanint A,5,3,2,1,0,0,0,3.121
+Summer 2022,HRD,4350,30,13616,Org Dev & Consulting,Clancy,James Patrick,8,5,0,0,0,0,0,3.438
+Summer 2022,PSYC,3301,6,13618,Intro Psych Stats,Vahedi,Meisam,53,4,1,0,0,0,1,3.879
+Summer 2022,HLT,4310,2,13619,Program Planning for Health,Markowitz,Eliz,8,5,5,0,2,0,1,2.784
+Summer 2022,SOCW,7391,2,13620,Field Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Summer 2022,INDE,6398,7,13633,Research,Lin PhD,Ying,0,0,0,0,0,1,0,
+Summer 2022,CHEE,6398,1,13640,Research,Karim,Alamgir,0,0,0,0,0,1,0,
+Summer 2022,CIS,3320,1,13642,Information Visualization,Lendasse,Amaury,17,4,4,0,1,0,2,3.296
+Summer 2022,INDE,8399,4,13654,Doctoral Dissertation,Feng,Qianmei,0,0,0,0,0,0,0,
+Summer 2022,ELCS,8312,2,13667,Lab of Practice-Res Meth Devel,Davis,Bradley,3,0,0,0,0,0,0,4.0
+Summer 2022,BUSI,4396,2,13668,Business Internship,Hopkins,Troy D,0,0,0,0,0,20,0,
 Summer 2022,GEOL,3360,4,13669,Field Geology II,Robinson,Alexander C,6,3,0,0,0,0,0,3.63
+Summer 2022,SPAN,4313,1,13672,Advanced Eng/Span Translation,Arboleda,Paola,6,7,2,0,0,0,1,3.245
+Summer 2022,PHLS,8199,1,13675,Dissertation,de Dios,Marcel A,0,0,0,0,0,2,0,
+Summer 2022,PHOP,6198,8,13692,Spec Prob-Physio Optics,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,8399,7,13694,Doctoral Dissertation,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,7399,1,13695,Masters Thesis,Khan,Shuhab D.,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6557,2,13700,Research Practicum B,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,1,13928,Selected Topics in Social Work,Lea III,Charles Herbert,11,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,2,13929,Selected Topics in Social Work,O'Neal,Vaughn,18,2,2,1,0,0,0,3.566
+Summer 2022,SOCW,7397,4,13930,Selected Topics in Social Work,Webb,Ann E,18,2,0,0,0,0,1,3.867
+Summer 2022,SOCW,7397,3,13931,Selected Topics in Social Work,Lucas,Virginia,24,2,0,0,0,0,0,3.91
+Summer 2022,LAW,5197,15,14191,Selected Topics,Lawrence,Jim E,0,0,0,0,0,3,0,
+Summer 2022,LAW,5197,17,14193,Selected Topics,Lawrence,Jim E,0,0,0,0,0,6,0,
+Summer 2022,LAW,5197,19,14195,Selected Topics,Lawrence,Jim E,0,0,0,0,0,3,0,
+Summer 2022,LAW,5197,21,14197,Selected Topics,Lawrence,Jim E,0,0,0,0,0,4,0,
+Summer 2022,CUIN,7347,1,14222,"Sem in Learning, Design & Tech",Jones,Chad M,15,0,0,0,0,0,1,3.934
+Summer 2022,CUIN,7356,2,14223,Issues in Distance Education,McNeil,Sara G,12,2,0,0,2,0,0,3.334
+Summer 2022,CUIN,7376,1,14225,New Tools Create Online Matls,McNeil,Sara G,12,2,0,0,2,0,0,3.334
+Summer 2022,CUIN,7356,3,14226,Issues in Distance Education,Dogan,Bulent,22,0,0,0,1,0,0,3.826
+Summer 2022,CUIN,7356,1,14227,Issues in Distance Education,Dogan,Bulent,23,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,7376,3,14228,New Tools Create Online Matls,Dogan,Bulent,33,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,7376,4,14229,New Tools Create Online Matls,Vyas,Anita,16,0,1,0,1,0,0,3.667
+Summer 2022,WCL,2352,1,14445,World Cinema,Centeno,Daniel,8,15,1,2,3,0,0,2.804
+Summer 2022,CUIN,6319,1,14463,Instr Design & Tech 2nd Lang,Leon,Maredil Josefina,11,3,0,0,0,0,0,3.691
+Summer 2022,CUIN,4332,5,14464,Literacy Assess Rdg Writing,Reis,Nancy,14,0,0,0,0,0,0,4.0
+Summer 2022,MANA,4385,1,14489,Intro to Strategic Management,Tabesh,Pooya,10,4,1,0,1,0,0,3.334
+Summer 2022,MANA,7343,1,14490,Intl Legal Environment of Mgmt,Abbott,Jeanna L,14,0,0,0,0,0,0,4.0
+Summer 2022,MIS,4397,1,14491,Selected Topics in MIS,Messinger,Jacob Nelson,12,0,0,0,0,0,1,3.863
+Summer 2022,MIS,7397,1,14492,Selected Topics in MIS,Campbell,Phillip James,11,3,0,0,0,0,0,3.809
+Summer 2022,MIS,7397,2,15309,Selected Topics in MIS,Messinger,Jacob Nelson,7,2,0,0,0,0,0,3.741
+Summer 2022,ACCT,2301,5,15310,Prin of Financial Accounting,Newman,Michael Ray,8,2,1,0,0,0,0,3.666
+Summer 2022,ACCT,2302,7,15311,Prin of Managerial Accounting,Newman,Michael Ray,11,6,0,0,0,0,1,3.666
+Summer 2022,ACCT,2302,8,15312,Prin of Managerial Accounting,Newman,Michael Ray,12,5,6,0,0,0,1,3.247
+Summer 2022,ACCT,3366,3,15313,Financial Reporting Frameworks,Parthasarathy,Kiran M,7,1,6,2,1,0,0,2.686
+Summer 2022,ACCT,3368,3,15318,Intermediate Accounting II,Sun,Xue,8,14,16,0,0,0,1,2.824
+Summer 2022,ACCT,3368,4,15319,Intermediate Accounting II,Sun,Xue,6,12,7,1,1,0,0,2.753
+Summer 2022,ACCT,5368,2,15320,Intermediate Accounting II,Sun,Xue,3,1,2,0,0,0,0,3.167
+Summer 2022,ACCT,3371,1,15321,Accounting Information Systems,Seijas,Nuria S,17,19,8,0,3,0,1,2.965
+Summer 2022,ACCT,5371,1,15322,Accounting Information Systems,Seijas,Nuria S,2,2,0,0,0,0,0,3.418
+Summer 2022,ACCT,4330,2,15325,Advanced Accounting,Ramaswamy,Vinita,1,0,0,0,0,0,0,4.0
+Summer 2022,ACCT,5330,2,15326,Advanced Accounting,Ramaswamy,Vinita,0,1,0,0,0,0,0,3.33
+Summer 2022,ACCT,7330,2,15327,Advanced Accounting,Ramaswamy,Vinita,7,2,0,0,0,0,0,3.851
+Summer 2022,ACCT,4335,5,15329,Financial Statement Auditing,Kuruvilla,Mohan,2,2,6,1,1,0,1,2.305
+Summer 2022,ACCT,5301,1,15331,Financial and Managerial Acct,Kuruvilla,Mohan,3,2,1,1,1,0,3,2.666
+Summer 2022,ACCT,5377,1,15332,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,4,4,0,1,0,0,1,3.186
+Summer 2022,CUIN,1103,11,15333,Educator Dispositions,Culpepper,Shea Mosley,3,0,0,0,0,0,1,3.89
+Summer 2022,ACCT,7364,1,15334,Transf Pricing: Theory & Pract,Mangano,Clifford A,16,3,1,0,0,0,0,3.734
+Summer 2022,BUSI,4305,1,15336,Business Ethics for Accountant,Newman,William Austin,1,1,0,0,0,0,0,3.665
+Summer 2022,GENB,5304,2,15337,Business Ethics for Accountant,Newman,William Austin,1,1,0,0,0,0,1,3.335
+Summer 2022,GENB,7304,2,15338,Bus Ethics for Accountants,Newman,William Austin,11,2,0,0,0,0,0,3.795
+Summer 2022,BUSI,4396,3,15339,Business Internship,Newman,Michael Ray,0,0,0,0,0,16,0,
+Summer 2022,GENB,5303,3,15340,Prof Acct Communication,Newman,Michael Ray,3,1,0,0,0,0,1,3.75
+Summer 2022,GENB,7303,3,15341,Prof Accounting Communication,Newman,Michael Ray,10,2,0,0,0,0,0,3.888
+Summer 2022,EDUC,3101,11,15349,Practicum for Preservice Tchrs,Thompson,Amber M,1,0,0,0,0,0,0,4.0
+Summer 2022,TLIM,3350,30,15355,Emergency Management Principle,Freedkin,Aaron Samuel,17,8,1,0,1,0,0,3.457
+Summer 2022,PHLS,8393,3,15420,Doctoral Practicum in Psy,Roche,Meghan K,0,0,0,0,0,2,0,
+Summer 2022,DIGM,3353,31,15422,Visual Communications Tech,Dozier,Devin K,19,9,4,1,1,0,0,3.216
+Summer 2022,MANA,4397,1,15423,Selected Topics in Mana,Im,Taehoon,13,7,1,0,1,0,0,3.364
+Summer 2022,FINA,4397,2,15426,Selected Topics in Finance,Stewart,Marcus,4,4,0,0,0,0,0,3.459
+Summer 2022,FINA,7397,1,15427,Selected Topics in Finance,Stewart,Marcus,5,5,0,0,0,0,0,3.5
+Summer 2022,ECON,2301,1,15429,Principles of Macroeconomics,Clarke,Christopher Arthur,7,23,16,6,12,0,2,2.104
+Summer 2022,AAS,6311,1,15431,Afr-Amer Soc & Phil Fndtns,Edwards,Crystal Latanya,5,1,1,0,0,0,0,3.336
+Summer 2022,SGNL,1301,2,15433,Elementary Sign Language I,Brittain,Terrell,2,3,1,2,0,0,0,2.378
+Summer 2022,AAS,2320,3,15437,Intro To African American Stdy,Boyce,Stephanie,27,2,1,0,2,0,2,3.646
+Summer 2022,HON,3397,1,15446,Honors Selected Topics,Galib,Christine,3,1,0,0,0,0,0,3.75
+Summer 2022,LAW,5297,1,15453,Selected Topics,Foteh,Samir Jabra,4,4,0,0,0,0,0,3.459
+Summer 2022,LAW,5341,1,15455,Disabilities and the Law,Roberts,Jessica,2,4,0,0,0,2,0,3.388
+Summer 2022,LAW,5397,1,15456,Selected Topics,Barks,Justen S,0,1,0,0,0,0,0,3.33
+Summer 2022,CNST,3265,1,15467,Construction Layout & Site Dvp,Lupher,Jacob John,17,11,1,0,0,0,0,3.495
+Summer 2022,CNST,4381,1,15469,Reinforced Conc & Bldg Codes,Elzafraney,Mohamed,10,0,0,0,0,0,0,3.835
+Summer 2022,MATH,1314,3,15471,College Algebra,Caputo,Matthew G,7,4,3,1,2,0,3,2.765
+Summer 2022,MATH,1332,1,15473,Elem Mathematical Modeling,Hafeez,Shahinda,4,9,3,2,3,0,5,2.413
+Summer 2022,MARK,4332,1,15474,Social Media Marketing,Noriega,Jaime L,27,13,4,4,0,0,3,3.278
+Summer 2022,CLAS,3345,1,15475,Myth&Performance in Greek Trag,Houlihan,James W,16,6,0,1,0,0,0,3.58
+Summer 2022,CLAS,3345,2,15476,Myth&Performance in Greek Trag,Houlihan,James W,14,8,0,0,0,0,0,3.651
+Summer 2022,MATH,2318,1,15477,Linear Algebra,Perepelitsa,Mikhail Antolyevic,8,4,3,2,0,0,1,3.078
+Summer 2022,SCLT,3375,30,15486,Maritime Operations,Chopra,Anuj,2,2,3,0,0,0,0,2.857
+Summer 2022,SCLT,4375,30,15489,Global Supply Chain,Velarde,Jose Manuel,18,6,12,0,3,0,0,2.872
+Summer 2022,ELCS,8330,2,15493,Statistical Analyses,Pettersson Cobb,Jennifer,1,7,2,0,0,0,0,2.834
+Summer 2022,SPEC,8301,1,15495,Professional Writing,Martens,Monica Lynn Curry,11,0,0,0,0,0,0,3.97
+Summer 2022,SPEC,6350,1,15496,Nature/Needs of Students w/GT,Hassett,Kristen Spring,2,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,5397,1,15497,Selected Topics,Kaushik,Krishna R,2,3,0,0,0,0,0,3.466
+Summer 2022,CHEE,6397,1,15498,Selected Topics,Kaushik,Krishna R,7,4,0,0,0,0,0,3.606
+Summer 2022,SCLT,4389,32,15499,Practicum in Supply Chain,Kidd,Margaret A,5,14,2,0,1,0,0,2.895
+Summer 2022,SCLT,4389,33,15500,Practicum in Supply Chain,Kidd,Margaret A,5,12,9,0,0,0,0,2.859
+Summer 2022,HRMA,2315,1,15505,Introduction to SPA Management,Doudna,Simone P,23,12,8,1,1,0,0,3.222
+Summer 2022,HRMA,3154,1,15506,Rest. Mrktg Chicago Style,Taylor Jr,Scott T,11,0,0,0,0,0,0,3.97
+Summer 2022,HRMA,3371,1,15507,Multicultrl Etiquette Hosp Ind,Kenyan,Erin Oeser,36,6,3,1,2,0,0,3.562
+Summer 2022,HRMA,4350,1,15508,Strategy&Innovation Hosp Ind,Morosan,Cristian,29,4,2,1,3,0,1,3.393
+Summer 2022,HRMA,4397,1,15509,Selected Topics Hosp Mgt,Legendre,Jungyoung Shin,16,3,2,1,0,0,0,3.53
+Summer 2022,HRMA,4462,1,15510,Practical Project Mgmt in Hosp,Ramirez,Arlene D,5,0,0,0,0,0,0,3.934
+Summer 2022,HRMA,6197,1,15511,Selected Topics,Padilla,Magdalena Manzano,6,0,0,0,0,0,0,4.0
+Summer 2022,COMM,4397,1,15512,Selected Topics Communication,Houk,Keith R,11,0,0,0,0,0,0,4.0
+Summer 2022,HRMA,6397,1,15514,Selected Topics,Legendre,Jungyoung Shin,18,0,0,0,0,0,0,3.982
+Summer 2022,COMM,4328,1,15515,Broadcast & Film Writing,Hamzah,Sahar Riyad,9,0,0,0,0,0,2,4.0
+Summer 2022,HRMA,7337,1,15516,Human Resources in Hospitality,Madera,Juan Manuel,8,0,0,0,0,0,0,4.0
+Summer 2022,COMM,4383,1,15517,Documentary Filmmaking,Hamzah,Sahar Riyad,10,2,0,0,0,0,0,3.833
+Summer 2022,HRMA,6397,2,15520,Selected Topics,Kenyan,Erin Oeser,11,1,0,0,0,0,0,3.944
+Summer 2022,PHLS,7327,1,15521,Counseling Children,Hurt,Kara Marie,10,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,7327,2,15522,Counseling Children,Hurt,Kara Marie,5,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,7301,1,15523,Practicum,Hurt,Kara Marie,0,0,0,0,0,10,1,
+Summer 2022,PHLS,7301,2,15524,Practicum,McCoy,Leah,0,0,0,0,0,7,0,
+Summer 2022,PHLS,7301,3,15525,Practicum,Smedley,Diane Renee,0,0,0,0,0,5,1,
+Summer 2022,PHLS,7301,4,15526,Practicum,Smedley,Diane Renee,0,0,0,0,0,10,1,
+Summer 2022,ENGI,2304,10,15527,Technical Communications,Salvo,Deborah C,23,1,0,0,0,0,0,3.917
+Summer 2022,ENGI,2304,11,15528,Technical Communications,Ellis,Kelly Ann,15,7,1,0,0,0,0,3.594
+Summer 2022,COMM,4357,1,15529,Intercultural Communication,Vaughn,Ginger Koto,16,3,0,0,0,0,1,3.877
+Summer 2022,ENGI,2304,12,15530,Technical Communications,Ellis,Kelly Ann,19,3,0,0,0,0,0,3.819
+Summer 2022,ENGI,2304,13,15531,Technical Communications,Ellis,Kelly Ann,19,3,0,0,0,0,0,3.849
+Summer 2022,ENGI,2304,14,15532,Technical Communications,Smith-Irving,Brandi,16,3,1,0,1,0,0,3.587
+Summer 2022,ENGI,2304,15,15533,Technical Communications,Smith-Irving,Brandi,15,1,3,0,1,0,0,3.401
+Summer 2022,ARCH,3397,1,15534,Selected Topics,Diehl,Tom,3,14,5,0,1,0,0,2.768
+Summer 2022,ARCH,6397,1,15536,Sel Tpcs-Arc/Urbn Desgn,Diehl,Tom,2,1,1,0,0,0,0,3.333
+Summer 2022,LAW,6321,1,15548,Professional Responsibility,Duncan,Meredith J,8,19,3,0,0,0,0,3.2
+Summer 2022,LAW,7397,1,15551,Selected Topics,Swift,Kenneth Richard,4,7,0,0,0,0,0,3.394
+Summer 2022,LAW,7397,2,15555,Selected Topics,Morath,Sarah,5,7,0,0,0,0,0,3.389
+Summer 2022,COMM,3311,2,15556,Editing Print & Digital Media,Crixell,Charles A,5,9,5,0,0,0,0,2.965
+Summer 2022,BIOL,3330,1,15557,Biological Field Research,Cheek,Ann Oliver,6,10,0,0,0,0,0,3.478
+Summer 2022,LAW,7397,3,15559,Selected Topics,Knake,Renee N,4,7,0,0,0,0,0,3.364
+Summer 2022,ACCT,4380,1,15562,Contro & Sec Intern Fin Inform,Kahl,Keith E,2,0,0,0,0,0,0,4.0
+Summer 2022,HIST,1377,50,15575,The U S To 1877,Erwing,Douglas A,13,0,0,0,0,0,0,3.949
+Summer 2022,HIST,1378,50,15576,The U S Since 1877,Higgins,Patrick Donovan,13,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8699,3,15584,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Summer 2022,CHEE,3369,1,15588,Chemical Engr Transport Proc,Zerze,Hasan,5,10,6,1,0,0,3,2.819
+Summer 2022,HDCS,4369,1,15589,Entrepreneurship,Hitchman Sr,Cal M,7,2,1,0,1,0,1,3.243
+Summer 2022,LAW,5297,2,15590,Selected Topics,Jones,Karen Lynn,1,2,0,0,0,1,0,3.333
+Summer 2022,LAW,7397,4,15591,Selected Topics,Warren,Gina S,2,4,0,0,0,0,0,3.388
+Summer 2022,SOCW,7306,1,15592,Building Financial Capacity,Powell,Torey Ian,14,3,0,0,0,0,0,3.862
+Summer 2022,SOCW,7340,2,15593,Clinical Practice with Child,Parks,Steven Lee,20,8,0,0,0,0,0,3.773
+Summer 2022,SOCW,7354,1,15594,Spirituality and Aging,Bajic,Miljana,22,1,0,0,0,0,0,3.87
+Summer 2022,MANA,7397,1,15595,Selected Topics in Management,Witt,Lawrence A,9,0,0,0,0,0,0,4.0
+Summer 2022,FINA,6335,1,15596,Managerial Finance,Wu,Guojun,15,0,0,0,0,0,0,4.0
+Summer 2022,GENB,7397,1,15597,Selected Topics,Miljanic,Andra Olivia,12,2,0,0,0,0,0,3.834
+Summer 2022,GENB,7397,2,15598,Selected Topics,Miljanic,Andra Olivia,8,1,0,0,0,0,0,3.889
+Summer 2022,INDE,3333,1,15601,Engineering Economy I,Wiggins,Nathanial David,18,1,0,0,0,0,2,3.93
+Summer 2022,ELCS,8312,3,15603,Lab of Practice-Res Meth Devel,Freelon,Rhoda,1,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8312,6,15606,Lab of Practice-Res Meth Devel,Lopez,Ruth Maria,1,1,0,0,0,0,0,3.5
+Summer 2022,INDE,4372,1,15610,Operation Control,Rypien,David V,7,0,0,0,0,0,0,4.0
+Summer 2022,INDE,6333,1,15611,Probability Stat For Engineers,Shahmoradi,Zahed,8,2,0,0,1,0,0,3.395
+Summer 2022,INDE,6332,1,15612,Egr Project Mgt,Rypien,David V,48,10,1,0,0,0,1,3.797
+Summer 2022,IEEM,6335,1,15614,Engr Mgmt of Organizations,Chang,Feng-Chang Roger,20,1,0,0,0,0,0,3.952
+Summer 2022,ELCS,6330,3,15615,Finance & School-Based Budgtng,Garcia-Velasquez,Erwin,12,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8355,2,15621,Policy Pol & Gov of Education,Davis,Tabitha Sundrell,10,0,0,0,0,0,0,4.0
+Summer 2022,EDRS,8382,2,15622,Statistical Analyses in Eductn,Davis,Bradley,4,2,0,1,0,0,0,3.191
+Summer 2022,ELCS,8361,1,15623,Public & Community Relations,Freelon,Rhoda,7,0,0,0,0,0,0,4.0
+Summer 2022,SOC,3312,3,15626,Sociology of Deviance,Colbert,Sharla Stettnisch,22,6,5,5,1,0,6,3.094
+Summer 2022,SOC,3390,1,15627,Sociology of Gender,Cooper,Chelsey Wells,16,3,1,0,0,0,1,3.75
+Summer 2022,SOC,3344,1,15628,Sociology of Aging,Davis,Mary A,24,9,7,1,1,0,3,3.27
+Summer 2022,SOC,3311,1,15629,Sociology of Law,Gallo,Joseph Ralph,26,11,12,0,1,0,0,3.22
+Summer 2022,RELS,1301,1,15630,Intro To Religious Studies,Langton,Karen J,12,0,0,0,0,0,0,4.0
+Summer 2022,RELS,1301,4,15633,Intro To Religious Studies,Mummert,Claire Elizabeth,5,1,0,0,0,0,0,3.778
+Summer 2022,BIOL,4340,1,15635,Research Methods,Ekeoba,Jacqueline Njideka,11,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,4340,1,15636,Research Methods,Ekeoba,Jacqueline Njideka,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEM,4340,1,15637,Research Methods,Ekeoba,Jacqueline Njideka,2,0,0,0,0,0,0,4.0
+Summer 2022,ARTS,1311,1,15638,Fundamentals of Graphic Design,Bootwala,Jennifer Elizabeth,1,8,1,1,2,0,1,2.41
+Summer 2022,ARTS,2311,1,15639,"Color, Materials and Methods",Bootwala,Jennifer Elizabeth,8,4,0,2,1,0,1,3.045
+Summer 2022,ARTS,3316,1,15643,Relief Printmaking,Nesbit,Tiffany Angel,13,0,0,0,0,0,0,3.949
+Summer 2022,ARTS,3384,1,15644,Sound Art,Meza,Abinadi,31,1,0,0,1,0,0,3.848
+Summer 2022,ARTS,6397,1,15645,Sel Topics/Studio Arts,Meza,Abinadi,4,0,0,0,0,0,0,4.0
+Summer 2022,KIN,4370,4,15653,Exercise Testing,Markofski,Melissa,11,17,3,3,1,0,2,2.877
+Summer 2022,KIN,3306,2,15658,Physiology-Human Performance,Breslin,Whitney L,12,21,7,2,2,0,1,2.826
+Summer 2022,NUTR,7313,1,15659,Urban Fitness,Alastuey,Lisa L,7,1,0,0,0,0,0,3.751
+Summer 2022,SOCW,7356,2,15660,Groups in Clinical Settings,Cheung,Poi Ten Ada,26,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,5,15661,Selected Topics in Social Work,Dettlaff,Alan J,12,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,6,15662,Selected Topics in Social Work,Dettlaff,Alan J,14,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,7,15663,Selected Topics in Social Work,Flores,Vanessa Marie,9,1,0,0,0,0,1,3.834
+Summer 2022,SOCW,7397,8,15664,Selected Topics in Social Work,Flores,Vanessa Marie,9,4,1,0,0,0,0,3.571
+Summer 2022,HLT,4307,2,15665,Research and Eval in Health,Haq,Arooba A,5,4,1,2,0,0,1,2.863
+Summer 2022,FINA,7397,3,15666,Selected Topics in Finance,Goudie,Thomas Lawrence,6,0,0,0,0,0,0,4.0
+Summer 2022,FORE,6397,1,15667,Selected Topics in Foresight,Sweeney,John Arthur,17,0,0,0,0,0,0,4.0
+Summer 2022,CIS,2332,1,15668,Info Tech Hdwr & Systems Sftwr,Peddoju,Suresh Kumar,19,0,0,0,0,0,0,3.965
+Summer 2022,MANA,7397,2,15669,Selected Topics in Management,Miljanic,Andra Olivia,4,1,0,0,0,0,0,3.8
+Summer 2022,CIS,2337,1,15671,Fund of Information Security,Shah,Ana,17,8,0,0,1,0,0,3.45
+Summer 2022,HRD,6355,30,15673,Designing OD Interventions,Hausmann,Robert Carl,7,0,0,0,0,0,0,3.953
+Summer 2022,PETR,6325,2,15677,Integrated Resrv Characterztn,Gonzalez,Reinaldo J,2,1,2,0,0,0,0,2.802
+Summer 2022,COSC,2436,201,15682,Programming and Data Structure,Rizk,Nouhad J,12,12,18,0,12,0,9,2.186
+Summer 2022,GEOL,6390,1,15708,3-D Seismic Exploration I,Marfurt,Kurt J,1,0,0,0,0,0,0,3.67
+Summer 2022,GEOL,7325,1,15709,Petrophysics & Formation Eval.,Myers,Michael Tolbert,1,2,0,0,0,0,0,3.443
+Summer 2022,GEOL,6393,1,15710,Seismic Amplitude Interpretatn,Hilterman,Fred,1,1,0,0,0,0,0,3.5
+Summer 2022,GERM,3398,1,16004,Independent Study,Kleinheider,Julia D,1,0,0,0,0,0,0,3.67
+Summer 2022,ACCT,5367,2,16012,Intermediate Accounting I,Kuruvilla,Mohan,0,1,1,0,0,0,0,2.665
+Summer 2022,CIS,6397,1,16014,Selected Topics,Conklin,William A,10,1,2,0,0,0,0,3.615
+Summer 2022,MUED,2342,2,16015,Music for Children,Bigwood,Cora Morgan,13,3,0,0,0,0,1,3.833
+Summer 2022,MUSI,2302,1,16016,Listening to Jazz,Marmolejo,Noe J,15,0,0,0,1,0,0,3.75
+Summer 2022,INDE,2333,2,16017,Engineering Statistics I,Wang,Yaping,34,52,18,1,1,0,0,3.129
+Summer 2022,HLT,3306,1,16018,Environmental Health,Proctor,Robin Ann,53,6,1,0,2,0,1,3.689
+Summer 2022,ACCT,5335,2,16019,Financial Statement Auditing,Kuruvilla,Mohan,0,1,1,0,0,0,0,2.665
+Summer 2022,ACCT,7390,1,16020,Contrl & Secur of Finan Inform,Kahl,Keith E,11,3,1,0,0,0,0,3.755
+Summer 2022,THEA,6297,1,16021,Selected Topics,Ferrarone,Jessica,13,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6297,2,16022,Selected Topics,Ferrarone,Jessica,12,0,0,0,0,0,0,4.0
+Summer 2022,THEA,6297,3,16023,Selected Topics,Ferrarone,Jessica,12,0,0,0,0,0,0,4.0
+Summer 2022,BTEC,1322,30,16025,Introduction to Biotechnology,Hosseinzadeh,Hemen,2,5,3,0,0,0,2,2.834
+Summer 2022,BTEC,4350,30,16029,Biotech Capstone Experience,Balan,Venkatesh,1,3,0,0,0,0,0,3.333
+Summer 2022,CIS,2348,2,16031,Info Systems Appl Development,Ratner,Edward,6,4,8,5,2,0,0,2.214
+Summer 2022,COSC,3360,301,16032,Operating Systems,Rincon Castro,Carlos Alberto,11,10,12,6,11,0,7,2.06
+Summer 2022,PHYS,2325,3,16033,University Physics I (lecture),Chen,Shuo,48,104,42,0,4,0,0,2.95
+Summer 2022,POLS,3316,1,16038,Stats for Political Scientists,Hanna,Tom Leard,14,1,2,0,0,0,0,3.648
+Summer 2022,FINA,4397,3,16047,Selected Topics in Finance,Kapatos,Nick Gus,6,2,0,0,1,0,0,3.37
+Summer 2022,NURS,4322,1,16048,Policy &Ethics in Prof Nursing,Quintana,Danielle,60,1,0,1,0,0,0,3.935
+Summer 2022,NURS,4297,1,16050,Special Topic in Nursing,Phan,Huong Thi,18,0,0,0,0,0,0,4.0
+Summer 2022,NURS,6316,1,16051,Healthcare Organizatn Behavior,Brohard,Cheryl L,2,0,0,0,0,0,1,4.0
+Summer 2022,NURS,6335,1,16052,Mgmt of Hlth Disrdrs in Adults,Dwyer,Carol Ann,6,2,0,0,0,0,0,3.75
+Summer 2022,NURS,6336,1,16053,Mgmt of Hlth Disordrs Clinical,Dwyer,Carol Ann,0,0,0,0,0,8,0,
+Summer 2022,NURS,8336,1,16054,Advanced Synthesis Practicum,Joseph,Beena Roby,0,0,0,0,0,6,0,
+Summer 2022,FINA,4323,1,16064,Investment & Mutual Fund Mgt,Blanchfield,Craig,34,11,6,0,1,0,0,3.487
+Summer 2022,NUTR,2332,4,16069,Intro To Human Nutrition,Hughes,Lindsay,15,10,12,1,1,0,1,2.932
+Summer 2022,CUIN,7331,5,16072,Supporting Striving Readers,Reis,Nancy,10,0,0,0,0,0,0,3.967
+Summer 2022,DRAM,1310,5,16073,Introduction to Theatre,Brincks,Alan,40,5,1,1,0,0,0,3.738
+Summer 2022,DRAM,1310,6,16074,Introduction to Theatre,Brincks,Alan,34,8,1,1,5,0,1,3.3
+Summer 2022,DRAM,1310,7,16075,Introduction to Theatre,Egging,Jon Leo,14,0,3,3,3,0,2,2.812
+Summer 2022,PHAR,5297,1,16085,Selected Topics in Pharmacy,Gee,Jodie Sue,26,15,2,0,0,0,0,3.558
+Summer 2022,POLS,3396,1,16086,Sel Topics Comp Internatl Pol,Kimondo,Gathoni Anne,18,3,3,0,0,0,2,3.598
+Summer 2022,BIOE,4313,1,16087,Intro to Neural Computation,Francis,Joseph Thachil,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,2301,1,16088,Introduction to Psychology,Zamanipour,Tina,53,4,1,0,0,0,0,3.897
+Summer 2022,BIOE,6306,1,16089,Adv Artificial Neural Networks,Francis,Joseph Thachil,5,0,1,0,0,0,0,3.612
+Summer 2022,PSYC,2301,2,16090,Introduction to Psychology,Weinstein,Andrew Philip,38,0,0,0,1,0,1,3.889
+Summer 2022,PSYC,2319,1,16092,Intro to Social Psychology,Shepherd,Justin M,26,10,3,0,0,0,0,3.59
+Summer 2022,PSYC,2319,5,16093,Intro to Social Psychology,Liu,Tingshu,41,12,4,0,2,0,0,3.52
+Summer 2022,PSYC,3301,3,16096,Intro Psych Stats,Godfrey,Donald Andrew,21,24,6,3,2,0,3,3.012
+Summer 2022,PSYC,3350,3,16098,Intro to Cognitive Psychology,Carlos,Brandon J,48,12,0,0,0,0,0,3.778
+Summer 2022,PSYC,4321,2,16100,Abnormal Psychology,Busch,Haley Conroy,44,7,2,1,1,0,4,3.673
+Summer 2022,PSYC,4321,4,16101,Abnormal Psychology,Lebeaut,Antoine M,41,6,5,0,2,0,1,3.501
+Summer 2022,PSYC,3331,1,16107,Psychology of Gender,Kehoe,Caitlin,23,18,9,2,5,0,0,2.953
+Summer 2022,ENGL,2307,1,16111,Intro To Drama,Presswood,Phillip Hilliard,20,1,0,1,0,0,2,3.818
+Summer 2022,ENGL,2315,2,16112,Literature and Film,Sicinski,Michael J,14,9,1,0,1,0,0,3.334
+Summer 2022,ENGL,4383,1,16113,Poetic Forms,Loan,Leisa Marie,7,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,4385,1,16114,Fiction Forms,Miller,Nicholas A,5,0,0,0,0,0,0,3.934
+Summer 2022,MARK,7399,1,16131,MS Marketing Prof Project,Koch,Steven F.,4,1,0,0,0,0,0,3.866
+Summer 2022,CUIN,7305,3,16135,"Design,Dev & Eval Presentation",Smith,Adrienne Linette,10,1,0,0,1,0,0,3.556
+Summer 2022,POLS,6312,1,16137,Institutions and Policy,Zhu,Ling,6,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8332,1,16138,Student Dev in Post Sec. Inst,Hall,Kayon,20,0,0,0,0,0,0,4.0
+Summer 2022,CIVE,4363,1,16139,Concrete Design,Belarbi,Abdeldjelil,1,7,5,0,1,0,2,2.618
+Summer 2022,CIVE,5397,1,16140,Selected Topics,Vipulanandan,Cumaraswamy,31,4,0,0,0,0,1,3.895
+Summer 2022,CIVE,5397,2,16141,Selected Topics,Norris,Debra B,1,2,1,0,0,0,0,2.835
+Summer 2022,CIVE,7397,1,16142,Selected Topics,Vipulanandan,Cumaraswamy,9,1,0,0,0,0,0,3.933
+Summer 2022,CIVE,7397,2,16143,Selected Topics,Norris,Debra B,6,2,0,0,1,0,0,3.223
+Summer 2022,SUBS,6397,1,16148,Selected Topics,Sun,Li,5,1,0,0,0,0,0,3.888
+Summer 2022,BIOE,4313,2,16150,Intro to Neural Computation,Francis,Joseph Thachil,3,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,6306,2,16151,Adv Artificial Neural Networks,Francis,Joseph Thachil,18,8,0,0,0,0,1,3.667
+Summer 2022,ECE,2100,1,16152,Circuit Analysis Laboratory,Ramachandran,Deepa,10,2,0,0,0,0,0,3.861
+Summer 2022,MECE,3369,1,16153,Solid Mechanics,Wang,Jiawen,5,4,6,1,0,0,0,2.648
+Summer 2022,PUBL,6343,1,16158,GIS for Urban Applications,Yuasa,Toshiyuki,1,1,0,0,0,0,0,3.5
+Summer 2022,PHED,1306,1,16161,Emergency Care & First Aid,Brown,Korey J,14,4,0,0,1,0,0,3.579
+Summer 2022,MECE,2361,1,16166,Intro Mechanical Design,Chang,Christiana,0,19,19,2,0,0,0,2.499
+Summer 2022,MECE,2361,2,16168,Intro Mechanical Design,Chang,Christiana,3,1,0,0,0,0,0,3.833
+Summer 2022,COMD,4489,1,16171,Clinical Procedures,Cizek,Laura S,13,2,0,0,0,0,1,3.823
+Summer 2022,ENGL,7399,1,16174,Essay,Mazella,David S,1,0,0,0,0,0,0,4.0
+Summer 2022,MANA,7397,3,16175,Selected Topics in Management,Vera,Dusya M,19,0,0,0,0,0,0,4.0
+Summer 2022,MATH,1351,3,16179,Introduction to Math Reasoning,Douglas,Casey,32,32,12,24,28,0,6,2.063
+Summer 2022,CNST,6399,1,16181,Thesis,Din,Zia Ud,0,0,0,0,0,0,0,
+Summer 2022,POLS,4198,1,16192,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,
+Summer 2022,POLS,4298,1,16193,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,
+Summer 2022,COSC,4351,201,16194,Fundamentals of Software Engr,Hilford,Victoria,14,5,2,0,0,0,0,3.524
+Summer 2022,INDE,2333,3,16197,Engineering Statistics I,Wiggins,Nathanial David,15,7,2,0,0,0,1,3.487
+Summer 2022,NUTR,4351,1,16199,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,25,14,10,1,3,0,2,2.951
+Summer 2022,MIS,7397,3,16200,Selected Topics in MIS,Campbell,Phillip James,2,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,2125,2,16202,University Physics Lab I,Maric,Sladjana,2,55,8,2,2,0,0,2.663
+Summer 2022,POLS,4498,1,16203,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,
+Summer 2022,POLS,4598,1,16204,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,
+Summer 2022,PHAR,5675,6,16220,Disease State Management,Rosario,Natalie,2,0,0,0,1,0,0,2.667
+Summer 2022,ELCS,8695,2,16230,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,2,0,
+Summer 2022,ELCS,8695,5,16233,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,
+Summer 2022,ELCS,8695,8,16236,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4.0
+Summer 2022,HON,3397,3,16239,Honors Selected Topics,Myrick,Keri D,5,0,0,0,0,0,0,3.934
+Summer 2022,HON,3397,4,16240,Honors Selected Topics,Barnes,Michael,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,8399,18,16247,Doctoral Dissertation,Cirino,Patrick C,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8399,19,16248,Doctoral Dissertation,Bollini,Praveen P,3,0,0,0,0,0,0,4.0
+Summer 2022,OPTO,5198,1,16249,Spec Prob Phys Optics,Piccolo,Marcus G,0,0,0,0,0,9,0,
+Summer 2022,OPTO,5198,2,16250,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,1,0,
+Summer 2022,OPTO,5198,3,16251,Spec Prob Phys Optics,Patel,Ryan,0,0,0,0,0,1,0,
+Summer 2022,OPTO,5298,1,16252,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,10,0,
+Summer 2022,OPTO,5298,2,16254,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,9,0,
+Summer 2022,OPTO,6230,1,16255,Contact Lens Pathology,Bergmanson,Jan Pg,0,0,0,0,0,19,0,
+Summer 2022,OPTO,6274,1,16256,Spec Contact Lens Workshops,Dempsey,Robert L.,0,0,0,0,0,20,0,
+Summer 2022,OPTO,6250,1,16257,Decision Making:Optometrc Prac,Dempsey,Robert L.,0,0,0,0,0,14,0,
+Summer 2022,OPTO,6254,1,16258,Optom & Special Needs Children,Dempsey,Robert L.,0,0,0,0,0,29,0,
+Summer 2022,CHEE,8399,21,16266,Doctoral Dissertation,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Summer 2022,IDNS,2197,2,16267,Top-Natrl Sci & Mth,Pattison,Donna,0,0,0,0,0,42,0,
+Summer 2022,PETR,6397,1,16268,Selected Topics,Mohamed,Mohamed Ibrahim,13,1,1,0,0,0,0,3.712
+Summer 2022,CHEE,8398,16,16269,Doctoral Research,Zerze,Gul,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,17,16270,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8398,20,16273,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,
+Summer 2022,CHEE,8398,21,16274,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Summer 2022,PSYC,3331,2,16275,Psychology of Gender,Mayorga,Nubia Angelina,40,10,0,2,2,0,2,3.604
+Summer 2022,COSC,3320,202,16277,Algorithms and Data Structures,Leiss,Ernst L,11,16,6,3,2,0,8,2.781
+Summer 2022,PHOP,8599,1,16278,Doctoral Dissertation,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,8399,1,16282,Doctoral Dissertation,Khan,Shuhab D.,1,0,0,0,0,0,0,4.0
+Summer 2022,COMM,7397,1,16285,Selected Topics - Comm,Ashley,Laura B,3,0,0,0,0,0,0,4.0
+Summer 2022,MATH,1300,1,16286,Fundamentals of Mathematics,Chang,James A,0,0,0,0,0,8,0,
+Summer 2022,CHEE,8298,7,16288,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8298,8,16289,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8298,10,16291,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,
+Summer 2022,CHEE,8298,11,16292,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8298,12,16293,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8298,14,16295,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8298,15,16296,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,
+Summer 2022,CHEE,8298,16,16297,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,
+Summer 2022,CHEE,8298,17,16298,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8298,18,16299,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8298,19,16300,Doctoral Research,Vekilov,Peter,0,0,0,0,0,0,0,
+Summer 2022,CHEE,8298,21,16302,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8498,7,16304,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8498,8,16305,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8498,10,16307,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,
+Summer 2022,CHEE,8498,11,16308,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8498,14,16311,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8498,15,16312,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,3,0,
+Summer 2022,CHEE,8498,16,16313,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,
+Summer 2022,CHEE,8498,17,16314,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2022,CHEE,8498,18,16315,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Summer 2022,CHEE,8498,19,16316,Doctoral Research,Vekilov,Peter,0,0,0,0,0,0,0,
+Summer 2022,CHEE,8498,21,16318,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Summer 2022,ELCS,8395,1,16319,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,5,0,
+Summer 2022,MANA,4341,1,16320,Leading Organizational Change,Im,Taehoon,20,12,1,0,0,0,0,3.566
+Summer 2022,GEOL,8399,2,16323,Doctoral Dissertation,Wang,Yuxuan,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,8698,2,16330,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2022,HIST,3394,1,16331,Sel Tops-Us History,Young,Nancy Beck,22,4,1,0,2,0,1,3.483
+Summer 2022,BIOL,6698,1,16334,Special Problems,Chung,Sanghyuk,0,0,0,0,0,9,0,
+Summer 2022,BIOL,6698,2,16335,Special Problems,Zufall,Rebecca A,0,0,0,0,0,2,0,
+Summer 2022,BCHS,8399,3,16338,Doctoral Dissertation,Widger,William R,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6257,11,16339,Research Practicum B,Rump,Rachel,3,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,7399,6,16340,Masters Thesis,Bergmanson,Jan Pg,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,8698,2,16341,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,2,0,
+Summer 2022,PHLS,8399,1,16342,Doctoral Dissertation,Correa-Fernandez,Virmarie,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8699,2,16343,Doctoral Dissertation,Correa-Fernandez,Virmarie,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,8698,3,16344,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,
+Summer 2022,BIOL,4397,1,16345,Selected Topics in Biology,Scott,Sean-Patrick,9,0,0,0,0,0,0,3.817
+Summer 2022,CIVE,8198,2,16353,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,3,16354,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,4,16355,Doctoral Research,Shaffer,Devin,0,0,0,0,0,5,0,
+Summer 2022,CIVE,8598,2,16356,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Summer 2022,ELET,2300,1,16357,Introductn To C++ Programming,Montero Hernandez,Samuel Antonio,13,15,10,5,9,0,3,2.353
+Summer 2022,CIVE,8598,3,16358,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Summer 2022,GEOL,8399,3,16359,Doctoral Dissertation,Wang,Guoquan,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,4,16360,Doctoral Research,Shaffer,Devin,0,0,0,0,0,5,0,
+Summer 2022,GEOL,8698,4,16361,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Summer 2022,BCHS,4397,1,16363,Topics-Biochem & Biophys Sci,Scott,Sean-Patrick,5,0,0,0,0,0,0,3.868
+Summer 2022,CIVE,8198,5,16365,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,7,16367,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Summer 2022,CIVE,8198,8,16368,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Summer 2022,CIVE,8198,9,16369,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,4,0,
+Summer 2022,CIVE,8198,10,16370,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,11,16371,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,
+Summer 2022,CIVE,8198,12,16372,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,
+Summer 2022,CIVE,8198,13,16373,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,14,16374,Doctoral Research,Momen,Mostafa,0,0,0,0,0,5,0,
+Summer 2022,CIVE,8198,15,16375,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8198,16,16376,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,2,0,
+Summer 2022,CIVE,8198,19,16379,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,6,16382,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,7,16383,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,8,16384,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Summer 2022,CIVE,8598,9,16385,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Summer 2022,CIVE,8598,10,16386,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,4,0,
+Summer 2022,CIVE,8598,11,16387,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,12,16388,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,
+Summer 2022,CIVE,8598,13,16389,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,
+Summer 2022,CIVE,8598,14,16390,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,15,16391,Doctoral Research,Momen,Mostafa,0,0,0,0,0,5,0,
+Summer 2022,CIVE,8598,16,16392,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Summer 2022,CIVE,8598,17,16393,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,2,0,
+Summer 2022,CIVE,8598,19,16395,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6557,3,16398,Research Practicum B,Twa,Michael D,1,0,0,0,0,0,0,3.67
+Summer 2022,PHOP,6557,4,16400,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,4398,1,16401,Independent Study,Zvolensky,Michael J,3,0,0,0,0,0,0,4.0
+Summer 2022,MARK,6A98,1,16402,Research,Habel,Johannes,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8398,3,16403,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8398,5,16405,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,5,0,
+Summer 2022,BIOE,8398,6,16406,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8398,7,16407,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8398,9,16409,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8398,10,16410,Doctoral Research,Larin,Kirill,0,0,0,0,0,8,0,
+Summer 2022,BIOE,8398,11,16411,Doctoral Research,Majd,Sheereen,0,0,0,0,0,3,0,
+Summer 2022,BIOE,8398,13,16413,Doctoral Research,Roh,Jinsook,0,0,0,0,0,3,0,
+Summer 2022,BIOE,8398,14,16414,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,6,0,
+Summer 2022,BIOE,8398,16,16416,Doctoral Research,Wu,Tianfu,0,0,0,0,0,3,0,
+Summer 2022,BIOE,8398,17,16417,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,3,0,
+Summer 2022,BIOE,8398,18,16418,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8398,19,16419,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6457,3,16422,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8699,1,16425,Doctoral Dissertation,Mohan,Chandra,2,0,0,0,0,0,0,4.0
+Summer 2022,CIVE,8198,21,16428,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8399,5,16430,Doctoral Dissertation,Francis,Joseph Thachil,1,0,0,0,0,0,0,4.0
+Summer 2022,CIVE,8598,21,16432,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8399,9,16435,Doctoral Dissertation,Majd,Sheereen,1,0,0,0,0,1,0,4.0
+Summer 2022,BIOE,8399,11,16437,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8399,12,16438,Doctoral Dissertation,Romero Ortega,Mario Ignacio,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8399,14,16440,Doctoral Dissertation,Wu,Tianfu,3,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,6698,4,16442,Special Problems,Mohan,Chandra,0,0,0,0,0,2,0,
+Summer 2022,BCHS,6698,1,16444,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Summer 2022,PHCA,8698,1,16445,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Summer 2022,PCOL,8698,1,16446,Doctoral Research,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,1,16447,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8298,2,16448,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8198,1,16449,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8198,2,16450,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Summer 2022,PHCA,8398,1,16452,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,7399,2,16453,Masters Thesis,Casey,John F,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8198,3,16454,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,4,0,
+Summer 2022,BIOE,8198,4,16455,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,3,16456,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,4,16457,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,4,0,
+Summer 2022,PCOL,6498,1,16459,Special Problems,Zhang,Ruiwen,0,0,0,0,0,0,0,
+Summer 2022,PCOL,6298,1,16460,Special Problems,Zhang,Ruiwen,0,0,0,0,0,0,0,
+Summer 2022,ECON,8391,1,16461,PhD Internship,Yi,Kei-Mu,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8399,2,16463,Doctoral Dissertation,Lin,Chin-Yo,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,6698,5,16464,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,2,16465,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Summer 2022,PSYC,3339,3,16468,Intro To Clinical Psychology,Li,Xinge,11,10,6,3,1,0,3,2.871
+Summer 2022,BIOL,6698,6,16471,Special Problems,Graur,Dan,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8399,16,16472,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8398,22,16473,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2022,COSC,8399,124,16475,Doctoral Dissertation,Shah,Shishir,1,0,0,0,0,0,0,4.0
+Summer 2022,PHCA,8698,2,16476,Doctoral Dissertation Research,Aparasu,Rajender R,0,0,0,0,0,2,0,
+Summer 2022,PHCA,6398,1,16477,Special Problems,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Summer 2022,MECE,8399,19,16478,Doctoral Dissertation,Selvamanickam,Venkat,1,0,0,0,0,0,0,4.0
+Summer 2022,ARTS,4398,2,16482,Independent Study,Parazette,Aaron,7,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8198,5,16483,Doctoral Research,Larin,Kirill,0,0,0,0,0,6,0,
+Summer 2022,BIOE,8298,5,16484,Doctoral Research,Larin,Kirill,0,0,0,0,0,5,0,
+Summer 2022,BIOE,8298,6,16485,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8198,6,16486,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,
+Summer 2022,OPTO,7495,1,16487,General Clinic IIIc,Herring,Ralph Jay,0,0,0,0,0,2,0,
+Summer 2022,CIVE,8399,2,16488,Doctoral Dissertation,Louie,Stacey M,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8398,23,16489,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2022,BIOL,7399,1,16492,Masters Thesis,Pennings,Steven C,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8198,7,16493,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,5,0,
+Summer 2022,BIOE,8298,7,16494,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,5,0,
+Summer 2022,BIOE,8699,2,16496,Doctoral Dissertation,May,Elebeoba E,1,0,0,0,0,0,0,4.0
+Summer 2022,PCOL,6298,2,16497,Special Problems,Ruan,Ke-He,0,0,0,0,0,1,0,
+Summer 2022,PCOL,6498,2,16498,Special Problems,Ruan,Ke-He,0,0,0,0,0,1,0,
+Summer 2022,PETR,8398,5,16502,Doctoral Research,Hathon,Lori A,0,0,0,0,0,1,0,
+Summer 2022,PETR,8398,8,16505,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,3,0,
+Summer 2022,PETR,8398,9,16506,Doctoral Research,Qin,Guan,0,0,0,0,0,1,0,
+Summer 2022,PETR,8398,10,16507,Doctoral Research,Wong,George K,0,0,0,0,0,4,0,
+Summer 2022,PETR,8598,1,16509,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Summer 2022,PETR,8598,2,16510,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,2,0,
+Summer 2022,PETR,8598,3,16511,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Summer 2022,COMD,6398,1,16515,Special Problems,Blake,Margaret T,1,0,0,0,0,0,0,4.0
+Summer 2022,MECE,8398,26,16517,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Summer 2022,HIST,1378,6,16518,The U S Since 1877,Ide,Derek Alan,56,55,31,17,14,0,17,2.677
+Summer 2022,MANA,8399,2,16519,Doctoral Dissertation,Vera,Dusya M,1,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,8398,1,16524,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Summer 2022,COMM,4398,1,16525,Independent Study,Radcliffe Andre,Jennifer,1,0,0,0,0,0,0,4.0
+Summer 2022,OPTO,5250,1,16526,Seminar Scientific Investigatn,Frishman,Laura J,12,0,0,0,0,0,0,4.0
+Summer 2022,BIOE,8198,8,16528,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8298,8,16529,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8298,9,16530,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8198,9,16531,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,2,0,
+Summer 2022,PHLS,8199,2,16532,Dissertation,Obasi,Ezemenari M,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,1,16536,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,2,16537,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,2,0,
+Summer 2022,MECE,8298,1,16538,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,2,16539,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,2,0,
+Summer 2022,MECE,8699,2,16541,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,3,16542,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,3,16543,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,
+Summer 2022,MARK,8399,2,16544,Doctoral Dissertation,Tirunillai,Seshadri N,1,0,0,0,0,0,0,4.0
+Summer 2022,MECE,8398,27,16546,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,4,16548,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,4,16549,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6359,6,16550,Directed Rsch in Clinical Psyc,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4.0
+Summer 2022,MARK,7399,2,16551,MS Marketing Prof Project,Koch,Steven F.,0,1,0,0,0,0,0,3.0
+Summer 2022,MECE,8398,28,16552,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Summer 2022,MECE,8399,20,16553,Doctoral Dissertation,Ghasemi,Hadi,1,0,0,0,0,1,0,4.0
+Summer 2022,MECE,8298,5,16554,Doctoral Research,Zhao,Bo,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,5,16555,Doctoral Research,Zhao,Bo,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,6,16556,Doctoral Research,Cescon,Marzia,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,6,16557,Doctoral Research,Cescon,Marzia,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,7,16558,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,3,0,
+Summer 2022,MECE,8298,7,16559,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,3,0,
+Summer 2022,MECE,8198,1,16560,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,
+Summer 2022,MECE,8398,29,16561,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,3,16562,Doctoral Research,Lekven,Arne,0,0,0,0,0,4,0,
+Summer 2022,MECE,8598,1,16563,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,
+Summer 2022,BIOL,8399,3,16565,Doctoral Dissertation,Azevedo,Ricardo,2,0,0,0,0,0,0,3.835
+Summer 2022,MECE,8699,3,16566,Doctoral Dissertation,Selvamanickam,Venkat,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,9,16570,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,0,0,
+Summer 2022,MECE,8398,24,16571,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,
+Summer 2022,MECE,8498,9,16572,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,0,0,
+Summer 2022,MECE,8399,22,16573,Doctoral Dissertation,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,
+Summer 2022,MECE,8298,10,16575,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,
+Summer 2022,MECE,8498,10,16576,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,
+Summer 2022,GEOL,8698,5,16577,Doctoral Research,Sun,Jiajia,0,0,0,0,0,3,0,
+Summer 2022,PETR,8398,11,16578,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,3,0,
+Summer 2022,BCHS,6698,2,16582,Special Problems,Lekven,Arne,0,0,0,0,0,1,0,
+Summer 2022,PETR,8598,6,16585,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Summer 2022,PETR,8598,8,16587,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Summer 2022,PETR,8198,1,16591,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Summer 2022,PETR,8198,2,16592,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,2,0,
+Summer 2022,MECE,8399,23,16594,Doctoral Dissertation,Ryou,Jae-Hyun,1,0,0,0,0,0,0,4.0
+Summer 2022,PETR,8198,5,16598,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Summer 2022,PETR,8198,7,16600,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Summer 2022,PETR,8198,8,16601,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Summer 2022,PETR,8198,9,16602,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Summer 2022,PETR,8198,10,16603,Doctoral Research,Wong,George K,0,0,0,0,0,2,0,
+Summer 2022,PETR,8198,11,16604,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Summer 2022,PETR,8598,10,16606,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Summer 2022,PETR,8598,11,16607,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Summer 2022,PETR,8598,12,16608,Doctoral Research,Wong,George K,0,0,0,0,0,2,0,
 Summer 2022,DRAM,1310,8,16611,Introduction to Theatre,Hinkel,Heidi Anne,22,16,6,6,3,0,0,2.881
 Summer 2022,DRAM,1310,9,16612,Introduction to Theatre,Hinkel,Heidi Anne,27,17,2,4,4,0,0,3.044
-Summer 2022,POLS,3356,1,12639,Intro-Constitutionl Law,Abbott Jr,Kenneth Wayne,13,4,2,0,0,0,0,3.457
-Summer 2022,CHEE,8398,6,10934,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,0
-Summer 2022,COMD,7391,16,13270,Clinic in Speech Lang Disorder,Cizek,Laura S,2,0,0,0,0,0,0,3.835
-Summer 2022,OPTO,7493,1,11095,General Clinic IIIA,Dempsey,Robert L.,0,0,0,0,0,85,0,0
-Summer 2022,CIVE,8598,19,16395,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,2319,5,16093,Intro to Social Psychology,Liu,Tingshu,41,12,4,0,2,0,0,3.52
-Summer 2022,BIOL,4398,1,17422,Independent Study,Ogletree-Hughes,Monique L,1,0,0,0,0,0,0,4
-Summer 2022,WGSS,2350,6,13511,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,13,1,1,0,0,0,1,3.778
-Summer 2022,KIN,4370,1,12874,Exercise Testing,Markofski,Melissa,4,10,7,0,0,0,0,2.889
-Summer 2022,ACCT,5331,2,12663,Federal Income Tax-Individual,Fernandez,Ramon,2,2,0,1,0,0,0,3
-Summer 2022,RELS,1301,1,15630,Intro To Religious Studies,Langton,Karen J,12,0,0,0,0,0,0,4
-Summer 2022,CHEE,8298,15,16296,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,0
-Summer 2022,ECE,8198,9,17118,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,5,16763,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,0
-Summer 2022,COMM,2356,1,12842,Business & Professional Comm,Salisbury,Shelby,32,17,7,1,6,0,2,3.027
-Summer 2022,AAS,2330,1,13516,Black Liberation Theology,Mitchell,Joshua,14,5,3,0,0,0,1,3.44
-Summer 2022,SPAN,3307,1,12601,Public Speaking in Spanish,Aguilar,Jacqueline,18,0,0,1,1,0,0,3.667
-Summer 2022,ACCT,5367,1,10877,Intermediate Accounting I,Kuruvilla,Mohan,2,1,1,0,0,0,1,3.25
-Summer 2022,LAW,6347,1,12950,Secured Financing,Dole,Richard F,0,2,1,0,0,7,0,0.866
-Summer 2022,LAW,5602,1,11992,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,4,0,0
-Summer 2022,PHLS,8357,1,12202,Clinical Interventions,de Dios,Marcel A,4,0,0,0,0,0,0,3.918
-Summer 2022,BCHS,6498,2,17209,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8198,7,16493,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,5,0,0
-Summer 2022,ECE,6198,4,16936,Research,Pan,Miao,0,0,0,0,0,1,0,0
-Summer 2022,PCOL,6498,2,16498,Special Problems,Ruan,Ke-He,0,0,0,0,0,1,0,0
-Summer 2022,PHAR,5663,1,11334,Pharmacy Management,Tolleson,Shane Russell,4,0,0,0,0,0,0,4
-Summer 2022,PHAR,5297,2,17026,Selected Topics in Pharmacy,Garey,Kevin W,2,0,0,0,0,0,0,4
-Summer 2022,CHEE,8398,17,16270,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,1,0,0
-Summer 2022,ECON,8699,3,10065,Doctoral Dissertation,Liu,Elaine Meichen,1,0,0,0,0,0,0,4
-Summer 2022,ARTS,2356,2,12955,Fundamentals of Photo/DM,Hillerbrand,Stephan C,16,0,0,0,0,0,1,4
-Summer 2022,PETR,8198,10,16603,Doctoral Research,Wong,George K,0,0,0,0,0,2,0,0
-Summer 2022,COSC,3337,201,13049,Data Science I,Rizk,Nouhad J,7,21,8,2,1,0,0,2.769
-Summer 2022,IART,6070,2,16183,Interdisciplinary Fieldwork,Calderon,Daniel,0,0,0,0,0,8,0,0
-Summer 2022,LAW,5228,2,12157,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,7,16772,Doctoral Research,Feng,Qin,0,0,0,0,0,2,0,0
-Summer 2022,CHEE,8399,10,10950,Doctoral Dissertation,Mountziaris,Triantafillos John,1,0,0,0,0,0,0,4
-Summer 2022,LAW,5600,1,12127,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,1,0,0
-Summer 2022,MANA,4396,2,16790,Management Internship,Carlin,Barbara A,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1102,6,13166,College Physics II (lab),Wood,Lowell T,2,13,3,1,1,0,0,2.684
-Summer 2022,INDE,7390,1,12399,Supply Chain Management,Keedy,Elias,10,15,2,0,0,0,0,3.357
-Summer 2022,LAW,5183,1,11250,Mediation Process,Willis,Tasha L,1,1,0,0,0,0,0,3.5
-Summer 2022,SOCW,7303,1,12361,Child Abuse and Neglect,Berger Cardoso,Jodi A,15,3,1,0,3,0,0,3.197
-Summer 2022,LAW,5514,1,11980,Judicial Externship I,Archer,Anna M,0,0,0,0,0,2,0,0
-Summer 2022,IART,6070,1,15646,Interdisciplinary Fieldwork,Meza,Abinadi,0,0,0,0,0,4,0,0
-Summer 2022,PHYS,8399,19,10341,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8399,3,12330,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,0
-Summer 2022,BUSI,2305,1,13468,Business Statistics,Wiley,Briceon C,21,30,47,24,13,0,26,2.153
-Summer 2022,HDFS,3300,2,12630,Educational Psychology,Conston,Toya,36,9,3,2,0,0,0,3.56
-Summer 2022,LAW,5514,1,11980,Judicial Externship I,Powers,William,0,0,0,0,0,2,0,0
-Summer 2022,TLIM,3363,34,12924,Technical Communications,Piercy,Penelope Junker,20,8,0,0,3,0,0,3.28
-Summer 2022,CHEE,8498,1,10956,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,8698,9,17066,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8399,7,10947,Doctoral Dissertation,Palmer,Jeremy,3,0,0,0,0,0,0,4
-Summer 2022,PSYC,8399,24,17388,Doctoral Dissertation,Ng,Vincent,0,0,0,0,0,1,0,0
-Summer 2022,SOCI,1301,3,12968,Introduction To Sociology,Nelson,Steven M,22,10,6,3,3,0,5,3.023
-Summer 2022,ECE,8399,3,16663,Doctoral Dissertation,Shih,Wei-Chuan,1,0,0,0,0,1,0,2
-Summer 2022,COMD,7391,17,13271,Clinic in Speech Lang Disorder,Ross,Byron L,2,0,0,0,0,0,0,4
-Summer 2022,BIOE,8398,22,16473,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6157,7,16653,Research Practicum B,Rump,Rachel,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8498,15,16312,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,3,0,0
-Summer 2022,SOCW,7389,1,11155,Field Practicum IV Macro,Parker,Jamie Lynne,0,0,0,0,0,10,0,0
-Summer 2022,BTEC,4350,30,16029,Biotech Capstone Experience,Balan,Venkatesh,1,3,0,0,0,0,0,3.333
-Summer 2022,BIOL,4397,1,16345,Selected Topics in Biology,Scott,Sean-Patrick,9,0,0,0,0,0,0,3.817
-Summer 2022,ENGL,8399,3,13184,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,8698,2,10706,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,6698,8,16780,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5283,1,11249,Mediation Externship,Willis,Tasha L,0,0,0,0,0,2,0,0
-Summer 2022,OPTO,6250,1,16257,Decision Making:Optometrc Prac,Dempsey,Robert L.,0,0,0,0,0,14,0,0
-Summer 2022,PHAR,5690,1,11121,Internal Medicine,Truong,Mabel,25,5,0,0,0,0,0,3.833
-Summer 2022,ECE,8198,3,10978,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,0
-Summer 2022,MECE,3336,1,13062,Mechanics II,Wang,Jiawen,6,8,10,4,0,0,5,2.513
-Summer 2022,MIS,4396,1,17359,MIS Internship,Johnson,Norman A.,0,0,0,0,0,3,0,0
-Summer 2022,PSYC,8399,17,12578,Doctoral Dissertation,Gallagher,Matthew Ward,1,0,0,0,0,2,0,1.333
-Summer 2022,PHLS,7301,4,15526,Practicum,Smedley,Diane,0,0,0,0,0,10,1,0
-Summer 2022,PUBL,6343,1,16158,GIS for Urban Applications,Yuasa,Toshiyuki,1,1,0,0,0,0,0,3.5
-Summer 2022,PSYC,6399,6,17389,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,9,16570,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,0,0,0
-Summer 2022,MATH,3325,1,12123,Transition to Advanced Math,Leger,Nicholas M,8,2,4,1,2,0,0,2.784
-Summer 2022,CNST,3355,1,12626,Strength of Construction Mtrls,Senouci,Ahmed,12,5,12,2,1,0,0,2.781
-Summer 2022,SOCW,7397,8,15664,Selected Topics in Social Work,Ruiz,Ashley Brown,9,4,1,0,0,0,0,3.571
-Summer 2022,CNST,4302,1,12628,Construction Law and Ethics,Ducran,Denis George,2,7,3,0,0,0,0,2.862
-Summer 2022,CHEE,8498,21,16318,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,8699,2,16343,Doctoral Dissertation,Correa-Fernandez,Virmarie,1,0,0,0,0,0,0,4
-Summer 2022,ENGL,7399,2,16765,Essay,Lee,Eunjeong,1,0,0,0,0,0,0,4
-Summer 2022,MATH,2414,1,11062,Calculus II,Xhabli,Blerina,31,15,13,4,23,0,10,2.295
-Summer 2022,ECE,3355,1,11907,Electronics,Ruchhoeft,Paul,6,3,2,4,0,0,0,2.755
-Summer 2022,KIN,3306,2,11605,Physiology-Human Performance,Park,Yoonjung,5,9,7,8,4,0,4,2.101
-Summer 2022,SOCW,7371,2,12895,Trauma & SW,Olson,Lindamarie E,28,0,0,0,0,0,0,3.976
-Summer 2022,LAW,5328,2,11593,Judicial Externship I,Powers,William,0,0,0,0,0,4,0,0
-Summer 2022,ECE,8498,16,16814,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,0
-Summer 2022,KIN,4315,1,12873,Motor Learning and Control,Layne,Charles S,4,39,30,3,1,0,0,2.507
-Summer 2022,CHEE,8498,2,10957,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,0
-Summer 2022,PHOP,8498,5,17207,Doctoral Research,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4
-Summer 2022,SPAN,2311,4,13219,Intermediate Spanish I,Benalcazar Astudillo,Diana Salome,10,5,3,0,1,0,1,3.106
-Summer 2022,MANA,7354,1,13488,Cultrl Issues in Global Mgt,Sebastijanovic,Marina,30,6,0,0,0,0,0,3.843
-Summer 2022,PSYC,3339,3,16468,Intro To Clinical Psychology,Li,Xinge,11,10,6,3,1,0,3,2.871
-Summer 2022,PHLS,6335,1,13561,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,10,1,0,0,0,0,0,3.939
-Summer 2022,LAW,5203,4,12161,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,2,0,0
-Summer 2022,GEOL,8698,8,16927,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,2,0,0
-Summer 2022,PHCA,8298,1,11666,Doctoral Dissertation Research,Johnson,Michael L,2,0,0,0,0,0,0,4
-Summer 2022,ECON,2302,1,10098,Principles of Microeconomics,Melendez Lugo,Joel,22,20,16,5,4,0,3,2.668
-Summer 2022,MATH,6386,1,12913,Big Data Analytics,Shastri,Dvijesh J,19,13,2,0,0,0,0,3.413
-Summer 2022,MATH,8698,4,12050,Doctoral Research,Josic,Kresimir,0,0,0,0,0,2,0,0
-Summer 2022,GEOL,3360,4,13669,Field Geology II,Sisson,Virginia B,6,3,0,0,0,0,0,3.63
-Summer 2022,SPEC,6367,2,13436,Special Education for Leaders,Hill,Deena Clair,9,0,0,0,0,0,0,4
-Summer 2022,ENGI,2304,13,15531,Technical Communications,Ellis,Kelly Ann,19,3,0,0,0,0,0,3.849
-Summer 2022,ACCT,5371,1,15322,Accounting Information Systems,Seijas,Nuria S,2,2,0,0,0,0,0,3.418
-Summer 2022,PSYC,6298,1,12060,Special Problems,Woods,Steven Paul,1,0,0,0,0,0,0,4
-Summer 2022,AAS,2320,1,12401,Intro To African American Stdy,Lyons,Da' Vonte,22,7,6,1,0,0,0,3.416
-Summer 2022,ECE,8298,2,10984,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,4,0,0
-Summer 2022,ECE,8498,19,16819,Doctoral Research,Fu,Xin,0,0,0,0,0,5,0,0
-Summer 2022,COMM,4378,1,11858,Social Impact of Info Tech,Ashley,Laura B,11,2,2,0,1,0,0,3.334
-Summer 2022,SOCW,7306,1,15592,Building Financial Capacity,Powell,Torey Ian,14,3,0,0,0,0,0,3.862
-Summer 2022,MANA,7397,1,15595,Selected Topics in Management,Witt,Lawrence A,9,0,0,0,0,0,0,4
-Summer 2022,CUIN,8310,3,11918,Laboratory of Practice,Cooper,Jane McIntosh,4,0,0,0,0,0,0,4
-Summer 2022,OPTO,7495,1,16487,General Clinic IIIc,Herring,Ralph Jay,0,0,0,0,0,2,0,0
-Summer 2022,BUSI,4396,2,13668,Business Internship,Hopkins,Troy D,0,0,0,0,0,20,0,0
-Summer 2022,ENGI,2304,10,15527,Technical Communications,Salvo,Deborah C,23,1,0,0,0,0,0,3.917
-Summer 2022,MARK,4362,1,11569,Applied Buyer Behavior,Noriega,Jaime L,28,15,2,1,2,0,0,3.279
-Summer 2022,MECE,8498,1,16536,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,0
-Summer 2022,HON,3397,4,16240,Honors Selected Topics,Barnes,Michael,1,0,0,0,0,0,0,4
-Summer 2022,CHEM,1305,1,12936,Foundations of Chemistry,St Hill,Lydia Ruth,6,14,6,4,0,0,1,2.788
-Summer 2022,COMM,4328,1,15515,Broadcast & Film Writing,Hamzah,Sahar Riyad,9,0,0,0,0,0,2,4
-Summer 2022,PHLS,8699,3,16984,Doctoral Dissertation,Master,Allison,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7397,13,17063,Selected Topics in Social Work,Cheung,Monit,1,0,0,0,0,0,0,4
-Summer 2022,BIOL,8698,2,16465,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8498,4,16667,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8298,9,16530,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,2,0,0
-Summer 2022,ARTS,2316,1,13553,Fundamentals of Painting,Alderson,Saran,14,0,0,0,0,0,0,4
-Summer 2022,NUTR,2332,4,16069,Intro To Human Nutrition,Hughes,Lindsay,15,10,12,1,1,0,1,2.932
-Summer 2022,DRAM,1310,1,12454,Introduction to Theatre,Young,Courtney Leigh,49,4,4,0,2,0,0,3.65
-Summer 2022,BIOL,2102,1,11435,Anatomy & Physiology II (lab),Gill,Tejendra,2,4,3,1,2,0,1,2.168
-Summer 2022,COMD,7391,3,11029,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,2,0,0,0,0,0,0,3.835
-Summer 2022,MARK,3336,1,10022,Introduction to Marketing,Zahn,William J,62,39,6,0,1,0,2,3.491
-Summer 2022,COSC,6309,201,13067,Intro Automata & Computability,Leiss,Ernst L,0,2,0,0,0,0,0,3
-Summer 2022,LAW,6300,3,11600,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,4,0,0
-Summer 2022,DIGM,1350,30,11893,Graphics for Digital Media,Beyl,Charles Eugene,8,8,0,0,0,0,3,3.418
-Summer 2022,TLIM,4372,30,12934,Proposal and Project Writing,Thomas,Jamie M,10,6,3,1,3,0,2,2.855
-Summer 2022,CHEE,8498,10,16307,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,0
-Summer 2022,CIVE,7397,2,16143,Selected Topics,Norris,Debra B,6,2,0,0,1,0,0,3.223
-Summer 2022,MANA,4338,1,12893,Performance Management Systems,Bozeman,Dennis,17,16,10,4,0,0,2,3.056
-Summer 2022,STAT,3331,1,11563,Statistical Anal Bus Appl I,Wiley,Briceon C,33,39,31,8,3,0,3,2.761
-Summer 2022,ENGL,1302,3,11356,First Year Writing II,Coleman,Quintin,4,7,6,1,4,0,3,2.258
-Summer 2022,ANTH,6398,1,16942,Special Problems,Brown,Kenneth L,2,0,0,0,0,0,0,4
-Summer 2022,WGSS,2350,4,13358,Intro To Women's Studies,Martinez,Itzel Areli,25,4,0,0,0,0,0,3.862
-Summer 2022,MECE,7399,2,17329,Masters Thesis,Ghasemi,Hadi,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,6698,10,16834,Special Problems,Yeo,Hye-Jeong,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8699,3,15584,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6365,7,17017,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,0,0,0
-Summer 2022,HLT,3381,1,12173,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,58,10,2,2,0,0,1,3.681
-Summer 2022,PHYS,1102,3,10834,College Physics II (lab),Maric,Sladjana,2,9,8,0,0,0,2,2.684
-Summer 2022,CHEM,1112,1,10578,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,3,0,0,0,0,3.088
-Summer 2022,OPTO,5198,1,16249,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,9,0,0
-Summer 2022,OPTO,5298,1,16252,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,10,0,0
-Summer 2022,PEP,7308,2,13470,Sports Facility Administration,Pearson,Demetrius W,5,1,0,0,0,0,0,3.778
-Summer 2022,DIGM,4398,1,17342,Independent Study,Rodwell,Elizabeth Ann,1,0,0,0,0,0,0,4
-Summer 2022,PHED,1306,1,16161,Emergency Care & First Aid,Brown,Korey J,14,4,0,0,1,0,0,3.579
-Summer 2022,ACCT,5335,1,10876,Financial Statement Auditing,Kuruvilla,Mohan,4,5,2,1,0,0,0,3.055
-Summer 2022,COMM,4392,1,11036,Professional Internship,Ashley,Laura B,0,0,0,0,0,16,0,0
-Summer 2022,PSYC,4321,4,16101,Abnormal Psychology,Lebeaut,Antoine M,41,6,5,0,2,0,1,3.501
-Summer 2022,PHYS,1101,1,10449,College Physics I (lab),Maric,Sladjana,4,8,8,2,0,0,0,2.681
-Summer 2022,SOCW,7376,1,13420,Social Work-LGBTQ Communities,Ovalle-Martinis,Cipactli,9,0,0,0,0,0,0,4
-Summer 2022,PHLS,7327,1,15521,Counseling Children,Hurt,Kara Marie,10,0,0,0,0,0,0,4
-Summer 2022,MECE,6387,1,13580,Intelligent Structural Systems,Song,Gangbing,5,7,5,0,0,0,2,3.078
-Summer 2022,CHEM,6698,21,11629,Special Problems,Harth,Eva M,0,0,0,0,0,4,0,0
-Summer 2022,CHEM,6399,4,10602,Masters Thesis,Zastrow,Melissa L,1,0,0,0,0,0,0,3.67
-Summer 2022,GEOL,8399,1,16282,Doctoral Dissertation,Khan,Shuhab D.,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,6257,5,12730,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4
-Summer 2022,PHYS,2325,1,12376,University Physics I (lecture),Bassler,Kevin E,9,9,6,0,0,0,3,3.084
-Summer 2022,COMM,3328,1,13389,Intro to Sports Production,Freedman,Michael,10,3,2,0,1,0,0,3.292
-Summer 2022,HLT,3325,3,13211,Medical Terminology,Burk,Kelly Ann,71,4,3,0,0,0,1,3.783
-Summer 2022,COSC,8398,125,12994,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,0
-Summer 2022,KIN,4398,1,12337,Independent Study,Cottingham,Michael,1,0,0,0,0,0,0,4
-Summer 2022,SOCW,7397,12,17062,Selected Topics in Social Work,Parks,Steven Lee,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8699,2,16496,Doctoral Dissertation,May,Elebeoba E,1,0,0,0,0,0,0,4
-Summer 2022,ECE,8498,5,16669,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,0
-Summer 2022,DRAM,1310,2,12456,Introduction to Theatre,Young,Courtney Leigh,41,7,3,1,3,0,3,3.431
-Summer 2022,PSYC,3341,4,12853,Physiological Psychology,Saiyed,Amna Shabbir,24,8,4,1,1,0,2,3.377
-Summer 2022,CIVE,8598,6,16382,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,2101,1,11338,Anatomy & Physiology Lab I,Gill,Tejendra,6,10,3,2,0,0,1,2.968
-Summer 2022,CHEM,8698,4,10707,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,5,0,0
-Summer 2022,HRMA,4132,1,11344,Bev Mgmt & Mktg Internship,Taylor,David C,3,0,0,0,0,0,0,4
-Summer 2022,WCL,3366,2,12643,Latin American and Latino Film,Centeno,Daniel,11,10,6,2,0,0,1,2.966
-Summer 2022,LAW,5197,19,14195,Selected Topics,Lawrence,Jim E,0,0,0,0,0,3,0,0
-Summer 2022,CHEM,2123,2,10118,Organic Chemistry Lab I,Zaitsev,Vladimir G,4,8,3,0,0,0,2,3.111
-Summer 2022,ECE,6298,2,16838,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,9,16884,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,0
-Summer 2022,BIOE,8399,9,16435,Doctoral Dissertation,Majd,Sheereen,1,0,0,0,0,1,0,2
-Summer 2022,MATH,6398,5,11072,Special Problems,Azencott,Robert Guy,0,0,0,0,0,2,0,0
-Summer 2022,BIOE,7399,5,12335,Masters Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4
-Summer 2022,BIOL,8698,10,16885,Doctoral Research,Meisel,Richard P,0,0,0,0,0,1,0,0
-Summer 2022,KIN,3306,2,15658,Physiology-Human Performance,Breslin,Whitney L,12,21,7,2,2,0,1,2.826
-Summer 2022,CUIN,7301,1,11782,CUIN Capstone Seminar,Brower,Samuel Richard,36,0,0,0,0,2,0,3.789
-Summer 2022,ACCT,3367,1,11258,Intermediate Accounting I,Kuruvilla,Mohan,5,11,10,5,3,0,9,2.343
-Summer 2022,PHYS,8399,8,10330,Doctoral Dissertation,Cardoso Barato,Andre,1,0,0,0,0,1,0,2
-Summer 2022,SOCW,7325,1,13421,Assessment in SW Practice,Borja,Sharon G,22,3,3,0,0,0,0,3.596
-Summer 2022,IDNS,7099,2,17424,Degree Completion,Halasyamani,P Shiv,0,0,0,0,0,1,0,0
-Summer 2022,PHAR,5690,2,11122,Internal Medicine,Sherer,Jeffrey T,0,2,0,0,0,0,0,3
-Summer 2022,CHEM,6698,10,10631,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,3,0,0
-Summer 2022,ELCS,8330,2,15493,Statistical Analyses,Pettersson-Cobb,Jennifer,1,7,2,0,0,0,0,2.834
-Summer 2022,GEOL,8698,6,16762,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8399,45,11515,Doctoral Dissertation,Lubchenko,Vassiliy,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8498,19,17035,Doctoral Research,Sharma,Pradeep,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,2301,2,16090,Introduction to Psychology,Weinstein,Andrew Philip,38,0,0,0,1,0,1,3.889
-Summer 2022,THEA,6280,1,12222,The teaching of Acting,Ferrarone,Jessica,13,0,0,0,0,0,0,4
-Summer 2022,ACCT,4330,2,15325,Advanced Accounting,Ramaswamy,Vinita,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,4363,1,16139,Concrete Design,Belarbi,Abdeldjelil,1,7,5,0,1,0,2,2.618
-Summer 2022,KIN,4390,1,11241,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4
-Summer 2022,CUIN,8199,1,17295,Dissertation,Lee,Mimi Miyoung,0,0,0,0,0,1,0,0
-Summer 2022,MATH,8698,8,12087,Doctoral Research,Cappanera,Loic,0,0,0,0,0,1,0,0
-Summer 2022,MATH,1342,5,11765,Elementary Statistical Methods,Weber,Thomas Christian,19,9,6,0,1,0,3,3.267
-Summer 2022,SOCW,7320,2,12169,Empowerment,Rabo,Amber L,19,1,0,0,1,0,0,3.73
-Summer 2022,COMD,7391,4,11030,Clinic in Speech Lang Disorder,Degge,Mary Chistine,1,0,0,0,0,0,0,3.67
-Summer 2022,SOCW,7320,1,12627,Empowerment,Kalu,Sandra Renee,21,1,0,0,0,0,1,3.955
-Summer 2022,COMD,7391,1,17107,Clinic in Speech Lang Disorder,Tragesser,Bridgid Jane,1,0,0,0,0,0,0,3.67
-Summer 2022,COMD,7391,10,11039,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,1,1,0,0,0,0,0,3.665
-Summer 2022,PSYC,6393,3,13091,Clinical Research Practicum,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4
-Summer 2022,MANA,6398,1,10021,Research,Keller,Robert T,0,1,0,0,0,0,0,3
-Summer 2022,PHYS,8698,22,16732,Doctoral Research,Ratti,Claudia,0,0,0,0,0,5,0,0
-Summer 2022,ACCT,2301,5,15310,Prin of Financial Accounting,Newman,Michael Ray,8,2,1,0,0,0,0,3.666
-Summer 2022,ENGL,4385,1,16114,Fiction Forms,Miller,Nicholas A,5,0,0,0,0,0,0,3.934
-Summer 2022,MATH,6315,1,12303,Masters Tutorial,Poliak,Cathy Dawn,30,0,0,0,1,0,1,3.85
-Summer 2022,MATH,6398,1,12828,Special Problems,Timofeyev,Ilya,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8399,14,16440,Doctoral Dissertation,Wu,Tianfu,3,0,0,0,0,0,0,4
-Summer 2022,PHLS,8399,7,16998,Doctoral Dissertation,Kim,Han Joe,1,0,0,0,0,1,0,2
-Summer 2022,SOCW,7397,16,17185,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4
-Summer 2022,ENGI,2304,3,12380,Technical Communications,Anderson,Roshawnda M,19,2,2,0,1,0,0,3.556
-Summer 2022,FINA,7397,3,15666,Selected Topics in Finance,Goudie,Thomas Lawrence,6,0,0,0,0,0,0,4
-Summer 2022,ECON,4390,4,13449,Economics Internship,Cubas Norando,German,16,0,0,0,0,0,0,4
-Summer 2022,HLT,4392,1,10887,Field Work in Community Health,Solari Williams,Kayce D.,19,2,0,1,1,0,0,3.594
-Summer 2022,BCHS,6698,6,16771,Special Problems,Liu,Yu,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1102,1,10832,College Physics II (lab),Wood,Lowell T,2,7,9,0,0,0,0,2.648
-Summer 2022,BIOL,8399,3,16565,Doctoral Dissertation,Azevedo,Ricardo,1,0,0,0,0,1,0,2
-Summer 2022,PHAR,5683,1,11335,Cardiology,Truong,Mabel,2,0,0,0,0,0,0,4
-Summer 2022,CHEM,8698,7,10710,Doctoral Research,May,Jeremy A,0,0,0,0,0,3,0,0
-Summer 2022,HIST,8699,2,13139,Doctoral Dissertation,Schafer Jr,James A,0,0,0,0,0,1,0,0
-Summer 2022,HDFS,1300,1,11898,Dev of Contemporary Families,Jordan,Erica F,37,21,2,1,1,0,3,3.468
-Summer 2022,THEA,6297,1,16021,Selected Topics,Ferrarone,Jessica,13,0,0,0,0,0,0,4
-Summer 2022,CIS,2348,1,12897,Info Systems Appl Development,Ratner,Edward,2,8,6,2,1,0,0,2.317
-Summer 2022,PHYS,8698,27,16737,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,3,0,0
-Summer 2022,CIVE,8198,11,16371,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,0
-Summer 2022,BIOE,8298,16,17365,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5424,1,12125,Death Penalty Clinic,Newberry,Jeffrey R,0,0,0,0,0,1,0,0
-Summer 2022,ENGL,1301,4,12459,First Year Writing I,Ely,Blaine,14,7,1,1,2,0,0,3.147
-Summer 2022,MATH,8399,1,11081,Doctoral Dissertation,Haynes,Alan K,1,0,0,0,0,0,0,4
-Summer 2022,COSC,8698,114,13252,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,3,0,0
-Summer 2022,CUIN,7356,2,14223,Issues in Distance Education,McNeil,Sara G,12,2,0,0,2,0,0,3.334
-Summer 2022,OPTO,6230,1,16255,Contact Lens Pathology,Dempsey,Robert L.,0,0,0,0,0,19,0,0
-Summer 2022,INDE,6321,1,13430,System Safety Engineering,Schulze,Lawrence John Henry,1,2,0,0,0,0,0,3.333
-Summer 2022,MATH,8699,2,11083,Doctoral Dissertation,Josic,Kresimir,1,0,0,0,0,0,0,4
-Summer 2022,HRMA,2315,1,15505,Introduction to SPA Management,Doudna,Simone P,23,12,8,1,1,0,0,3.222
-Summer 2022,COSC,3360,301,16032,Operating Systems,Rincon Castro,Carlos Alberto,11,10,12,6,11,0,7,2.06
-Summer 2022,DIGM,1376,30,13440,User Experience (UX)Principles,Showers,April Marie,16,7,5,6,1,0,1,2.857
-Summer 2022,COSC,6353,101,12901,Software Design,Singh,Raj Kumar,23,2,0,0,0,0,1,3.88
-Summer 2022,TLIM,3363,30,12921,Technical Communications,Tangeman,Anthony C,12,9,3,0,1,0,0,3.214
-Summer 2022,COMM,3368,1,11156,Principles of Public Relations,Ashley,Laura B,22,2,1,0,0,0,0,3.787
-Summer 2022,SOCW,7373,1,12648,Human Sexuality & Sw,Gracely,Jill Marie,25,1,0,0,0,0,0,3.962
-Summer 2022,PHYS,1101,2,10450,College Physics I (lab),Wood,Lowell T,1,11,5,1,0,0,0,2.593
-Summer 2022,NURS,4218,1,13545,Emergency Nursing,Edwards-Maddox,Shermel Vinese,22,0,0,0,0,0,0,4
-Summer 2022,BIOL,4340,1,15635,Research Methods,Ekeoba,Jacqueline Njideka,11,0,0,0,0,0,0,4
-Summer 2022,NURS,4220,1,12690,Clinical Decision Making,Obey,Faye B,7,9,1,0,0,0,0,3.412
-Summer 2022,MATH,8698,11,12104,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,2,0,0
-Summer 2022,MANA,   6A25,2,11742,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,24,9,2,0,0,0,0,3.647
-Summer 2022,SOC,3390,1,15627,Sociology of Gender,Cooper,Chelsey Wells,16,3,1,0,0,0,1,3.75
-Summer 2022,COSC,8698,101,16949,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,0
-Summer 2022,EDRS,8382,1,12633,Statistical Analyses in Eductn,Davis,Bradley,4,0,0,0,0,0,0,4
-Summer 2022,OPTO,8384,1,11097,Practice Management II,Loayza,Cristian,21,9,0,0,0,0,0,3.612
-Summer 2022,CNST,4381,1,15469,Reinforced Conc & Bldg Codes,Elzafraney,Mohamed,10,0,0,0,0,0,0,3.835
-Summer 2022,BIOL,6698,18,17029,Special Problems,Feng,Qin,0,0,0,0,0,2,0,0
-Summer 2022,SPEC,8395,1,17034,Doctoral Thesis,Hawkins,Jacqueline McLean,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8398,1,10929,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,0
-Summer 2022,GEOL,1103,4,13403,Physical Geology Lab,Hauptvogel,Daniel William,5,2,1,0,0,0,1,3.5
-Summer 2022,NUTR,6312,1,12956,Capstone II,Haubrick,Kevin,2,1,0,0,0,0,0,3.777
-Summer 2022,PHYS,8698,5,16714,Doctoral Research,Chen,Shuo,0,0,0,0,0,3,0,0
-Summer 2022,ECE,8398,13,16869,Doctoral Research,Chen,Jiefu,0,0,0,0,0,2,0,0
-Summer 2022,SPEC,7394,1,13450,Diagnostician Internship I,Hassett,Kristen Spring,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,4313,1,16087,Intro to Neural Computation,Francis,Joseph Thachil,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,6557,2,13700,Research Practicum B,Coates,Daniel R,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,8399,1,12509,Doctoral Dissertation,Burns,Alan R,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,8399,2,11943,Doctoral Dissertation,Hernandez,Arturo E,2,0,0,0,0,0,0,4
-Summer 2022,MATH,8399,4,10173,Doctoral Dissertation,Cappanera,Loic,1,0,0,0,0,0,0,4
-Summer 2022,GERM,3398,1,16004,Independent Study,Kleinheider,Julia D,1,0,0,0,0,0,0,3.67
-Summer 2022,COSC,8698,118,17150,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,0
-Summer 2022,MECE,2334,1,11923,Thermodynamics,Love,Holley Carole,5,16,11,2,0,0,3,2.677
-Summer 2022,GEOL,1340,1,11092,Earth Systems,Lytwyn,Jennifer N,26,52,44,16,14,0,10,2.414
-Summer 2022,SCM,   6A01,1,11767,SCM Concepts,Sahin,Funda,23,10,4,1,0,0,1,3.404
-Summer 2022,DRAM,1310,5,16073,Introduction to Theatre,Brincks,Alan,40,5,1,1,0,0,0,3.738
-Summer 2022,WGSS,2350,1,13084,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,24,4,1,1,0,0,0,3.667
-Summer 2022,ACCT,2301,2,11453,Prin of Financial Accounting,Sykes,Mary Reeves,7,15,6,2,1,0,7,2.892
-Summer 2022,MATH,2415,1,12393,Calculus III,Pan,Tsorng-Whay,5,3,4,0,2,0,1,2.643
-Summer 2022,OPTO,5298,1,16252,Spec Prob Phys Optics,Quintero,Sam,0,0,0,0,0,10,0,0
-Summer 2022,THEA,6180,1,12228,Applying Methods Acting/Voice,Ferrarone,Jessica,7,4,0,0,0,0,0,3.666
-Summer 2022,PHYS,8698,21,16731,Doctoral Research,Pinsky,Lawrence S,0,0,0,0,0,2,0,0
-Summer 2022,OPTO,8338,1,11096,Recent Developments/Round,Dempsey,Robert L.,16,16,0,0,0,0,0,3.418
-Summer 2022,NUTR,6301,1,12645,Clinic Aspects of Nutr Support,Ferrell,Carla Denise,8,1,0,0,1,0,1,3.368
-Summer 2022,SOCW,7397,14,17064,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4
-Summer 2022,COMM,3360,1,12674,Principles of Strategic Comm,Choi,Ho Joon,16,4,0,2,1,0,0,3.348
-Summer 2022,SCLT,3381,30,12170,Industrial and Consumer Sales,Blount,James,15,4,0,0,0,0,1,3.703
-Summer 2022,BIOE,8398,1,11413,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,0
-Summer 2022,HRMA,6397,2,15520,Selected Topics,Kenyan,Erin Oeser,11,1,0,0,0,0,0,3.944
-Summer 2022,ECE,8498,13,16700,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,0
-Summer 2022,PHAR,5675,4,12522,Disease State Management,De La Cruz,Austin Isaac,3,0,0,0,0,0,0,4
-Summer 2022,BIOE,8298,12,17137,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,0
-Summer 2022,SOCW,6293,1,12622,Field Practicum I - Foundation,Parker,Jamie Lynne,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8398,2,10009,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,3,0,0
-Summer 2022,MECE,8498,5,16555,Doctoral Research,Zhao,Bo,0,0,0,0,0,1,0,0
-Summer 2022,PHAR,5675,2,11369,Disease State Management,Gee,Jodie Sue,3,0,0,0,0,0,0,4
-Summer 2022,PHYS,8698,13,16723,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,4,0,0
-Summer 2022,MECE,8498,24,17133,Doctoral Research,Ostilla Monico,Rodolfo,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8398,28,16552,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8298,3,16456,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,0
-Summer 2022,CNST,3351,1,13529,Construction Estimating II,Sulehri,Hassan,21,13,0,0,0,0,0,3.618
-Summer 2022,HRMA,4350,1,15508,Strategy&Innovation Hosp Ind,Morosan,Cristian,29,4,2,1,3,0,1,3.393
-Summer 2022,GOVT,2306,50,12217,US and Texas Const/Politics,Cooper,Carol B,10,2,0,0,1,0,0,3.412
-Summer 2022,MATH,2131,1,12235,Linear Alg Labs w/MATLAB,Ansari,Haseeb E,13,0,1,0,0,0,1,3.786
-Summer 2022,BIOL,8698,8,16865,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,0
-Summer 2022,NURS,6321,1,13542,Leadership Practicum,Brohard,Cheryl L,9,0,0,0,0,0,0,4
-Summer 2022,PETR,8598,8,16587,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,0
-Summer 2022,TLIM,4390,30,12935,Current Issues Ldshp & Innov,Mehring,Brian George,6,3,1,0,0,0,0,3.533
-Summer 2022,ACCT,5332,1,12771,Corporate Taxation,Fernandez,Ramon,1,3,1,0,0,0,0,3.066
-Summer 2022,TLIM,4341,32,12927,Production & Service Operation,Chance,Michael Dean,11,6,3,1,0,0,0,3.191
-Summer 2022,PSYC,6365,5,13294,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8398,29,16561,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8198,15,17361,Doctoral Research,Majd,Sheereen,0,0,0,0,0,0,0,0
-Summer 2022,SOCW,7397,4,17343,Selected Topics in Social Work,Parker,Jamie Lynne,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,14,17070,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,0
-Summer 2022,MARK,8399,2,16544,Doctoral Dissertation,Tirunillai,Seshadri N,1,0,0,0,0,0,0,4
-Summer 2022,PHCA,8398,1,16452,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4
-Summer 2022,CNST,3185,1,12517,Construction Experience,Eldin,Neil N,22,9,2,6,6,0,3,2.778
-Summer 2022,PHYS,1101,6,13165,College Physics I (lab),Wood,Lowell T,2,9,6,0,0,0,1,2.881
-Summer 2022,ECE,2202,1,12180,Circuit Analysis II,Shattuck,David P,2,8,3,4,2,0,1,2.263
-Summer 2022,ELED,4320,2,16979,Social Studies Ele Sch,Ford,Haley Michelle Grimland,21,3,1,0,0,0,1,3.813
-Summer 2022,COMM,3369,2,13392,Strategic Comm. Writing,Belton,Stephanie,16,3,0,0,0,0,1,3.755
-Summer 2022,POLS,6312,1,16137,Institutions and Policy,Zhu,Ling,6,0,0,0,0,0,0,4
-Summer 2022,ACCT,7378,1,12908,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,25,3,0,0,0,0,0,3.893
-Summer 2022,BCHS,8698,8,16966,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8198,13,11010,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8498,10,16697,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,8199,3,16909,Doctoral Dissertation,Coulson-Thomas,Vivien J,0,0,0,0,0,0,0,0
-Summer 2022,PETR,7399,2,17355,Masters Thesis,Hathon,Lori A,0,1,0,0,0,0,0,3.33
-Summer 2022,MECE,8399,11,17274,Doctoral Dissertation,Liu,Dong,1,0,0,0,0,0,0,4
-Summer 2022,ECE,6198,1,10970,Research,Chen,Ji,0,0,0,0,0,3,0,0
-Summer 2022,ENGI,1331,4,13525,Computing for Engineers,Luna Singh,Jennifer Austin,11,6,6,1,1,0,4,3.053
-Summer 2022,HIST,1378,50,15576,The U S Since 1877,Higgins,Patrick,13,0,0,0,0,0,0,4
-Summer 2022,ECE,8298,4,16670,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5120,1,13415,Texas Legal Research,Badeaux,Katherine Stein,7,10,0,0,0,0,0,3.392
-Summer 2022,BCHS,8399,4,17086,Doctoral Dissertation,Sen,Mehmet,0,0,0,0,0,1,0,0
-Summer 2022,SCLT,3375,30,15486,Maritime Operations,Chopra,Anuj,2,2,3,0,0,0,0,2.857
-Summer 2022,HRD,6354,1,12527,Facilitating Adult Group Proc.,Forney,Warren T,11,0,0,0,0,0,1,4
-Summer 2022,ENGL,4390,1,12095,Professional Internship,Zentz,Lauren R,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8298,11,16678,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,0
-Summer 2022,BIOL,8698,13,17068,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,8698,2,16330,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8399,27,10349,Doctoral Dissertation,Ren,Zhifeng,1,0,0,0,0,0,0,3.67
-Summer 2022,BIOE,8399,11,16437,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4
-Summer 2022,LAW,5400,2,11596,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,6,0,0
-Summer 2022,HRMA,6398,1,16778,Special Problems,Back,KiJoon,1,0,0,0,0,0,0,4
-Summer 2022,CUIN,7392,1,13369,Internship,Gronseth,Susie L B,2,0,0,0,0,0,0,4
-Summer 2022,ELCS,8395,5,16657,Doctoral Thesis,Johnson PhD,Detra DeVerne,0,0,0,0,0,0,0,0
-Summer 2022,GEOL,7325,1,15709,Petrophysics & Formation Eval.,Myers,Michael Tolbert,1,2,0,0,0,0,0,3.443
-Summer 2022,ECE,8298,24,16917,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,0
-Summer 2022,ARTS,4398,3,16980,Independent Study,Politzer,David,1,0,0,0,0,0,0,4
-Summer 2022,PEP,8199,1,17413,Doctoral Dissertation,Ledoux,Tracey A,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,3350,3,16098,Intro to Cognitive Psychology,Carlos,Brandon J,48,12,0,0,0,0,0,3.778
-Summer 2022,GEOL,3355,1,13039,Field Geology I,Kalakay,Thomas J,4,4,1,0,0,0,0,3.297
-Summer 2022,SGNL,1302,1,11762,Elementary Sign Language II,Brittain,Robyn Michelle,10,9,0,0,1,0,0,3.334
-Summer 2022,ENGL,2307,1,16111,Intro To Drama,Presswood,Phillip Hilliard,20,1,0,1,0,0,2,3.818
-Summer 2022,MATH,1351,3,16179,Introduction to Math Reasoning,Douglas,Casey,16,16,6,12,14,0,3,2.063
-Summer 2022,SOCI,1301,1,12686,Introduction To Sociology,Adams,Jennifer Lauren,41,4,2,0,1,0,2,3.736
-Summer 2022,MANA,4336,2,13473,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,14,16,4,1,0,0,3,3.191
-Summer 2022,NUTR,3334,1,11245,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,22,25,3,3,0,0,1,3.183
-Summer 2022,CHEE,3321,1,10006,Analytical Methods Chem Engr,Malamataris,Nikolaos,4,1,4,0,0,0,1,2.963
-Summer 2022,DIGM,2325,30,12354,Info Tech for Digital Media,Hargrove,Mark Stephen,9,6,2,0,3,0,0,2.9
-Summer 2022,ILAS,7099,2,17382,Degree Completion,Scarrow,Susan E,0,0,0,0,0,13,0,0
-Summer 2022,CHEE,8399,6,10946,Doctoral Dissertation,Rimer,Jeffrey,0,0,0,0,0,5,0,0
-Summer 2022,SPAN,1501,5,10512,Elementary Spanish I,Miranda Moreno,Sujaila Abigail,2,2,5,1,5,0,1,1.557
-Summer 2022,MIS,6341,1,10003,Information Systems,Silva,Leiser O,14,0,0,0,0,0,0,4
-Summer 2022,LAW,5600,1,12127,Judicial Externship I,Archer,Anna M,0,0,0,0,0,1,0,0
-Summer 2022,COMM,4398,4,17240,Independent Study,Salisbury,Shelby,1,0,0,0,0,0,0,4
-Summer 2022,WCL,2352,1,14445,World Cinema,Centeno,Daniel,8,15,1,2,3,0,0,2.804
-Summer 2022,BIOE,5319,1,13076,Intro to Global Healthcare,Akay PhD,Metin,6,3,0,0,0,0,0,3.667
-Summer 2022,BIOE,8298,15,17363,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,0
-Summer 2022,CIVE,8198,9,16369,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,4,0,0
-Summer 2022,CHEE,8298,4,10927,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6359,1,13099,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,1,0,0,0,0,0,0,4
-Summer 2022,PCOL,6298,1,16460,Special Problems,Zhang,Ruiwen,0,0,0,0,0,0,0,0
-Summer 2022,BIOE,8298,7,16494,Doctoral Research,Naash,Muna,0,0,0,0,0,5,0,0
-Summer 2022,BIOE,8398,23,16489,Doctoral Research,Balan,Venkatesh,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,8698,6,10709,Doctoral Research,Do,Loi H,0,0,0,0,0,2,0,0
-Summer 2022,ECE,6398,5,16937,Research,Pan,Miao,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8398,120,12990,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,7399,1,16492,Masters Thesis,Pennings,Steven C,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,7399,3,17008,Masters Thesis,Zheng,Yingcai,1,0,0,0,0,0,0,4
-Summer 2022,PETR,8198,1,16591,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6567,1,13167,Research Practicum A,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,23,17090,Doctoral Research,Agrawal,Ashutosh,0,0,0,0,0,0,0,0
-Summer 2022,PHOP,6557,5,16648,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
-Summer 2022,MECE,8298,19,17036,Doctoral Research,Sharma,Pradeep,0,0,0,0,0,1,0,0
-Summer 2022,TLIM,3363,32,12925,Technical Communications,Peterson,Kathryn Marie,22,0,0,0,0,0,0,3.97
-Summer 2022,SOCW,7340,2,15593,Clinical Practice with Child,Parks,Steven Lee,20,8,0,0,0,0,0,3.773
-Summer 2022,CIS,3347,1,12898,IS Infrastructure and Networks,Viseh,Mehran,10,7,18,0,1,0,0,2.713
-Summer 2022,CIS,3355,1,11604,Integrated Information Systems,Peddoju,Suresh Kumar,3,17,10,0,0,0,0,2.822
-Summer 2022,ATP,6191,1,11774,Clinical Experience I,Harrison,Layci,17,0,0,0,0,0,0,4
-Summer 2022,ENGI,1331,3,13057,Computing for Engineers,Luna Singh,Jennifer Austin,8,9,7,3,2,0,8,2.632
-Summer 2022,CHEE,8398,3,10931,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,0
-Summer 2022,MARK,7399,2,16551,MS Marketing Prof Project,Koch,Steven F.,0,1,0,0,0,0,0,3
-Summer 2022,ECON,2302,3,13459,Principles of Microeconomics,Hadah,Hussain,6,9,2,1,0,0,1,3.129
-Summer 2022,PHCA,8199,1,11623,Doctoral Dissertation Defense,Thornton,James D,1,0,0,0,0,0,0,4
-Summer 2022,PCEU,8399,2,16914,Doctoral Dissertation,Hu,Ming,0,0,0,0,0,1,0,0
-Summer 2022,NUTR,4347,1,11568,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,2,7,1,1,1,0,0,2.502
-Summer 2022,TECH,3365,1,12912,Appl of Discrete Mthds in Tech,Schroeder,Susan L,12,7,3,1,1,0,0,3.18
-Summer 2022,NUTR,4352,1,12374,Child and Adolescent Nutrition,Vollrath,Kirstin,32,26,14,2,1,0,0,3.116
-Summer 2022,THEA,6281,1,12223,The teaching of Voice,Wetzel,Molly Elizabeth,13,0,0,0,0,0,0,4
-Summer 2022,TLIM,3330,30,13582,Innovation Principles,Feriante,Chris,1,6,5,0,13,0,2,1.32
-Summer 2022,SOC,3344,1,15628,Sociology of Aging,Davis,Mary A,24,9,7,1,1,0,3,3.27
-Summer 2022,HRMA,4360,1,13413,Hospitality Internship,Shepherd,Ashley,27,0,0,0,0,0,1,4
-Summer 2022,HLT,3325,2,13210,Medical Terminology,Bloom,Joel A,32,4,0,0,0,0,0,3.861
-Summer 2022,ECE,6198,5,17163,Research,Roysam,Badrinath,0,0,0,0,0,0,0,0
-Summer 2022,MATH,1325,1,11058,Calc for Bus & Social Sciences,Constante,Beatrice,7,10,2,2,2,0,2,2.725
-Summer 2022,PETR,8598,2,16510,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,2,0,0
-Summer 2022,BCHS,6398,2,17054,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8699,2,16541,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8399,19,16248,Doctoral Dissertation,Bollini,Praveen P,3,0,0,0,0,0,0,4
-Summer 2022,MATH,8698,9,12088,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,3,0,0
-Summer 2022,ECE,7399,2,17151,Masters Thesis,Chen,Jiefu,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,6398,2,17252,Special Problems,Murphy,Michael,0,0,0,0,0,1,0,0
+Summer 2022,CNST,6399,4,16614,Thesis,Song,Lingguang,1,0,0,0,0,0,0,4.0
+Summer 2022,PCOL,6498,3,16615,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Summer 2022,PCOL,6298,3,16616,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Summer 2022,PCOL,6498,5,16619,Special Problems,Kumar,Ashok,0,0,0,0,0,0,0,
+Summer 2022,PCOL,6298,5,16620,Special Problems,Kumar,Ashok,0,0,0,0,0,0,0,
+Summer 2022,SOCW,8699,1,16621,Dissertation,Torres,Isabel,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,11,16624,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,11,16625,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,12,16626,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,
+Summer 2022,MECE,8298,12,16627,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,
+Summer 2022,BIOL,8698,4,16628,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,13,16629,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Summer 2022,MECE,8398,1,16630,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,13,16631,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,14,16634,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,2,0,
+Summer 2022,MECE,8398,9,16635,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,14,16636,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,2,0,
+Summer 2022,MECE,8399,8,16637,Doctoral Dissertation,Ardebili,Haleh,1,0,0,0,0,0,0,4.0
+Summer 2022,MECE,8298,15,16639,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,15,16640,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Summer 2022,PHLS,8199,3,16644,Dissertation,Reitzel,Lorraine R,1,0,0,0,0,0,0,4.0
 Summer 2022,PHOP,6157,5,16645,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
-Summer 2022,BIOE,8399,16,16472,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4
-Summer 2022,ECE,7399,3,17152,Masters Thesis,Fu,Xin,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,3331,1,16107,Psychology of Gender,Kehoe,Caitlin,23,18,9,2,5,0,0,2.953
-Summer 2022,COMM,2311,1,11853,Writing for Print and Digital,Radcliffe Andre,Jennifer,10,9,0,0,1,0,0,3.284
-Summer 2022,COSC,6368,301,12649,Artificial Intelligence,Vilalta,Ricardo,41,19,0,0,0,0,0,3.551
-Summer 2022,SOC,3312,3,15626,Sociology of Deviance,Colbert,Sharla Stettnisch,22,6,5,5,1,0,6,3.094
-Summer 2022,GOVT,2305,2,12232,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,5,12,6,2,1,0,2,2.591
-Summer 2022,PSYC,3341,2,11913,Physiological Psychology,Matchanova,Anastasia,28,11,9,1,2,0,1,3.209
-Summer 2022,INDS,2355,2,13535,Design History I,Williams,Celeste,13,1,0,0,0,0,0,3.881
-Summer 2022,GEOL,8399,3,16359,Doctoral Dissertation,Wang,Guoquan,0,0,0,0,0,1,0,0
-Summer 2022,SPAN,1502,3,10516,Elementary Spanish II,Ruffino,Gustavo,7,3,0,0,0,0,0,3.766
-Summer 2022,PHAR,5644,1,11519,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,2,0,1,0,0,0,0,3.333
-Summer 2022,GOVT,2305,1,11260,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,8,13,4,1,0,0,1,3.026
-Summer 2022,CUIN,7386,1,17400,Trends & Issues K12 Scien Educ,Rodriguez,Alberto J,16,2,0,0,0,0,0,3.852
-Summer 2022,BIOE,8398,9,16409,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,0
-Summer 2022,KIN,3304,2,12101,Human Structure & Phys Perform,Breslin,Whitney L,5,15,10,1,0,0,1,2.785
-Summer 2022,HON,3399,1,17332,Senior Honors Thesis,Chen,Hua,1,0,0,0,0,0,0,4
-Summer 2022,MATH,4389,3,12373,Survey of Undergraduate Math,Blecher,David P,5,3,4,1,0,0,1,2.872
-Summer 2022,LAW,5200,1,13442,Depositions,Daw,Willie,4,6,0,0,0,0,0,3.367
-Summer 2022,ECE,8298,15,16795,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,0
-Summer 2022,ARLD,6391,1,17196,Internship in Arts Organizatn,Fernando,Fleurette S,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8399,2,16488,Doctoral Dissertation,Louie,Stacey M,0,0,0,0,0,0,0,0
-Summer 2022,ECE,8398,1,10985,Doctoral Research,Jackson,David R,0,0,0,0,0,2,0,0
-Summer 2022,PHOP,6557,3,16398,Research Practicum B,Twa,Michael D,1,0,0,0,0,0,0,3.67
-Summer 2022,LAW,5200,1,13442,Depositions,Chung,Jennifer,4,6,0,0,0,0,0,3.367
-Summer 2022,MANA,8399,1,10883,Doctoral Dissertation,Keller,Robert T,1,0,0,0,0,0,0,4
-Summer 2022,LAW,6318,2,10547,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,22,17057,Doctoral Research,Zhu,Weihang,0,0,0,0,0,3,0,0
-Summer 2022,CHEE,8398,8,10936,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,0
-Summer 2022,PETR,8398,10,16507,Doctoral Research,Wong,George K,0,0,0,0,0,4,0,0
-Summer 2022,PSYC,8399,18,16753,Doctoral Dissertation,Viana,Andres G,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,8698,16,10718,Doctoral Research,Harth,Eva M,0,0,0,0,0,3,0,0
-Summer 2022,ECE,6398,1,10971,Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,PCEU,8698,1,17082,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,7399,1,13695,Masters Thesis,Khan,Shuhab D.,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,6393,1,15710,Seismic Amplitude Interpretatn,Hilterman,Fred,1,1,0,0,0,0,0,3.5
-Summer 2022,MATH,6308,1,13221,Advanced Linear Algebra I,Haynes,Alan K,2,0,0,0,0,0,0,4
-Summer 2022,ECE,8298,6,16672,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8190,1,12297,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5103,1,10033,Health Law Journal,Fowler,Leah Robbins,0,0,0,0,0,0,0,0
-Summer 2022,ELCS,8398,1,17103,Independent Study,Messa,Emily Alice,1,0,0,0,0,0,0,4
-Summer 2022,COSC,3340,201,13056,Intro. to Automata and Comp.,Leiss,Ernst L,4,10,8,4,0,0,1,2.627
-Summer 2022,HLT,2320,1,12172,Introduction to Public Health,Proctor,Robin Ann,67,10,2,2,1,0,1,3.663
-Summer 2022,ACCT,3366,2,13424,Financial Reporting Frameworks,Parthasarathy,Kiran M,15,10,6,6,1,0,9,2.894
-Summer 2022,ITEC,1301,1,12457,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,6,13,1,6,0,0,2,2.705
-Summer 2022,ELCS,6301,1,13030,Leadership for Equity,Stewart,Cedric Benjamin,15,0,0,0,0,0,0,4
-Summer 2022,OPTO,7150,1,11094,Developmental Optometry,Chandler,Moriah Adine,73,14,3,0,0,0,0,3.778
-Summer 2022,PHAR,5693,1,11125,Advanced Community Pharmacy,Tolleson,Shane Russell,40,7,0,0,0,0,0,3.851
-Summer 2022,OPTO,6115,1,12449,Clinical Integration,Gostovic,Anita Ticak,0,0,0,0,0,45,0,0
-Summer 2022,COMM,1303,1,13296,Writing for Communicators,Lyn,Robyn,20,12,7,0,1,0,0,3.234
-Summer 2022,CHEE,8399,18,16247,Doctoral Dissertation,Cirino,Patrick C,0,0,0,0,0,1,0,0
-Summer 2022,LAW,6321,1,15548,Professional Responsibility,Duncan,Meredith J,8,19,3,0,0,0,0,3.2
-Summer 2022,ELET,3405,1,11349,Microprocessor Architecture,Soneja,Chandrayee,2,2,2,1,1,0,0,2.334
-Summer 2022,CUIN,7376,1,14225,New Tools Create Online Matls,McNeil,Sara G,12,2,0,0,2,0,0,3.334
-Summer 2022,PHAR,5675,1,11113,Disease State Management,Tolleson,Shane Russell,11,2,0,0,0,0,0,3.846
-Summer 2022,BIOL,2102,6,11677,Anatomy & Physiology II (lab),Gill,Tejendra,4,6,4,0,0,0,0,2.859
-Summer 2022,BIOE,8398,3,16403,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,6397,2,17168,Selected Topics,Kaushik,Krishna R,1,1,0,0,0,0,0,3.5
-Summer 2022,PUBL,6321,1,11755,Seminar in Urban Politics,Thurmond,James H,5,2,0,0,0,0,0,3.761
-Summer 2022,BIOL,1106,3,10106,Biol for Science Majors I(Lab),Medrano,Ana I,14,2,1,0,0,0,0,3.726
-Summer 2022,PSYC,8399,4,11949,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4
-Summer 2022,ECE,6198,6,17203,Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8398,11,16411,Doctoral Research,Majd,Sheereen,0,0,0,0,0,3,0,0
-Summer 2022,INDE,8399,4,13654,Doctoral Dissertation,Feng,Qianmei,0,0,0,0,0,0,0,0
-Summer 2022,ELCS,8395,11,17396,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,0
-Summer 2022,ECE,8498,1,10990,Doctoral Research,Wolfe,John C,0,0,0,0,0,0,0,0
-Summer 2022,ECE,8198,4,10979,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,0
-Summer 2022,WGSS,3322,1,12699,Intersectionalities,De Los Reyes Heredia,Jose Guillermo,25,1,0,1,0,0,1,3.84
-Summer 2022,CNST,4341,1,12693,Project Controls,Sulehri,Hassan,28,5,1,0,0,0,0,3.794
-Summer 2022,PSYC,4321,1,12195,Abnormal Psychology,Ridgely,Natalie,16,15,14,7,1,0,3,2.767
-Summer 2022,ELCS,8398,4,17300,Independent Study,Davis,Tiffany J,1,0,0,0,0,0,0,4
-Summer 2022,HDFS,3300,1,12629,Educational Psychology,Conston,Toya,41,6,1,0,1,0,1,3.762
-Summer 2022,SAER,8388,1,12867,Sem-Res Ed Ldshp Pol St,Davis,Tiffany J,16,3,0,0,0,0,0,3.859
-Summer 2022,HLT,4307,2,15665,Research and Eval in Health,Haq,Arooba A,5,4,1,2,0,0,1,2.863
-Summer 2022,LAW,5297,1,15453,Selected Topics,Foteh,Samir Jabra,4,4,0,0,0,0,0,3.459
-Summer 2022,LAW,5297,2,15590,Selected Topics,Jones,Karen Lynn,1,2,0,0,0,1,0,2.5
-Summer 2022,SGNL,1301,2,15433,Elementary Sign Language I,Brittain,Terrell,2,3,1,2,0,0,0,2.378
-Summer 2022,SGNL,1301,1,11591,Elementary Sign Language I,Brittain,Terrell,2,3,3,1,0,0,0,2.52
-Summer 2022,COSC,8398,127,12996,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8399,6,16706,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,2305,9,12868,Intro to Methods in Psychology,Yoruk,Harun,34,13,8,1,1,0,1,3.392
-Summer 2022,COMM,3380,1,13394,Electronic Field Production,Crowe,Craig Warren,10,4,0,0,0,0,0,3.502
-Summer 2022,MANA,7340,1,13524,Management of High Tech Org.,Keller,Robert T,21,6,0,0,0,0,1,3.704
-Summer 2022,PHAR,5686,2,12327,Psychiatry,Truong,Mabel,2,0,0,0,0,0,0,4
-Summer 2022,ENGI,2304,6,12381,Technical Communications,Downey,Carlton M,12,2,1,0,2,0,0,3.333
-Summer 2022,ECE,8298,20,16812,Doctoral Research,Fu,Xin,0,0,0,0,0,5,0,0
-Summer 2022,EDUC,3101,11,15349,Practicum for Preservice Tchrs,Thompson,Amber M,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,2305,11,12870,Intro to Methods in Psychology,Anderson,Jill Annette,17,21,4,1,0,0,0,3.217
-Summer 2022,MAS,3340,1,11612,Mexican Amer Urban Communities,Pino,Diana,12,9,6,1,1,0,4,3.012
-Summer 2022,SOCW,7385,1,11154,Field Practicum IV- Clinical,Parker,Jamie Lynne,0,0,0,0,0,17,0,0
-Summer 2022,BIOE,8398,5,16405,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,5,0,0
-Summer 2022,MATH,8698,12,13239,Doctoral Research,Nicol,Matthew J.,0,0,0,0,0,1,0,0
-Summer 2022,ACCT,5330,2,15326,Advanced Accounting,Ramaswamy,Vinita,0,1,0,0,0,0,0,3.33
-Summer 2022,CHEM,6698,6,10627,Special Problems,Xu,Shoujun,0,0,0,0,0,3,0,0
-Summer 2022,MECE,8498,10,16576,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,6336,4,17123,Directed Rsch in Social Psyc,Damian,Rodica Ioana,0,0,0,0,0,2,0,0
-Summer 2022,BCHS,6698,9,16802,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,2,0,0
-Summer 2022,PHYS,8399,49,17375,Doctoral Dissertation,Ren,Zhifeng,1,0,0,0,0,0,0,3.67
-Summer 2022,CUIN,7347,1,14222,"Sem in Learning, Design & Tech",Jones,Chad M,15,0,0,0,0,0,1,3.934
-Summer 2022,SCM,4311,1,13169,Project Management,Wayhan,Victor Brian,73,32,5,1,0,0,4,3.589
-Summer 2022,MANA,4350,1,12638,International Management,Celly,Nikhil,30,4,2,0,0,0,0,3.75
-Summer 2022,MARK,3337,1,10843,Professional Selling,Tueffert,Curt F,31,4,0,0,0,0,0,3.895
-Summer 2022,FINA,7377,1,12962,Electric Power Markets,Gasca,Amparo Amy,21,5,0,0,0,0,0,3.693
-Summer 2022,OPTO,5298,2,16254,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,9,0,0
-Summer 2022,PHAR,5493,1,10007,Introduction to Community IPPE,Hatfield,Catherine L,59,47,1,0,0,0,0,3.542
-Summer 2022,ENGL,1302,4,11469,First Year Writing II,Martiniuk,Jill,3,5,5,4,3,0,2,1.902
-Summer 2022,BIOL,1107,1,10573,Biology for Science Majors II,Hanke,Marc H,10,3,3,0,0,0,0,3.438
-Summer 2022,SPEC,6327,1,12857,Measurement Eval Research,Cole,Jana Belinda,18,0,1,0,1,0,0,3.634
-Summer 2022,SCLT,3376,30,12970,Global Trade Intermediaries,Blount,James,5,0,0,0,0,0,0,3.802
-Summer 2022,MANA,4347,1,13350,Ethics and Corp Soc Respon.,Salaiz,Ashley,28,15,4,1,0,0,0,3.41
-Summer 2022,SOCW,7397,8,15664,Selected Topics in Social Work,Newton,Vanessa Marie,9,4,1,0,0,0,0,3.571
-Summer 2022,PHLA,6220,1,17255,Leadership Concepts II,Varkey,Divya A,7,0,0,0,0,0,0,4
-Summer 2022,TLIM,3363,31,12923,Technical Communications,Piercy,Penelope Junker,13,7,5,1,1,0,1,3.062
-Summer 2022,PHIL,1361,2,12179,Philosophy and the Arts,Drapela,Nick Gerard,9,5,6,3,0,0,1,2.855
-Summer 2022,OPTO,6251,1,11093,Spanish for Optometrists,Dempsey,Robert L.,0,0,0,0,0,13,0,0
-Summer 2022,PHLS,8699,5,17397,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,6294,1,12623,Field Practicum II,Gonzales,Shelley A,0,0,0,0,0,3,0,0
-Summer 2022,BCHS,6698,12,17003,Special Problems,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,4,16549,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,0
-Summer 2022,OPTO,8993,1,16920,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,2,0,0
-Summer 2022,ACCT,4332,1,11460,Corporate Taxation,Fernandez,Ramon,1,3,0,0,0,0,0,3.333
-Summer 2022,CHEM,8399,2,10691,Doctoral Dissertation,Lee,T Randall,1,0,0,0,0,0,0,4
-Summer 2022,ELCS,8395,1,16319,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,5,0,0
-Summer 2022,CHEE,8298,18,16299,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,8699,2,10723,Doctoral Dissertation,Jacobson,Allan J,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6157,10,17092,Research Practicum B,Ritchey,Eric R,0,0,0,0,0,1,0,0
-Summer 2022,GENB,5304,2,15337,Business Ethics for Accountant,Newman,William Austin,1,1,0,0,0,0,1,3.335
-Summer 2022,PHOP,6457,3,16422,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8598,11,16387,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,0
-Summer 2022,PCEU,6698,1,17208,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,0,0,0
-Summer 2022,ELCS,8312,3,15603,Lab of Practice-Res Meth Devel,Freelon,Rhoda,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,6167,6,16652,Research Practicum A,Marsack,Jason,1,0,0,0,0,0,0,4
-Summer 2022,ELED,3320,1,11952,Survey Literature Child Adol,Tyson,Eleanore S,18,2,0,0,0,0,1,3.851
-Summer 2022,PHAR,5692,1,11124,Advanced Hospital Pharmacy,Truong,Mabel,31,2,0,0,0,0,0,3.939
-Summer 2022,DRAM,1310,7,16075,Introduction to Theatre,Egging,Jon Leo,14,0,3,3,3,0,2,2.812
-Summer 2022,PSYC,6352,1,11994,Directed Rsch in I/O Psyc,Spitzmuller,Christiane,5,0,0,0,0,0,0,4
-Summer 2022,PHYS,2325,3,16033,University Physics I (lecture),Chen,Shuo,48,104,42,0,4,0,0,2.95
-Summer 2022,ELCS,6332,1,11622,Student Develop/Student Affair,Messa,Emily Alice,8,0,0,0,0,0,1,4
-Summer 2022,PHYS,8698,1,16709,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,2,0,0
-Summer 2022,HIST,1377,50,15575,The U S To 1877,Erwing,Douglas A,13,0,0,0,0,0,0,3.949
-Summer 2022,HRMA,3371,1,15507,Multicultrl Etiquette Hosp Ind,Kenyan,Erin Oeser,36,6,3,1,2,0,0,3.562
-Summer 2022,HDCS,3304,1,11558,Visual Merchandising,Stewart,Barbara L,0,7,4,2,1,0,0,2.191
-Summer 2022,GENB,7304,2,15338,Bus Ethics for Accountants,Newman,William Austin,11,2,0,0,0,0,0,3.795
-Summer 2022,SCLT,4389,33,15500,Practicum in Supply Chain,Kidd,Margaret A,5,12,9,0,0,0,0,2.859
-Summer 2022,CHEE,6398,1,13640,Research,Karim,Alamgir,0,0,0,0,0,1,0,0
-Summer 2022,ACCT,7390,1,16020,Contrl & Secur of Finan Inform,Kahl,Keith E,11,3,1,0,0,0,0,3.755
-Summer 2022,COMM,4397,1,15512,Selected Topics Communication,Houk,Keith R,11,0,0,0,0,0,0,4
-Summer 2022,LAW,5500,1,12010,Government and Nonprofit Exter,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,0
-Summer 2022,ENTR,4394,1,12188,RED Labs Accelerator,McCormick,Kelly,2,0,0,0,0,0,0,4
-Summer 2022,NURS,6335,1,16052,Mgmt of Hlth Disrdrs in Adults,Dwyer,Carol Ann,6,2,0,0,0,0,0,3.75
-Summer 2022,MECE,8399,20,16553,Doctoral Dissertation,Ghasemi,Hadi,1,0,0,0,0,1,0,2
-Summer 2022,MECE,8399,8,16637,Doctoral Dissertation,Ardebili,Haleh,1,0,0,0,0,0,0,4
-Summer 2022,BUSI,4305,1,15336,Business Ethics for Accountant,Newman,William Austin,1,1,0,0,0,0,0,3.665
-Summer 2022,PHCA,8199,3,13231,Doctoral Dissertation Defense,Abughosh,Susan M,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8298,8,16289,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,0
-Summer 2022,MATH,1342,2,13407,Elementary Statistical Methods,Weber,Thomas Christian,10,7,6,1,4,0,1,2.643
-Summer 2022,MANA,4330,1,12360,Intro to Strategic HR Mgt,Sebastijanovic,Marina,34,11,4,0,0,0,0,3.585
-Summer 2022,BCHS,4397,1,16363,Topics-Biochem & Biophys Sci,Scott,Sean-Patrick,5,0,0,0,0,0,0,3.868
-Summer 2022,CHEM,8698,14,10716,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,3,0,0
-Summer 2022,SPAN,1501,3,13215,Elementary Spanish I,Molinete,Julio Antonio,7,2,0,0,0,0,0,3.594
-Summer 2022,SOCW,7384,1,11131,Field Practicum III - Clinical,Parker,Jamie Lynne,0,0,0,0,0,11,0,0
-Summer 2022,HRD,3351,1,12369,Instructional Design for HRD,Pereira-Leon,Maura Josefina,22,17,1,1,0,0,2,3.431
-Summer 2022,ENTR,7394,1,12189,RED Labs Accelerator,McCormick,Kelly,2,0,0,0,0,0,0,4
-Summer 2022,CHEE,8399,5,10945,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6257,8,13108,Research Practicum B,Ostrin,Lisa,2,0,0,0,0,0,0,4
-Summer 2022,OPTO,8099,1,17229,Degree Completion,Lambreghts,Kimberly,0,0,0,0,0,1,0,0
-Summer 2022,SPAN,8699,3,10097,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,0
-Summer 2022,PETR,8198,7,16600,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,0
-Summer 2022,HIST,1377,1,13070,The U S To 1877,Clavin,Matthew J,19,76,23,2,5,0,5,2.829
-Summer 2022,MATH,3339,2,13185,Statistics for the Sciences,Wang,Wenshuang,32,12,12,8,18,0,3,2.37
-Summer 2022,CHEM,1312,1,12445,Fundamentals of Chemistry 2,Czader,Arkadiusz,7,17,36,21,59,0,8,1.25
-Summer 2022,ECE,2201,1,12216,Circuit Analysis I,Shattuck,David P,7,9,14,6,6,0,1,2.127
-Summer 2022,MATH,1324,1,11057,Finite Math with Applications,Almus,Melahat,12,9,12,3,12,0,6,2.049
-Summer 2022,NUTR,4334,1,11761,Community Nutrition,Cepni,Aliye Beyza,31,43,12,5,5,0,2,2.883
-Summer 2022,OPTO,8696,1,11098,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,28,0,0
-Summer 2022,MUED,2342,1,12957,Music for Children,Bigwood,Cora Morgan,17,1,0,0,0,0,0,3.871
-Summer 2022,KIN,4310,1,11239,Measurement Tech Human Perf,Thrasher,Timothy Adam,3,8,7,3,1,0,0,2.424
-Summer 2022,PHAR,5678,1,11114,Transplant Therapeutics,Truong,Mabel,1,0,0,0,0,0,0,4
-Summer 2022,COMM,4398,1,16525,Independent Study,Radcliffe Andre,Jennifer,1,0,0,0,0,0,0,4
-Summer 2022,ECON,8699,7,17380,Doctoral Dissertation,Cubas Norando,German,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8498,22,16853,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,8399,18,10704,Doctoral Dissertation,Brgoch,Jakoah,1,0,0,0,0,0,0,4
-Summer 2022,ECE,8398,9,16846,Doctoral Research,Wolfe,John C,0,0,0,0,0,0,0,0
-Summer 2022,BIOL,8698,11,16913,Doctoral Research,Fujita,Masaya,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8395,10,17356,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,0
-Summer 2022,HDCS,4302,1,13521,Apparel Analysis,Gatterson,Beverly,19,7,0,0,1,0,0,3.507
-Summer 2022,PSYC,3301,3,16096,Intro Psych Stats,Godfrey,Donald Andrew,21,24,6,3,2,0,3,3.012
-Summer 2022,MATH,2318,3,11562,Linear Algebra,Perepelitsa,Mikhail Antolyevic,13,8,7,3,4,0,4,2.648
-Summer 2022,MECE,3360,1,11378,Experimental Methods,Chen,Xuemei,11,4,4,1,1,0,1,3.064
-Summer 2022,NUTR,2332,3,13088,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,22,9,11,0,0,0,1,3.207
-Summer 2022,PHAR,5217,1,12942,Pediatric Therapeutics,Martinez,Brigetta,46,1,0,0,0,0,0,3.979
-Summer 2022,ELCS,8191,1,12177,Special Field Projects,Shockley,Gerald,15,0,0,0,0,0,0,4
-Summer 2022,TLIM,3345,30,12919,Human Resources in Technology,Kirtley,Melinda Gayle,21,3,0,0,2,0,0,3.577
-Summer 2022,CUIN,6319,1,14463,Instr Design & Tech 2nd Lang,Leon,Maredil Josefina,11,3,0,0,0,0,0,3.691
-Summer 2022,BIOE,8398,17,16417,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,3,0,0
-Summer 2022,PHAR,5206,1,12940,Pharmacy and Geriatrics,Fernandez,Julianna M,21,24,2,0,0,0,0,3.404
-Summer 2022,ACCT,7375,1,11461,Corporate Taxation,Fernandez,Ramon,4,9,0,0,0,0,0,3.435
-Summer 2022,NUTR,4312,1,11760,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,8,11,7,7,0,0,3,2.606
-Summer 2022,KIN,4370,4,15653,Exercise Testing,Markofski,Melissa,11,17,3,3,1,0,2,2.877
-Summer 2022,ACCT,7330,2,15327,Advanced Accounting,Ramaswamy,Vinita,7,2,0,0,0,0,0,3.851
-Summer 2022,CUIN,1350,1,12611,Mathematics for Teachers 1,Burris,Justin T,25,6,0,0,0,0,0,3.732
-Summer 2022,COSC,8399,124,16475,Doctoral Dissertation,Shah,Shishir,1,0,0,0,0,0,0,4
-Summer 2022,INDE,6398,1,10998,Research,Lim,Gino Jinho,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,6698,5,16764,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,3,0,0
-Summer 2022,CHEM,1112,17,12528,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,2,0,0,0,1,3.166
-Summer 2022,CHEM,6698,14,10634,Special Problems,Bittner,Eric R,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,8599,1,16278,Doctoral Dissertation,Ostrin,Lisa,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,8598,4,13153,Doctoral Research,Coates,Daniel R,2,0,0,0,0,0,0,4
-Summer 2022,CHEM,6698,13,10633,Special Problems,Zastrow,Melissa L,0,0,0,0,0,3,0,0
-Summer 2022,PETR,6325,1,11357,Integrated Resrv Characterztn,Gonzalez,Reinaldo J,3,1,1,0,0,0,0,3.4
-Summer 2022,PEP,7393,1,11246,Internship & Practicum,Walsh,David W,2,0,0,0,0,0,0,4
-Summer 2022,PHOP,6357,5,11794,Research Practicum B,Burns,Alan R,1,0,0,0,0,0,0,4
-Summer 2022,PETR,8198,8,16601,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8198,1,17398,Independent Study,Santi,Kristi L,0,0,0,0,0,1,0,0
-Summer 2022,COMM,6398,4,10051,Special Problems,Vardeman,Jennifer E,0,0,0,0,0,0,0,0
-Summer 2022,PSYC,7399,13,17162,Masters Thesis,Woods,Steven Paul,1,0,0,0,0,0,0,4
-Summer 2022,MATH,2413,1,11060,Calculus I,Perepelitsa,Irina,12,28,11,7,25,0,15,1.924
-Summer 2022,TLIM,4342,30,12932,Quality Improvement Methods,Chance,Michael Dean,10,13,3,0,0,0,0,3.269
-Summer 2022,CHEM,1111,2,10114,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,1,0,1,0,1,3.048
-Summer 2022,COMM,4365,2,12363,Digital PR and Advertising,Choi,Ho Joon,14,5,2,0,0,0,0,3.571
-Summer 2022,DANC,2303,2,12688,Introduction to Dance,Bobet,Jacqueline A,11,7,7,2,4,0,4,2.624
-Summer 2022,HON,3397,1,15446,Honors Selected Topics,Galib,Christine,3,1,0,0,0,0,0,3.75
-Summer 2022,OPTO,6254,1,16258,Optom & Special Needs Children,Martinez,Muriel L,0,0,0,0,0,29,0,0
-Summer 2022,MARK,4396,1,11611,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,27,0,0
-Summer 2022,WGSS,2350,3,13339,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,2,0,0,1,0,0,3.75
-Summer 2022,SOCW,7325,2,13422,Assessment in SW Practice,Fernandez,Jason,22,0,0,0,0,0,0,3.985
-Summer 2022,SOCW,7388,1,11132,Field Practicum III Macro,Gonzales,Shelley A,0,0,0,0,0,3,0,0
-Summer 2022,HRMA,6360,1,11014,Graduate Directed Practicum,Back,KiJoon,18,0,0,0,0,0,0,3.982
-Summer 2022,KIN,4190,1,11778,Sport Administration Seminar,Walsh,David W,11,1,0,0,0,0,0,3.889
-Summer 2022,SPAN,1502,1,10514,Elementary Spanish II,Monarrez Martinez,Sendy Patricia,16,3,1,2,3,0,1,3.027
-Summer 2022,CNST,6399,4,16614,Thesis,Song,Lingguang,1,0,0,0,0,0,0,4
-Summer 2022,MANA,7343,1,14490,Intl Legal Environment of Mgmt,Abbott,Jeanna L,14,0,0,0,0,0,0,4
-Summer 2022,ACCT,5367,2,16012,Intermediate Accounting I,Kuruvilla,Mohan,0,1,1,0,0,0,0,2.665
-Summer 2022,ECE,8298,23,16852,Doctoral Research,Chen,Jiefu,0,0,0,0,0,6,0,0
-Summer 2022,LAW,5210,1,10038,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6567,6,13177,Research Practicum A,Patel,Nimesh Bhikhu,2,0,0,0,0,0,0,4
-Summer 2022,CHEE,8298,5,10928,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,0
-Summer 2022,ECE,6298,1,16837,Research,Chen,Ji,0,0,0,0,0,0,0,0
-Summer 2022,PSYC,6352,4,12790,Directed Rsch in I/O Psyc,Ng,Vincent,0,0,0,0,0,1,0,0
-Summer 2022,SPEC,6350,1,15496,Nature/Needs of Students w/GT,Hassett,Kristen Spring,2,0,0,0,0,0,0,4
-Summer 2022,MECE,8498,23,17089,Doctoral Research,Agrawal,Ashutosh,0,0,0,0,0,0,0,0
-Summer 2022,CHEM,8399,6,10694,Doctoral Dissertation,Baldelli,Steve,1,0,0,0,0,0,0,4
-Summer 2022,MIS,4398,1,17291,Independent Study,Scamell,Richard W,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8399,12,16438,Doctoral Dissertation,Romero Ortega,Mario Ignacio,0,0,0,0,0,0,0,0
-Summer 2022,PHLS,8393,2,12206,Doctoral Practicum in Psy,Sohn McCormick,Anita Luisa,0,0,0,0,0,8,0,0
-Summer 2022,MANA,4348,1,12894,Global Leadership,Walker,William A,15,1,1,0,0,0,0,3.804
-Summer 2022,CUIN,7354,1,17399,Perspectives in Science & Math,Wong,Sissy S,19,0,0,0,0,0,0,3.983
-Summer 2022,ENGL,2306,1,12452,Intro To Poetry,Loan,Leisa Marie,24,1,0,0,0,0,0,3.92
-Summer 2022,ECE,8298,16,16804,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,5,0,0
-Summer 2022,TLIM,3340,31,12953,Org Leadership & Supervision,Burns,Maria,27,1,0,0,0,0,2,3.929
-Summer 2022,FINA,7397,1,15427,Selected Topics in Finance,Stewart,Marcus,5,5,0,0,0,0,0,3.5
-Summer 2022,MATH,8698,6,12054,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,3,0,0
-Summer 2022,CUIN,8399,5,17310,Doctoral Dissertation,Hale,Margaret Ann,1,0,0,0,0,1,0,2
-Summer 2022,GEOL,8698,5,16577,Doctoral Research,Sun,Jiajia,0,0,0,0,0,3,0,0
-Summer 2022,DIGM,4396,30,12709,Internship in Digital Media,Waite,Jerry J,7,0,0,0,0,0,0,3.906
-Summer 2022,BIOE,8298,4,16457,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,4,0,0
-Summer 2022,PSYC,6398,10,12097,Independent Studies,Neighbors,Clayton T,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,4398,1,16401,Independent Study,Zvolensky,Michael J,3,0,0,0,0,0,0,4
-Summer 2022,MANA,7397,2,15669,Selected Topics in Management,Miljanic,Andra Olivia,4,1,0,0,0,0,0,3.8
-Summer 2022,ECE,6198,3,16864,Research,Li,Xingpeng,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5398,1,11017,Special Research and Writing,Vetter,Greg R,1,0,0,0,0,0,0,4
-Summer 2022,SOCW,7365,1,12168,Crisis Intervention,Battle,Jennifer Alene,26,0,0,0,0,0,0,4
-Summer 2022,PSYC,2319,3,12685,Intro to Social Psychology,Anderson,Jill Annette,10,12,12,3,3,0,2,2.46
-Summer 2022,TLIM,3340,32,13447,Org Leadership & Supervision,Evans,Gerald S,32,3,0,0,0,0,0,3.886
-Summer 2022,POLS,4398,1,12562,Independent Study,Cross,Renee D,6,0,0,0,0,0,0,4
-Summer 2022,MANA,7397,3,16175,Selected Topics in Management,Vera,Dusya M,19,0,0,0,0,0,0,4
-Summer 2022,FINA,4330,1,12964,Corporate Finance,Mai,Thien Anh Thu,15,9,10,1,0,0,3,3.133
-Summer 2022,MUSI,1117,1,12211,Aural Skills II,Garza,Paul Victor,10,1,6,0,3,0,1,2.618
-Summer 2022,MATH,3321,3,12883,Engineering Mathematics,West,James David,4,8,7,4,9,0,4,1.74
-Summer 2022,WGSS,2350,2,11917,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,28,1,1,0,0,0,0,3.856
-Summer 2022,RELS,3370,1,11930,The Bible and Modern Science,Ott,Aaron Frederick,4,3,3,3,1,0,0,2.429
-Summer 2022,SCLT,4312,30,12969,Inventory & Materials Handling,Hu,Minxiang,11,10,3,1,1,0,0,3.052
-Summer 2022,MANA,4341,1,16320,Leading Organizational Change,Im,Taehoon,20,12,1,0,0,0,0,3.566
-Summer 2022,LAW,5424,1,12125,Death Penalty Clinic,Dow,David R,0,0,0,0,0,1,0,0
-Summer 2022,PEP,7398,2,17157,Adv Special Problem Human Perf,Lee,Dong Hun,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8198,14,17297,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6398,5,12006,Independent Studies,Ng,Vincent,0,0,0,0,0,1,0,0
-Summer 2022,INTB,3355,1,11590,Global Environment of Business,Miljanic,Andra Olivia,67,33,11,2,5,0,1,3.294
-Summer 2022,SOCW,7356,1,11336,Groups in Clinical Settings,OBryant,Michelle,23,0,0,0,0,0,0,4
-Summer 2022,SOCW,7340,1,12396,Clinical Practice with Child,Rivera,Jaime,20,2,1,1,0,0,0,3.571
-Summer 2022,PHAR,5217,1,12942,Pediatric Therapeutics,Ozuna,Ronnie,46,1,0,0,0,0,0,3.979
-Summer 2022,CNST,4315,1,12914,Steel Construction,Chang,Chi Chung,4,9,0,0,0,0,0,3.206
-Summer 2022,LAW,5378,1,12388,Statutory Interpretation & Rea,Bush,Darren,15,20,0,0,0,0,0,3.4
-Summer 2022,BIOL,1106,2,10105,Biol for Science Majors I(Lab),Medrano,Ana I,16,2,0,0,0,0,0,3.761
-Summer 2022,MATH,3363,1,12885,Introduction To Pde,Caglar,Atife,5,4,7,2,6,0,1,1.89
-Summer 2022,ACCT,3368,3,15318,Intermediate Accounting II,Sun,Xue,8,14,16,0,0,0,1,2.824
-Summer 2022,ENGL,3330,1,11947,Beg Creative Writing-Fiction,Stockwell,Patrick Edward,24,0,0,0,0,0,0,3.945
-Summer 2022,PSYC,2319,4,12872,Intro to Social Psychology,Anderson,Jill Annette,6,17,15,3,2,0,0,2.473
-Summer 2022,CIVE,8598,16,16392,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,0
-Summer 2022,WGSS,3321,1,13086,Gender in Transnational Persp,Al-Sowayel,Dina,17,3,2,0,1,0,1,3.507
-Summer 2022,PHAR,5681,3,11118,Infectious Diseases,Gonzales-Luna,Anne J,3,1,0,0,0,0,0,3.75
-Summer 2022,CIVE,8598,2,16356,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,0
-Summer 2022,FINA,7361,2,13530,Risk Management,Hogan,Kenneth David,18,0,0,0,0,0,0,4
-Summer 2022,COMD,7391,11,13269,Clinic in Speech Lang Disorder,Jacobson,Shannon,1,0,0,0,0,0,0,4
-Summer 2022,PHAR,5696,5,12281,Ambulatory Care - Primary Care,Tolleson,Shane Russell,1,2,0,0,0,0,0,3.333
-Summer 2022,NUTR,6307,1,13033,Community Nutrition Practice,Haubrick,Kevin,0,0,0,0,0,3,0,0
-Summer 2022,ILAS,7099,1,17285,Degree Completion,Scarrow,Susan E,0,0,0,0,0,9,0,0
-Summer 2022,CLAS,3345,2,15476,Myth&Performance in Greek Trag,Houlihan,James W,14,8,0,0,0,0,0,3.651
-Summer 2022,CHEE,8298,14,16295,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8298,11,16292,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,0
-Summer 2022,MATH,8698,7,12086,Doctoral Research,Onofrei,Daniel T,0,0,0,0,0,1,0,0
-Summer 2022,HRMA,6198,2,16986,Special Problems,Koh,Yoon,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,6398,12,16898,Independent Studies,Alward,Beau Andrew,2,0,0,0,0,0,0,4
-Summer 2022,MECE,8598,1,16563,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,0
-Summer 2022,LAW,6500,1,12009,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,0
-Summer 2022,MECE,8399,9,17091,Doctoral Dissertation,Franchek,Matthew,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8698,29,16739,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,2,0,0
-Summer 2022,PETR,8399,7,12436,Doctoral Dissertation,Wong,George K,0,0,0,0,0,3,0,0
-Summer 2022,COMD,7391,2,11028,Clinic in Speech Lang Disorder,Chapman,Amanda,0,2,0,0,0,0,0,3.33
-Summer 2022,ECE,6398,6,17351,Research,Mayerich,David Matthew,0,0,0,0,0,1,0,0
-Summer 2022,ACCT,4335,4,13512,Financial Statement Auditing,Kuruvilla,Mohan,7,7,7,3,1,0,0,2.68
-Summer 2022,PSYC,4321,2,16100,Abnormal Psychology,Busch,Haley Conroy,44,7,2,1,1,0,4,3.673
-Summer 2022,HLT,3325,1,13209,Medical Terminology,Bloom,Joel A,91,6,1,1,0,0,0,3.832
-Summer 2022,FINA,4320,1,11769,Investment Management,Doshi,Hitesh B,19,22,2,0,0,0,0,3.395
-Summer 2022,BCHS,8698,6,16904,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8399,5,16915,Doctoral Dissertation,Reitzel,Lorraine R,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,1102,2,10833,College Physics II (lab),Wood,Lowell T,0,8,4,0,0,0,2,2.694
-Summer 2022,PSYC,8399,1,11933,Doctoral Dissertation,Grigorenko,Elena L,2,0,0,0,0,1,0,2.667
-Summer 2022,TLIM,3371,30,13591,Budgeting and Financial Princ,Burns,Maria,16,0,0,0,0,0,3,4
-Summer 2022,PETR,8598,10,16606,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8598,9,16385,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,0
-Summer 2022,CHEE,8398,13,11011,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,7,0,0
-Summer 2022,TECH,7099,1,17328,Degree Completion,Zouridakis,George,0,0,0,0,0,1,0,0
-Summer 2022,HRD,6303,30,12911,Assessment & Evaluation in Hrd,Alston PhD,Carmen M,7,0,0,0,0,0,0,4
-Summer 2022,PHYS,8698,9,16719,Doctoral Research,Curran,Seamus A,0,0,0,0,0,1,0,0
-Summer 2022,ARTS,1311,1,15638,Fundamentals of Graphic Design,Bootwala,Jennifer Elizabeth,1,8,1,1,2,0,1,2.41
-Summer 2022,PHLS,8199,1,13675,Dissertation,de Dios,Marcel A,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,7398,1,16832,Candidacy Research,Obasi,Ezemenari M,0,0,0,0,0,0,0,0
-Summer 2022,FINA,4397,2,15426,Selected Topics in Finance,Stewart,Marcus,4,4,0,0,0,0,0,3.459
-Summer 2022,LAW,5500,1,12010,Government and Nonprofit Exter,Van Arsdel,Kristina G,0,0,0,0,0,3,0,0
-Summer 2022,PETR,8399,3,12432,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,8698,18,10719,Doctoral Research,Guloy,Arnold M,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8399,1,16342,Doctoral Dissertation,Correa-Fernandez,Virmarie,1,0,0,0,0,0,0,4
-Summer 2022,MARK,4332,1,15474,Social Media Marketing,Noriega,Jaime L,27,13,4,4,0,0,3,3.278
-Summer 2022,PHLS,8366,1,12204,"Assmt Child/Adol Aff, Beh, Per",Kahn,David Andrew,5,0,0,0,0,0,0,4
-Summer 2022,CHEM,6698,19,10638,Special Problems,Carrow,Bradley,0,0,0,0,0,5,0,0
-Summer 2022,CHEE,8398,21,16274,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,0
-Summer 2022,ECON,2302,2,13457,Principles of Microeconomics,Le,Hoanh Yen Thi,4,2,3,1,0,0,0,2.867
-Summer 2022,ECE,3331,1,11606,Program Appl in Elec Comp Engr,Hebert,Thomas James,2,4,1,0,0,0,0,3.284
-Summer 2022,HRMA,4462,1,15510,Practical Project Mgmt in Hosp,Ramirez,Arlene D,5,0,0,0,0,0,0,3.934
-Summer 2022,PHAR,5297,3,17067,Selected Topics in Pharmacy,Zhang,Yang,0,0,0,0,0,1,0,0
-Summer 2022,COMD,7192,1,16978,Advanced Practicum,Cizek,Laura S,1,0,0,0,0,0,0,3.67
-Summer 2022,MATH,6498,6,11078,Special Problems,Fitzgibbon,William E,0,0,0,0,0,10,0,0
-Summer 2022,LAW,5328,1,11592,Judicial Externship I,Powers,William,0,0,0,0,0,4,0,0
-Summer 2022,LAW,5600,1,12127,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8199,2,16532,Dissertation,Obasi,Ezemenari M,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8698,112,13261,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7329,1,17012,SW Practice for Policy Change,Pritzker,Suzanne,1,0,0,0,0,0,0,4
-Summer 2022,COMM,1307,5,12838,Media and Society,Lyn,Robyn,5,1,2,0,0,0,0,3.416
-Summer 2022,SCM,3301,1,10461,SCM Fundamentals,Khumawala,Basheer M,70,42,8,1,1,0,1,3.459
-Summer 2022,HDCS,1300,2,12184,Human Ecosystems & Tech Change,Gatterson,Beverly,22,7,0,0,1,0,3,3.545
-Summer 2022,PHOP,6160,1,11101,Gen Sem Visual Sciences,Porter,Jason,18,0,0,0,0,1,0,3.789
-Summer 2022,HRMA,3361,1,12610,Hospitality Marketing,Johnson,Tucker A,20,1,4,0,0,0,1,3.587
-Summer 2022,MATH,3339,3,11745,Statistics for the Sciences,Labate,Demetrio,8,3,6,3,4,0,3,2.278
-Summer 2022,ATP,6303,1,13119,Gen Med/Pharm 1 -System & Eval,Knoblauch,Mark Alan,9,5,3,0,0,0,0,3.353
-Summer 2022,MECE,8498,20,17040,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5203,1,12160,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,0
-Summer 2022,COSC,8698,122,13200,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,3,0,0
-Summer 2022,ECE,8498,14,16701,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,0,0,0
-Summer 2022,POLS,8399,18,12833,Doctoral Dissertation,Shea,Patrick,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8598,15,16391,Doctoral Research,Momen,Mostafa,0,0,0,0,0,5,0,0
-Summer 2022,CIVE,8398,2,17369,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8399,6,17113,Doctoral Dissertation,Carales,Vincent D,0,0,0,0,0,1,0,0
-Summer 2022,MANA,4346,1,13474,Leadership Development,Evans,Klavdia Markelova,42,2,3,0,0,0,1,3.83
-Summer 2022,BIOL,2101,2,11339,Anatomy & Physiology Lab I,Gill,Tejendra,6,13,3,1,0,0,0,2.972
-Summer 2022,NUTR,2332,1,12214,Intro To Human Nutrition,Alastuey,Lisa L,21,22,17,4,2,0,3,2.753
-Summer 2022,LAW,6217,1,12653,Negotia & Creative Prblm Slvng,Block,Nathan Matthew,1,7,0,0,0,6,0,1.833
-Summer 2022,MUSI,1312,1,12212,Music Theory II,Garza,Paul Victor,9,3,5,0,2,0,1,2.877
-Summer 2022,THEA,6297,2,16022,Selected Topics,Ferrarone,Jessica,12,0,0,0,0,0,0,4
-Summer 2022,OPTO,7150,1,11094,Developmental Optometry,Dempsey,Robert L.,73,14,3,0,0,0,0,3.778
-Summer 2022,MUED,2342,2,16015,Music for Children,Bigwood,Cora Morgan,13,3,0,0,0,0,1,3.833
-Summer 2022,PHCA,8298,5,17081,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4
-Summer 2022,HRD,3340,1,11728,Principles of HRD,Hattier,Beth,18,7,1,0,0,0,0,3.59
-Summer 2022,TLIM,3355,30,12920,Project Management Principles,Moore,George P,9,7,3,0,1,0,0,3.167
-Summer 2022,ARTS,3384,1,15644,Sound Art,Meza,Abinadi,31,1,0,0,1,0,0,3.848
-Summer 2022,GOVT,2305,5,11759,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,9,5,4,1,0,0,2,3.088
-Summer 2022,PSYC,7397,2,16876,Selected Topics in Psychology,Cirino,Paul,0,0,0,0,0,2,0,0
-Summer 2022,SPAN,2312,6,10555,Intermediate Spanish II,Mejia Lara,Airy Sindik,11,9,3,1,0,0,0,3.25
-Summer 2022,PSYC,6365,3,13192,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4
-Summer 2022,GENB,7303,1,11758,Prof Accounting Communication,Newman,Michael Ray,9,0,0,0,0,0,0,3.963
-Summer 2022,BIOE,8198,1,16449,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,0
-Summer 2022,SOCW,8699,1,16621,Dissertation,Torres,Isabel,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,6698,3,16708,Special Problems,Schwartz,Robert J,0,0,0,0,0,3,0,0
-Summer 2022,INAR,3360,1,13163,Human Factors in Interior Arch,Vos,Gordon A,3,2,0,0,0,0,0,3.6
-Summer 2022,MECE,8399,19,16478,Doctoral Dissertation,Selvamanickam,Venkat,1,0,0,0,0,0,0,4
-Summer 2022,LAW,5299,19,12658,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,8698,9,16954,Doctoral Research,Castagna,John P,0,0,0,0,0,3,0,0
-Summer 2022,LAW,6355,3,11602,Govt Nonprofit Extshp II,Van Arsdel,Kristina G,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,8698,13,10715,Doctoral Research,Cai,Chengzhi,0,0,0,0,0,2,0,0
-Summer 2022,ARCH,3198,1,17239,Independent Study,Burrow,Robert W,0,1,0,0,0,0,0,3
-Summer 2022,ARTS,4198,1,17075,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4
-Summer 2022,COMD,6398,1,16515,Special Problems,Blake,Margaret T,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8498,11,16308,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,0
-Summer 2022,HRMA,4397,1,15509,Selected Topics Hosp Mgt,Legendre,Jungyoung Shin,16,3,2,1,0,0,0,3.53
-Summer 2022,HRMA,2160,1,11739,Professional Development,Dawson,Mary,27,6,0,0,0,0,0,3.808
-Summer 2022,HRD,4350,30,13616,Org Dev & Consulting,Clancy,James Patrick,8,5,0,0,0,0,0,3.438
-Summer 2022,BUSI,1301,1,13491,Business Principles,Thompson,Joseph Lee,96,13,4,0,3,0,3,3.69
-Summer 2022,CNST,3372,1,12586,Soil Mechanics & Foundations,Meyer,Joseph Ray,8,7,0,0,0,0,1,3.467
-Summer 2022,ENTR,3312,1,10525,Corporate Entrepreneurship,Karonika,John R,28,14,2,0,3,0,1,3.313
-Summer 2022,HLT,4310,2,13619,Program Planning for Health,Markowitz,Eliz,8,5,5,0,2,0,1,2.784
-Summer 2022,POLS,3316,1,16038,Stats for Political Scientists,Hanna,Tom Leard,14,0,2,1,0,0,0,3.53
-Summer 2022,OPTO,8990,1,11099,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,58,0,0
-Summer 2022,BIOL,8698,3,16562,Doctoral Research,Lekven,Arne,0,0,0,0,0,4,0,0
-Summer 2022,COMM,1307,1,12836,Media and Society,Olson,Beth M,3,4,3,2,1,0,0,2.436
-Summer 2022,EDRS,8382,2,15622,Statistical Analyses in Eductn,Davis,Bradley,4,2,0,1,0,0,0,3.191
-Summer 2022,HRD,4396,1,11727,Internship in HRD,Owens-Shepard,Toya,19,0,2,0,0,0,1,3.794
-Summer 2022,ARCH,6303,3,13607,Visual Studies III,Logan,Jason,5,4,0,0,0,0,0,3.629
-Summer 2022,LAW,7397,1,15551,Selected Topics,Swift,Kenneth Richard,4,7,0,0,0,0,0,3.394
-Summer 2022,ELET,1401,1,13614,Circuit Theory and Lab II,Moges,Mequanint A,5,3,2,1,0,0,0,3.121
-Summer 2022,PHAR,5297,5,17237,Selected Topics in Pharmacy,Trivedi PhD,Meghana,0,0,0,0,0,1,0,0
-Summer 2022,KIN,4360,2,17415,Adaptive Athletics Management,Cottingham,Michael,1,0,0,0,0,0,0,4
-Summer 2022,SPEC,6367,3,13606,Special Education for Leaders,Malechuk,Brian Edward,14,0,0,0,0,0,0,4
-Summer 2022,BIOE,8198,4,16455,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8698,2,16711,Doctoral Research,Bellwied,Rene,0,0,0,0,0,5,0,0
-Summer 2022,ECE,6398,7,17366,Research,Nguyen,Hien V,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,6698,23,11649,Special Problems,Chiang,Naihao,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,7392,1,11950,Psychology Practicum,Fetterman,Adam Kent,4,0,0,0,0,0,0,4
-Summer 2022,MATH,6398,33,10757,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8399,8,16862,Doctoral Dissertation,Le,Hung Quang,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8498,15,16640,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,16,16817,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,2101,3,11340,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,2,2,3,0,1,2.546
-Summer 2022,GOVT,2305,6,12198,"US Govt: Congress,Pres & Crts",Davis,Sharon M,11,13,9,3,0,0,1,2.926
-Summer 2022,FINA,4328,1,12915,Principles of Personal Finance,Coleman,Alfred G,5,7,0,1,1,0,0,2.882
-Summer 2022,WGSS,2360,1,13085,Introduction to LGBT Studies,Stone,Lauren Michelle,11,5,1,1,1,0,0,3.263
-Summer 2022,MECE,8498,3,16542,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8332,1,16138,Student Dev in Post Sec. Inst,Hall,Kayon,20,0,0,0,0,0,0,4
-Summer 2022,INDE,4372,1,15610,Operation Control,Rypien,David V,7,0,0,0,0,0,0,4
-Summer 2022,PHOP,6257,11,16339,Research Practicum B,Rump,Rachel,3,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,3,16543,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,7399,5,17242,Masters Thesis,Mann,Paul,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,7399,7,16761,Masters Thesis,Spitzmuller,Christiane,0,0,0,0,0,0,0,0
-Summer 2022,GENB,5303,3,15340,Prof Acct Communication,Newman,Michael Ray,3,1,0,0,0,0,1,3.75
-Summer 2022,SOCW,7391,2,13620,Field Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7388,1,11132,Field Practicum III Macro,Parker,Jamie Lynne,0,0,0,0,0,3,0,0
-Summer 2022,PSYC,8399,9,11991,Doctoral Dissertation,Walker,Rheeda L,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8498,8,16305,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6157,9,16749,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4
-Summer 2022,OPTO,8384,1,11097,Practice Management II,Sorrenson,Laurie L.,21,9,0,0,0,0,0,3.612
-Summer 2022,HRD,4344,1,11730,Designing E-Learning,Bennett,LaTasha,42,1,2,0,0,0,0,3.86
-Summer 2022,LAW,5419,1,11018,Consumer Law Clinic,Marquez,Ryan Michael,0,2,0,0,0,0,0,3.33
-Summer 2022,PSYC,3350,4,16971,Intro to Cognitive Psychology,Anderson,Jill Annette,10,9,2,0,1,0,0,3.092
-Summer 2022,MECE,8298,20,17041,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,0
-Summer 2022,HON,3301,1,11631,Readings in Medicine & Society,Reynolds,Aaron E,16,2,0,0,0,0,0,3.889
-Summer 2022,HLT,4392,2,13587,Field Work in Community Health,Solari Williams,Kayce D.,0,1,1,0,0,0,0,2.5
-Summer 2022,ENGI,2304,11,15528,Technical Communications,Ellis,Kelly Ann,15,7,1,0,0,0,0,3.594
-Summer 2022,LAW,5328,1,11592,Judicial Externship I,Archer,Anna M,0,0,0,0,0,4,0,0
-Summer 2022,IRW,1300,2,12707,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,5,0,0
-Summer 2022,PHAR,5681,3,11118,Infectious Diseases,Garey,Kevin W,3,1,0,0,0,0,0,3.75
-Summer 2022,PHCA,8698,1,16445,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8398,27,16546,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,0
-Summer 2022,CUIN,7376,3,14228,New Tools Create Online Matls,Dogan,Bulent,33,0,0,0,0,0,0,4
-Summer 2022,ECON,3370,1,11157,Introduction To Econometrics,Boul,Ruxandra,8,8,6,2,3,0,4,2.58
-Summer 2022,BUSI,4350,3,13595,Business Law and Ethics,Williams,John M,13,2,0,0,0,0,0,3.889
-Summer 2022,HIST,3394,1,16331,Sel Tops-Us History,Young,Nancy Beck,22,3,1,0,3,0,1,3.391
-Summer 2022,PHAR,5297,4,17187,Selected Topics in Pharmacy,Sansgiry,Sujit Sharad,0,0,0,0,0,11,0,0
-Summer 2022,SOCW,7389,1,11155,Field Practicum IV Macro,Gonzales,Shelley A,0,0,0,0,0,10,0,0
-Summer 2022,GEOL,3360,3,13041,Field Geology II,Murphy,Michael,6,3,0,0,0,0,0,3.483
-Summer 2022,ELCS,8355,2,15621,Policy Pol & Gov of Education,Davis,Tabitha Sundrell,10,0,0,0,0,0,0,4
-Summer 2022,SOCW,7366,1,12647,Grief/Bereave Therapy,Rodgers,Beverly J,26,2,0,0,0,0,0,3.893
-Summer 2022,BIOL,2102,2,11436,Anatomy & Physiology II (lab),Gill,Tejendra,4,10,2,3,0,0,1,2.772
-Summer 2022,BCHS,8698,5,16883,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,0
-Summer 2022,DIGM,2352,30,11748,Digital Photography,Snyder,Philip Charles,12,0,2,0,2,0,1,3.147
-Summer 2022,HIST,1378,7,17346,The U S Since 1877,Thompson,Joseph Lee,34,2,3,1,3,0,0,3.457
-Summer 2022,WGSS,2360,3,13504,Introduction to LGBT Studies,Pegoda,Andrew Joseph,10,7,2,1,1,0,0,3.19
-Summer 2022,MATH,3336,2,12884,Discrete Mathematics,Ru,Min,7,16,5,0,0,0,0,3.06
-Summer 2022,MECE,8298,21,17058,Doctoral Research,Sun,Li,0,0,0,0,0,3,0,0
-Summer 2022,RELS,2310,1,13573,Bible and Western Culture I,Allen,Paul J,12,0,0,0,0,0,0,3.945
-Summer 2022,PHAR,5681,2,11770,Infectious Diseases,Truong,Mabel,8,0,0,0,0,0,0,4
-Summer 2022,LAW,6500,1,12009,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,2,0,0
-Summer 2022,CIVE,8198,14,16374,Doctoral Research,Momen,Mostafa,0,0,0,0,0,5,0,0
-Summer 2022,GEOL,8698,10,16955,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,10,0,0
-Summer 2022,LAW,5600,1,12127,Judicial Externship I,Powers,William,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8398,26,16517,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,6390,1,15708,3-D Seismic Exploration I,Marfurt,Kurt J,1,0,0,0,0,0,0,3.67
-Summer 2022,LAW,6354,2,10548,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,1,0,0
-Summer 2022,ECON,8699,9,17409,Doctoral Dissertation,Craig,Steven G,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8498,11,16698,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5514,1,11980,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,2,0,0
-Summer 2022,PCOL,8399,1,12323,Doctoral Dissertation,McConnell,Bradley K,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8198,21,16428,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,0,0,0
-Summer 2022,MECE,8298,1,16538,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8398,12,10940,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,3,0,0
-Summer 2022,PHOP,6167,7,17093,Research Practicum A,Della Santina,Luca,1,0,0,0,0,0,0,4
-Summer 2022,COSC,8698,125,13279,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,0
-Summer 2022,PHAR,5672,1,11111,Clinical Pharmaceutical Resch,Tolleson,Shane Russell,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8398,3,17417,Doctoral Research,Li,Hongyi,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8698,7,16717,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,2,0,0
-Summer 2022,HLT,1353,1,10031,Personal Health,Rafique,Kiran Sajid,90,7,1,1,0,0,1,3.835
-Summer 2022,HDFS,4316,1,12207,Dynamics of Family Relations,Rab,Saira,16,4,1,0,1,0,0,3.485
-Summer 2022,MANA,4397,1,15423,Selected Topics in Mana,Im,Taehoon,13,7,1,0,1,0,0,3.364
-Summer 2022,TLIM,4342,31,12930,Quality Improvement Methods,O'Kelley,Donna K,7,17,4,1,1,0,0,2.922
-Summer 2022,ELCS,8330,1,13451,Statistical Analyses,Pettersson-Cobb,Jennifer,8,1,1,0,0,0,0,3.7
-Summer 2022,MANA,3335,2,12165,Intro Org Behavior and Mgmt,Salaiz,Ashley,38,5,5,1,0,0,0,3.633
-Summer 2022,ELET,6396,1,17338,Master's Project,Pollonini,Luca,1,0,0,0,0,0,0,4
-Summer 2022,SPEC,8301,1,15495,Professional Writing,Martens,Monica Lynn Curry,11,0,0,0,0,0,0,3.97
-Summer 2022,SOCW,7368,1,11908,Trauma Treatment for Children,Laury,Renita Lynn,24,0,0,0,0,0,0,4
-Summer 2022,ENGL,2315,1,13129,Literature and Film,Pegoda,Andrew Joseph,6,7,3,0,2,0,6,2.925
-Summer 2022,CIVE,8598,8,16384,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,0
-Summer 2022,PHIL,1321,2,11667,Logic I,Haaga,Curtis W,11,8,8,2,1,0,5,2.889
-Summer 2022,COSC,8698,128,13207,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,3,0,0
-Summer 2022,PHAR,5670,1,11110,Community Pharmaceutical Care,Tolleson,Shane Russell,8,2,1,0,0,0,0,3.636
-Summer 2022,BIOL,2121,2,11752,Microbiology for Science Major,Knapp,Richard D,8,1,0,0,0,0,0,3.779
-Summer 2022,PHOP,6167,5,16649,Research Practicum A,Ribelayga,Christophe Pierre,2,0,0,0,0,0,0,4
-Summer 2022,BIOE,8398,19,16419,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6336,3,13196,Directed Rsch in Social Psyc,Knee,Clifford R,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,8121,1,11932,Clinical Psychology Internship,Vincent,John P,0,0,0,0,0,8,0,0
-Summer 2022,CHEM,6698,5,10626,Special Problems,May,Jeremy A,0,0,0,0,0,4,0,0
-Summer 2022,BIOE,8398,13,16413,Doctoral Research,Roh,Jinsook,0,0,0,0,0,3,0,0
-Summer 2022,GEOL,8698,12,16972,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8198,8,16368,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,0
-Summer 2022,CHEM,6698,1,10623,Special Problems,Do,Loi H,0,0,0,0,0,1,0,0
-Summer 2022,MATH,8398,21,11399,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,3321,2,17169,Analytical Methods Chem Engr,Malamataris,Nikolaos,0,0,1,0,0,0,0,2.33
-Summer 2022,BIOE,6349,1,13503,Biomedical Microdevices,Majd,Sheereen,7,0,0,0,1,0,0,3.376
-Summer 2022,PHAR,5457,1,12943,Institutional IPPE,Hatfield,Catherine L,95,10,0,0,0,0,0,3.905
-Summer 2022,RELS,1301,4,15633,Intro To Religious Studies,Mummert,Claire Elizabeth,5,1,0,0,0,0,0,3.778
-Summer 2022,NURS,4297,1,16050,Special Topic in Nursing,Phan,Huong Thi,18,0,0,0,0,0,0,4
-Summer 2022,POLS,4598,1,16204,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,0
-Summer 2022,PETR,5397,1,16789,Selected Topics,Mohamed,Mohamed Ibrahim,0,0,0,0,0,0,1,0
-Summer 2022,PHAR,5668,1,11109,Managed Care Pharmacy,Tolleson,Shane Russell,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8398,4,10932,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5206,4,12162,Govt Nonprofit Extshp II,Van Arsdel,Kristina G,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5603,1,11966,Govt Nonprofit Extshp II,Van Arsdel,Kristina G,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8399,22,17277,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8199,6,17108,Dissertation,Allan,Blake A,1,0,0,0,0,0,0,4
-Summer 2022,ACCT,3371,1,15321,Accounting Information Systems,Seijas,Nuria S,17,19,8,0,3,0,1,2.965
-Summer 2022,SPAN,1502,5,13217,Elementary Spanish II,Pueyo Castan,Josefa,2,12,6,1,4,0,1,2.174
-Summer 2022,LAW,6217,1,12653,Negotia & Creative Prblm Slvng,Kelly,Tara Kay,1,7,0,0,0,6,0,1.833
-Summer 2022,LAW,6220,1,13414,Trademark Prosecution,Hunt,Lee Burton,3,8,0,0,0,0,0,3.303
-Summer 2022,PHAR,5642,1,11104,Emergency Medicine,Truong,Mabel,5,4,0,0,0,0,0,3.556
-Summer 2022,PHYS,8698,12,16722,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,3,0,0
-Summer 2022,THEA,6381,1,12224,Scenic Des for H.S. Director,Rigdon,Kevin L,13,0,0,0,0,0,0,4
-Summer 2022,SOCW,7397,4,13930,Selected Topics in Social Work,Webb,Ann E,18,2,0,0,0,0,1,3.867
-Summer 2022,SCLT,3387,30,11892,Procurement,Elliott,Stephen Dwight,14,8,4,1,1,0,2,3.108
-Summer 2022,ECE,8298,13,16681,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,4,0,0
-Summer 2022,LAW,5206,4,12162,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,8393,1,12205,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,7,0,0
-Summer 2022,ECE,8498,6,16693,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,2301,3,12274,Introduction to Psychology,Shen,Shutian,37,14,3,0,2,0,0,3.524
-Summer 2022,PHYS,1102,2,10833,College Physics II (lab),Maric,Sladjana,0,8,4,0,0,0,2,2.694
-Summer 2022,PHYS,1101,4,11158,College Physics I (lab),Wood,Lowell T,1,14,7,0,0,0,1,2.712
-Summer 2022,CHEM,2323,1,12905,Organic Chemistry I,Zaitsev,Vladimir G,10,8,14,25,31,0,11,1.307
-Summer 2022,PHYS,8698,19,16729,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,3,0,0
-Summer 2022,CHEE,8498,16,16313,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,0
-Summer 2022,COMM,4355,1,12675,Organizational Comm,Lee,Jaesub,12,2,1,0,1,0,0,3.438
-Summer 2022,ENGI,2304,7,13059,Technical Communications,Wilson,Chad A,17,4,0,0,3,0,0,3.292
-Summer 2022,COMM,3370,1,13050,History of Cinema,Houk,Keith R,18,11,1,0,0,0,2,3.556
-Summer 2022,SOCI,1301,4,12702,Introduction To Sociology,Nelson,Steven M,14,13,6,1,3,0,4,2.874
-Summer 2022,MATH,1314,5,11764,College Algebra,Constante,Beatrice,8,5,1,3,2,0,2,2.685
-Summer 2022,COMM,4303,3,13397,Communication Law and Ethics,Dulin,Matt,13,23,5,3,2,0,1,2.87
-Summer 2022,KIN,3360,1,12642,Professional Prep for Sp Admin,Pearson,Demetrius W,3,4,5,2,2,0,0,2.25
-Summer 2022,LAW,5228,1,12156,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,6,0,0
-Summer 2022,BIOL,6698,6,16471,Special Problems,Graur,Dan,0,0,0,0,0,2,0,0
-Summer 2022,LAW,7397,4,15591,Selected Topics,Warren,Gina S,2,4,0,0,0,0,0,3.388
-Summer 2022,PETR,8398,5,16502,Doctoral Research,Hathon,Lori A,0,0,0,0,0,1,0,0
-Summer 2022,HRMA,4132,2,16967,Bev Mgmt & Mktg Internship,Dawson,Mary,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,11,16624,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8498,7,16304,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,0
-Summer 2022,BIOE,8398,23,16489,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,0
-Summer 2022,COMD,7391,8,11033,Clinic in Speech Lang Disorder,Walker,Dionne A,1,1,0,0,0,0,0,3.665
-Summer 2022,LAW,5229,2,12159,Judicial Externship II,Worrell,Carey Ann,0,0,0,0,0,1,0,0
-Summer 2022,MATH,8398,10,10803,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,0
-Summer 2022,COSC,6398,103,17251,Special Problems,Cheng,Albert M K,0,0,0,0,0,1,0,0
-Summer 2022,PETR,8598,12,16608,Doctoral Research,Wong,George K,0,0,0,0,0,2,0,0
-Summer 2022,COSC,3399,101,17189,Senior Honors Thesis,Eick,Christoph F,1,0,0,0,0,0,0,3.67
-Summer 2022,CIVE,8598,3,16358,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8298,25,16932,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7397,7,15663,Selected Topics in Social Work,Newton,Vanessa Marie,9,1,0,0,0,0,1,3.834
-Summer 2022,PSYC,3325,1,11902,Psychology of Personality,Hotze,Mary Louise,45,12,0,0,2,0,1,3.633
-Summer 2022,COMM,3300,1,13390,Health Communication,Yamasaki,Jill S,42,15,1,0,2,0,1,3.567
-Summer 2022,CHEM,2123,1,10117,Organic Chemistry Lab I,Zaitsev,Vladimir G,7,3,6,0,1,0,0,2.844
-Summer 2022,TLIM,4341,30,12928,Production & Service Operation,Terrell,John Allen,22,9,3,0,1,0,0,3.401
-Summer 2022,CHEE,8399,15,10955,Doctoral Dissertation,Conrad,Jacinta C,0,0,0,0,0,0,0,0
-Summer 2022,OPTO,7493,1,11095,General Clinic IIIA,Herring,Ralph Jay,0,0,0,0,0,85,0,0
-Summer 2022,CNST,3265,1,15467,Construction Layout & Site Dvp,Lupher,Jacob John,17,11,1,0,0,0,0,3.495
-Summer 2022,PHLS,8193,1,12124,Internship in Psychology,Allan,Blake A,0,0,0,0,0,7,0,0
-Summer 2022,IART,6070,2,16183,Interdisciplinary Fieldwork,Politzer,David,0,0,0,0,0,8,0,0
-Summer 2022,POLS,3310,1,11459,Intro to Political Theory,Lund,Peter S,7,3,1,0,3,0,2,2.739
-Summer 2022,SOCW,7323,1,11766,Organizatnl Behavior & Change,Mayer,Margaret,10,1,0,0,0,0,0,3.909
-Summer 2022,ECON,4390,4,13449,Economics Internship,Pinto,Pablo M,16,0,0,0,0,0,0,4
-Summer 2022,CUIN,7301,5,17402,CUIN Capstone Seminar,Zhang,Jie,18,0,0,0,0,0,0,3.927
-Summer 2022,FINA,4397,3,16047,Selected Topics in Finance,Kapatos,Nick Gus,6,2,0,0,1,0,0,3.37
-Summer 2022,ECE,8498,7,16694,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,4,0,0
-Summer 2022,LAW,5203,4,12161,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,2,0,0
-Summer 2022,PHYS,8399,6,10328,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,8321,1,11944,Clinical Psyc Internship,Vincent,John P,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8498,15,16799,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,0
-Summer 2022,ENGL,4383,1,16113,Poetic Forms,Loan,Leisa Marie,7,0,0,0,0,0,0,4
-Summer 2022,NURS,6316,1,16051,Healthcare Organizatn Behavior,Brohard,Cheryl L,2,0,0,0,0,0,1,4
-Summer 2022,ECE,8498,8,16695,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,0
-Summer 2022,MATH,8698,5,12051,Doctoral Research,Mamonov,Alexander V,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,18,16982,Doctoral Research,Prosperetti,Andrea,0,0,0,0,0,1,0,0
-Summer 2022,KIN,4398,2,16952,Independent Study,Ogunrinde,Joyce,1,0,0,0,0,0,0,4
-Summer 2022,ELET,6396,2,17373,Master's Project,Zouridakis,George,1,0,0,0,0,0,0,4
-Summer 2022,PEP,7398,1,17156,Adv Special Problem Human Perf,Arellano,Christopher,1,0,0,0,0,0,0,4
-Summer 2022,HRMA,3154,1,15506,Rest. Mrktg Chicago Style,Taylor Jr,Scott T,11,0,0,0,0,0,0,3.97
-Summer 2022,SPEC,4367,1,12756,Consultation and Coaching,Carp,Charlotte Lynn,19,4,0,0,0,0,0,3.754
-Summer 2022,PSYC,2308,2,13492,Child Development,Trent,Erika S,35,14,4,5,1,0,0,3.294
-Summer 2022,PSYC,2319,1,16092,Intro to Social Psychology,Shepherd,Justin M,26,10,3,0,0,0,0,3.59
-Summer 2022,OPTO,8696,1,11098,General Clinic IV,Loayza,Cristian,0,0,0,0,0,28,0,0
-Summer 2022,THEA,6383,1,12226,Light/Cost Des for HS Director,Willson,Paige A,12,0,0,0,0,0,0,4
-Summer 2022,MARK,3337,2,13346,Professional Selling,Suki,Yara D,28,3,0,0,0,0,0,3.85
-Summer 2022,HRMA,3352,1,12609,Human Resource Management,Guchait,Priyanko,17,6,1,1,0,0,0,3.494
-Summer 2022,BIOE,8198,13,17138,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,0
-Summer 2022,ELET,4398,1,17099,Independent Study,Lent,Marino Ricardo,1,0,0,0,0,0,0,4
-Summer 2022,PCOL,6498,5,16619,Special Problems,Kumar,Ashok,0,0,0,0,0,0,0,0
-Summer 2022,GEOL,8698,16,17051,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6359,7,16922,Directed Rsch in Clinical Psyc,Viana,Andres G,1,0,0,0,0,0,0,4
-Summer 2022,MIS,7397,3,16200,Selected Topics in MIS,Campbell,Phillip James,2,0,0,0,0,0,0,4
-Summer 2022,CHEE,8298,19,16300,Doctoral Research,Vekilov,Peter,0,0,0,0,0,0,0,0
-Summer 2022,CHEM,6698,15,10635,Special Problems,Wu,Judy,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8399,10,17065,Doctoral Dissertation,Master,Allison,1,0,0,0,0,0,0,4
-Summer 2022,THEA,6383,1,12226,Light/Cost Des for HS Director,Rigdon,Kevin L,12,0,0,0,0,0,0,4
-Summer 2022,BIOE,8298,8,16529,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,0
-Summer 2022,ECON,3320,1,13077,Intro to Econ Data Analysis,Melendez Lugo,Joel,8,12,8,1,2,0,1,2.742
-Summer 2022,SOCW,7391,1,11133,Field Practicum Elective,Parker,Jamie Lynne,0,0,0,0,0,8,0,0
-Summer 2022,MECE,8399,22,16573,Doctoral Dissertation,Joshi,Shailendra Pramod,0,0,0,0,0,0,0,0
-Summer 2022,BIOL,6698,12,16861,Special Problems,Alward,Beau Andrew,0,0,0,0,0,1,0,0
-Summer 2022,MECE,2361,2,16168,Intro Mechanical Design,Hammami,Farah,3,1,0,0,0,0,0,3.833
-Summer 2022,BIOL,6698,13,16889,Special Problems,Meisel,Richard P,0,0,0,0,0,2,0,0
-Summer 2022,CIVE,8198,13,16373,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,0
-Summer 2022,CUIN,8390,3,11791,Doctoral Thesis,Hausmann,Robert Carl,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8698,28,16738,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,0
-Summer 2022,NUTR,3336,1,11267,Nutritional Pathophysiology,Haubrick,Kevin,23,18,4,1,0,0,1,3.305
-Summer 2022,DIGM,1350,31,13437,Graphics for Digital Media,Pittman,Natalie,4,7,5,1,4,0,1,2.113
-Summer 2022,DIGM,3353,30,12145,Visual Communications Tech,Dozier,Devin K,27,4,2,2,1,0,0,3.482
-Summer 2022,ENGI,2304,15,15533,Technical Communications,Smith-Irving,Brandi,15,1,3,0,1,0,0,3.401
-Summer 2022,PHLS,8399,6,16991,Doctoral Dissertation,Fan,Weihua,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,6398,6,12016,Independent Studies,Knee,Clifford R,1,0,0,0,0,0,0,4
-Summer 2022,PHLS,7301,3,15525,Practicum,Smedley,Diane,0,0,0,0,0,5,1,0
-Summer 2022,BIOE,8398,10,16410,Doctoral Research,Larin,Kirill,0,0,0,0,0,8,0,0
-Summer 2022,PHYS,8398,14,10305,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,0
-Summer 2022,ECON,8699,8,17381,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,2,0,0
-Summer 2022,CHEM,8399,20,11970,Doctoral Dissertation,Zastrow,Melissa L,1,0,0,0,0,0,0,4
-Summer 2022,BIOL,6698,17,17021,Special Problems,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8398,5,16683,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8198,6,16486,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,0
-Summer 2022,MECE,8498,17,16906,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,9,16572,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,0,0,0
-Summer 2022,PHOP,6257,3,12508,Research Practicum B,Cheng,Han,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8398,1,10969,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,7399,6,16340,Masters Thesis,Bergmanson,Jan Pg,1,0,0,0,0,0,0,4
-Summer 2022,MUSI,8296,2,16944,Doctoral Essay,Dirst,Matthew C,0,0,0,0,0,0,0,0
-Summer 2022,SOCW,7397,10,17039,Selected Topics in Social Work,Parker,Jamie Lynne,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8399,16,12455,Doctoral Dissertation,Alfano,Candice A,1,0,0,0,0,0,0,4
-Summer 2022,PHYS,8698,10,16720,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,0
-Summer 2022,INDE,3333,1,15601,Engineering Economy I,Wiggins,Nathanial David,18,1,0,0,0,0,2,3.93
-Summer 2022,ACCT,3377,1,10871,Cost Accounting,Serrato,Darlene Marie  Bohac,5,5,2,0,1,0,0,3.076
-Summer 2022,HDFS,3318,1,11926,Human Ecol of Adult Developmt,Rab,Saira,43,3,0,0,0,0,0,3.913
-Summer 2022,PSYC,3331,2,16275,Psychology of Gender,Mayorga,Nubia Angelina,40,10,0,2,2,0,2,3.604
-Summer 2022,GOVT,2306,1,11153,US and Texas Const/Politics,Cole,Jeffrey Bryan,8,5,3,3,1,0,0,2.883
-Summer 2022,MANA,7380,1,13486,People Analytics,Abbott,Jeanna L,35,1,0,0,0,0,0,3.945
-Summer 2022,MATH,2414,3,10740,Calculus II,Weber,Thomas Christian,9,12,7,7,5,0,6,2.243
-Summer 2022,MATH,1342,1,11561,Elementary Statistical Methods,Wang,Wenshuang,9,13,10,8,20,0,3,1.656
-Summer 2022,THEA,6297,3,16023,Selected Topics,Ferrarone,Jessica,12,0,0,0,0,0,0,4
-Summer 2022,HDFS,4394,1,10886,Internship in HDFS,Conston,Toya,20,0,0,0,0,0,1,3.984
-Summer 2022,SPEC,4353,1,12604,Technology in Special Pops,Goodrich,Elizabeth A,8,9,3,0,0,0,2,3.3
-Summer 2022,LAW,5228,1,12156,Judicial Externship I,Powers,William,0,0,0,0,0,6,0,0
-Summer 2022,CHEE,8298,10,16291,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,0
-Summer 2022,CIS,2337,1,15671,Fund of Information Security,Shah,Ana,17,8,0,0,1,0,0,3.45
-Summer 2022,INDE,6336,1,13590,Reliability Engineering,Keedy,Elias,9,4,1,0,1,0,0,3.311
-Summer 2022,ECE,8398,14,16929,Doctoral Research,Becker,Aaron T,0,0,0,0,0,2,0,0
-Summer 2022,ELCS,8395,6,16658,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,0
-Summer 2022,COMM,1302,1,12673,Intro To Comm Theory,Lee,Jaesub,6,5,7,3,0,0,1,2.62
-Summer 2022,CHEE,8399,17,11144,Doctoral Dissertation,Economou,Demetre J,0,0,0,0,0,0,0,0
-Summer 2022,LAW,5229,2,12159,Judicial Externship II,Powers,William,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6392,1,11935,Intervention Practicum,Vincent,John P,0,0,0,0,0,7,0,0
-Summer 2022,PETR,8198,2,16592,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5328,1,11592,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,4,0,0
-Summer 2022,ACCT,5377,1,15332,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,4,4,0,1,0,0,1,3.186
-Summer 2022,SPAN,8699,4,10566,Dissertation,Solino,Maria Elena,0,0,0,0,0,0,0,0
-Summer 2022,PHOP,6198,8,13692,Spec Prob-Physio Optics,Burns,Alan R,1,0,0,0,0,0,0,4
-Summer 2022,MECE,2361,2,16168,Intro Mechanical Design,Chang,Christiana,3,1,0,0,0,0,0,3.833
-Summer 2022,MATH,4396,1,17248,Senior Research Project,Kalantar,Mehrdad,1,0,0,0,0,0,0,4
-Summer 2022,ECE,6398,4,16840,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,0
-Summer 2022,SOC,7399,1,17144,Masters Thesis,Monserud,Maria Aleksandrovna,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8399,9,16930,Doctoral Dissertation,Becker,Aaron T,2,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,10,16575,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,0
-Summer 2022,HIST,8699,3,13140,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,0,0,0
-Summer 2022,COSC,8398,231,13029,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,0
-Summer 2022,HLT,4307,1,12059,Research and Eval in Health,Kamdar-Sharif,Amber,28,5,1,0,0,0,0,3.765
-Summer 2022,PHYS,1301,1,10198,College Physics I (lecture),Cardoso Barato,Andre,41,26,28,4,1,0,9,3.013
-Summer 2022,ENGL,1302,12,13125,First Year Writing II,Downey,Carlton M,20,2,0,0,2,0,1,3.583
-Summer 2022,MANA,3335,1,12164,Intro Org Behavior and Mgmt,Currie,Daniel David,100,26,2,1,0,0,1,3.713
-Summer 2022,ACCT,2301,3,10519,Prin of Financial Accounting,Sykes,Mary Reeves,18,9,3,2,1,0,2,3.312
-Summer 2022,FINA,4396,1,11836,Finance Internship,Kumar,Praveen,0,0,0,0,0,48,1,0
-Summer 2022,CUIN,1103,11,15333,Educator Dispositions,Culpepper,Shea Mosley,3,0,0,0,0,0,1,3.89
-Summer 2022,TMTH,3360,1,12163,Applied Technical Statistics,Schroeder,Susan L,5,6,9,5,2,0,3,2.308
-Summer 2022,MATH,6315,1,12303,Masters Tutorial,Fu,Wenjiang,30,0,0,0,1,0,1,3.85
-Summer 2022,PHLS,7301,2,15524,Practicum,McCoy,Leah,0,0,0,0,0,7,0,0
-Summer 2022,OPTO,6274,1,16256,Spec Contact Lens Workshops,Dempsey,Robert L.,0,0,0,0,0,20,0,0
-Summer 2022,CUIN,8399,2,13373,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,0,0,0
-Summer 2022,LAW,5203,1,12160,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,3,0,0
-Summer 2022,PHOP,8399,7,13694,Doctoral Dissertation,Das,Vallabh E,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8398,7,16407,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,0
-Summer 2022,PHIL,1301,1,13032,Intro To Philosophy,Haaga,Curtis W,24,12,3,0,1,0,1,3.45
-Summer 2022,POLS,3396,1,16086,Sel Topics Comp Internatl Pol,Kimondo,Gathoni Anne,18,3,3,0,0,0,2,3.598
-Summer 2022,ENGL,1302,2,11355,First Year Writing II,Swensen,Russel,8,1,3,3,5,0,2,2.217
-Summer 2022,ECON,8699,1,10064,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,4,0,0
-Summer 2022,ENGL,2305,2,17214,Intro To Fiction,Bose,Godhuly,14,6,1,1,0,0,0,3.425
-Summer 2022,BIOE,8699,3,16792,Doctoral Dissertation,Merchant,Fatima Aziz,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6372,1,11102,Experimental Quant in VS,Benoit,Julia S,5,9,0,0,0,0,0,3.357
-Summer 2022,BIOL,6352,1,13410,Molecular Mech Disease,Lin,Chin-Yo,18,9,0,0,0,0,0,3.654
-Summer 2022,PHLA,6260,1,17254,Healthcare Finance,Varkey,Divya A,7,0,0,0,0,0,0,4
-Summer 2022,LAW,6500,1,12009,Govt Nonprofit Extshp II,Van Arsdel,Kristina G,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,8399,8,17013,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,0
-Summer 2022,CHEM,6698,16,10636,Special Problems,Daugulis,Olafs,0,0,0,0,0,3,0,0
-Summer 2022,CIVE,8198,15,16375,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8198,1,13352,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8298,12,16679,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,0,0,0
-Summer 2022,GEOL,7399,6,17306,Masters Thesis,Sun,Jiajia,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6457,5,16715,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4
-Summer 2022,HIST,8699,1,11707,Doctoral Dissertation,Perales,Monica,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8699,3,16566,Doctoral Dissertation,Selvamanickam,Venkat,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5303,1,12387,Criminal Law,Kaufman,Zachary Daniel,13,18,1,0,0,0,0,3.427
-Summer 2022,PHYS,1102,4,11160,College Physics II (lab),Wood,Lowell T,4,7,8,1,0,0,0,2.601
-Summer 2022,MATH,3336,1,13405,Discrete Mathematics,Papadakis,Emanuel Ioannis,8,7,5,0,2,0,1,2.909
-Summer 2022,HDFS,4316,2,13244,Dynamics of Family Relations,Rab,Saira,29,3,2,1,3,0,1,3.378
-Summer 2022,PHAR,5206,1,12940,Pharmacy and Geriatrics,Hatfield,Catherine L,21,24,2,0,0,0,0,3.404
-Summer 2022,CHEM,8698,19,10720,Doctoral Research,Miljanic,Ognjen S,0,0,0,0,0,2,0,0
-Summer 2022,ENGL,3301,1,12269,Intro To Literary Studies,Murray,Christopher Brean,16,3,1,0,0,0,0,3.618
-Summer 2022,ENGL,1302,1,11259,First Year Writing II,Salome,Melanie Rebecca,8,8,5,0,1,0,2,2.94
-Summer 2022,CHEM,8399,13,10700,Doctoral Dissertation,Guloy,Arnold M,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,2120,1,11750,Microbiology for Non-Science,Knapp,Richard D,3,4,0,1,0,0,0,3.166
-Summer 2022,NUTR,4353,2,12952,Cultural Comp for Nutr Prof,Yoon,Cynthia Yursun,24,1,0,0,0,0,1,3.92
-Summer 2022,ECE,2100,1,16152,Circuit Analysis Laboratory,Ramachandran,Deepa,10,2,0,0,0,0,0,3.861
-Summer 2022,LAW,5197,17,14193,Selected Topics,Lawrence,Jim E,0,0,0,0,0,6,0,0
-Summer 2022,MATH,8698,2,12026,Doctoral Research,Labate,Demetrio,0,0,0,0,0,7,0,0
-Summer 2022,LAW,6300,2,11599,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,5,0,0
-Summer 2022,NURS,6338,1,12951,Advanced Pathophysiology,Schrader PhD,Patricia K,4,2,1,0,0,0,0,3.429
-Summer 2022,SOC,7395,1,17145,Internship in Sociology,Karner,Tracy Xavia,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8598,21,16432,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,0,0,0
-Summer 2022,MARK,8399,1,11485,Doctoral Dissertation,Ahearne,Michael,1,0,0,0,0,0,0,4
-Summer 2022,POLS,7399,1,11533,Masters Thesis,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8298,18,16810,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,0
-Summer 2022,CUIN,7305,3,16135,"Design,Dev & Eval Presentation",Smith,Adrienne Linette,10,1,0,0,1,0,0,3.556
-Summer 2022,CHEE,8398,7,10935,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,5397,2,16141,Selected Topics,Norris,Debra B,1,2,1,0,0,0,0,2.835
-Summer 2022,COMD,7391,7,11032,Clinic in Speech Lang Disorder,Ivey,Michelle L,2,0,0,0,0,0,0,3.67
-Summer 2022,CHEM,6698,7,10628,Special Problems,Lee,T Randall,0,0,0,0,0,5,0,0
-Summer 2022,PHCA,8199,4,17072,Doctoral Dissertation Defense,Essien,Ekere James,1,0,0,0,0,0,0,4
-Summer 2022,PHAR,5646,1,11772,Medication Safety,Truong,Mabel,2,0,0,0,0,0,0,4
-Summer 2022,COMD,6399,3,11527,Masters Thesis,Dial,Heather Raye,0,0,0,0,0,0,0,0
-Summer 2022,LAW,5407,10,11597,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,2,0,0
-Summer 2022,NUTR,6308,1,13055,Clinical Nutrition Practice I,Haubrick,Kevin,0,0,0,0,0,1,0,0
-Summer 2022,MARK,8399,3,17241,Doctoral Dissertation,Hess,James D,1,0,0,0,0,0,0,4
-Summer 2022,ECE,8298,5,16671,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,0,0,0
-Summer 2022,HRMA,6198,1,16985,Special Problems,Kim,Jaewook,1,0,0,0,0,0,0,4
-Summer 2022,SOCW,7397,15,17184,Selected Topics in Social Work,Powell,Torey Ian,1,0,0,0,0,0,0,4
-Summer 2022,FINA,3332,1,11363,Prin of Financial Management,Chisholm,Darla,22,24,29,14,1,0,16,2.53
-Summer 2022,SOCW,7371,1,12397,Trauma & SW,Amtsberg,Donna K.,27,0,0,0,0,0,0,3.988
-Summer 2022,MIS,4374,1,12607,Info Technology Project Mgmt,Campbell,Phillip James,15,12,2,0,0,0,1,3.391
-Summer 2022,HRMA,4361,1,12881,Marketing Strategies,Taylor,David C,24,9,4,1,2,0,0,3.251
-Summer 2022,CHEE,3369,1,15588,Chemical Engr Transport Proc,Zerze,Hasan,5,10,6,1,0,0,3,2.819
-Summer 2022,PHAR,5297,1,16085,Selected Topics in Pharmacy,Gee,Jodie Sue,26,15,2,0,0,0,0,3.558
-Summer 2022,MATH,1342,3,12619,Elementary Statistical Methods,Caputo,Matthew G,8,11,6,4,2,0,1,2.549
-Summer 2022,OPTO,6254,1,16258,Optom & Special Needs Children,Dempsey,Robert L.,0,0,0,0,0,29,0,0
-Summer 2022,COMM,3317,2,13388,Multimedia Journalism,Smith,Camilo Hannibal,9,2,2,0,0,0,1,3.564
-Summer 2022,FORE,6397,1,15667,Selected Topics in Foresight,Sweeney,John Arthur,16,0,0,0,0,0,0,4
-Summer 2022,PHAR,5217,1,12942,Pediatric Therapeutics,Nguyen,Kimberly A,46,1,0,0,0,0,0,3.979
-Summer 2022,TLIM,3363,33,12922,Technical Communications,Tangeman,Anthony C,20,2,1,0,1,0,0,3.639
-Summer 2022,ACCT,3366,3,15313,Financial Reporting Frameworks,Parthasarathy,Kiran M,7,1,6,2,1,0,0,2.686
-Summer 2022,SOCW,7397,5,15661,Selected Topics in Social Work,Dettlaff,Alan J,12,0,0,0,0,0,0,4
-Summer 2022,NURS,3337,1,11929,Rdg/Interpreting Sci Lit,Phan,Huong Thi,35,26,0,1,0,0,0,3.532
-Summer 2022,LAW,6300,2,11599,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,5,0,0
-Summer 2022,GOVT,2305,3,12669,"US Govt: Congress,Pres & Crts",Lothamer,Lucas J,18,8,3,1,1,0,1,3.291
-Summer 2022,PSYC,7393,1,12098,Field Practicum in Psychology,Vincent,John P,0,0,0,0,0,10,0,0
-Summer 2022,HRMA,6197,1,15511,Selected Topics,Padilla,Magdalena Manzano,6,0,0,0,0,0,0,4
-Summer 2022,HRMA,7337,1,15516,Human Resources in Hospitality,Madera,Juan Manuel,8,0,0,0,0,0,0,4
-Summer 2022,CHEE,8298,7,16288,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,0
-Summer 2022,MATH,5341,1,12620,Mathematical Modeling,He,Jiwen,6,0,0,0,0,0,0,4
-Summer 2022,CHEE,8398,20,16273,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,0
-Summer 2022,PHOP,6198,3,13193,Spec Prob-Physio Optics,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8298,7,16494,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,5,0,0
-Summer 2022,ECE,8498,18,16816,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,7398,1,17309,Masters Research,Brandon,Alan,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8498,5,10960,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,0
-Summer 2022,ARTS,6397,1,15645,Sel Topics/Studio Arts,Meza,Abinadi,4,0,0,0,0,0,0,4
-Summer 2022,PSYC,8399,3,11948,Doctoral Dissertation,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,1308,1,12938,Biology for Non-Science Majors,Ibrahim,Abdalla Zanouny,6,9,4,3,1,0,0,2.739
-Summer 2022,COMM,2327,1,13387,Introduction to Screen Writing,Vaughan,Thomas Michael,11,6,1,0,0,0,0,3.446
-Summer 2022,BUSI,4350,5,13612,Business Law and Ethics,Williams,John M,38,5,2,1,0,0,0,3.71
-Summer 2022,ENGL,1301,2,11783,First Year Writing I,Julian,Jennifer La'Vonne,19,3,0,2,0,0,0,3.598
-Summer 2022,INDE,2333,3,16197,Engineering Statistics I,Wiggins,Nathanial David,15,7,2,0,0,0,1,3.487
-Summer 2022,INDE,8598,7,13324,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,2,0,0
-Summer 2022,HDCS,4369,1,15589,Entrepreneurship,Hitchman Sr,Cal M,7,2,1,0,1,0,1,3.243
-Summer 2022,INDE,6333,1,15611,Probability Stat For Engineers,Shahmoradi,Zahed,8,2,0,0,1,0,0,3.395
-Summer 2022,MECE,8498,2,16537,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,2,0,0
-Summer 2022,SOCW,7391,2,13620,Field Practicum Elective,Parker,Jamie Lynne,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8298,2,10925,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,0
-Summer 2022,ECE,8498,2,10991,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,4,0,0
-Summer 2022,BCHS,6698,1,16444,Special Problems,Widger,William R,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,7399,6,12453,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,2,0,0
-Summer 2022,ELCS,8695,10,17419,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,0
-Summer 2022,DIGM,2353,30,11894,Page Layout and Design,De Vega,Jaime M,16,3,1,0,2,0,1,3.289
-Summer 2022,PHYS,1102,5,12781,College Physics II (lab),Maric,Sladjana,2,9,6,0,0,0,0,2.668
-Summer 2022,PHYS,1102,4,11160,College Physics II (lab),Maric,Sladjana,4,7,8,1,0,0,0,2.601
-Summer 2022,SCLT,3385,30,12944,Transport Economics and Policy,Poisler,Marco A,26,9,0,0,2,0,1,3.594
-Summer 2022,SOCW,7397,2,13929,Selected Topics in Social Work,O'Neal,Vaughn,18,2,2,1,0,0,0,3.566
-Summer 2022,MECE,3245,1,11656,Materials Science Laboratory,Hammami,Farah,13,13,3,0,1,0,1,3.288
-Summer 2022,NUTR,7313,1,15659,Urban Fitness,Alastuey,Lisa L,7,1,0,0,0,0,0,3.751
-Summer 2022,INDE,6332,1,15612,Egr Project Mgt,Rypien,David V,48,10,1,0,0,0,1,3.797
-Summer 2022,BIOE,8198,17,17367,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,0
-Summer 2022,PCOL,6498,3,16615,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,0
-Summer 2022,PUBL,6325,1,11368,Capstone Problem Project,Thurmond,James H,0,0,0,0,0,0,0,0
-Summer 2022,MATH,8398,4,11145,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8399,4,16692,Doctoral Dissertation,Bao,Jiming,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8198,5,16365,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,0
-Summer 2022,OPTO,8992,1,16919,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8298,10,16677,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,0
-Summer 2022,PHYS,8698,17,16727,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,0
-Summer 2022,PEP,7398,3,17236,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4
-Summer 2022,CUIN,8399,4,17299,Doctoral Dissertation,Li,Miao,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8298,22,16851,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8298,13,17298,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,0
-Summer 2022,ENGL,8399,1,12703,Doctoral Dissertation,Tolliver,Cedric,1,0,0,0,0,0,0,4
-Summer 2022,BCHS,8698,4,16841,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,0
-Summer 2022,KIN,3305,2,12286,Sport Sociology,Graham,Marilynn Hadassah,70,18,4,1,0,0,6,3.631
-Summer 2022,MECT,4372,1,12446,Materials Technology,Basaran,Burak,3,19,8,0,0,0,0,2.833
-Summer 2022,RELS,2360,1,12966,Introduction to Buddhism,Huynh,Trung,4,2,1,0,0,0,0,3.429
-Summer 2022,INDS,2355,1,13534,Design History I,Williams,Celeste,7,0,0,0,0,0,0,3.953
-Summer 2022,THEA,6287,1,12672,Acting Styles,Noble,Adam S,12,0,0,0,0,0,0,4
-Summer 2022,MANA,4396,1,11610,Management Internship,Carlin,Barbara A,0,0,0,0,0,13,0,0
-Summer 2022,COMM,3311,2,15556,Editing Print & Digital Media,Crixell,Charles A,5,9,5,0,0,0,0,2.965
-Summer 2022,PSYC,2301,1,16088,Introduction to Psychology,Zamanipour,Tina,53,4,1,0,0,0,0,3.897
-Summer 2022,MATH,1314,2,12365,College Algebra,Chang,James A,7,5,2,0,0,0,7,3.31
-Summer 2022,MARK,7376,1,12636,Brand Management,Koch,Steven F.,30,0,0,0,0,0,0,4
-Summer 2022,KIN,4345,1,11240,Econ and Finc Aspects of Sport,Lee,Dong Hun,11,12,0,0,0,0,0,3.478
-Summer 2022,CIVE,8198,4,16355,Doctoral Research,Shaffer,Devin,0,0,0,0,0,5,0,0
-Summer 2022,ELCS,8371,1,12858,Legal Issues Sch District Levl,Causey,Ashley,5,1,0,0,0,0,0,3.778
-Summer 2022,COMM,1307,2,12837,Media and Society,Lyn,Robyn,25,4,2,1,1,0,2,3.545
+Summer 2022,GEOL,8399,4,16646,Doctoral Dissertation,Choi,Yunsoo,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6167,4,16647,Research Practicum A,Ritchey,Eric R,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6557,5,16648,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Summer 2022,PHOP,6167,5,16649,Research Practicum A,Ribelayga,Christophe Pierre,2,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6157,6,16650,Research Practicum B,Frishman,Laura J,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6457,4,16651,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6167,6,16652,Research Practicum A,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,6157,7,16653,Research Practicum B,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,8598,9,16654,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8395,3,16655,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,
+Summer 2022,ELCS,8395,5,16657,Doctoral Thesis,Johnson PhD,Detra DeVerne,0,0,0,0,0,0,0,
+Summer 2022,ELCS,8395,6,16658,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,
+Summer 2022,ELCS,8395,7,16659,Doctoral Thesis,Lopez,Ruth Maria,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8399,3,16663,Doctoral Dissertation,Shih,Wei-Chuan,1,0,0,0,0,1,0,4.0
+Summer 2022,ECE,8298,3,16665,Doctoral Research,Yao,Yan,0,0,0,0,0,4,0,
+Summer 2022,ECE,8498,3,16666,Doctoral Research,Yao,Yan,0,0,0,0,0,4,0,
+Summer 2022,ECE,8498,4,16667,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,5,16669,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,4,16670,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Summer 2022,ECE,8298,5,16671,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,0,0,
+Summer 2022,ECE,8298,6,16672,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,7,16673,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,8,16675,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Summer 2022,ECE,8298,9,16676,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,10,16677,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Summer 2022,ECE,8298,11,16678,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Summer 2022,ECE,8298,12,16679,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8399,17,16680,Doctoral Dissertation,Das,Mini,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8298,13,16681,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,4,0,
+Summer 2022,ECE,8298,14,16682,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,
+Summer 2022,ECE,8398,5,16683,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Summer 2022,ECE,8399,4,16692,Doctoral Dissertation,Bao,Jiming,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8498,6,16693,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,
+Summer 2022,ECE,8498,7,16694,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,4,0,
+Summer 2022,ECE,8498,8,16695,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Summer 2022,ECE,8498,9,16696,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Summer 2022,ECE,8498,10,16697,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,11,16698,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Summer 2022,ECE,8498,12,16699,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,0,0,
+Summer 2022,ECE,8498,13,16700,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Summer 2022,ECE,8498,14,16701,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,0,0,
+Summer 2022,PHOP,6367,2,16702,Research Practicum A,Ritchey,Eric R,0,0,0,0,0,1,0,
+Summer 2022,ECE,8398,6,16703,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Summer 2022,ECE,8398,7,16704,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2022,ECE,8399,5,16705,Doctoral Dissertation,Mayerich,David Matthew,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8399,6,16706,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6157,8,16707,Research Practicum B,Porter,Jason,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,6698,3,16708,Special Problems,Schwartz,Robert J,0,0,0,0,0,3,0,
+Summer 2022,PHYS,8698,1,16709,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,2,0,
+Summer 2022,PHOP,6198,10,16710,Spec Prob-Physio Optics,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,8698,2,16711,Doctoral Research,Bellwied,Rene,0,0,0,0,0,5,0,
+Summer 2022,PHYS,8698,5,16714,Doctoral Research,Chen,Shuo,0,0,0,0,0,3,0,
+Summer 2022,PHOP,6457,5,16715,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,8698,6,16716,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,2,0,
+Summer 2022,PHYS,8698,7,16717,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,2,0,
+Summer 2022,PHYS,8698,8,16718,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,2,0,
+Summer 2022,PHYS,8698,9,16719,Doctoral Research,Curran,Seamus A,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,10,16720,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,11,16721,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,4,0,
+Summer 2022,PHYS,8698,12,16722,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,3,0,
+Summer 2022,PHYS,8698,13,16723,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,4,0,
+Summer 2022,PHYS,8698,15,16725,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,3,0,
+Summer 2022,PHYS,8698,16,16726,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,17,16727,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,18,16728,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,19,16729,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,3,0,
+Summer 2022,PHYS,8698,20,16730,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,21,16731,Doctoral Research,Pinsky,Lawrence S,0,0,0,0,0,2,0,
+Summer 2022,PHYS,8698,22,16732,Doctoral Research,Ratti,Claudia,0,0,0,0,0,5,0,
+Summer 2022,PHYS,8698,23,16733,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,5,0,
+Summer 2022,PHYS,8698,24,16734,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,3,0,
+Summer 2022,PHYS,8698,27,16737,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,3,0,
+Summer 2022,PHYS,8698,28,16738,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,29,16739,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,2,0,
+Summer 2022,BCHS,6698,4,16742,Special Problems,Wang,Yuhong,0,0,0,0,0,2,0,
+Summer 2022,PHOP,6157,9,16749,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2022,PHOP,8299,2,16750,Doctoral Dissertation,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
 Summer 2022,HIST,3394,2,16752,Sel Tops-Us History,Pegoda,Andrew Joseph,4,2,3,2,3,0,1,2.049
-Summer 2022,MATH,5383,1,13408,Number Theory,Ru,Min,5,5,0,0,0,0,0,3.467
-Summer 2022,BIOE,4303,1,13079,Biomaterials,Abidian,Mohammad Reza,4,1,0,0,0,0,0,3.668
-Summer 2022,PHLS,6310,2,12635,Intro To Educ Research,Lee,Jungeun,7,1,0,0,0,0,0,3.875
-Summer 2022,CUST,6370,1,11756,Cultural Found Amer Edu,Carales,Vincent D,9,2,0,0,2,0,1,3.155
-Summer 2022,HDCS,1300,4,13519,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,15,2,1,1,3,0,1,3.091
-Summer 2022,ENGI,2304,14,15532,Technical Communications,Smith-Irving,Brandi,16,3,1,0,1,0,0,3.587
-Summer 2022,PHOP,6257,10,13111,Research Practicum B,Bergmanson,Jan Pg,1,0,0,0,0,0,0,4
-Summer 2022,LAW,5397,1,15456,Selected Topics,Barks,Justen S,0,1,0,0,0,0,0,3.33
-Summer 2022,MATH,6398,11,10137,Special Problems,Haynes,Alan K,0,0,0,0,0,1,0,0
-Summer 2022,ECE,6398,3,16800,Research,Chen,Ji,0,0,0,0,0,3,0,0
-Summer 2022,BIOL,3396,1,12826,Senior Research Project,Lin,Chin-Yo,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,7397,1,16875,Selected Topics in Psychology,Vujanovic,Anka Anna,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,8299,2,16750,Doctoral Dissertation,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8498,17,16314,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5198,1,11015,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,3.67
-Summer 2022,SPAC,6398,1,17266,Special Problems,Bannova,Olga,0,1,0,0,0,0,0,3
-Summer 2022,OPTO,5198,2,16250,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,6698,14,16938,Special Problems,Warner,Margaret,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,8199,1,12334,Doctoral Dissertation,Das,Vallabh E,1,0,0,0,0,0,0,4
-Summer 2022,LAW,6300,11,12331,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,1,0,0
-Summer 2022,MATH,8398,19,11383,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5400,2,11596,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,6,0,0
-Summer 2022,MECT,3342,1,11358,Elements of Plant Design,El Nahas,Medhat A,6,12,8,0,0,0,0,2.923
-Summer 2022,ELCS,8398,2,17104,Independent Study,Louis,Dave A,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,3341,3,12852,Physiological Psychology,Bodet III,Jean Philippe,36,15,6,2,1,0,0,3.444
-Summer 2022,COSC,3320,202,16277,Algorithms and Data Structures,Leiss,Ernst L,11,16,6,3,2,0,8,2.781
-Summer 2022,PSYC,4321,5,16975,Abnormal Psychology,Saiyed,Amna Shabbir,24,4,0,0,2,0,0,3.556
-Summer 2022,ACCT,4331,2,11986,Federal Income Tax-Individual,Fernandez,Ramon,1,18,6,0,0,0,0,2.892
-Summer 2022,LAW,5385,1,12153,Introduction to the Laws of EU,Willis,Tasha L,2,8,0,0,0,0,0,3.398
-Summer 2022,KIN,4350,1,11244,Sport Marketing,Walsh,David W,9,32,22,6,2,0,1,2.577
-Summer 2022,SOCW,6294,1,12623,Field Practicum II,Parker,Jamie Lynne,0,0,0,0,0,3,0,0
-Summer 2022,BIOE,4313,2,16150,Intro to Neural Computation,Francis,Joseph Thachil,3,0,0,0,0,0,0,4
-Summer 2022,BIOE,5319,1,13076,Intro to Global Healthcare,Akay,Yasemin M,6,3,0,0,0,0,0,3.667
-Summer 2022,CHEE,8399,4,10944,Doctoral Dissertation,Varadarajan,Navin,7,0,0,0,0,0,0,4
-Summer 2022,MECE,6368,1,17222,Mechanical Design Proj,Sharma,Pradeep,1,0,0,0,0,0,0,4
-Summer 2022,PEP,8350,2,17166,HHP Candidacy Project Research,Parikh,Pranav J,1,0,0,0,0,0,0,4
-Summer 2022,PHAR,5645,1,11771,Pharmacy Informatics,Truong,Mabel,2,0,0,0,0,0,0,4
-Summer 2022,MATH,2413,3,10122,Calculus I,Sosa,Moses,16,7,10,6,9,0,11,2.285
-Summer 2022,ENGL,3327,1,12450,Masterpieces of British Lit I,Long,Steven A.,19,3,2,1,1,0,2,3.462
-Summer 2022,MATH,2318,1,15477,Linear Algebra,Perepelitsa,Mikhail Antolyevic,8,4,3,2,0,0,1,3.078
-Summer 2022,MATH,8698,10,13238,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,3,0,0
-Summer 2022,HDCS,1300,3,12909,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,35,4,2,1,2,0,1,3.538
-Summer 2022,OPTO,6230,1,16255,Contact Lens Pathology,Bergmanson,Jan Pg,0,0,0,0,0,19,0,0
-Summer 2022,COMD,4489,1,16171,Clinical Procedures,Cizek,Laura S,13,2,0,0,0,0,1,3.823
-Summer 2022,PHLS,7301,1,15523,Practicum,Hurt,Kara Marie,0,0,0,0,0,10,1,0
-Summer 2022,BIOL,2121,1,11751,Microbiology for Science Major,Knapp,Richard D,5,4,1,0,0,0,0,3.4
-Summer 2022,ELCS,8350,1,12364,Resource Management,Young,Yolanda Yvette,6,0,0,0,0,0,0,4
-Summer 2022,BIOE,8198,8,16528,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,0
-Summer 2022,COMD,7391,9,11034,Clinic in Speech Lang Disorder,Devore,Danielle R,2,0,0,0,0,0,0,3.67
-Summer 2022,CIVE,8598,7,16383,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,0
-Summer 2022,INDE,8398,6,13314,Doctoral Research,Peng PhD,Jiming Ouyang,0,0,0,0,0,1,0,0
-Summer 2022,ARLD,6198,1,17009,Special Prob in Arts Leadrshp,Fernando,Fleurette S,1,0,0,0,0,0,0,4
-Summer 2022,ENGL,8698,1,13260,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,3,0,0
-Summer 2022,ECE,8498,12,16699,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,0,0,0
-Summer 2022,BIOE,8399,17,16680,Doctoral Dissertation,Das,Mini,1,0,0,0,0,0,0,4
-Summer 2022,PCOL,8399,3,16820,Doctoral Dissertation,Statsyuk,Alexander V,1,0,0,0,0,0,0,4
-Summer 2022,BCHS,8698,7,16939,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,1112,7,10838,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,0,0,0,0,3.269
-Summer 2022,ECE,8498,23,16854,Doctoral Research,Chen,Jiefu,0,0,0,0,0,6,0,0
-Summer 2022,OPTO,8338,1,11096,Recent Developments/Round,Wheat,Joe L,16,16,0,0,0,0,0,3.418
-Summer 2022,BIOE,6343,1,13081,Global Healthcare,Akay PhD,Metin,14,0,0,0,0,0,0,3.882
-Summer 2022,PHAR,5207,1,12941,Herbal Medicine,Ruan,Ke-He,17,3,0,0,0,0,0,3.85
-Summer 2022,BIOL,2101,5,11342,Anatomy & Physiology Lab I,Gill,Tejendra,5,7,3,1,3,0,0,2.526
-Summer 2022,PHAR,5685,1,11119,Critical Care,Truong,Mabel,4,1,0,0,0,0,0,3.8
-Summer 2022,GEOL,8399,7,17371,Doctoral Dissertation,Mann,Paul,1,0,0,0,0,0,0,4
-Summer 2022,CHEE,8399,11,10951,Doctoral Dissertation,Karim,Alamgir,7,0,0,0,0,0,0,4
-Summer 2022,PHYS,8698,15,16725,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,3,0,0
-Summer 2022,ENGL,1301,6,12106,First Year Writing I,Decarion,Andrew P,6,2,0,0,3,0,0,2.757
-Summer 2022,GOVT,2306,3,12668,US and Texas Const/Politics,Cole,Jeffrey Bryan,7,8,3,1,0,0,0,3.071
-Summer 2022,LAW,5299,17,12659,Special Problems,Vetter,Greg R,0,0,0,0,0,4,0,0
-Summer 2022,PHYS,8698,33,17079,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8198,16,16376,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,2,0,0
-Summer 2022,IDNS,7099,1,17370,Degree Completion,Fitzgibbon,William E,0,0,0,0,0,1,0,0
-Summer 2022,ECE,8498,3,16666,Doctoral Research,Yao,Yan,0,0,0,0,0,4,0,0
-Summer 2022,INDE,8699,3,13328,Doctoral Dissertation,Lee,Tae Woo,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8198,9,16531,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5410,1,10042,Law Review,Sanders,Joseph,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8298,7,16673,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,11,16625,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8698,131,17149,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8398,9,16635,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,4398,1,17165,Independent Study,Rimer,Jeffrey,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8198,2,16353,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,0
-Summer 2022,PHCA,6498,2,17307,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4
-Summer 2022,CIS,6399,1,17202,Master's Thesis,Zhang,Yunpeng,1,0,0,0,0,0,0,4
-Summer 2022,PHYS,8399,5,10327,Doctoral Dissertation,Bellwied,Rene,1,0,0,0,0,0,0,4
-Summer 2022,ECON,8699,5,13287,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,22,17059,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,6335,4,13560,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,8,0,0,0,0,0,0,4
-Summer 2022,SPAN,2312,12,10556,Intermediate Spanish II,Abend Van Dalen,Raquel Andreina de la Trinidad,10,7,3,0,1,0,0,3.222
-Summer 2022,OPTO,8991,1,11100,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,51,0,0
-Summer 2022,ENGL,1301,1,10071,First Year Writing I,O'Bryan,Ann Patricia,13,2,1,0,5,0,0,2.857
-Summer 2022,DRAM,1310,6,16074,Introduction to Theatre,Brincks,Alan,34,8,1,1,5,0,1,3.3
-Summer 2022,CNST,3331,1,12625,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,15,9,8,1,0,0,0,3.152
-Summer 2022,KIN,3350,1,11589,Psych Aspects Sport Exercise,Gray,Jon Phillip,50,4,2,0,0,0,2,3.839
-Summer 2022,SPEC,7391,1,12606,Collab Consulting & Coaching,Carp,Charlotte Lynn,21,2,0,0,0,0,0,3.87
-Summer 2022,THEA,6182,1,12230,Applying Methods Light/Costume,Willson,Paige A,12,0,0,0,0,0,0,4
-Summer 2022,ECON,2301,3,13471,Principles of Macroeconomics,Loaeza Albino,Eva Davinia,2,3,4,0,0,0,0,2.631
-Summer 2022,MATH,1324,2,10121,Finite Math with Applications,Sosa,Moses,10,6,3,2,0,0,2,3.017
-Summer 2022,MANA,   6A83,1,11743,Strategic Analysis,Celly,Nikhil,27,2,0,0,0,0,0,3.931
-Summer 2022,CUIN,7331,5,16072,Supporting Striving Readers,Reis,Nancy,10,0,0,0,0,0,0,3.967
-Summer 2022,GENB,7397,2,15598,Selected Topics,Miljanic,Andra Olivia,8,1,0,0,0,0,0,3.889
-Summer 2022,NURS,4216,1,12447,Perioperative Nursing,Quintana,Danielle,28,0,0,0,0,0,0,4
-Summer 2022,BIOE,8198,5,16483,Doctoral Research,Larin,Kirill,0,0,0,0,0,6,0,0
-Summer 2022,EDS,6397,1,17253,Selected Topics,Lendasse,Amaury,9,1,0,0,1,0,0,3.395
-Summer 2022,MECE,4398,1,17312,Independent Study,Love,Holley Carole,3,0,0,0,0,0,0,4
-Summer 2022,ECON,4390,3,12100,Economics Internship,Thornton,Rebecca Achee,17,2,0,0,0,0,0,3.895
-Summer 2022,LAW,5341,1,15455,Disabilities and the Law,Roberts,Jessica,2,4,0,0,0,2,0,2.541
-Summer 2022,CHEM,1112,18,12602,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,1,2,2,0,1,2.6
-Summer 2022,CHEM,6698,2,10624,Special Problems,Brgoch,Jakoah,0,0,0,0,0,2,0,0
-Summer 2022,GEOL,8698,2,16341,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5328,2,11593,Judicial Externship I,Worrell,Carey Ann,0,0,0,0,0,4,0,0
-Summer 2022,PHAR,5664,1,11108,Legal & Regulatory Affairs,Tolleson,Shane Russell,1,0,0,0,0,0,0,4
-Summer 2022,NURS,6338,1,12951,Advanced Pathophysiology,Reeve,Kathleen D,4,2,1,0,0,0,0,3.429
-Summer 2022,LAW,6234,1,16981,Juvenile Representation II,Dow,Katya Glockner,0,0,0,0,0,1,0,0
-Summer 2022,FINA,6398,1,16880,Research,Bean,Gregory S.,1,0,0,0,0,0,0,4
-Summer 2022,ECON,8391,1,16461,PhD Internship,Yi,Kei-Mu,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8698,102,13242,Doctoral Research,Chen,Guoning,0,0,0,0,0,4,0,0
-Summer 2022,CHEE,8298,17,16298,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5229,2,12159,Judicial Externship II,Van Arsdel,Kristina G,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8598,10,16386,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,4,0,0
-Summer 2022,MECE,8298,15,16639,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,0
-Summer 2022,OPTO,5198,3,16251,Spec Prob Phys Optics,Patel,Ryan,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,6698,8,16798,Special Problems,Willson,Richard,0,0,0,0,0,1,0,0
-Summer 2022,ECE,6598,1,10975,Research,Pan,Miao,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5603,1,11966,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8399,1,10941,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,2319,2,11417,Intro to Social Psychology,Serrano Aguirre,Surizaday,45,7,3,0,0,0,0,3.776
-Summer 2022,HDCS,3303,1,11557,Retailing and Consumer Science,Rifai,Rana Ihsan,11,1,1,3,1,0,1,2.904
-Summer 2022,SPAN,3308,1,12694,Written Com-Hisp Herit Learner,Aguilar,Jacqueline,23,0,0,0,0,0,0,4
-Summer 2022,MANA,7375,1,11903,Global Leadership,Vera,Dusya M,33,1,0,0,0,0,0,3.863
-Summer 2022,SOCW,7368,1,11908,Trauma Treatment for Children,Amtsberg,Donna K.,24,0,0,0,0,0,0,4
-Summer 2022,CUIN,4332,5,14464,Literacy Assess Rdg Writing,Reis,Nancy,14,0,0,0,0,0,0,4
-Summer 2022,HRD,3350,30,12370,Workforce Diversity and Global,Polesello,Daiane,11,2,3,1,2,0,0,2.983
-Summer 2022,MATH,2312,2,12366,Precalculus,May,Jennifer Ruhnow,8,6,2,1,3,0,1,2.75
-Summer 2022,ECE,8298,21,16813,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,0
-Summer 2022,SCLT,4389,32,15499,Practicum in Supply Chain,Kidd,Margaret A,5,14,2,0,1,0,0,2.895
-Summer 2022,PHYS,2326,1,12378,University Physics II(lecture),Varghese,Oomman K,11,10,4,0,0,0,3,3.174
-Summer 2022,INDE,2333,1,10032,Engineering Statistics I,Wiggins,Nathanial David,21,9,1,0,0,0,0,3.485
-Summer 2022,OPTO,6251,1,11093,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,13,0,0
-Summer 2022,ELED,4320,1,13564,Social Studies Ele Sch,Ford,Haley Michelle Grimland,22,0,1,1,1,0,0,3.653
-Summer 2022,INDE,6372,1,17129,Advanced Linear Optimization,Lim,Gino Jinho,1,1,1,0,0,0,0,2.78
-Summer 2022,NUTR,4346,1,12634,Research in Nutrition,Haubrick,Kevin,19,8,8,1,1,0,1,3.109
-Summer 2022,LAW,6300,3,11600,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,4,0,0
-Summer 2022,COMM,4383,1,15517,Documentary Filmmaking,Hamzah,Sahar Riyad,9,2,0,0,0,0,0,3.818
-Summer 2022,PHYS,8698,8,16718,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,2,0,0
-Summer 2022,COMM,2311,5,12840,Writing for Print and Digital,Radcliffe Andre,Jennifer,13,4,2,1,0,0,0,3.384
-Summer 2022,THEA,6384,1,12225,Directing,Cook,Rena R,12,0,0,0,0,0,0,4
-Summer 2022,BCHS,6698,13,17143,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,0
-Summer 2022,LAW,6349,1,11021,Consumer Law Clinic,Marquez,Ryan Michael,1,1,0,0,0,0,0,3.5
-Summer 2022,WGSS,4360,1,12079,Capstone Internship Course,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,0,0,4
-Summer 2022,PETR,8598,6,16585,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8298,1,10924,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,0
-Summer 2022,CNST,6399,1,16181,Thesis,Din,Zia Ud,0,0,0,0,0,0,0,0
-Summer 2022,BUSI,3300,1,13464,Intro to Personal Finance,Harvey,Danny,44,0,1,0,3,0,0,3.708
-Summer 2022,MATH,2312,1,11059,Precalculus,Almus,Melahat,14,7,9,2,12,0,11,2.16
-Summer 2022,MATH,1314,3,15471,College Algebra,Caputo,Matthew G,7,4,3,1,2,0,3,2.765
-Summer 2022,PSYC,3301,4,12823,Intro Psych Stats,Nguyen,My Viet Ha,7,14,9,5,9,0,7,2.151
-Summer 2022,ECE,8398,15,16931,Doctoral Research,Pan,Miao,0,0,0,0,0,3,0,0
-Summer 2022,ARLD,6691,1,12231,Internship in Arts Organizatn,Luks Jacobs,Joel,1,0,0,0,0,0,0,4
-Summer 2022,HDCS,3300,1,11731,Org Decisions,Hitchman Sr,Cal M,11,7,1,0,2,0,1,3.08
-Summer 2022,NUTR,3101,1,11455,Dietetics As a Profession,Scott,Claudia W,11,6,0,0,0,0,0,3.608
-Summer 2022,CLAS,3345,1,15475,Myth&Performance in Greek Trag,Houlihan,James W,16,6,0,1,0,0,0,3.58
-Summer 2022,LAW,5245,1,11138,Civil Practice Clinic II,Krasny,Frederick A,0,1,0,0,0,0,0,3.33
-Summer 2022,SPAN,8699,1,10095,Dissertation,Rivera Garza,Cristina,2,0,0,0,0,0,0,4
-Summer 2022,CIVE,8598,13,16389,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,0
-Summer 2022,PHOP,8398,2,13285,Doctoral Research,Das,Vallabh E,1,0,0,0,0,0,0,4
-Summer 2022,PHYS,8698,23,16733,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,5,0,0
-Summer 2022,MECE,8498,13,16631,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8698,18,16728,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,16,17088,Doctoral Research,Chung,Sanghyuk,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8198,7,16367,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,0
-Summer 2022,PHYS,8398,27,10317,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,3310,1,11901,Indstrl-Orgnztnl Psy,Van Egdom,Drake Alexander,33,9,12,1,3,0,0,3.229
-Summer 2022,MECE,3381,1,12220,Finite Elements for Mech Engr,Chen,Xuemei,17,21,15,3,3,0,3,2.813
-Summer 2022,BIOL,8698,12,16948,Doctoral Research,Sater,Amy,0,0,0,0,0,3,0,0
-Summer 2022,CIVE,8198,12,16372,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,0
-Summer 2022,ENGL,8399,4,13186,Doctoral Dissertation,Shepley,Nathan,0,0,0,0,0,0,0,0
-Summer 2022,LAW,5424,1,12125,Death Penalty Clinic,Jeu Tebbano,Cassandra,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8699,1,11934,Doctoral Dissertation,Hoff,Kevin,0,0,0,0,0,1,0,0
-Summer 2022,HRD,6358,30,12641,Global Human Resource Devel,Waight,Consuelo L,7,0,0,0,0,0,0,4
-Summer 2022,BIOL,6698,9,16796,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,0
-Summer 2022,ECON,8699,2,17377,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8398,16,16416,Doctoral Research,Wu,Tianfu,0,0,0,0,0,3,0,0
-Summer 2022,FINA,   6A98,1,17076,Research,George,Thomas J,1,0,0,0,0,0,0,4
-Summer 2022,PHYS,6698,9,16786,Special Problems,Curran,Seamus A,0,0,0,0,0,1,0,0
-Summer 2022,POLS,4498,1,16203,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,0
-Summer 2022,GEOL,8698,15,17042,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5228,2,12157,Judicial Externship I,Archer,Anna M,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,8698,6,16770,Doctoral Research,Khurana,Seema,0,0,0,0,0,1,0,0
-Summer 2022,ELCS,8399,1,12844,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,0
-Summer 2022,KIN,1304,1,11345,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,190,26,7,2,3,0,4,3.773
-Summer 2022,MUSI,1182,1,12215,Group Piano II,Van Kekerix,Todd Evan,11,0,1,0,0,0,0,3.806
-Summer 2022,ACCT,7364,1,15334,Transf Pricing: Theory & Pract,Mangano,Clifford A,16,3,1,0,0,0,0,3.734
-Summer 2022,MECE,8298,7,16559,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,3,0,0
-Summer 2022,INDE,4315,1,12277,Supply Chain Design Management,Wang,Yaping,6,8,3,0,0,0,0,3.235
-Summer 2022,ENGL,3352,1,12233,19th Century American Fiction,Wood,Barry Albert,13,15,0,0,0,0,2,3.394
-Summer 2022,CUIN,4375,1,13427,Classroom Management,Thompson,Alan M,17,1,0,0,0,0,0,3.908
-Summer 2022,KIN,4340,1,11252,Sport Governance,Walsh,David W,2,12,2,0,0,0,0,3.021
-Summer 2022,PSYC,3350,6,12855,Intro to Cognitive Psychology,Anderson,Jill Annette,23,14,1,0,0,0,0,3.466
-Summer 2022,SOCW,7326,1,12167,Disparities in Health,Torres,Isabel,15,8,0,0,0,0,0,3.667
-Summer 2022,PETR,6325,2,15677,Integrated Resrv Characterztn,Gonzalez,Reinaldo J,2,1,2,0,0,0,0,2.802
-Summer 2022,CUIN,8310,1,12732,Laboratory of Practice,Hutchison,Laveria F,8,0,0,0,0,0,0,4
-Summer 2022,PCOL,6298,2,16497,Special Problems,Ruan,Ke-He,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5328,2,11593,Judicial Externship I,Archer,Anna M,0,0,0,0,0,4,0,0
-Summer 2022,PHAR,5695,1,11127,Geriatrics,Tolleson,Shane Russell,3,0,0,0,0,0,0,4
-Summer 2022,PHCA,8698,2,16476,Doctoral Dissertation Research,Aparasu,Rajender R,0,0,0,0,0,2,0,0
-Summer 2022,COMM,4354,1,13398,Organizational Crisis Comm.,Uhrick,Jan,3,0,0,0,0,0,0,4
-Summer 2022,SOC,7396,1,17146,Internship in Sociology,Baumle,Amanda K,0,0,0,0,0,0,0,0
-Summer 2022,CHEM,8698,9,10712,Doctoral Research,Teets,Thomas,0,0,0,0,0,6,0,0
-Summer 2022,PHLS,8199,5,17094,Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,6365,2,13187,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,1,0,0
-Summer 2022,INDE,6398,7,13633,Research,Lin PhD,Ying,0,0,0,0,0,1,0,0
-Summer 2022,PCOL,6498,1,16459,Special Problems,Zhang,Ruiwen,0,0,0,0,0,0,0,0
-Summer 2022,CHEE,8398,2,10930,Doctoral Research,Harold,Michael P,0,0,0,0,0,5,0,0
-Summer 2022,BIOL,6698,19,17053,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,0
-Summer 2022,LAW,6300,11,12331,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,6698,9,10630,Special Problems,Bao,Jiming,0,0,0,0,0,2,0,0
-Summer 2022,PSYC,6398,13,17246,Independent Studies,Damian,Rodica Ioana,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,16,16817,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,0
-Summer 2022,PHLS,8393,3,15420,Doctoral Practicum in Psy,Roche,Meghan K,0,0,0,0,0,2,0,0
-Summer 2022,MECE,8298,12,16627,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,8399,4,16833,Doctoral Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,0
-Summer 2022,PSYC,7399,11,17056,Masters Thesis,Fetterman,Adam Kent,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,8399,2,16323,Doctoral Dissertation,Wang,Yuxuan,1,0,0,0,0,0,0,4
-Summer 2022,TLIM,4342,32,12931,Quality Improvement Methods,O'Kelley,Donna K,5,10,4,1,1,0,0,2.825
-Summer 2022,HIST,4379,1,13426,Sex and Violence in Old South,Deyle,Steven H,15,15,2,1,2,0,0,3.152
-Summer 2022,MANA,4385,1,14489,Intro to Strategic Management,Tabesh,Pooya,10,4,1,0,1,0,0,3.334
-Summer 2022,ARCH,3397,1,15534,Selected Topics,Diehl,Tom,3,14,5,0,1,0,0,2.768
-Summer 2022,KIN,1352,6,11609,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,97,10,2,0,0,0,0,3.875
-Summer 2022,TLIM,3345,1,12918,Human Resources in Technology,Mehring,Brian George,7,8,2,3,3,0,1,2.537
-Summer 2022,MATH,8698,15,13226,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,0
-Summer 2022,HLT,4302,1,13585,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,29,9,3,0,0,0,1,3.586
-Summer 2022,PEP,6309,1,11346,Policies & Govt of Sport Org.,Hawkins,Billy J,12,0,0,0,0,0,0,3.973
-Summer 2022,ACCT,5331,1,10875,Federal Income Tax-Individual,Fernandez,Ramon,0,2,2,0,0,0,0,2.665
-Summer 2022,MANA,7346,1,11741,Global Human Resource Mgmt,Werner,Steve,12,0,0,0,0,0,0,4
-Summer 2022,PETR,8598,11,16607,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,0
-Summer 2022,CHEM,8698,11,10714,Doctoral Research,Cuny,Gregory D,0,0,0,0,0,1,0,0
-Summer 2022,COMM,7397,1,16285,Selected Topics - Comm,Ashley,Laura B,3,0,0,0,0,0,0,4
-Summer 2022,MECE,8398,24,16571,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,0
-Summer 2022,NURS,6336,1,16053,Mgmt of Hlth Disordrs Clinical,Dwyer,Carol Ann,0,0,0,0,0,8,0,0
-Summer 2022,PHYS,8398,41,11501,Doctoral Research,Bittner,Eric R,0,0,0,0,0,1,0,0
-Summer 2022,MATH,1324,6,11625,Finite Math with Applications,Caglar,Atife,18,4,7,3,1,0,1,3.081
-Summer 2022,TLIM,3340,30,12917,Org Leadership & Supervision,Lattier,Gregory Jeff,27,5,3,1,3,0,3,3.299
-Summer 2022,GOVT,2306,10,11912,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,9,18,8,1,0,0,2,2.899
-Summer 2022,TLIM,3360,30,13446,Law & Ethics-Tech & Innovation,Soliz,Rudy,30,0,1,0,1,0,1,3.813
-Summer 2022,OPTO,6115,2,13078,Clinical Integration,Dempsey,Robert L.,0,0,0,0,0,42,0,0
-Summer 2022,MECE,2361,1,16166,Intro Mechanical Design,Chang,Christiana,0,19,19,2,0,0,0,2.499
-Summer 2022,GOVT,2306,2,11254,US and Texas Const/Politics,Lopez-Hisijos,Lucia,20,1,0,0,2,0,0,3.566
-Summer 2022,PSYC,2305,1,12846,Intro to Methods in Psychology,Babalola,Olusegun Maria,28,23,3,1,6,0,3,2.995
-Summer 2022,SOCW,7376,1,13420,Social Work-LGBTQ Communities,Keo,Bec Sokha,9,0,0,0,0,0,0,4
-Summer 2022,ACCT,4335,5,15329,Financial Statement Auditing,Kuruvilla,Mohan,2,2,6,1,1,0,1,2.305
-Summer 2022,PCOL,6298,3,16616,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,0
-Summer 2022,ANTH,7399,1,17244,Masters Thesis,Storey,Rebecca,0,0,0,0,0,1,0,0
-Summer 2022,COSC,8399,129,17174,Doctoral Dissertation,Verma,Rakesh M,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8398,24,17048,Doctoral Research,Pollonini,Luca,0,0,0,0,0,2,0,0
-Summer 2022,HLT,4393,1,10888,Field Work in Com Health,Solari Williams,Kayce D.,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,7399,2,16453,Masters Thesis,Casey,John F,1,0,0,0,0,0,0,4
-Summer 2022,BIOL,1307,1,10577,Biology for Science Majors II,Farmer,Lisa M,11,10,14,9,1,0,2,2.525
-Summer 2022,BIOE,8198,11,17020,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,0
-Summer 2022,SUBS,6397,1,16148,Selected Topics,Sun,Li,5,1,0,0,0,0,0,3.888
-Summer 2022,MECE,8399,23,16594,Doctoral Dissertation,Ryou,Jae-Hyun,1,0,0,0,0,0,0,4
-Summer 2022,ARTS,2311,1,15639,"Color, Materials and Methods",Bootwala,Jennifer Elizabeth,8,4,0,2,1,0,1,3.045
-Summer 2022,ATP,6302,1,11776,Emergency Care,Yellen,Joshua B,15,2,0,0,0,0,0,3.882
-Summer 2022,PSYC,8399,7,11982,Doctoral Dissertation,Babcock,Julia,2,0,0,0,0,0,0,4
-Summer 2022,COMD,7391,1,13275,Clinic in Speech Lang Disorder,Sims,Frankie B,1,1,0,0,0,0,0,3.665
-Summer 2022,ECE,8398,7,16704,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,0
-Summer 2022,PHYS,8698,16,16726,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8498,18,16983,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,7399,5,11953,Masters Thesis,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5103,1,10033,Health Law Journal,Mantel,Jessica,0,0,0,0,0,0,0,0
-Summer 2022,PHOP,6257,2,12507,Research Practicum B,Burns,Alan R,1,0,0,0,0,0,0,4
-Summer 2022,HIST,8699,2,17134,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,0,0,0
-Summer 2022,MARK,4398,1,17327,Independent Study,Herman,Carl,1,0,0,0,0,0,0,4
-Summer 2022,AAS,2320,2,10846,Intro To African American Stdy,Thompson,Kevin Bernard,29,3,2,0,0,0,1,3.804
-Summer 2022,PHLS,6310,1,12389,Intro To Educ Research,Lee,Jungeun,25,3,1,0,0,0,0,3.816
-Summer 2022,MATH,2312,4,10739,Precalculus,Caglar,Atife,7,9,6,0,2,0,1,2.792
-Summer 2022,ECE,8498,9,16696,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,0
-Summer 2022,THEA,6386,1,12193,Drama in Context,Shimko,Robert B,12,0,0,0,0,0,0,3.973
-Summer 2022,KIN,4360,1,12375,Adaptive Athletics Management,Cottingham,Michael,13,0,0,0,0,0,0,3.949
-Summer 2022,BIOE,8298,2,16448,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,0
-Summer 2022,ECE,8598,3,10994,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,0
-Summer 2022,BIOL,2302,1,11452,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,21,20,13,8,1,0,3,2.789
-Summer 2022,ARCH,6602,1,10868,Arch Design/Build Workshop,Peters,Patrick A,8,1,0,0,0,0,0,3.816
-Summer 2022,BIOL,3330,1,15557,Biological Field Research,Cheek,Ann Oliver,6,10,0,0,0,0,0,3.478
-Summer 2022,ELCS,6330,2,13434,Finance & School-Based Budgtng,Merricks,Michelle Fernandez,13,1,0,0,0,0,0,3.929
-Summer 2022,PHYS,1102,6,13166,College Physics II (lab),Maric,Sladjana,2,13,3,1,1,0,0,2.684
+Summer 2022,PSYC,8399,18,16753,Doctoral Dissertation,Viana,Andres G,0,0,0,0,0,2,0,
+Summer 2022,PSYC,8399,19,16754,Doctoral Dissertation,Vujanovic,Anka Anna,0,0,0,0,0,1,0,
+Summer 2022,PSYC,7399,7,16761,Masters Thesis,Spitzmuller,Christiane,1,0,0,0,0,1,0,4.0
+Summer 2022,GEOL,8698,6,16762,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,5,16763,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6698,5,16764,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,3,0,
+Summer 2022,ENGL,7399,2,16765,Essay,Lee,Eunjeong,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,8698,3,16766,Doctoral Research,Briggs,James M,0,0,0,0,0,2,0,
+Summer 2022,BIOL,6698,7,16767,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,6,16770,Doctoral Research,Khurana,Seema,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6698,6,16771,Special Problems,Liu,Yu,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,7,16772,Doctoral Research,Feng,Qin,0,0,0,0,0,2,0,
+Summer 2022,BCHS,6698,7,16775,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Summer 2022,HRMA,6398,1,16778,Special Problems,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,6698,8,16780,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Summer 2022,GEOL,8698,7,16783,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,0,0,
+Summer 2022,PHYS,6698,9,16786,Special Problems,Curran,Seamus A,0,0,0,0,0,1,0,
+Summer 2022,PETR,5397,1,16789,Selected Topics,Mohamed,Mohamed Ibrahim,0,0,0,0,0,0,1,
+Summer 2022,MANA,4396,2,16790,Management Internship,Carlin,Barbara A,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8699,3,16792,Doctoral Dissertation,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,15,16795,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,
+Summer 2022,BIOL,6698,9,16796,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6698,8,16798,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,15,16799,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,
+Summer 2022,ECE,6398,3,16800,Research,Chen,Ji,0,0,0,0,0,3,0,
+Summer 2022,BCHS,6698,9,16802,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,2,0,
+Summer 2022,PSYC,7399,8,16803,Masters Thesis,Cirino,Paul,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8298,16,16804,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,5,0,
+Summer 2022,ECE,8298,17,16805,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Summer 2022,BIOL,6698,10,16808,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,3,0,
+Summer 2022,ECE,8298,18,16810,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,19,16811,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,20,16812,Doctoral Research,Fu,Xin,0,0,0,0,0,5,0,
+Summer 2022,ECE,8298,21,16813,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,16,16814,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,17,16815,Doctoral Research,Chen,Ji,0,0,0,0,0,4,0,
+Summer 2022,ECE,8498,18,16816,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,16,16817,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,16,16818,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,19,16819,Doctoral Research,Fu,Xin,0,0,0,0,0,5,0,
+Summer 2022,PCOL,8399,3,16820,Doctoral Dissertation,Statsyuk,Alexander V,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8498,20,16821,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,5,0,
+Summer 2022,ECE,8498,21,16822,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Summer 2022,PHLS,8199,4,16826,Dissertation,Arbona,Consuelo,0,0,0,0,0,0,0,
+Summer 2022,PHLS,8399,3,16827,Doctoral Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2022,PHLS,7398,1,16832,Candidacy Research,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Summer 2022,PHLS,8399,4,16833,Doctoral Dissertation,Obasi,Ezemenari M,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6698,10,16834,Special Problems,Yeo,Hye-Jeong,0,0,0,0,0,1,0,
+Summer 2022,ECE,6298,1,16837,Research,Chen,Ji,0,0,0,0,0,0,0,
+Summer 2022,ECE,6298,2,16838,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Summer 2022,ECE,6198,2,16839,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Summer 2022,ECE,6398,4,16840,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Summer 2022,BCHS,8698,4,16841,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2022,ECE,8699,1,16844,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Summer 2022,ECE,8398,8,16845,Doctoral Research,Chen,Ji,0,0,0,0,0,1,0,
+Summer 2022,ECE,8398,9,16846,Doctoral Research,Wolfe,John C,0,0,0,0,0,0,0,
+Summer 2022,ILAS,3150,1,16847,Internship Practicum,Connolly,Sally,6,2,1,0,1,0,0,3.2
+Summer 2022,ECE,8699,3,16849,Doctoral Dissertation,Shireen,Wajiha,0,0,0,0,0,0,0,
+Summer 2022,ECE,8298,22,16851,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,23,16852,Doctoral Research,Chen,Jiefu,0,0,0,0,0,6,0,
+Summer 2022,ECE,8498,22,16853,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,23,16854,Doctoral Research,Chen,Jiefu,0,0,0,0,0,6,0,
+Summer 2022,ECE,8198,8,16857,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Summer 2022,ECE,8398,12,16860,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,
+Summer 2022,BIOL,6698,12,16861,Special Problems,Alward,Beau Andrew,0,0,0,0,0,1,0,
+Summer 2022,ECE,8399,8,16862,Doctoral Dissertation,Le,Hung Quang,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,6298,3,16863,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Summer 2022,ECE,6198,3,16864,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,8,16865,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Summer 2022,ECE,8398,13,16869,Doctoral Research,Chen,Jiefu,0,0,0,0,0,2,0,
+Summer 2022,PSYC,7397,1,16875,Selected Topics in Psychology,Vujanovic,Anka Anna,0,0,0,0,0,1,0,
+Summer 2022,PSYC,7397,2,16876,Selected Topics in Psychology,Cirino,Paul,0,0,0,0,0,2,0,
+Summer 2022,PSYC,7397,4,16878,Selected Topics in Psychology,Harris,Gerald E,0,0,0,0,0,1,0,
+Summer 2022,FINA,6398,1,16880,Research,Bean,Gregory S.,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,8399,20,16882,Doctoral Dissertation,Damian,Rodica Ioana,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,8698,5,16883,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,9,16884,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,
+Summer 2022,BIOL,8698,10,16885,Doctoral Research,Meisel,Richard P,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6698,11,16886,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6352,5,16887,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6398,11,16888,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,0,0,
+Summer 2022,BIOL,6698,13,16889,Special Problems,Meisel,Richard P,0,0,0,0,0,2,0,
+Summer 2022,PSYC,7399,9,16891,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6398,12,16898,Independent Studies,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,8698,6,16904,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,17,16906,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,17,16907,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Summer 2022,PHOP,8199,3,16909,Doctoral Dissertation,Coulson-Thomas,Vivien J,0,0,0,0,0,0,0,
+Summer 2022,BIOL,8698,11,16913,Doctoral Research,Fujita,Masaya,0,0,0,0,0,1,0,
+Summer 2022,PCEU,8399,2,16914,Doctoral Dissertation,Hu,Ming,0,0,0,0,0,1,0,
+Summer 2022,PHLS,8399,5,16915,Doctoral Dissertation,Reitzel,Lorraine R,0,0,0,0,0,1,0,
+Summer 2022,ECE,8298,24,16917,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,24,16918,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Summer 2022,OPTO,8992,1,16919,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,2,0,
+Summer 2022,OPTO,8993,1,16920,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,2,0,
+Summer 2022,PSYC,6359,7,16922,Directed Rsch in Clinical Psyc,Viana,Andres G,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,7399,10,16923,Masters Thesis,Hoff,Kevin,0,0,0,0,0,1,0,
+Summer 2022,GEOL,8398,2,16924,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,0,0,
+Summer 2022,GEOL,8698,8,16927,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,2,0,
+Summer 2022,ECE,8398,14,16929,Doctoral Research,Becker,Aaron T,0,0,0,0,0,2,0,
+Summer 2022,ECE,8399,9,16930,Doctoral Dissertation,Becker,Aaron T,2,0,0,0,0,0,0,4.0
+Summer 2022,ECE,8398,15,16931,Doctoral Research,Pan,Miao,0,0,0,0,0,3,0,
+Summer 2022,ECE,8298,25,16932,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2022,ECE,8498,25,16933,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2022,ECE,8399,10,16934,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,6198,4,16936,Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2022,ECE,6398,5,16937,Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2022,BIOL,6698,14,16938,Special Problems,Warner,Margaret,0,0,0,0,0,1,0,
+Summer 2022,BCHS,8698,7,16939,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Summer 2022,HON,4398,1,16940,Independent Study,Cremins,Robert Paul,1,0,0,0,0,0,0,4.0
+Summer 2022,ANTH,6398,1,16942,Special Problems,Brown,Kenneth L,2,0,0,0,0,0,0,4.0
+Summer 2022,MUSI,8296,2,16944,Doctoral Essay,Dirst,Matthew C,0,0,0,0,0,0,0,
+Summer 2022,BIOL,6698,15,16947,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,2,0,
+Summer 2022,BIOL,8698,12,16948,Doctoral Research,Sater,Amy,0,0,0,0,0,3,0,
+Summer 2022,COSC,8698,101,16949,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8399,21,16950,Doctoral Dissertation,Hoff,Kevin,0,0,0,0,0,3,0,
+Summer 2022,KIN,4398,2,16952,Independent Study,Ogunrinde,Joyce,1,0,0,0,0,0,0,4.0
+Summer 2022,COSC,8399,110,16953,Doctoral Dissertation,Gurkan,Deniz,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,8698,9,16954,Doctoral Research,Castagna,John P,0,0,0,0,0,3,0,
+Summer 2022,GEOL,8698,10,16955,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,10,0,
+Summer 2022,GEOL,8399,5,16957,Doctoral Dissertation,Li,Aibing,1,0,0,0,0,0,0,4.0
 Summer 2022,SOC,3311,2,16958,Sociology of Law,Gallo,Joseph Ralph,28,3,11,1,3,0,4,3.13
-Summer 2022,PHYS,1102,5,12781,College Physics II (lab),Wood,Lowell T,2,9,6,0,0,0,0,2.668
-Summer 2022,PHLS,6335,2,13562,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,11,0,0,0,0,0,0,3.97
-Summer 2022,FORE,6396,1,11740,Internship,Hines,Andrew Lewis,6,0,0,0,0,0,0,4
-Summer 2022,CHEE,8399,8,10948,Doctoral Dissertation,Orman,Mehmet,4,0,0,0,0,0,0,4
-Summer 2022,MATH,8398,1,12540,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,1,0,0
-Summer 2022,BCHS,6698,7,16775,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,0
-Summer 2022,ECE,6399,3,17177,Masters Thesis,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,0
-Summer 2022,LAW,6234,1,16981,Juvenile Representation II,Fisher,Dena L,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,7399,1,12291,Masters Thesis,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8298,10,17019,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,0
-Summer 2022,PHCA,8298,2,12543,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4
-Summer 2022,COSC,4353,101,12900,Software Design,Singh,Raj Kumar,19,8,3,0,1,0,0,3.366
-Summer 2022,SOCW,7356,2,15660,Groups in Clinical Settings,Cheung,Poi Ten Ada,26,0,0,0,0,0,0,4
-Summer 2022,MANA,7351,1,12637,Mgt of  Global Organizations,Keller,Robert T,12,6,0,0,0,0,0,3.444
-Summer 2022,PSYC,4321,3,12856,Abnormal Psychology,Gioia,Anthony,19,10,6,4,2,0,0,2.879
-Summer 2022,KIN,4302,1,12961,Fitness and Human Sexuality,Alastuey,Lisa L,7,15,12,5,2,0,2,2.431
-Summer 2022,COMM,3383,1,11905,Non-linear Editing,Crowe,Craig Warren,13,1,1,0,0,0,1,3.822
-Summer 2022,POLS,3311,2,12386,Intro Compar Politics,Vardy,Ronald V,17,4,0,0,2,0,1,3.421
-Summer 2022,PSYC,3350,2,12353,Intro to Cognitive Psychology,Anderson,Jill Annette,22,12,1,0,0,0,0,3.534
-Summer 2022,MATH,1300,1,16286,Fundamentals of Mathematics,Chang,James A,0,0,0,0,0,8,0,0
-Summer 2022,ELCS,6330,1,12238,Finance & School-Based Budgtng,Franklin,Delesa,12,3,0,0,0,0,0,3.822
-Summer 2022,MATH,6298,3,11065,Special Problems,Timofeyev,Ilya,0,0,0,0,0,4,0,0
-Summer 2022,ENGL,1302,11,13124,First Year Writing II,Rolater,Sara C,9,8,0,1,3,0,3,2.842
-Summer 2022,HDFS,4393,2,11414,Internship in HDFS,Conston,Toya,16,3,0,1,0,0,1,3.7
-Summer 2022,BIOE,6306,2,16151,Adv Artificial Neural Networks,Francis,Joseph Thachil,18,8,0,0,0,0,1,3.667
-Summer 2022,PHLS,8364,1,12203,"Prof Prac Psy: Eth,Law,& Iss",Anderson,Jacqueline R,20,1,0,0,0,0,0,3.811
-Summer 2022,ECE,3337,1,11607,Signals and Systems Analysis,Hebert,Thomas James,5,7,3,0,0,0,1,3.111
-Summer 2022,CHEM,8698,5,10708,Doctoral Research,Lee,T Randall,0,0,0,0,0,4,0,0
-Summer 2022,ATP,7301,1,11780,"Head, Neck & Spine Evaluation",Harrison,Layci,13,2,0,0,0,0,0,3.867
-Summer 2022,CHEM,8399,4,10692,Doctoral Dissertation,Harth,Eva M,3,0,0,0,0,0,0,4
-Summer 2022,LAW,5328,1,11592,Judicial Externship I,Van Arsdel,Kristina G,0,0,0,0,0,4,0,0
-Summer 2022,LAW,5603,1,11966,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,6306,1,16089,Adv Artificial Neural Networks,Francis,Joseph Thachil,5,0,1,0,0,0,0,3.612
-Summer 2022,PSYC,6365,8,17390,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,0
-Summer 2022,INDE,8198,7,13367,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,2,0,0
-Summer 2022,BIOE,4349,1,13502,Biomedical Microdevices,Majd,Sheereen,2,0,0,0,0,0,0,3.835
-Summer 2022,PSYC,8399,10,11993,Doctoral Dissertation,Spitzmuller,Christiane,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8498,6,16556,Doctoral Research,Cescon,Marzia,0,0,0,0,0,1,0,0
-Summer 2022,CIVE,8198,19,16379,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,0
-Summer 2022,POLS,8399,9,12333,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,1,0,0,0,0,0,0,4
-Summer 2022,CHEM,8698,15,10717,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,2,0,0
-Summer 2022,MATH,8698,1,11988,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8398,16,16269,Doctoral Research,Zerze,Gul,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,7399,14,17318,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,0
-Summer 2022,PETR,8198,5,16598,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,6,16557,Doctoral Research,Cescon,Marzia,0,0,0,0,0,1,0,0
-Summer 2022,DIGM,3353,32,11896,Visual Communications Tech,Bravo,Gina C,36,0,0,2,0,0,0,3.816
-Summer 2022,SPEC,8391,2,13453,Leadership Coaching,McCormick,Marina,13,2,0,0,0,0,0,3.757
-Summer 2022,CIVE,5397,1,16140,Selected Topics,Vipulanandan,Cumaraswamy,31,4,0,0,0,0,1,3.895
-Summer 2022,LAW,5203,1,12160,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,3,0,0
-Summer 2022,LAW,7397,3,15559,Selected Topics,Knake,Renee N,4,7,0,0,0,0,0,3.364
-Summer 2022,PEP,8699,1,17007,Doctoral Dissertation,Layne,Charles S,0,0,0,0,0,0,0,0
-Summer 2022,ELCS,8398,5,17348,Independent Study,Zou,Yali,1,0,0,0,0,0,0,4
-Summer 2022,PHCA,8199,2,12542,Doctoral Dissertation Defense,Johnson,Michael L,2,0,0,0,0,0,0,4
-Summer 2022,ENGL,3331,1,13557,Beg Creative Writing-Poetry,Rattner,Nicholas,18,1,0,0,0,0,0,3.93
-Summer 2022,MARK,3339,1,13132,Marketing Strategy & Planning,Lish,Alan D,22,9,1,0,0,0,0,3.605
-Summer 2022,OPTO,6115,1,12449,Clinical Integration,Dempsey,Robert L.,0,0,0,0,0,45,0,0
-Summer 2022,LAW,5203,4,12161,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,0
-Summer 2022,MECE,2361,1,16166,Intro Mechanical Design,Hammami,Farah,0,19,19,2,0,0,0,2.499
-Summer 2022,CIS,3320,1,13642,Information Visualization,Lendasse,Amaury,17,4,4,0,1,0,2,3.296
-Summer 2022,SPAN,2311,3,10084,Intermediate Spanish I,Cicerchia,Jose,15,5,3,0,1,0,1,3.293
-Summer 2022,BIOL,1106,4,10107,Biol for Science Majors I(Lab),Medrano,Ana I,22,1,1,0,0,0,0,3.834
-Summer 2022,MANA,   6A25,3,13483,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,5,2,0,0,0,0,0,3.714
-Summer 2022,BIOE,8298,6,16485,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,0
-Summer 2022,PHLS,8199,4,16826,Dissertation,Arbona,Consuelo,0,0,0,0,0,0,0,0
-Summer 2022,ECE,8498,20,16821,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,5,0,0
-Summer 2022,CIVE,8598,4,16360,Doctoral Research,Shaffer,Devin,0,0,0,0,0,5,0,0
-Summer 2022,MECE,8298,21,17058,Doctoral Research,Zhu,Weihang,0,0,0,0,0,3,0,0
-Summer 2022,COMD,7391,6,11031,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,1,0,0,0,0,0,0,3.67
-Summer 2022,PHAR,5660,1,11106,Pharmaceutical Industry,Tolleson,Shane Russell,1,0,0,0,0,0,0,4
-Summer 2022,PHOP,6157,6,16650,Research Practicum B,Frishman,Laura J,1,0,0,0,0,0,0,4
-Summer 2022,ECE,8399,5,16705,Doctoral Dissertation,Mayerich,David Matthew,1,0,0,0,0,0,0,4
-Summer 2022,PSYC,3350,1,12359,Intro to Cognitive Psychology,Santacroce,Lindsay,22,25,8,4,0,0,0,3.113
-Summer 2022,BUSI,3300,3,13465,Intro to Personal Finance,Munchbach,Jim,42,5,1,0,1,0,1,3.722
-Summer 2022,KIN,4691,1,11243,Internship in Sport Admin 2,Walsh,David W,9,2,1,0,0,0,0,3.584
-Summer 2022,ELCS,6310,1,12832,Strategic Engagement,Davis,Kenneth D,16,0,0,0,0,0,0,3.979
+Summer 2022,GEOL,8698,11,16965,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,7,0,
+Summer 2022,BCHS,8698,8,16966,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Summer 2022,HRMA,4132,2,16967,Bev Mgmt & Mktg Internship,Dawson,Mary,1,0,0,0,0,0,0,4.0
+Summer 2022,COMD,7170,1,16968,Graduate Seminar in SLP,Cizek,Laura S,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,3350,4,16971,Intro to Cognitive Psychology,Anderson,Jill Annette,10,9,2,0,1,0,0,3.092
+Summer 2022,GEOL,8698,12,16972,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Summer 2022,BIOL,6698,16,16973,Special Problems,McKeon,Frank D,0,0,0,0,0,1,0,
+Summer 2022,PSYC,4321,5,16975,Abnormal Psychology,Saiyed,Amna Shabbir,24,4,0,0,2,0,0,3.556
+Summer 2022,COMM,4398,2,16976,Independent Study,Crowe,Craig Warren,3,0,0,0,0,0,0,4.0
+Summer 2022,COMD,7192,1,16978,Advanced Practicum,Cizek,Laura S,1,0,0,0,0,0,0,3.67
+Summer 2022,ELED,4320,2,16979,Social Studies Ele Sch,Ford,Haley Michelle Grimland,21,3,1,0,0,0,1,3.813
+Summer 2022,ARTS,4398,3,16980,Independent Study,Politzer,David,1,0,0,0,0,0,0,4.0
+Summer 2022,LAW,6234,1,16981,Juvenile Representation II,Dow,Katya Glockner,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,18,16982,Doctoral Research,Prosperetti,Andrea,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,18,16983,Doctoral Research,Prosperetti,Andrea,0,0,0,0,0,1,0,
+Summer 2022,PHLS,8699,3,16984,Doctoral Dissertation,Master,Allison,0,0,0,0,0,1,0,
+Summer 2022,HRMA,6198,1,16985,Special Problems,Kim,Jaewook,1,0,0,0,0,0,0,4.0
+Summer 2022,HRMA,6198,2,16986,Special Problems,Koh,Yoon,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,8698,13,16987,Doctoral Research,Mann,Paul,0,0,0,0,0,3,0,
+Summer 2022,GEOL,8698,14,16988,Doctoral Research,Suppe,John,0,0,0,0,0,1,0,
+Summer 2022,COMM,4398,3,16989,Independent Study,Houk,Keith R,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8399,6,16991,Doctoral Dissertation,Fan,Weihua,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8399,7,16998,Doctoral Dissertation,Kim,Han Joe,1,0,0,0,0,1,0,4.0
+Summer 2022,BCHS,6698,12,17003,Special Problems,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Summer 2022,PEP,8699,1,17007,Doctoral Dissertation,Layne,Charles S,0,0,0,0,0,0,0,
+Summer 2022,GEOL,7399,3,17008,Masters Thesis,Zheng,Yingcai,1,0,0,0,0,0,0,4.0
+Summer 2022,ARLD,6198,1,17009,Special Prob in Arts Leadrshp,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7329,1,17012,SW Practice for Policy Change,Pritzker,Suzanne,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8399,8,17013,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Summer 2022,PSYC,6365,7,17017,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8298,10,17019,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8198,11,17020,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Summer 2022,BIOL,6698,17,17021,Special Problems,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Summer 2022,PHAR,5297,2,17026,Selected Topics in Pharmacy,Garey,Kevin W,2,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,6698,18,17029,Special Problems,Feng,Qin,0,0,0,0,0,2,0,
+Summer 2022,SPEC,8395,1,17034,Doctoral Thesis,Hawkins,Jacqueline McLean,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,19,17035,Doctoral Research,Sharma,Pradeep,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,19,17036,Doctoral Research,Sharma,Pradeep,0,0,0,0,0,1,0,
+Summer 2022,SOCW,7397,10,17039,Selected Topics in Social Work,Parker,Jamie Lynne,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,20,17040,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Summer 2022,MECE,8298,20,17041,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Summer 2022,GEOL,8698,15,17042,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8398,24,17048,Doctoral Research,Pollonini,Luca,0,0,0,0,0,2,0,
+Summer 2022,GEOL,8698,16,17051,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Summer 2022,BIOL,6698,19,17053,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6398,2,17054,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,21,17055,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2022,PSYC,7399,11,17056,Masters Thesis,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Summer 2022,MECE,8498,22,17057,Doctoral Research,Sun,Li,0,0,0,0,0,3,0,
+Summer 2022,MECE,8298,21,17058,Doctoral Research,Sun,Li,0,0,0,0,0,3,0,
+Summer 2022,MECE,8298,22,17059,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2022,SOCW,7397,11,17061,Selected Topics in Social Work,Acquati,Chiara,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,12,17062,Selected Topics in Social Work,Parks,Steven Lee,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,13,17063,Selected Topics in Social Work,Cheung,Monit,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,14,17064,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8399,10,17065,Doctoral Dissertation,Master,Allison,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,8698,9,17066,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Summer 2022,PHAR,5297,3,17067,Selected Topics in Pharmacy,Zhang,Yang,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,13,17068,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Summer 2022,GEOL,8399,6,17069,Doctoral Dissertation,Brandon,Alan,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,14,17070,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2022,PHCA,8199,4,17072,Doctoral Dissertation Defense,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Summer 2022,PHCA,8298,4,17073,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,6398,3,17074,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Summer 2022,ARTS,4198,1,17075,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Summer 2022,FINA,6A98,1,17076,Research,George,Thomas J,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,8698,15,17077,Doctoral Research,Warner,Margaret,0,0,0,0,0,1,0,
+Summer 2022,PHYS,8698,33,17079,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Summer 2022,PHCA,8199,5,17080,Doctoral Dissertation Defense,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2022,PHCA,8298,5,17081,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2022,PCEU,8698,1,17082,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2022,BCHS,8399,4,17086,Doctoral Dissertation,Sen,Mehmet,0,0,0,0,0,1,0,
+Summer 2022,BIOL,6698,20,17087,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Summer 2022,BIOL,8698,16,17088,Doctoral Research,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,23,17089,Doctoral Research,Agrawal,Ashutosh,0,0,0,0,0,0,0,
+Summer 2022,MECE,8298,23,17090,Doctoral Research,Agrawal,Ashutosh,0,0,0,0,0,0,0,
+Summer 2022,MECE,8399,9,17091,Doctoral Dissertation,Franchek,Matthew,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6157,10,17092,Research Practicum B,Ritchey,Eric R,0,0,0,0,0,1,0,
+Summer 2022,PHOP,6167,7,17093,Research Practicum A,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,8199,5,17094,Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,
+Summer 2022,ELET,4398,1,17099,Independent Study,Lent,Marino Ricardo,1,0,0,0,0,0,0,4.0
+Summer 2022,FINA,4397,5,17100,Selected Topics in Finance,Goudie,Thomas Lawrence,4,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8398,1,17103,Independent Study,Messa,Emily Alice,1,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8398,2,17104,Independent Study,Louis,Dave A,0,0,0,0,0,1,0,
+Summer 2022,COMD,7391,1,17107,Clinic in Speech Lang Disorder,Tragesser,Bridgid Jane,1,0,0,0,0,0,0,3.67
+Summer 2022,PHLS,8199,6,17108,Dissertation,Allan,Blake A,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,7399,12,17112,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8399,6,17113,Doctoral Dissertation,Carales,Vincent D,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,11,17114,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8198,12,17115,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2022,MECE,7399,1,17116,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2022,ECE,8198,9,17118,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Summer 2022,ECE,8598,7,17119,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6336,4,17123,Directed Rsch in Social Psyc,Damian,Rodica Ioana,0,0,0,0,0,2,0,
+Summer 2022,INDE,6372,1,17129,Advanced Linear Optimization,Lim,Gino Jinho,1,1,1,0,0,0,0,2.78
 Summer 2022,BIOL,2120,2,17130,Microbiology for Non-Science,Knapp,Richard D,0,1,0,0,0,0,0,2.67
-Summer 2022,CHEE,8498,19,16316,Doctoral Research,Vekilov,Peter,0,0,0,0,0,0,0,0
-Summer 2022,MECE,8498,16,16818,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,0
-Summer 2022,CHEE,8498,18,16315,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,0
-Summer 2022,INDS,3360,1,13164,Human Factors,Vos,Gordon A,2,0,0,0,0,0,0,3.835
-Summer 2022,SPEC,8360,1,12616,Instruct Probs in Special Pop,Kent,Shawn Christopher,8,0,0,0,0,0,0,3.959
-Summer 2022,PHYS,8698,20,16730,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,8298,14,17362,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,0
-Summer 2022,SPAN,8699,2,10096,Dissertation,Goodin-Mayeda,Carrie Elizabeth,0,0,0,0,0,1,0,0
-Summer 2022,OPTO,8099,1,17229,Degree Completion,Dempsey,Robert L.,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,6359,6,16550,Directed Rsch in Clinical Psyc,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4
-Summer 2022,LAW,5602,1,11992,Govt Nonprofit Extshp I,Van Arsdel,Kristina G,0,0,0,0,0,4,0,0
-Summer 2022,ENGL,8199,1,17153,Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,8399,12,12007,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,0
-Summer 2022,SOCW,7397,11,17061,Selected Topics in Social Work,Acquati,Chiara,1,0,0,0,0,0,0,4
-Summer 2022,NURS,3636,1,11925,Nur Process for Colabrtive Prc,Quintana,Danielle,8,43,11,1,0,0,0,3.095
-Summer 2022,KIN,4310,2,13505,Measurement Tech Human Perf,Parikh,Pranav J,35,8,2,0,0,0,0,3.719
-Summer 2022,ACCT,5301,1,15331,Financial and Managerial Acct,Kuruvilla,Mohan,3,2,1,1,1,0,3,2.666
-Summer 2022,HLT,3301,1,10462,Health Behavior Theories,Bennett,Kristin C,50,3,2,0,2,0,0,3.708
-Summer 2022,HDCS,4375,1,11559,Strategies in E-Tailing,Kellough,James David,35,3,1,1,1,0,1,3.699
-Summer 2022,PSYC,2344,2,12351,Cultural Psychology,Grigorenko,Elena L,7,7,4,3,6,0,6,2.21
-Summer 2022,ACCT,4331,1,11809,Federal Income Tax-Individual,Fernandez,Ramon,9,23,5,3,0,0,0,3.033
-Summer 2022,HLT,1353,2,13214,Personal Health,Rafique,Kiran Sajid,89,7,0,0,2,0,0,3.793
-Summer 2022,SPAN,2308,1,10557,Span for Heritage Learners II,Martinez,Raquel,17,4,3,0,2,0,1,3.308
-Summer 2022,PSYC,2301,6,12845,Introduction to Psychology,Orr,Michael F,4,4,5,2,4,0,2,2.175
-Summer 2022,PSYC,2344,1,12848,Cultural Psychology,Brooks,Jasmin R,22,13,9,2,9,0,1,2.721
-Summer 2022,MATH,6498,4,11077,Special Problems,Timofeyev,Ilya,0,0,0,0,0,4,0,0
-Summer 2022,BUSI,4396,3,15339,Business Internship,Newman,Michael Ray,0,0,0,0,0,16,0,0
-Summer 2022,ECON,6691,1,11725,Master's Internship,Rizvanoghlu,Islam,10,0,0,0,0,0,0,4
-Summer 2022,GENB,7397,1,15597,Selected Topics,Miljanic,Andra Olivia,12,2,0,0,0,0,0,3.834
-Summer 2022,ECE,8198,8,16857,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,0
-Summer 2022,LAW,5357,1,11603,Evidence,Gomez,Alissa R,11,17,0,0,0,7,0,2.667
-Summer 2022,DANC,2303,1,12196,Introduction to Dance,Bobet,Jacqueline A,10,8,5,3,1,0,1,2.766
-Summer 2022,LAW,5197,15,14191,Selected Topics,Lawrence,Jim E,0,0,0,0,0,3,0,0
-Summer 2022,ENGL,2305,1,13053,Intro To Fiction,Presswood,Phillip Hilliard,19,4,1,0,0,0,0,3.778
-Summer 2022,LAW,5407,10,11597,Judicial Externship I,Archer,Anna M,0,0,0,0,0,2,0,0
-Summer 2022,LAW,5228,1,12156,Judicial Externship I,Archer,Anna M,0,0,0,0,0,6,0,0
-Summer 2022,EDUC,7099,1,13702,Degree Completion,Arbona,Consuelo,0,0,0,0,0,4,0,0
-Summer 2022,ELCS,8695,2,16230,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,2,0,0
-Summer 2022,SOCW,6293,1,12622,Field Practicum I - Foundation,Gonzales,Shelley A,0,0,0,0,0,1,0,0
-Summer 2022,PHOP,6198,10,16710,Spec Prob-Physio Optics,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4
-Summer 2022,BIOE,8398,6,16406,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,2,0,0
-Summer 2022,COMM,4398,3,16989,Independent Study,Houk,Keith R,1,0,0,0,0,0,0,4
-Summer 2022,GEOL,8698,7,16783,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,0,0,0
-Summer 2022,INDE,8399,7,13326,Doctoral Dissertation,Lin PhD,Ying,1,0,0,0,0,0,0,4
-Summer 2022,CIVE,8598,14,16390,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,0
-Summer 2022,BIOL,6698,7,16767,Special Problems,Sater,Amy,0,0,0,0,0,1,0,0
-Summer 2022,PSYC,4398,2,17418,Independent Study,Zvolensky,Michael J,1,0,0,0,0,0,0,4
-Summer 2022,MECE,8298,17,16907,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,14,16634,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,2,0,0
-Summer 2022,BUSI,4350,1,13593,Business Law and Ethics,Williams,John M,189,49,6,3,2,0,0,3.63
-Summer 2022,BIOL,2102,4,11438,Anatomy & Physiology II (lab),Gill,Tejendra,6,8,5,4,0,0,1,2.667
-Summer 2022,HIST,1378,6,16518,The U S Since 1877,Ide,Derek Alan,56,55,31,17,14,0,17,2.677
-Summer 2022,GEOL,1303,1,11255,Physical Geology,Lytwyn,Jennifer N,24,40,27,21,12,0,10,2.363
-Summer 2022,ECON,2301,2,13469,Principles of Macroeconomics,Biju,Nabila Rahman,9,13,12,1,0,0,1,2.867
-Summer 2022,BIOL,1306,1,10108,Biology for Science Majors I,Gifford,Jenifer,26,32,22,15,10,0,1,2.486
-Summer 2022,PHYS,1101,3,10451,College Physics I (lab),Wood,Lowell T,2,8,5,0,0,0,2,2.8
-Summer 2022,MATH,2415,5,11136,Calculus III,West,James David,6,0,7,7,11,0,3,1.398
-Summer 2022,MATH,4377,1,10125,Advanced Linear Algebra I,Haynes,Alan K,9,1,1,0,0,0,0,3.757
-Summer 2022,BIOE,6303,1,13080,Biomaterials,Abidian,Mohammad Reza,7,2,0,0,1,0,0,3.4
-Summer 2022,AAS,2320,3,15437,Intro To African American Stdy,Boyce,Stephanie,27,2,1,0,2,0,2,3.646
-Summer 2022,HRD,6355,30,15673,Designing OD Interventions,Hausmann,Robert Carl,7,0,0,0,0,0,0,3.953
-Summer 2022,GEOL,8399,4,16646,Doctoral Dissertation,Choi,Yunsoo,1,0,0,0,0,0,0,4
-Summer 2022,ELCS,8695,5,16233,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,0
-Summer 2022,PSYC,7399,9,16891,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,0
-Summer 2022,PETR,8198,11,16604,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,0
-Summer 2022,GEOL,8399,5,16957,Doctoral Dissertation,Li,Aibing,1,0,0,0,0,0,0,4
-Summer 2022,BCHS,6398,3,17074,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,0
-Summer 2022,MECE,8298,24,17132,Doctoral Research,Ostilla Monico,Rodolfo,0,0,0,0,0,1,0,0
-Summer 2022,BIOE,7399,4,11998,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4
-Summer 2022,ELCS,8398,3,17194,Independent Study,Templeton,Toni,1,0,0,0,0,0,0,4
-Summer 2022,SPAN,3375,2,12692,US Hispanic Culture & Civiliza,Cuesta,Mabel,11,5,0,0,1,0,1,3.412
-Summer 2022,LAW,5339,1,12878,Trusts and Wills,Fagundes,Dave,5,8,1,0,0,12,0,1.718
-Summer 2022,BUSI,4396,1,13597,Business Internship,Hopkins,Troy D,0,0,0,0,0,79,0,0
-Summer 2022,COSC,3380,201,12899,Database Systems,Hilford,Victoria,60,27,2,0,0,0,1,3.581
-Summer 2022,PHYS,1101,6,13165,College Physics I (lab),Maric,Sladjana,2,9,6,0,0,0,1,2.881
-Summer 2022,FINA,4396,2,17391,Finance Internship,Kumar,Praveen,0,0,0,0,0,4,0,0
-Summer 2022,OPTO,6115,2,13078,Clinical Integration,Gostovic,Anita Ticak,0,0,0,0,0,42,0,0
-Summer 2022,ENGL,3328,1,10569,Masterpieces of British Lit II,Wood,Barry Albert,13,11,0,0,2,0,2,3.13
-Summer 2022,CHEE,8498,4,10959,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,0
-Summer 2022,FINA,7364,1,13487,Intl Bus & Political Risk Mgt,Miljanic,Andra Olivia,17,4,0,0,0,0,0,3.747
-Summer 2022,CUIN,4361,1,13531,Second Language Methodology,Burgess Monroy,Miguel,19,1,0,0,0,0,0,3.95
-Summer 2022,PSYC,6365,4,13282,Dir Rsch in Dev Cog Beh Neuro,Alward,Beau Andrew,2,0,0,0,0,0,0,4
-Summer 2022,ATP,7101,1,11779,"Head, Neck & Spine Eval Lab",Harrison,Layci,15,0,0,0,0,0,0,4
-Summer 2022,GEOL,3355,2,13404,Field Geology I,Lindline,Jennifer,5,4,0,0,0,0,0,3.519
-Summer 2022,PETR,8399,10,12439,Doctoral Dissertation,Sakhaee Pour,Ahmad,3,0,0,0,0,0,0,4
-Summer 2022,BCHS,6230,1,17211,Grad Biochem Lab Rotation I,Widger,William R,1,0,0,0,0,0,0,4
-Summer 2022,CHEM,6399,5,10603,Masters Thesis,Cai,Chengzhi,0,1,0,0,0,0,0,3
-Summer 2022,PHYS,4340,1,15636,Research Methods,Ekeoba,Jacqueline Njideka,1,0,0,0,0,0,0,4
+Summer 2022,MECE,8298,24,17132,Doctoral Research,Ostilla Monico,Rodolfo,0,0,0,0,0,1,0,
+Summer 2022,MECE,8498,24,17133,Doctoral Research,Ostilla Monico,Rodolfo,0,0,0,0,0,1,0,
+Summer 2022,HIST,8699,2,17134,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8298,12,17137,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8198,13,17138,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Summer 2022,PCOL,6498,6,17142,Special Problems,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6698,13,17143,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Summer 2022,SOC,7399,1,17144,Masters Thesis,Monserud,Maria Aleksandrovna,0,0,0,0,0,1,0,
+Summer 2022,SOC,7395,1,17145,Internship in Sociology,Karner,Tracy Xavia,1,0,0,0,0,0,0,4.0
+Summer 2022,SOC,7396,1,17146,Internship in Sociology,Baumle,Amanda K,0,0,0,0,0,0,0,
+Summer 2022,COSC,8698,131,17149,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Summer 2022,COSC,8698,118,17150,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Summer 2022,ECE,7399,2,17151,Masters Thesis,Chen,Jiefu,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,7399,3,17152,Masters Thesis,Fu,Xin,1,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,8199,1,17153,Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Summer 2022,PEP,7398,1,17156,Adv Special Problem Human Perf,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Summer 2022,PEP,7398,2,17157,Adv Special Problem Human Perf,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Summer 2022,PEP,8350,1,17158,HHP Candidacy Project Research,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,7399,13,17162,Masters Thesis,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,6198,5,17163,Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Summer 2022,ECE,6598,2,17164,Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Summer 2022,CHEE,4398,1,17165,Independent Study,Rimer,Jeffrey,1,0,0,0,0,0,0,4.0
+Summer 2022,PEP,8350,2,17166,HHP Candidacy Project Research,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Summer 2022,PEP,8350,3,17167,HHP Candidacy Project Research,Park,Yoonjung,1,0,0,0,0,0,0,4.0
+Summer 2022,CHEE,6397,2,17168,Selected Topics,Kaushik,Krishna R,1,1,0,0,0,0,0,3.5
+Summer 2022,CHEE,3321,2,17169,Analytical Methods Chem Engr,Malamataris,Nikolaos,0,0,1,0,0,0,0,2.33
+Summer 2022,COSC,8399,129,17174,Doctoral Dissertation,Verma,Rakesh M,0,0,0,0,0,1,0,
+Summer 2022,ECE,6399,3,17177,Masters Thesis,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,
+Summer 2022,CIVE,8198,22,17179,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,6,0,
+Summer 2022,CIVE,8598,22,17180,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,6,0,
+Summer 2022,SOCW,7397,15,17184,Selected Topics in Social Work,Powell,Torey Ian,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,16,17185,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,17,17186,Selected Topics in Social Work,Mollhagen,Amber Mayo,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5297,4,17187,Selected Topics in Pharmacy,Sansgiry,Sujit Sharad,0,0,0,0,0,11,0,
+Summer 2022,COSC,3399,101,17189,Senior Honors Thesis,Eick,Christoph F,1,0,0,0,0,0,0,3.67
+Summer 2022,COSC,4398,101,17190,Independent Study,Cheng,Albert M K,0,0,0,0,0,2,0,
+Summer 2022,ELCS,8398,3,17194,Independent Study,Templeton,Toni,1,0,0,0,0,0,0,4.0
+Summer 2022,HON,4398,2,17195,Independent Study,Rhoden,Brenda,2,0,0,0,0,0,0,4.0
+Summer 2022,ARLD,6391,1,17196,Internship in Arts Organizatn,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Summer 2022,CIVE,7399,2,17201,Master's Thesis,Louie,Stacey M,0,0,0,0,0,1,0,
+Summer 2022,CIS,6399,1,17202,Master's Thesis,Zhang,Yunpeng,1,0,0,0,0,0,0,4.0
+Summer 2022,ECE,6198,6,17203,Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,ECE,6298,4,17204,Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2022,PHOP,8498,5,17207,Doctoral Research,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Summer 2022,PCEU,6698,1,17208,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,0,0,
+Summer 2022,BCHS,6498,2,17209,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6230,1,17211,Grad Biochem Lab Rotation I,Widger,William R,1,1,0,0,0,0,0,3.665
+Summer 2022,MANA,4346,2,17212,Leadership Development,Evans,Klavdia Markelova,9,0,0,0,0,0,0,4.0
+Summer 2022,ENGL,2305,2,17214,Intro To Fiction,Bose,Godhuly,14,6,1,1,0,0,0,3.425
+Summer 2022,MECE,8399,1,17221,Doctoral Dissertation,Wang,Su Su,0,0,0,0,0,0,0,
+Summer 2022,MECE,6368,1,17222,Mechanical Design Proj,Sharma,Pradeep,1,0,0,0,0,0,0,4.0
+Summer 2022,PHLS,6397,1,17233,Selected Topics,Smedley,Diane Renee,10,0,0,0,0,0,1,4.0
+Summer 2022,MUSI,7399,1,17235,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,1,0,
+Summer 2022,PEP,7398,3,17236,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Summer 2022,PHAR,5297,5,17237,Selected Topics in Pharmacy,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Summer 2022,ARCH,3198,1,17239,Independent Study,Burrow,Robert W,0,1,0,0,0,0,0,3.0
+Summer 2022,COMM,4398,4,17240,Independent Study,Salisbury,Shelby,1,0,0,0,0,0,0,4.0
+Summer 2022,MARK,8399,3,17241,Doctoral Dissertation,Hess,James D,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,7399,5,17242,Masters Thesis,Mann,Paul,1,0,0,0,0,0,0,4.0
+Summer 2022,ANTH,7399,1,17244,Masters Thesis,Storey,Rebecca,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6398,13,17246,Independent Studies,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Summer 2022,MATH,4396,1,17248,Senior Research Project,Kalantar,Mehrdad,1,0,0,0,0,0,0,4.0
+Summer 2022,COSC,6398,103,17251,Special Problems,Cheng,Albert M K,0,0,0,0,0,1,0,
+Summer 2022,GEOL,6398,2,17252,Special Problems,Murphy,Michael,0,0,0,0,0,1,0,
+Summer 2022,EDS,6397,1,17253,Selected Topics,Lendasse,Amaury,9,1,0,0,1,0,0,3.395
+Summer 2022,PHLA,6260,1,17254,Healthcare Finance,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Summer 2022,PHLA,6220,1,17255,Leadership Concepts II,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Summer 2022,PHLA,7199,1,17256,Masters Thesis,Varkey,Divya A,0,0,0,0,0,1,0,
+Summer 2022,COSC,6398,131,17258,Special Problems,Wu,Panruo,0,0,0,0,0,1,0,
+Summer 2022,PSYC,8199,2,17265,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,2,0,
+Summer 2022,SPAC,6398,1,17266,Special Problems,Bannova,Olga,0,1,0,0,0,0,0,3.0
+Summer 2022,CHEE,6198,1,17270,Research,Karim,Alamgir,0,0,0,0,0,1,0,
+Summer 2022,MECE,8399,11,17274,Doctoral Dissertation,Liu,Dong,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,8399,22,17277,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,1,0,
+Summer 2022,PHOP,8198,1,17281,Doctoral Research,Coulson-Thomas,Vivien J,0,0,0,0,0,0,0,
+Summer 2022,CUIN,7356,4,17282,Issues in Distance Education,Dogan,Bulent,1,0,0,0,0,0,0,4.0
+Summer 2022,MIS,4398,1,17291,Independent Study,Scamell,Richard W,1,0,0,0,0,0,0,4.0
+Summer 2022,CUIN,8199,1,17295,Dissertation,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8198,14,17297,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,13,17298,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,
+Summer 2022,CUIN,8399,4,17299,Doctoral Dissertation,Li,Miao,0,0,0,0,0,1,0,
+Summer 2022,ELCS,8398,4,17300,Independent Study,Davis,Tiffany J,1,0,0,0,0,0,0,4.0
+Summer 2022,COSC,8399,127,17303,Doctoral Dissertation,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Summer 2022,GEOL,7399,6,17306,Masters Thesis,Sun,Jiajia,0,0,0,0,0,1,0,
+Summer 2022,PHCA,6498,2,17307,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Summer 2022,PHCA,6298,2,17308,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Summer 2022,GEOL,7398,1,17309,Masters Research,Brandon,Alan,0,0,0,0,0,1,0,
+Summer 2022,CUIN,8399,5,17310,Doctoral Dissertation,Hale,Margaret Ann,1,0,0,0,0,1,0,4.0
+Summer 2022,MECE,4398,1,17312,Independent Study,Love,Holley Carole,3,0,0,0,0,0,0,4.0
+Summer 2022,MECE,8398,10,17313,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2022,CUIN,8398,4,17316,Independent Study,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Summer 2022,PSYC,7399,14,17318,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Summer 2022,CUIN,8398,3,17323,Independent Study,Hale,Margaret Ann,2,0,0,0,0,0,0,4.0
+Summer 2022,MARK,4398,1,17327,Independent Study,Herman,Carl,1,0,0,0,0,0,0,4.0
+Summer 2022,MECE,7399,2,17329,Masters Thesis,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Summer 2022,HON,3399,1,17332,Senior Honors Thesis,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2022,ELET,6396,1,17338,Master's Project,Pollonini,Luca,1,0,0,0,0,0,0,4.0
+Summer 2022,DIGM,4398,1,17342,Independent Study,Rodwell,Elizabeth Ann,1,0,0,0,0,0,0,4.0
+Summer 2022,SOCW,7397,4,17343,Selected Topics in Social Work,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Summer 2022,BCHS,6498,4,17345,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Summer 2022,HIST,1378,7,17346,The U S Since 1877,Thompson,Joseph Lee,34,2,3,1,2,0,1,3.54
+Summer 2022,ELCS,8398,5,17348,Independent Study,Zou,Yali,1,0,0,0,0,0,0,4.0
+Summer 2022,HIST,1377,6,17350,The U S To 1877,McDonald,Eric John,26,12,2,2,3,0,4,3.178
+Summer 2022,ECE,6398,6,17351,Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2022,PETR,7399,2,17355,Masters Thesis,Hathon,Lori A,0,1,0,0,0,0,0,3.33
+Summer 2022,ELCS,8395,10,17356,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,
+Summer 2022,MIS,4396,1,17359,MIS Internship,Johnson,Norman A.,0,0,0,0,0,3,0,
+Summer 2022,COSC,6398,119,17360,Special Problems,Ordonez,Carlos,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8198,15,17361,Doctoral Research,Majd,Sheereen,0,0,0,0,0,0,0,
+Summer 2022,BIOE,8298,14,17362,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,15,17363,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,
+Summer 2022,BIOE,8198,16,17364,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8298,16,17365,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Summer 2022,ECE,6398,7,17366,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Summer 2022,BIOE,8198,17,17367,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Summer 2022,HIST,4398,1,17368,Independent Study,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Summer 2022,CIVE,8398,2,17369,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Summer 2022,GEOL,8399,7,17371,Doctoral Dissertation,Mann,Paul,1,0,0,0,0,0,0,4.0
+Summer 2022,BTEC,6399,3,17372,Thesis,Iyer,Rupa S,0,0,0,0,0,0,0,
+Summer 2022,ELET,6396,2,17373,Master's Project,Zouridakis,George,1,0,0,0,0,0,0,4.0
+Summer 2022,PHYS,8399,49,17375,Doctoral Dissertation,Ren,Zhifeng,1,0,0,0,0,0,0,3.67
+Summer 2022,ECON,8699,2,17377,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,1,0,
+Summer 2022,ECON,8699,6,17379,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,2,0,
+Summer 2022,ECON,8699,7,17380,Doctoral Dissertation,Cubas Norando,German,0,0,0,0,0,2,0,
+Summer 2022,ECON,8699,8,17381,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,2,0,
+Summer 2022,PSYC,8399,24,17388,Doctoral Dissertation,Ng,Vincent,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6399,6,17389,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Summer 2022,PSYC,6365,8,17390,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Summer 2022,FINA,4396,2,17391,Finance Internship,Kumar,Praveen,0,0,0,0,0,4,0,
+Summer 2022,ELCS,8395,11,17396,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,
+Summer 2022,PHLS,8699,5,17397,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Summer 2022,ELCS,8198,1,17398,Independent Study,Santi,Kristi L,0,0,0,0,0,1,0,
+Summer 2022,CUIN,7354,1,17399,Perspectives in Science & Math,Wong,Sissy S,19,0,0,0,0,0,0,3.983
+Summer 2022,CUIN,7386,1,17400,Trends & Issues K12 Scien Educ,Rodriguez,Alberto J,16,2,0,0,0,0,0,3.852
+Summer 2022,CUIN,7301,5,17402,CUIN Capstone Seminar,Zhang,Jie,19,0,0,0,0,0,0,3.913
+Summer 2022,KIN,4398,3,17408,Independent Study,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Summer 2022,ECON,8699,9,17409,Doctoral Dissertation,Craig,Steven G,0,0,0,0,0,2,0,
+Summer 2022,PEP,8199,1,17413,Doctoral Dissertation,Ledoux,Tracey A,1,0,0,0,0,0,0,4.0
+Summer 2022,KIN,4360,2,17415,Adaptive Athletics Management,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Summer 2022,CIVE,8398,3,17417,Doctoral Research,Li,Hongyi,0,0,0,0,0,1,0,
+Summer 2022,PSYC,4398,2,17418,Independent Study,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Summer 2022,ELCS,8695,10,17419,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,
+Summer 2022,CHEM,3396,1,17421,Senior Research Project,Meen,James K,1,0,0,0,0,0,0,4.0
+Summer 2022,BIOL,4398,1,17422,Independent Study,Ogletree-Hughes,Monique L,1,0,0,0,0,0,0,4.0

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2022-03 (Fall 2022).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2022-03 (Fall 2022).csv
@@ -1,0 +1,6857 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Fall 2022,PHYS,2325,1,10002,University Physics I (lecture),Chu,Ching Wu,31,65,15,7,6,0,27,2.914
+Fall 2022,FINA,6387,2,10004,Managerial Analysis,Basu,Swati,14,0,0,0,0,0,0,3.906
+Fall 2022,GENB,7A97,1,10005,Selected Topics,Haseley,Ken A.,12,0,0,0,0,0,0,4.0
+Fall 2022,GENB,7A97,2,10006,Selected Topics,Haseley,Ken A.,9,3,1,0,0,0,0,3.615
+Fall 2022,GENB,7A97,3,10007,Selected Topics,Williams,John M,12,0,0,0,0,0,0,4.0
+Fall 2022,GENB,7A97,4,10008,Selected Topics,Williams,John M,13,0,0,0,0,0,0,4.0
+Fall 2022,SCM,6301,1,10009,Supply Chain Mgt Foundations,Smith,Gordon D,12,2,0,0,0,0,0,3.81
+Fall 2022,SCM,6301,2,10010,Supply Chain Mgt Foundations,Smith,Gordon D,8,1,0,0,0,0,0,3.926
+Fall 2022,MANA,6A25,1,10011,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,9,3,0,0,0,0,0,3.695
+Fall 2022,MANA,6A25,2,10012,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,10,2,1,0,0,0,0,3.667
+Fall 2022,MANA,6332,1,10013,Organiztnl Behavior & Mangemnt,Werner,Steve,12,0,0,0,0,0,0,4.0
+Fall 2022,BZAN,6310,5,10014,Quant Analysis for Busn Dec,Johnson,Norman A.,9,3,0,0,0,0,0,3.778
+Fall 2022,BZAN,6310,6,10015,Quant Analysis for Busn Dec,Johnson,Norman A.,10,3,0,0,0,0,0,3.744
+Fall 2022,COMM,6399,1,10018,Masters Thesis,Camaj,Lindita,2,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,8334,1,10019,Social Policy Analysis,Ali,Samira Bano,7,0,0,0,0,0,1,4.0
+Fall 2022,SOCW,8323,1,10020,Research Methods III,Sampson,McClain,6,1,0,0,0,0,0,3.904
+Fall 2022,SOCW,8395,3,10021,Pre-Dissertation Research,Torres,Isabel,0,0,0,0,0,0,0,
+Fall 2022,PHIL,1301,3,10022,Intro To Philosophy,Haaga,Curtis W,23,17,4,0,1,0,1,3.297
+Fall 2022,PHIL,1301,4,10023,Intro To Philosophy,Haaga,Curtis W,42,16,0,0,0,0,0,3.622
+Fall 2022,PHIL,1305,1,10024,Intro To Ethics,Aiman,Edwin E,31,27,5,2,3,0,2,3.157
+Fall 2022,PHIL,1361,1,10025,Philosophy and the Arts,Drapela,Nick Gerard,11,19,10,3,0,0,7,2.876
+Fall 2022,ARCH,1500,1,10026,Design Studio I,Lutz,Shawn M,8,4,2,0,0,0,0,3.429
+Fall 2022,ARCH,1500,3,10028,Design Studio I,Murray,Cara,4,6,1,0,0,0,2,3.303
+Fall 2022,ARCH,1500,5,10030,Design Studio I,Li,Leyuan,8,5,0,0,0,0,1,3.565
+Fall 2022,ARCH,1500,7,10032,Design Studio I,Wells,Adam C,2,8,2,0,0,0,2,3.11
+Fall 2022,ARCH,1500,9,10034,Design Studio I,Gaines,Preston,6,4,2,0,0,0,0,3.278
+Fall 2022,ARCH,1500,11,10036,Design Studio I,Kudless,Andrew Justin,6,3,2,0,1,0,1,3.001
+Fall 2022,ARCH,1500,13,10038,Design Studio I,Olwi,Asmaa,3,3,0,0,0,0,5,3.5
+Fall 2022,ARCH,2350,1,10040,Hist of the Built Environmt I,Ramaswamy,Deepa,60,92,11,2,8,0,4,3.049
+Fall 2022,ARCH,2500,1,10047,Arc/Int Arc Design Studio III,Gonzales,Michael A,8,8,1,0,0,0,1,3.354
+Fall 2022,ARCH,2500,5,10049,Arc/Int Arc Design Studio III,Li,Leyuan,12,4,1,0,0,0,1,3.608
+Fall 2022,ARCH,2500,9,10051,Arc/Int Arc Design Studio III,Wienert,Ross George,6,10,1,0,0,0,1,3.275
+Fall 2022,ARCH,2500,11,10053,Arc/Int Arc Design Studio III,Murray,Cara,4,7,4,2,0,0,1,2.765
+Fall 2022,ARCH,2500,13,10055,Arc/Int Arc Design Studio III,Medina Vilela,Mario Andre,5,8,3,0,1,0,0,2.922
+Fall 2022,ARCH,4373,1,10061,Urban Environments,Rifaat,Shafik I,36,76,0,0,1,0,2,3.298
+Fall 2022,ARCH,5500,3,10064,Architecture Design Studio IX,Longoria,Rafael R,5,1,0,0,0,0,0,3.668
+Fall 2022,ARCH,6301,1,10066,Visual Studies I,Logan,Jason,5,4,0,0,0,0,0,3.629
+Fall 2022,ARCH,6340,1,10068,Architectural History Survey I,Ramaswamy,Deepa,7,3,0,0,0,0,0,3.7
+Fall 2022,ARCH,7600,1,10076,Architecture Design Studio V,Race,Bruce Alan,3,5,0,0,0,0,0,3.458
+Fall 2022,INDS,2340,1,10078,Visual Communication,Jamjoom,Zain Ahmed,11,9,4,1,1,0,2,3.102
+Fall 2022,INDS,2355,1,10080,Design History I,Ramirez,Enrique,16,1,3,2,0,0,1,3.289
+Fall 2022,INDS,3500,1,10084,Industrial Design Studio V,Feng,Jeff Feng,3,5,0,0,0,0,0,3.499
+Fall 2022,INDS,4500,1,10086,Industrial Design Studio VII,Kimbrough,Mark S,8,3,1,0,0,0,0,3.638
+Fall 2022,ACCT,2301,1,10089,Prin of Financial Accounting,Goble,Samuel,38,45,24,8,7,0,10,2.868
+Fall 2022,ACCT,2301,3,10091,Prin of Financial Accounting,Goble,Samuel,43,60,35,12,7,0,11,2.827
+Fall 2022,ACCT,2301,4,10092,Prin of Financial Accounting,Goble,Samuel,35,41,23,4,2,0,2,3.044
+Fall 2022,ACCT,3377,1,10093,Cost Accounting,Lin,Haijin,19,16,9,4,1,0,3,2.959
+Fall 2022,ACCT,3377,2,10094,Cost Accounting,Lin,Haijin,22,14,6,2,0,0,4,3.273
+Fall 2022,ACCT,3368,1,10096,Intermediate Accounting II,Muslu,Volkan,2,10,7,1,2,0,0,2.319
+Fall 2022,ACCT,4335,3,10101,Financial Statement Auditing,Zhao,Yuping,16,38,11,2,0,0,0,3.054
+Fall 2022,ACCT,4375,1,10103,Internal Audit Entity Environ,Brant Jr.,Robert Edward,6,11,3,0,0,0,0,3.249
+Fall 2022,ACCT,5367,1,10105,Intermediate Accounting I,Noland,Thomas R,6,3,3,0,0,0,3,3.278
+Fall 2022,ACCT,6331,1,10106,Financial Accounting,Larson,Chad R,17,4,1,0,1,0,0,3.565
+Fall 2022,ACCT,6331,2,10107,Financial Accounting,Larson,Chad R,12,18,3,1,0,0,3,3.225
+Fall 2022,ACCT,6331,4,10108,Financial Accounting,Lobo,Gerald,14,15,0,0,0,0,2,3.358
+Fall 2022,ACCT,7330,1,10109,Advanced Accounting,Ramaswamy,Vinita,7,5,0,0,0,0,0,3.583
+Fall 2022,ACCT,7330,2,10110,Advanced Accounting,Ramaswamy,Vinita,15,11,4,0,0,0,1,3.444
+Fall 2022,ACCT,7340,2,10112,Financial Statement Analysis,Lu,Tong,14,3,2,0,0,0,0,3.597
+Fall 2022,ACCT,7375,1,10114,Corporate Taxation,Fernandez,Ramon,7,9,2,0,0,0,0,3.314
+Fall 2022,ACCT,8699,1,10115,Doctoral Dissertation,Lobo,Gerald,1,0,0,0,0,1,0,4.0
+Fall 2022,ACCT,8999,1,10116,Doctoral Dissertation,Lu,Tong,0,0,0,0,0,1,0,
+Fall 2022,ENTR,3310,1,10117,Entrepreneurship,Ortega,Carlos Alberto,149,55,7,1,3,0,2,3.625
+Fall 2022,ENTR,3310,2,10118,Entrepreneurship,Wilbur,Stephen,138,95,29,9,5,0,3,3.244
+Fall 2022,ENTR,3312,1,10119,Corporate Entrepreneurship,Karonika,John R,27,11,2,1,1,0,6,3.429
+Fall 2022,ENTR,3312,2,10120,Corporate Entrepreneurship,Karonika,John R,26,13,4,2,3,0,0,3.078
+Fall 2022,ENTR,3312,3,10121,Corporate Entrepreneurship,Lish,Alan D,36,47,13,1,1,0,2,3.174
+Fall 2022,FINA,3332,3,10122,Prin of Financial Management,Chisholm,Darla,28,30,50,31,21,0,37,2.073
+Fall 2022,FINA,4354,1,10123,Risk Management,Kapatos,Nick Gus,16,31,10,2,0,0,2,3.012
+Fall 2022,FINA,4355,1,10124,International Risk Management,Kapatos,Nick Gus,7,7,1,0,0,0,0,3.312
+Fall 2022,FINA,4357,1,10125,Commercial Liability,Kapatos,Nick Gus,9,12,3,2,0,0,1,3.115
+Fall 2022,FINA,6387,1,10126,Managerial Analysis,Basu,Swati,24,11,0,0,0,0,1,3.723
+Fall 2022,FINA,6398,1,10127,Research,Bean,Gregory S.,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8699,3,10130,Doctoral Dissertation,Jacobs,Kris,0,0,0,0,0,1,0,
+Fall 2022,BUSI,4396,1,10132,Business Internship,Hopkins,Troy D,0,0,0,0,0,34,0,
+Fall 2022,GENB,6398,1,10133,Research,Ma,Xiao,1,0,0,0,0,0,0,4.0
+Fall 2022,MANA,3335,1,10134,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,232,54,6,1,2,0,2,3.693
+Fall 2022,MANA,3335,4,10135,Intro Org Behavior and Mgmt,Currie,Daniel David,174,97,20,4,2,0,3,3.428
+Fall 2022,MANA,4330,1,10137,Intro to Strategic HR Mgt,Phillips,James S,157,57,9,3,4,0,5,3.535
+Fall 2022,MANA,4330,2,10138,Intro to Strategic HR Mgt,Fernandez,Alejandro,8,0,0,0,0,0,0,3.876
+Fall 2022,MANA,8999,1,10142,Doctoral Dissertation,Atwater,Leanne E,1,0,0,0,0,0,0,4.0
+Fall 2022,MARK,3337,1,10143,Professional Selling,Ahearne,Michael,164,88,16,5,2,0,6,3.462
+Fall 2022,MARK,4389,1,10144,Marketing Strategy & Planning,Koch,Steven F.,30,1,0,0,0,0,0,3.957
+Fall 2022,MARK,4389,2,10145,Marketing Strategy & Planning,Lish,Alan D,26,10,2,2,0,0,0,3.434
+Fall 2022,MARK,4389,3,10146,Marketing Strategy & Planning,Randazzo,Gary W,22,8,1,0,0,0,0,3.635
+Fall 2022,MARK,4389,4,10147,Marketing Strategy & Planning,Beveridge,Ivana,26,5,0,0,0,0,1,3.807
+Fall 2022,MARK,4373,1,10148,Advanced Professional Selling,Bremer,Justin,28,0,0,0,0,0,0,4.0
+Fall 2022,MARK,4374,1,10149,Sales Management,Webb,James R,18,1,0,0,0,0,1,3.878
+Fall 2022,MARK,4374,2,10150,Sales Management,Webb,James R,23,0,1,0,0,0,0,3.903
+Fall 2022,MARK,4375,1,10151,Key Account Selling,Webb,James R,16,3,0,0,0,0,0,3.755
+Fall 2022,MARK,7374,1,10152,New Product Development,Lish,Alan D,11,11,1,0,0,0,1,3.392
+Fall 2022,MARK,8398,1,10153,Special Problems,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,4330,1,10157,Advanced Accounting,Ramaswamy,Vinita,1,5,3,0,0,0,0,3.034
+Fall 2022,ENTR,3312,4,10159,Corporate Entrepreneurship,Lish,Alan D,25,62,8,2,1,0,2,3.126
+Fall 2022,ACCT,7370,1,10160,Adv Fin Statement Auditing,Zhao,Yuping,41,5,0,0,0,0,0,3.877
+Fall 2022,ENTR,7336,1,10175,Entrepreneurship Overview,Wilbur,Stephen,13,13,1,0,0,0,0,3.396
+Fall 2022,ACCT,2301,8,10177,Prin of Financial Accounting,Goble,Samuel,53,77,19,8,6,0,8,3.083
+Fall 2022,STAT,3331,1,10178,Statistical Anal Bus Appl I,Wiley,Briceon C,102,82,63,20,1,0,24,2.952
+Fall 2022,SCM,3301,2,10180,SCM Fundamentals,Miller,Bradley D,292,207,42,8,0,0,4,3.417
+Fall 2022,BCIS,1305,1,10181,Business Computer Applications,Felvegi,Emese,22,3,1,0,0,0,0,3.808
+Fall 2022,BCIS,1305,2,10182,Business Computer Applications,Felvegi,Emese,168,46,16,9,10,0,0,3.402
+Fall 2022,MIS,3370,1,10183,Info Systems Development Tools,Knighton,William B,18,11,14,3,4,0,13,2.72
+Fall 2022,MIS,3371,1,10184,Transaction Processing Sys I,Messinger,Jacob Nelson,65,28,9,1,1,0,1,3.449
+Fall 2022,FINA,4370,1,10186,Energy Trading,Smith III,Edwin A,11,4,5,1,0,0,1,3.19
+Fall 2022,FINA,4371,1,10187,Energy Value Chain,Slaughter,Andrew Jeremy,3,8,0,0,1,0,1,2.973
+Fall 2022,MARK,4373,2,10189,Advanced Professional Selling,Pingel,John W,31,0,0,0,0,0,0,3.989
+Fall 2022,ARED,6365,1,10198,Integrative Art Teaching,Boyaki Wilson,Amanda R,1,1,0,0,0,0,0,3.335
+Fall 2022,CUIN,3310,1,10199,Bilingual Education,Leon,Maredil Josefina,13,1,0,0,0,0,0,3.858
+Fall 2022,CUIN,4375,2,10200,Classroom Management,Snead,Lauren Oropeza,16,0,0,0,0,0,0,3.979
+Fall 2022,CUIN,7336,1,10202,Popular Culture in Education,Brower,Samuel Richard,8,1,0,0,0,0,0,3.852
+Fall 2022,CUIN,8398,7,10203,Independent Study,Chung,Sheng Kuan,0,1,0,0,0,0,0,3.33
+Fall 2022,EDUC,4314,1,10204,Student Teaching Sec,Culpepper,Shea Mosley,15,5,0,0,0,0,3,3.701
+Fall 2022,EDUC,4315,1,10205,Student Teaching Sec,Thompson,Amber M,12,0,0,0,0,0,1,4.0
+Fall 2022,EDUC,4316,1,10206,Student Teach Art Elem,Culpepper,Shea Mosley,6,0,0,0,0,0,1,4.0
+Fall 2022,EDUC,4317,1,10207,Student Tch Art Sec,Thompson,Amber M,5,0,0,0,0,0,0,4.0
+Fall 2022,EDUC,4318,1,10208,Student Tch Music Elem,McGinnis,Emily Jane,3,0,0,0,0,0,0,4.0
+Fall 2022,EDUC,4319,1,10209,Student Tch Music Sec,McGinnis,Emily Jane,3,0,0,0,0,0,0,4.0
+Fall 2022,EDUC,4325,1,10210,Student Teaching 4-8 2Nd 7 Wks,Thompson,Amber M,17,1,0,0,0,0,0,3.963
+Fall 2022,PHLS,6325,1,10212,Theories of Counseling,Lee,Jungeun,11,1,0,0,0,0,0,3.834
+Fall 2022,PHLS,6330,1,10213,Human Growth-Developmnt,Whitaker,Rachael Gwin,10,2,0,0,0,0,0,3.888
+Fall 2022,HDFS,1300,1,10214,Dev of Contemporary Families,Jordan,Erica F,83,50,5,2,3,0,1,3.392
+Fall 2022,HDFS,1300,7,10220,Dev of Contemporary Families,Jordan,Erica F,71,49,15,4,2,0,2,3.284
+Fall 2022,HDFS,4393,1,10224,Internship in HDFS,Conston,Toya,15,0,0,0,0,0,1,4.0
+Fall 2022,HLT,1353,1,10225,Personal Health,Rafique,Kiran Sajid,78,11,3,3,2,0,1,3.592
+Fall 2022,HLT,2320,1,10226,Introduction to Public Health,Proctor,Robin Ann,79,16,2,0,1,0,2,3.681
+Fall 2022,HLT,3300,1,10227,Social Health and Wellness,Farmer,Jennifer,85,9,3,1,1,0,1,3.704
+Fall 2022,HLT,3306,1,10228,Environmental Health,Behjat,Amirmohsen,41,45,24,6,10,0,13,2.804
+Fall 2022,HLT,4306,1,10229,Women's Health Issues,Solari Williams,Kayce D.,52,19,2,3,1,0,1,3.52
+Fall 2022,HLT,4392,1,10230,Field Work in Community Health,Solari Williams,Kayce D.,37,9,2,0,0,0,1,3.715
+Fall 2022,HLT,4393,1,10231,Field Work in Com Health,Solari Williams,Kayce D.,4,2,0,0,0,0,0,3.557
+Fall 2022,PHLS,6322,1,10232,Dimensions in Women's Health,Solari Williams,Kayce D.,2,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,4394,1,10233,Internship in HDFS,Conston,Toya,15,0,0,0,0,0,1,4.0
+Fall 2022,PHLS,6345,1,10234,Atypical Growth & Behavior,Hurt,Kara Marie,20,4,0,0,0,0,0,3.833
+Fall 2022,CUIN,4336,1,10235,Popular Culture in Education,Brower,Samuel Richard,14,3,0,0,0,0,1,3.804
+Fall 2022,HLT,3301,1,10236,Health Behavior Theories,Drenner,Kelli Linn,19,26,3,0,0,0,0,3.278
+Fall 2022,HLT,4302,1,10237,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,41,17,10,5,2,0,5,3.138
+Fall 2022,HLT,3381,1,10238,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,64,22,2,1,0,0,0,3.652
+Fall 2022,PHLS,8319,1,10239,Infer Stats in Psych/Educ Res,Fan,Weihua,12,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,6111,1,10240,Grad Bioengineering Seminar,Larin,Kirill,0,0,0,0,0,65,0,
+Fall 2022,CHEE,2332,1,10241,Chem Engr Thermodyn I,Malamataris,Nikolaos,9,12,12,4,7,0,13,2.243
+Fall 2022,CHEE,3300,1,10242,Materials Science & Engr I,Donnelly,Vincent M.,4,6,5,3,1,0,11,2.422
+Fall 2022,CHEE,3333,1,10243,Chem Engr Thermodyn II,Orman,Mehmet,13,22,12,6,0,0,9,2.811
+Fall 2022,CHEE,3334,1,10244,Stat/Num Tchqs for Chem Engrs,Nikolaou,Michael,14,22,13,0,5,0,4,2.747
+Fall 2022,CHEE,3363,1,10245,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,7,16,21,6,3,0,17,2.377
+Fall 2022,CHEE,4321,1,10246,Chemical Engineering Design I,Smith,Christopher Michael,25,21,1,0,0,0,0,3.454
+Fall 2022,CHEE,4361,1,10247,Chm Engr Practices,Cirino,Patrick C,36,7,3,0,0,0,0,3.653
+Fall 2022,CHEE,4367,1,10250,Chemical Reaction Engineering,Bollini,Praveen P,56,37,2,1,1,0,1,3.424
+Fall 2022,CHEE,6111,1,10252,Graduate Seminar,Mountziaris,Triantafillos John,0,0,0,0,0,66,0,
+Fall 2022,CHEE,8298,2,10260,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,4,0,
+Fall 2022,CHEE,8298,3,10261,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8298,4,10262,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,5,0,
+Fall 2022,CHEE,8298,5,10263,Doctoral Research,Donnelly,Vincent M.,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8298,6,10264,Doctoral Research,Economou,Demetre J,0,0,0,0,0,0,0,
+Fall 2022,CHEE,8298,7,10265,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8298,8,10266,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8298,9,10267,Doctoral Research,Karim,Alamgir,0,0,0,0,0,6,0,
+Fall 2022,CHEE,8298,10,10268,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8298,11,10269,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8398,3,10273,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8398,4,10274,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,3,0,
+Fall 2022,CHEE,8398,6,10276,Doctoral Research,Economou,Demetre J,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8398,7,10277,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8398,8,10278,Doctoral Research,Harold,Michael P,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8398,9,10279,Doctoral Research,Karim,Alamgir,0,0,0,0,0,4,0,
+Fall 2022,CHEE,8398,10,10280,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8398,11,10281,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8398,13,10283,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8399,1,10284,Doctoral Dissertation,Balakotaiah,Vemuri,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8399,2,10285,Doctoral Dissertation,Bollini,Praveen P,2,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8399,3,10286,Doctoral Dissertation,Cirino,Patrick C,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8399,4,10287,Doctoral Dissertation,Conrad,Jacinta C,0,0,0,0,0,0,0,
+Fall 2022,CHEE,8399,5,10288,Doctoral Dissertation,Donnelly,Vincent M.,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8399,7,10290,Doctoral Dissertation,Grabow,Lars C,1,0,0,0,0,1,0,4.0
+Fall 2022,CHEE,8399,8,10291,Doctoral Dissertation,Harold,Michael P,5,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8399,9,10292,Doctoral Dissertation,Karim,Alamgir,10,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8399,10,10293,Doctoral Dissertation,Krishnamoorti,Ramanan,1,0,0,0,0,3,0,4.0
+Fall 2022,CHEE,8399,11,10294,Doctoral Dissertation,Mountziaris,Triantafillos John,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8498,1,10295,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8498,2,10296,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8598,2,10309,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8598,4,10311,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8598,7,10314,Doctoral Research,Grabow,Lars C,0,0,0,0,0,3,0,
+Fall 2022,CHEE,8598,8,10315,Doctoral Research,Harold,Michael P,0,0,0,0,0,3,0,
+Fall 2022,ENGR,2301,1,10316,Mechanics I,Belarbi,Abdeldjelil,22,10,10,6,2,0,3,2.827
+Fall 2022,CIVE,3339,1,10318,Geotechnical Engineering,Vipulanandan,Cumaraswamy,9,17,20,0,0,0,0,2.589
+Fall 2022,CIVE,8198,1,10321,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8298,1,10322,Doctoral Research,Milillo,Pietro,0,0,0,0,0,4,0,
+Fall 2022,CIVE,8398,1,10323,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,
+Fall 2022,CIVE,8399,1,10324,Doctoral Dissertation,Mo,Larry Yi-Lung,0,0,0,0,0,0,0,
+Fall 2022,CIVE,8498,1,10325,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8598,1,10326,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8999,1,10328,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,ECE,3441,1,10336,Digital Logic Design,Sheth,Bhavin R.,10,15,4,3,5,0,8,2.63
+Fall 2022,ECE,3436,1,10338,Microprocessor Systems,De La Rosa-Pohl,Diana,47,2,1,0,0,0,0,3.913
+Fall 2022,ECE,5317,1,10340,Microwave Engineering,Chen,Ji,3,9,0,0,1,0,0,2.975
+Fall 2022,ECE,6111,2,10341,Graduate Research Seminar,Li,Xingpeng,0,0,0,0,0,2,0,
+Fall 2022,ECE,6111,3,10342,Graduate Research Seminar,Yao,Yan,0,0,0,0,0,2,0,
+Fall 2022,ECE,6111,4,10343,Graduate Research Seminar,Han,Zhu,0,0,0,0,0,1,0,
+Fall 2022,ECE,6198,2,10345,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2022,ECE,6198,4,10347,Research,Chen,Ji,0,0,0,0,0,1,0,
+Fall 2022,ECE,6198,8,10351,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,
+Fall 2022,ECE,6198,18,10361,Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2022,ECE,6298,2,10373,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2022,ECE,6298,4,10375,Research,Chen,Ji,0,0,0,0,0,2,0,
+Fall 2022,ECE,6298,8,10379,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,
+Fall 2022,ECE,6298,17,10388,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2022,ECE,6298,18,10389,Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2022,ECE,6298,20,10391,Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Fall 2022,ECE,6298,27,10398,Research,Yao,Yan,0,0,0,0,0,4,0,
+Fall 2022,ECE,6351,1,10400,Microwave Engineering,Chen,Ji,7,2,0,0,0,0,0,3.741
+Fall 2022,ECE,6398,4,10404,Research,Chen,Ji,0,0,0,0,0,5,0,
+Fall 2022,ECE,6398,7,10407,Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,8,10408,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,5,0,
+Fall 2022,ECE,6398,12,10412,Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,13,10413,Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,16,10416,Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,17,10417,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,18,10418,Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,20,10420,Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,25,10425,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2022,ECE,6398,27,10427,Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2022,ECE,7399,2,10458,Masters Thesis,Chen,Yuhua,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,7399,3,10459,Masters Thesis,Krishnamoorthy,Harish Sarma,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,7399,5,10461,Masters Thesis,Nguyen,Hien V,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8198,3,10464,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Fall 2022,ECE,8198,5,10466,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Fall 2022,ECE,8198,8,10469,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Fall 2022,ECE,8198,11,10472,Doctoral Research,Han,Zhu,0,0,0,0,0,1,0,
+Fall 2022,ECE,8198,14,10475,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2022,ECE,8198,16,10477,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Fall 2022,ECE,8198,17,10478,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2022,ECE,8198,22,10483,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2022,ECE,8198,27,10488,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Fall 2022,ECE,8198,28,10489,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,2,10492,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,3,10493,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,0,0,
+Fall 2022,ECE,8298,4,10494,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Fall 2022,ECE,8298,5,10495,Doctoral Research,Chen,Jiefu,0,0,0,0,0,4,0,
+Fall 2022,ECE,8298,8,10498,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,10,10500,Doctoral Research,Fu,Xin,0,0,0,0,0,4,0,
+Fall 2022,ECE,8298,11,10501,Doctoral Research,Han,Zhu,0,0,0,0,0,4,0,
+Fall 2022,ECE,8298,12,10502,Doctoral Research,Jackson,David R,0,0,0,0,0,4,0,
+Fall 2022,ECE,8298,13,10503,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,14,10504,Doctoral Research,Li,Xingpeng,0,0,0,0,0,4,0,
+Fall 2022,ECE,8298,16,10506,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,20,10510,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,21,10511,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,3,0,
+Fall 2022,ECE,8298,23,10513,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,3,0,
+Fall 2022,ECE,8298,24,10514,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2022,ECE,8298,27,10517,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Fall 2022,ECE,8298,28,10518,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Fall 2022,ECE,8398,1,10519,Doctoral Research,Bao,Jiming,0,0,0,0,0,3,0,
+Fall 2022,ECE,8398,2,10520,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2022,ECE,8398,3,10521,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,0,0,
+Fall 2022,ECE,8398,4,10522,Doctoral Research,Chen,Ji,0,0,0,0,0,3,0,
+Fall 2022,ECE,8398,5,10523,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Fall 2022,ECE,8398,6,10524,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2022,ECE,8398,7,10525,Doctoral Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,8,10526,Doctoral Research,Wolfe,John C,0,0,0,0,0,1,0,
+Fall 2022,ECE,8398,9,10527,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2022,ECE,8398,10,10528,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2022,ECE,8398,11,10529,Doctoral Research,Fu,Xin,0,0,0,0,0,4,0,
+Fall 2022,ECE,8398,12,10530,Doctoral Research,Han,Zhu,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,13,10531,Doctoral Research,Jackson,David R,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,14,10532,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,6,0,
+Fall 2022,ECE,8398,15,10533,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2022,ECE,8398,17,10535,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,18,10536,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,19,10537,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,25,10541,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,26,10542,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,3,0,
+Fall 2022,ECE,8398,27,10543,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Fall 2022,ECE,8398,28,10544,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,29,10545,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,2,0,
+Fall 2022,ECE,8398,30,10546,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,3,0,
+Fall 2022,ECE,8399,1,10549,Doctoral Dissertation,Bao,Jiming,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,2,10550,Doctoral Dissertation,Becker,Aaron T,3,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,3,10551,Doctoral Dissertation,Brankovic,Stanko R,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,4,10552,Doctoral Dissertation,Chen,Ji,0,0,0,0,0,0,0,
+Fall 2022,ECE,8399,5,10553,Doctoral Dissertation,Chen,Jiefu,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,8,10556,Doctoral Dissertation,Contreras-Vidal,Jose Luis,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,11,10558,Doctoral Dissertation,Fu,Xin,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,12,10559,Doctoral Dissertation,Han,Zhu,3,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,13,10560,Doctoral Dissertation,Jackson,David R,0,0,0,0,0,0,0,
+Fall 2022,ECE,8399,15,10562,Doctoral Dissertation,Li,Xingpeng,3,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,19,10566,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,23,10570,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2022,ECE,8399,26,10572,Doctoral Dissertation,Shan,Xiaonan,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8399,28,10574,Doctoral Dissertation,Wolfe,John C,0,0,0,0,0,1,0,
+Fall 2022,ECE,8399,29,10575,Doctoral Dissertation,Yao,Yan,0,0,0,0,0,2,0,
+Fall 2022,ECE,8399,30,10576,Doctoral Dissertation,Shireen,Wajiha,0,0,0,0,0,2,0,
+Fall 2022,ECE,8498,2,10579,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,3,10580,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,0,0,
+Fall 2022,ECE,8498,4,10581,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Fall 2022,ECE,8498,5,10582,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Fall 2022,ECE,8498,6,10583,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,10,10587,Doctoral Research,Fu,Xin,0,0,0,0,0,4,0,
+Fall 2022,ECE,8498,11,10588,Doctoral Research,Han,Zhu,0,0,0,0,0,4,0,
+Fall 2022,ECE,8498,12,10589,Doctoral Research,Jackson,David R,0,0,0,0,0,4,0,
+Fall 2022,ECE,8498,13,10590,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,14,10591,Doctoral Research,Li,Xingpeng,0,0,0,0,0,4,0,
+Fall 2022,ECE,8498,15,10592,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,17,10594,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,18,10595,Doctoral Research,Pan,Miao,0,0,0,0,0,2,0,
+Fall 2022,ECE,8498,20,10597,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,21,10598,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Fall 2022,ECE,8498,22,10599,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,4,0,
+Fall 2022,ECE,8498,23,10600,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,24,10601,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,3,0,
+Fall 2022,ECE,8498,25,10602,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2022,ECE,8498,27,10604,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2022,ECE,8498,29,10606,Doctoral Research,Le,Hung Quang,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,1,10607,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,2,10608,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,3,10609,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,5,10611,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Fall 2022,ECE,8598,6,10612,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,8,10614,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,4,0,
+Fall 2022,ECE,8598,11,10617,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Fall 2022,ECE,8598,13,10619,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Fall 2022,ECE,8598,15,10621,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,16,10622,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,18,10624,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,19,10625,Doctoral Research,Pan,Miao,0,0,0,0,0,2,0,
+Fall 2022,ECE,8598,21,10627,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,22,10628,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,3,0,
+Fall 2022,ECE,8598,24,10630,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Fall 2022,ECE,8598,28,10634,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2022,ECE,8598,30,10636,Doctoral Research,Le,Hung Quang,0,0,0,0,0,1,0,
+Fall 2022,ECE,8699,2,10638,Doctoral Dissertation,Becker,Aaron T,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,4,10640,Doctoral Dissertation,Chen,Ji,0,0,0,0,0,0,0,
+Fall 2022,ECE,8699,5,10641,Doctoral Dissertation,Chen,Jiefu,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,8,10644,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2022,ECE,8699,10,10646,Doctoral Dissertation,Fu,Xin,3,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,11,10647,Doctoral Dissertation,Han,Zhu,3,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,13,10649,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,0,0,0,0,0,0,0,
+Fall 2022,ECE,8699,14,10650,Doctoral Dissertation,Li,Xingpeng,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,18,10654,Doctoral Dissertation,Pan,Miao,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,21,10657,Doctoral Dissertation,Rajashekara,Kaushik,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,22,10658,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,2,0,
+Fall 2022,ECE,8699,24,10660,Doctoral Dissertation,Shan,Xiaonan,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,8699,27,10663,Doctoral Dissertation,Wolfe,John C,0,0,0,0,0,1,0,
+Fall 2022,INDE,3330,1,10667,Financial and Cost Management,Wiggins,Nathanial David,35,7,4,2,2,0,1,3.334
+Fall 2022,INDE,3333,1,10668,Engineering Economy I,Schulze,Lawrence John Henry,1,9,0,0,0,0,1,3.133
+Fall 2022,INDE,3364,1,10669,Engineering Statistics II,Wang,Yaping,14,11,8,2,0,0,0,3.01
+Fall 2022,INDE,3382,1,10670,Stochastic Models,Xiang,Yisha,19,19,14,0,0,0,0,3.001
+Fall 2022,INDE,4111,1,10671,Industrial Engineering Seminar,Peng PhD,Jiming Ouyang,31,0,0,0,0,0,0,3.989
+Fall 2022,INDE,6111,1,10672,Graduate Seminar,Peng PhD,Jiming Ouyang,0,0,0,0,0,50,0,
+Fall 2022,INDE,6372,1,10673,Advanced Linear Optimization,Peng PhD,Jiming Ouyang,17,16,15,0,1,0,3,2.906
+Fall 2022,INDE,8198,1,10676,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Fall 2022,INDE,8298,1,10678,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2022,INDE,8298,2,10679,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,1,0,
+Fall 2022,INDE,8298,3,10680,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,2,0,
+Fall 2022,INDE,8398,1,10681,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2022,INDE,8398,2,10682,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Fall 2022,INDE,8399,1,10684,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Fall 2022,INDE,8399,2,10685,Doctoral Dissertation,Feng,Qianmei,0,0,0,0,0,1,0,
+Fall 2022,INDE,8399,5,10687,Doctoral Dissertation,Lin PhD,Ying,2,0,0,0,0,0,0,4.0
+Fall 2022,INDE,8598,1,10690,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2022,INDE,8699,3,10693,Doctoral Dissertation,Peng PhD,Jiming Ouyang,1,0,0,0,0,0,0,3.67
+Fall 2022,MECE,2334,1,10695,Thermodynamics,Love,Holley Carole,8,14,5,7,0,0,3,2.609
+Fall 2022,MECE,2361,1,10696,Intro Mechanical Design,Chang,Christiana,14,32,34,4,0,0,1,2.71
+Fall 2022,MECE,3245,1,10698,Materials Science Laboratory,Chen,Xuemei,22,39,9,1,0,0,1,3.146
+Fall 2022,MECE,3360,1,10701,Experimental Methods,Chen,Xuemei,21,35,19,2,2,0,0,2.853
+Fall 2022,MECE,4371,1,10704,Thermal-Fluids Laboratory,Love,Holley Carole,50,7,0,0,0,0,0,3.767
+Fall 2022,MECE,4372,1,10707,Mechs-Cntrls-Vibrtn Lab,Song,Gangbing,8,24,7,0,0,0,0,3.043
+Fall 2022,MECE,8111,1,10710,Graduate Seminar,Sharma,Pradeep,0,0,0,0,0,43,0,
+Fall 2022,MECE,6384,1,10711,Methods of Applied Math I,Kulkarni,Yashashree,9,13,13,6,3,0,5,2.402
+Fall 2022,CHEE,8298,13,10712,Doctoral Research,Orman,Mehmet,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8399,12,10713,Doctoral Dissertation,Nikolaou,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,INDE,6383,1,10715,Engr Design and Prototyping,Kamrani,Ali K,12,11,1,1,0,0,1,3.254
+Fall 2022,CHEE,8298,14,10717,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8399,13,10718,Doctoral Dissertation,Orman,Mehmet,2,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8598,9,10720,Doctoral Research,Karim,Alamgir,0,0,0,0,0,5,0,
+Fall 2022,PETR,6350,1,10721,Natural Gas Engineering,Farouq-Ali,Syed,2,2,0,0,0,0,0,3.583
+Fall 2022,GHL,1337,1,10723,Intro To Hospitality Industry,Doudna,Simone P,38,25,4,3,5,0,1,3.134
+Fall 2022,GHL,1337,2,10724,Intro To Hospitality Industry,Doudna,Simone P,26,25,4,3,2,0,0,3.134
+Fall 2022,GHL,1345,1,10725,"Safety, Sanitation in Hosp Ind",Beiza,Alberto,17,13,7,4,2,0,1,2.846
+Fall 2022,GHL,2365,1,10726,Tourism,Draper,Jason A,13,3,1,0,0,0,0,3.706
+Fall 2022,GHL,3160,1,10727,Hospitality Practicum II,Doudna,Simone P,1,2,1,0,0,0,0,2.918
+Fall 2022,GHL,3336,1,10728,Beverage Management,Corsi,Aaron James,27,3,0,0,1,0,2,3.625
+Fall 2022,GHL,2343,1,10729,Hospitality Cost Controls,Haskell,Rebecca Erin,22,13,3,2,0,0,1,3.367
+Fall 2022,GHL,2343,2,10730,Hospitality Cost Controls,Jarvis,Nathan Alexander,14,8,5,4,6,0,0,2.549
+Fall 2022,GHL,3345,1,10731,Wine Appreciation,Taylor,David C,28,4,4,0,4,0,4,3.292
+Fall 2022,GHL,3352,1,10733,Human Resource Management,Gip,Huy,15,11,1,2,1,0,0,3.189
+Fall 2022,GHL,3361,2,10735,Hospitality Marketing,Lee,Hyun Kyung,7,4,2,0,0,0,1,3.41
+Fall 2022,GHL,3361,3,10736,Hospitality Marketing,Johnson,Tucker A,25,8,2,3,3,0,0,3.171
+Fall 2022,GHL,4343,1,10738,Financial Admin for Hosp.Ind.,Mao-Clark,Xiaodan,12,6,0,1,0,0,0,3.439
+Fall 2022,GHL,4353,1,10739,Leadership in Hospitality Ind,Maneethai,Dustin,27,9,5,0,0,0,1,3.529
+Fall 2022,GHL,4353,2,10740,Leadership in Hospitality Ind,Guchait,Priyanko,24,9,7,3,7,0,2,2.8
+Fall 2022,GHL,6345,1,10741,Wine Appreciation,Taylor,David C,10,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6360,1,10743,Graduate Directed Practicum,Back,KiJoon,2,0,0,0,0,0,0,4.0
+Fall 2022,GHL,3358,2,10749,Hospitality Industry Law,Barth,Stephen C,11,6,2,4,8,0,6,2.194
+Fall 2022,GHL,2350,1,10750,Mgmt Principles in Hospitality,Liu,Wenfang,10,5,1,0,0,0,0,3.521
+Fall 2022,LAW,5103,1,10753,Health Law Journal,Mantel,Jessica,0,0,0,0,0,0,0,
+Fall 2022,LAW,5104,1,10754,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,2,0,
+Fall 2022,LAW,5110,1,10755,Law Review,Sanders,Joseph,0,0,0,0,0,3,0,
+Fall 2022,LAW,5147,1,10756,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,3,0,
+Fall 2022,LAW,5151,1,10757,Tax Research,Dykes,Christopher,5,2,0,0,0,0,1,3.573
+Fall 2022,LAW,5198,1,10758,Special Rsch & Writing,Vetter,Greg R,4,0,1,0,0,0,0,3.534
+Fall 2022,LAW,5210,1,10759,Law Review,Sanders,Joseph,0,0,0,0,0,8,0,
+Fall 2022,LAW,5247,2,10760,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,9,0,
+Fall 2022,LAW,5288,1,10761,Tax Ethics,Stewart,Jennifer,5,5,0,0,0,1,1,3.302
+Fall 2022,LAW,5292,1,10762,Tax Procedure,Vasquez Jr,Juan F,3,1,0,0,0,0,0,3.668
+Fall 2022,LAW,5298,1,10763,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,4.0
+Fall 2022,LAW,5319,1,10764,Intro To American Law,Kalu,Vivian O,21,10,3,0,0,0,0,3.452
+Fall 2022,LAW,5322,1,10765,Pretrial Litigation,Hawk,Amy Elizabeth,4,13,0,0,0,3,0,3.371
+Fall 2022,LAW,5328,1,10766,Judicial Externship I,Powers,William,0,0,0,0,0,4,0,
+Fall 2022,LAW,5355,1,10767,Oil and Gas,Mason,Jasper,6,21,0,0,0,0,0,3.393
+Fall 2022,LAW,5381,1,10768,Legal Negotiation,Blanco,Ileana Margarita,14,28,1,0,0,1,0,3.402
+Fall 2022,LAW,5386,1,10769,Trial Advocacy,Baldassano,Steven L,14,14,0,0,0,3,0,3.382
+Fall 2022,LAW,5398,1,10770,Special Research and Writing,Vetter,Greg R,4,0,0,0,0,0,0,3.918
+Fall 2022,LAW,5405,1,10772,Immigration Clinic,Messer,Teresa Pham,4,4,0,0,0,0,0,3.376
+Fall 2022,LAW,5406,2,10773,Civil Procedure,Salib,Peter,31,40,0,0,0,0,2,3.441
+Fall 2022,LAW,5406,3,10774,Civil Procedure,Ragazzo,Robert A,28,43,2,0,0,0,0,3.356
+Fall 2022,LAW,5409,6,10775,Contracts,Hawkins,James R,20,15,2,0,0,0,0,3.397
+Fall 2022,LAW,5414,1,10776,Immigration Clinic II,Messer,Teresa Pham,1,0,0,0,0,0,0,3.67
+Fall 2022,LAW,5418,2,10777,Torts,Duncan,Meredith J,32,40,2,0,0,0,1,3.441
+Fall 2022,LAW,5459,1,10779,Federal Income Tax,Wells,Douglas,18,34,0,0,0,9,1,3.397
+Fall 2022,LAW,6209,1,10780,Health Law Journal,Mantel,Jessica,0,0,0,0,0,4,0,
+Fall 2022,LAW,6211,1,10781,Houston Buiness/Tax Journal,Wells,Douglas,0,0,0,0,0,5,0,
+Fall 2022,LAW,6300,1,10782,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,4,0,
+Fall 2022,LAW,6318,1,10785,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,12,0,
+Fall 2022,LAW,6354,1,10787,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,16,0,
+Fall 2022,LAW,6356,1,10788,Law Review,Sanders,Joseph,0,0,0,0,0,17,0,
+Fall 2022,LAW,6358,1,10789,Health Law Journal,Mantel,Jessica,0,0,0,0,0,7,0,
+Fall 2022,LAW,5406,5,10790,Civil Procedure,Crump,David L,36,25,6,0,0,2,1,3.384
+Fall 2022,LAW,5390,1,10791,Environmental Law,Irvine,Charles W,8,10,0,0,1,1,0,3.211
+Fall 2022,AAS,2320,1,10800,Intro To African American Stdy,Smith,Marlon Antoine,9,9,8,4,3,0,0,2.475
+Fall 2022,AFSC,1201,1,10801,Foundations of the USAF I,Carrizales,Micheal,4,0,0,0,0,0,0,3.918
+Fall 2022,AFSC,1201,2,10802,Foundations of the USAF I,Carrizales,Micheal,4,0,0,0,0,0,0,3.918
+Fall 2022,AFSC,2201,1,10804,Evolution of Air Power I,Carrizales,Micheal,1,0,0,0,0,0,0,4.0
+Fall 2022,AFSC,2201,2,10805,Evolution of Air Power I,Carrizales,Micheal,3,0,0,0,0,0,0,4.0
+Fall 2022,ANTH,6300,1,10808,Anthropological Theory,Gordon,Andrew J,4,1,0,0,0,0,1,3.8
+Fall 2022,ANTH,6399,2,10814,Masters Thesis,Brown,Kenneth L,0,0,0,0,0,4,0,
+Fall 2022,ANTH,6399,3,10815,Masters Thesis,Gordon,Andrew J,0,0,0,0,0,1,0,
+Fall 2022,ANTH,7399,1,10819,Masters Thesis,Sen,Debarati,1,0,0,0,0,0,0,3.67
+Fall 2022,ANTH,7399,2,10820,Masters Thesis,Brown,Kenneth L,0,0,0,0,0,1,0,
+Fall 2022,ARAB,1501,1,10823,Beginning Arabic I,Taha,Asmaa,4,2,2,0,0,0,5,3.333
+Fall 2022,ARAB,1501,3,10824,Beginning Arabic I,Taha,Asmaa,9,3,0,0,0,0,7,3.75
+Fall 2022,ARAB,2311,1,10825,Intermediate Arabic I,Sayyid,Huda,16,3,1,1,0,0,1,3.572
+Fall 2022,ARTS,1316,1,10826,Fundamentals of Drawing,Willis,William H,21,0,0,0,0,0,1,4.0
+Fall 2022,ARTS,1316,2,10827,Fundamentals of Drawing,Reeves,Cory,18,2,1,0,0,0,1,3.81
+Fall 2022,ARTS,1316,3,10828,Fundamentals of Drawing,Welsh,Douglas Paul,18,4,0,0,0,0,0,3.848
+Fall 2022,ARTS,1316,4,10829,Fundamentals of Drawing,Alderson,Saran,19,1,1,0,1,0,0,3.652
+Fall 2022,ARTS,1316,5,10830,Fundamentals of Drawing,Francis,Mark,19,1,0,1,0,0,1,3.762
+Fall 2022,ARTS,1316,6,10831,Fundamentals of Drawing,Griffin,Alvin Garrett,16,2,1,1,1,0,1,3.335
+Fall 2022,ARTS,2316,1,10832,Fundamentals of Painting,Stephan,Hollie,13,5,1,0,1,0,0,3.45
+Fall 2022,ARTS,2316,2,10833,Fundamentals of Painting,Kidd,Julia A,17,2,0,0,0,0,1,3.929
+Fall 2022,ARTS,6380,1,10834,Seminar,Magsamen,Mary,11,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,1304,1,10835,Art Hist II(15th C to Present),Lee,Kyoung Yong,32,82,40,23,17,0,11,2.421
+Fall 2022,ARTH,4383,1,10836,Contemporary Painting,Barrera,Debra,28,5,0,2,1,0,0,3.538
+Fall 2022,CHIN,1501,1,10837,Elementary Chinese I,Zhang,Jing,16,4,3,0,2,0,1,3.214
+Fall 2022,CHIN,1501,3,10839,Elementary Chinese I,Zhang,Jing,15,2,1,0,0,0,0,3.796
+Fall 2022,CHIN,2311,1,10841,Intermediate Chinese I,Zhang,Jing,11,2,2,1,1,0,0,3.216
+Fall 2022,CHIN,3301,1,10842,Advanced Mandarin Chinese I,Zhang,Jing,7,4,0,0,0,0,0,3.666
+Fall 2022,SGNL,1301,1,10843,Elementary Sign Language I,Brittain,Robyn Michelle,1,5,4,5,4,0,2,1.649
+Fall 2022,SGNL,2301,2,10844,Intermediate Sign Language I,Marcelle,John,1,10,5,1,0,0,2,2.783
+Fall 2022,COMD,2338,1,10845,Phonetics,Bunta,Ferenc,12,12,3,1,1,0,1,3.058
+Fall 2022,COMD,6328,1,10846,Acquired Cognitive Disorders,Thiessen,Amber L,19,13,2,0,0,0,0,3.442
+Fall 2022,COMD,6387,1,10847,Voice Disorders,Joshi,Ashwini,18,11,1,0,0,0,0,3.512
+Fall 2022,COMD,7322,1,10848,Speech Sound Disorders,Cizek,Laura S,24,7,1,0,0,0,0,3.678
+Fall 2022,COMD,7391,2,10849,Clinic in Speech Lang Disorder,Tragesser,Bridgid Jane,2,1,0,0,0,0,0,3.667
+Fall 2022,COMD,7391,3,10850,Clinic in Speech Lang Disorder,Jacobson,Shannon,2,1,0,0,0,0,0,3.337
+Fall 2022,COMD,7391,4,10851,Clinic in Speech Lang Disorder,Townsend,Alayna,2,1,0,0,0,0,0,3.557
+Fall 2022,COMD,7391,5,10852,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,2,1,0,0,0,0,0,3.337
+Fall 2022,COMD,7391,6,10853,Clinic in Speech Lang Disorder,Devore,Danielle R,3,0,0,0,0,0,0,3.67
+Fall 2022,COMD,7391,7,10854,Clinic in Speech Lang Disorder,Sims,Frankie B,3,1,0,0,0,0,0,3.668
+Fall 2022,COMD,7392,1,10856,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,2,0,0,0,0,0,0,4.0
+Fall 2022,COMD,7392,2,10857,Adv Pract Sp & Lang Dis,Hoppe,Martha Ann,4,0,0,0,0,0,0,4.0
+Fall 2022,COMD,7392,3,10858,Adv Pract Sp & Lang Dis,Walker,Dionne A,3,0,0,0,0,0,0,3.89
+Fall 2022,SPCH,1318,1,10859,Interpersonal Communication,Uhrick,Jan,27,2,0,1,0,0,0,3.8
+Fall 2022,COMM,2300,1,10860,Communication Research Methods,Lyn,Robyn,22,9,2,0,7,0,4,2.967
+Fall 2022,COMM,3326,1,10861,Graphics Applications,Economou-Clarke,Ann M,15,4,1,0,0,0,0,3.667
+Fall 2022,COMM,4303,1,10863,Communication Law and Ethics,Bundage Juvane,Stephanie,10,0,0,0,0,0,0,3.901
+Fall 2022,COMM,4331,1,10865,Persuasion,Salisbury,Shelby,18,8,2,0,2,0,0,3.333
+Fall 2022,COMM,4360,1,10866,Media Planning & Placement,Kelley,Larry D.,6,9,5,0,0,0,0,3.001
+Fall 2022,COMM,6370,1,10867,Public Relations Management,Vardeman,Jennifer E,12,4,0,0,1,0,0,3.452
+Fall 2022,DANC,1245,1,10869,Modern Dance I Part I,Beasant III III,John J,17,0,0,0,0,0,0,4.0
+Fall 2022,DANC,1300,1,10870,Dance as a Fine Art,Beasant III III,John J,14,2,0,0,0,0,0,3.834
+Fall 2022,DANC,2305,1,10871,Dance Composition I,Stokes,Karen E,7,1,0,0,0,0,0,3.751
+Fall 2022,DANC,2303,1,10872,Introduction to Dance,Bobet,Jacqueline A,42,22,20,8,12,0,16,2.686
+Fall 2022,DANC,4110,1,10873,Dance Ensemble,Beasant III III,John J,1,0,0,0,0,0,0,4.0
+Fall 2022,DANC,4302,1,10874,Advanced Technique and Theory,Estrada,Maria Gabriela,10,2,0,0,0,0,0,3.806
+Fall 2022,ECON,2302,1,10875,Principles of Microeconomics,Pei,Yang,75,59,22,4,1,0,7,3.232
+Fall 2022,ECON,3334,2,10876,Intermediate Macroeconomics,Jiu,Haibin Brett,5,10,11,6,2,0,1,2.158
+Fall 2022,ECON,3371,1,10877,Economics of Money & Banking,Dasari,Babu,16,13,9,1,0,0,1,3.111
+Fall 2022,ECON,3370,1,10878,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,4,6,1,1,2,0,2,2.643
+Fall 2022,ECON,3370,2,10879,Introduction To Econometrics,Boul,Ruxandra,11,9,3,8,4,0,4,2.419
+Fall 2022,ECON,4390,1,10880,Economics Internship,Thornton,Rebecca Achee,10,0,0,0,0,0,0,3.934
+Fall 2022,ECON,8399,1,10881,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,2,0,
+Fall 2022,ENGL,1301,1,10882,First Year Writing I,Downey,Carlton M,15,5,1,0,3,0,0,3.181
+Fall 2022,ENGL,1301,2,10883,First Year Writing I,Downey,Carlton M,18,1,0,0,1,0,3,3.734
+Fall 2022,ENGL,1301,3,10884,First Year Writing I,Rolater,Sara C,14,7,0,1,1,0,2,3.305
+Fall 2022,ENGL,1301,4,10885,First Year Writing I,Rolater,Sara C,10,4,4,3,1,0,2,2.834
+Fall 2022,ENGL,1301,5,10886,First Year Writing I,Rolater,Sara C,13,4,4,0,2,0,2,3.059
+Fall 2022,ENGL,1301,6,10887,First Year Writing I,Anderson,Claire F,14,5,1,0,3,0,2,3.203
+Fall 2022,ENGL,1301,7,10888,First Year Writing I,Anderson,Claire F,20,0,1,1,2,0,1,3.403
+Fall 2022,ENGL,1301,8,10889,First Year Writing I,Burns,William,12,6,3,0,2,0,1,3.087
+Fall 2022,ENGL,1301,9,10890,First Year Writing I,Burns,William,9,9,4,0,3,0,0,2.8
+Fall 2022,ENGL,1301,10,10891,First Year Writing I,Chatham,Donna Marie,13,3,1,1,7,0,0,2.494
+Fall 2022,ENGL,1301,11,10892,First Year Writing I,Murray,Christopher Brean,12,10,2,0,1,0,0,3.28
+Fall 2022,ENGL,1301,12,10893,First Year Writing I,Murray,Christopher Brean,14,5,4,0,2,0,0,3.147
+Fall 2022,ENGL,1301,15,10894,First Year Writing I,Presswood,Phillip Hilliard,22,1,0,0,1,0,0,3.792
+Fall 2022,ENGL,1301,16,10895,First Year Writing I,Popoola,Olufeyikewa I,9,5,1,0,0,0,0,3.511
+Fall 2022,ENGL,1301,18,10896,First Year Writing I,Radtke,Jamie,7,8,3,2,2,0,3,2.697
+Fall 2022,ENGL,1301,19,10897,First Year Writing I,O'Bryan,Ann Patricia,15,3,2,1,2,0,2,3.203
+Fall 2022,ENGL,1301,28,10898,First Year Writing I,Presswood,Phillip Hilliard,19,1,1,1,2,0,1,3.389
+Fall 2022,ENGL,1301,33,10899,First Year Writing I,Colchado,Lea,12,2,2,0,2,0,0,3.222
+Fall 2022,ENGL,1301,40,10900,First Year Writing I,Brooks,Stuart,14,2,0,1,1,0,1,3.372
+Fall 2022,ENGL,1301,42,10901,First Year Writing I,Repass,Scott,9,2,2,3,3,0,0,2.544
+Fall 2022,ENGL,1301,48,10902,First Year Writing I,Repass,Scott,11,5,2,0,1,0,0,3.316
+Fall 2022,ENGL,1301,50,10903,First Year Writing I,Budhwar,Kartika,16,1,2,0,0,0,0,3.685
+Fall 2022,ENGL,1301,54,10904,First Year Writing I,Brooks,Stuart,16,2,0,1,0,0,0,3.615
+Fall 2022,ENGL,1301,61,10905,First Year Writing I,Alcorn III,Charles William,20,2,1,0,2,0,0,3.454
+Fall 2022,ENGL,1301,63,10906,First Year Writing I,Rolater,Sara C,8,6,0,1,3,0,1,2.797
+Fall 2022,ENGL,1301,70,10907,First Year Writing I,Johnston,Leah Beth,17,5,3,0,0,0,0,3.52
+Fall 2022,ENGL,1301,73,10908,First Year Writing I,Downey,Carlton M,13,3,1,0,1,0,0,3.463
+Fall 2022,ENGL,1301,89,10909,First Year Writing I,Johnston,Leah Beth,18,3,0,0,4,0,0,3.253
+Fall 2022,ENGL,1302,2,10910,First Year Writing II,Jones,Baylea,6,10,1,0,3,0,0,2.751
+Fall 2022,ENGL,1302,4,10911,First Year Writing II,Kozma,Andrew,13,4,1,1,4,0,2,2.927
+Fall 2022,ENGL,1302,10,10912,First Year Writing II,Kozma,Andrew,9,9,0,0,4,0,3,2.804
+Fall 2022,ENGL,1302,13,10913,First Year Writing II,Sicinski,Michael J,11,6,1,0,3,0,4,2.969
+Fall 2022,ENGL,1302,15,10914,First Year Writing II,Long,Steven A.,13,3,1,0,1,0,1,3.5
+Fall 2022,ENGL,1302,16,10915,First Year Writing II,Sicinski,Michael J,5,9,1,0,5,0,4,2.401
+Fall 2022,ENGL,1302,19,10916,First Year Writing II,Campese,Kathleen Ann,15,6,0,0,3,0,1,3.209
+Fall 2022,ENGL,1302,34,10917,First Year Writing II,Coleman,Quintin,17,1,0,0,1,0,0,3.667
+Fall 2022,ENGL,1302,35,10918,First Year Writing II,Garcia,Serena Mari,11,3,3,0,6,0,1,2.594
+Fall 2022,ENGL,1370,1,10919,Composition II-Honors,Barnes,Michael,5,0,0,1,0,0,0,3.445
+Fall 2022,ENGL,1370,2,10920,Composition II-Honors,Barnes,Michael,6,3,0,0,0,0,0,3.593
+Fall 2022,ENGL,2305,5,10921,Intro To Fiction,Lagana,Karen E,28,1,0,0,1,0,0,3.822
+Fall 2022,ENGL,2307,2,10922,Intro To Drama,Rizzo,Kaitlin M,25,2,1,1,0,0,0,3.759
+Fall 2022,ENGL,2307,7,10923,Intro To Drama,Presswood,Phillip Hilliard,25,2,1,0,1,0,1,3.656
+Fall 2022,ENGL,2316,4,10924,Literature and Culture,Zachow,Alix V,21,3,4,0,0,0,1,3.466
+Fall 2022,ENGL,3330,1,10925,Beg Creative Writing-Fiction,Mitchell,Josephine Margaret,19,1,0,0,0,0,0,3.917
+Fall 2022,ENGL,4390,1,10926,Professional Internship,Zentz,Lauren R,0,0,0,0,0,1,0,
+Fall 2022,FREN,1501,1,10927,Elementary French I,Wilson,Celine Madeleine Alice,10,5,4,3,1,0,0,2.898
+Fall 2022,FREN,1502,1,10929,Elementary French II,Green,Viola V,5,9,7,2,0,0,3,2.753
+Fall 2022,FREN,2311,1,10931,Intermediate French I,Gnanwo Hounfodji,Raymond,1,2,4,1,1,0,2,2.074
+Fall 2022,FREN,2312,1,10932,Intermediate French II,Chalhoub,Rania Maria,11,5,0,1,1,0,2,3.297
+Fall 2022,GERM,2311,1,10933,Intermediate German I,Kleinheider,Julia D,4,10,2,2,1,0,1,2.841
+Fall 2022,GERM,3333,1,10934,Ger Conversatn&Composit,Kleinheider,Julia D,4,2,0,0,0,0,3,3.612
+Fall 2022,HIST,1301,1,10935,The U.S. to 1877,Clavin,Matthew J,5,29,40,22,20,0,14,1.785
+Fall 2022,HIST,3378,1,10937,The Modern Middle East,Al-Sowayel,Dina,19,9,3,0,1,0,1,3.355
+Fall 2022,HIST,8699,1,10938,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Fall 2022,HIST,8999,1,10940,Doctoral Dissertation,Neumann,Kristina Marie,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8999,8,10941,Doctoral Dissertation,Goldberg,Mark A.,0,0,0,0,0,1,0,
+Fall 2022,HIST,8999,9,10942,Doctoral Dissertation,Schafer Jr,James A,0,0,0,0,0,1,0,
+Fall 2022,HON,2301,1,10943,The Human Situation: Antiquity,Barnes,Michael,155,74,6,2,3,0,3,3.503
+Fall 2022,HON,2301,2,10944,The Human Situation: Antiquity,Sommers,Tamler S,176,105,13,1,3,0,9,3.493
+Fall 2022,ITAL,2311,2,10955,Intermediate Italian I,Ercolani,Monica,16,8,3,0,1,0,0,3.322
+Fall 2022,LATI,1301,1,10956,Elementary Latin I,Kidder,Kathleen,8,8,3,0,1,0,0,3.001
+Fall 2022,LATI,2311,1,10957,Intermediate Latin I,Armstrong,Richard H,7,9,0,0,0,0,1,3.582
+Fall 2022,MAS,2340,1,10958,Intro Mexican American Studies,Rodriguez,Andre,13,17,3,0,1,0,1,3.206
+Fall 2022,MSCI,1125,1,10960,Phys Readiness Training,Gilley,Timothy O,4,7,0,0,0,0,1,3.364
+Fall 2022,MSCI,1210,1,10961,Introduction to the Army,Thomas,Roland,2,1,0,0,0,0,0,3.557
+Fall 2022,MSCI,2210,1,10963,Leadership & Decision Making,Sweeney,Sean C,7,1,0,1,1,0,0,3.233
+Fall 2022,MSCI,2210,2,10964,Leadership & Decision Making,Sweeney,Sean C,2,0,0,0,0,0,0,4.0
+Fall 2022,MSCI,3310,1,10966,Training Management & WFF,Eley,Justin,7,0,0,0,0,0,0,4.0
+Fall 2022,MSCI,4310,1,10969,The Army Officer,Comiskey,Melissa C,12,2,0,0,0,0,0,3.81
+Fall 2022,MUED,4305,1,10971,General Music/Elem & Sec Schls,Derges,Julie D,13,7,1,0,0,0,0,3.54
+Fall 2022,MUSA,1300,1,10972,Applied Voice,Averyt,Zachary Benjamin,2,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,1300,2,10973,Applied Voice,Clayton Vasquez,Cynthia L,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1310,2,10974,Applied Piano,Morgulis,Tali,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1320,2,10975,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,1330,1,10978,Applied Flute,Russell,Peggy,2,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,1330,2,10979,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,1334,1,10980,Applied Clarinet,Griffin,Randall S,0,2,0,0,0,0,0,2.67
+Fall 2022,MUSA,1334,2,10981,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1336,1,10982,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1342,2,10983,Applied French Horn,Reed,Gavin Davis,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1344,1,10984,Applied Trombone,Kauk,Brian Keith,3,1,0,0,0,0,0,3.585
+Fall 2022,MUSA,1346,1,10985,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1348,1,10986,Applied Euphonium,Freeman,Phillip I,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2300,1,10987,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,3.89
+Fall 2022,MUSA,2300,2,10988,Applied Voice,Evans,Joseph,2,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,2300,3,10989,Applied Voice,Jones,Timothy J,4,0,0,0,0,0,0,3.918
+Fall 2022,MUSA,2300,4,10990,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2326,1,10993,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2330,1,10994,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2330,2,10995,Applied Flute,Suhr,Melissa D,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2336,1,10997,Applied Bassoon,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2342,2,10998,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,2344,1,10999,Applied Trombone,Kauk,Brian Keith,5,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2346,1,11000,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2348,1,11001,Applied Euphonium,Freeman,Phillip I,1,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,2378,1,11002,Applied Jazz Guitar,Wheeler,Mike,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3400,1,11003,Applied Voice,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3400,2,11004,Applied Voice,Clayton Vasquez,Cynthia L,4,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,3400,5,11005,Applied Voice,Jones,Timothy J,2,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,3400,6,11006,Applied Voice,Sonnenberg,Melanie,3,0,0,0,0,0,0,3.89
+Fall 2022,MUSA,3430,2,11007,Applied Flute,Suhr,Melissa D,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3434,2,11008,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3436,1,11009,Applied Bassoon,Wagner,Elise L,4,0,0,0,0,0,0,3.918
+Fall 2022,MUSA,3442,2,11010,Applied French Horn,Reed,Gavin Davis,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3448,1,11011,Applied Euphonium,Freeman,Phillip I,2,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,4400,2,11012,Applied Voice,Clayton Vasquez,Cynthia L,0,0,0,0,0,0,0,
+Fall 2022,MUSA,4402,1,11013,Applied Composition,Maroney,Marcus K,4,0,0,0,0,0,0,3.918
+Fall 2022,MUSA,4410,2,11014,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4420,1,11015,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4430,2,11016,Applied Flute,Suhr,Melissa D,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4434,2,11017,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4436,1,11019,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4438,1,11020,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4442,2,11021,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4444,1,11022,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4446,1,11023,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4448,1,11024,Applied Euphonium,Freeman,Phillip I,2,0,0,0,0,0,0,3.835
+Fall 2022,MUSA,6400,2,11026,Applied Voice,Evans,Joseph,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6442,1,11027,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8241,1,11028,Doctoral Recital II,Mueller,Jebediah Lee,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,1100,1,11029,Marching Band,Kubos,Cameron Kade,162,0,0,0,0,0,2,4.0
+Fall 2022,MUSI,1102,1,11030,Wind Ensemble,Bertman,David Garry,57,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,1102,2,11031,Wind Ensemble,Bertman,David Garry,65,1,0,0,0,0,0,3.985
+Fall 2022,MUSI,1110,1,11033,Jazz Orchestra,Marmolejo,Noe J,27,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,1120,1,11037,University Chorus,DeSpain,Kaitlin Elizabeth,5,0,0,0,0,0,0,3.934
+Fall 2022,MUSI,1121,1,11038,Concert Chorus,Mueller,Jebediah Lee,23,2,0,0,0,0,1,3.88
+Fall 2022,MUSI,1140,1,11039,Orchestra,Krager,Franz A,56,0,0,0,0,0,0,3.971
+Fall 2022,MUSI,1181,2,11042,Group Piano I,Van Kekerix,Todd Evan,6,5,2,0,0,0,0,3.181
+Fall 2022,MUSI,1116,1,11043,Aural Skills I,Lee,Ji Yeon,10,2,3,1,0,0,1,3.313
+Fall 2022,MUSI,1311,1,11045,Music Theory I,Lee,Ji Yeon,13,0,2,1,0,0,1,3.459
+Fall 2022,MUSI,1160,1,11046,Italian and English Diction,Suits,Brian J,11,9,0,0,0,0,0,3.501
+Fall 2022,MUSI,2181,1,11047,Group Piano III,Van Kekerix,Todd Evan,4,10,0,0,0,0,0,3.215
+Fall 2022,MUSI,2181,2,11048,Group Piano III,Van Kekerix,Todd Evan,4,4,0,0,0,0,0,3.376
+Fall 2022,MUSI,2116,1,11049,Aural Skills III,Guez,Jonathan Charles,16,7,1,0,0,0,0,3.57
+Fall 2022,MUSI,2210,1,11050,Theory III,Guez,Jonathan Charles,12,7,4,0,0,0,1,3.233
+Fall 2022,MUED,2320,1,11051,Computers for Musicians,Welch,Carl Chapman,6,4,0,1,0,0,0,3.394
+Fall 2022,MUED,2320,2,11052,Computers for Musicians,Welch,Carl Chapman,12,2,1,0,1,0,0,3.479
+Fall 2022,MUSI,2361,1,11053,Music and Culture,Lange,Barbara Rose,29,27,7,0,1,0,3,3.235
+Fall 2022,MUED,3100,1,11054,Woodwinds,Bell,Priscilla Garrett,29,2,0,0,0,0,0,3.882
+Fall 2022,MUED,3101,1,11055,Woodwinds,Bell,Priscilla Garrett,11,2,3,0,0,0,1,3.438
+Fall 2022,MUED,3104,1,11056,Strings,Hansen,Erin Melissa,7,8,4,0,1,0,0,3.0
+Fall 2022,MUSI,3215,1,11057,Introduction To Large Forms,Lee,Ji Yeon,8,5,0,2,2,0,0,2.921
+Fall 2022,MUSI,3215,2,11058,Introduction To Large Forms,Garza,Paul Victor,12,3,0,0,1,0,2,3.459
+Fall 2022,MUSI,3215,3,11059,Introduction To Large Forms,Koozin,Timothy,7,6,1,0,1,0,1,3.156
+Fall 2022,MUSI,1307,1,11060,Listening to Classical Music,Diehl,Alaina B,35,0,1,1,0,0,3,3.829
+Fall 2022,MUSI,1307,2,11061,Listening to Classical Music,Diehl,Alaina B,24,10,2,1,0,0,2,3.478
+Fall 2022,MUSI,3301,1,11062,Listening To World Music,Diehl,Alaina B,27,6,0,1,1,0,0,3.61
+Fall 2022,MUSI,3363,1,11063,History of Music II,Bertagnolli,Paul A,15,18,18,8,8,0,1,2.343
+Fall 2022,MUSI,4102,1,11064,Acting for Opera,Edelson,Lawrence Michael,18,3,0,0,0,0,0,3.716
+Fall 2022,MUSI,4120,1,11065,Percussion Ensemble,Wilkins,Blake M,12,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4220,1,11066,Choral Conducting I,Weber,Mary E,17,5,0,0,0,0,0,3.758
+Fall 2022,MUSI,4230,1,11067,Instrumental Conducting I,Bertman,David Garry,21,2,0,0,0,0,1,3.913
+Fall 2022,MUED,4344,1,11068,MS/JS/HS Inst Admin&Ens Tech,Meals,Cory Dewitt,24,6,1,0,0,0,0,3.678
+Fall 2022,MUSI,6104,1,11069,New Music Ensemble,Smith,Robert Thomas,8,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8300,1,11070,Doct Research Seminar,Pollack,Howard J,3,0,0,0,0,0,0,3.78
+Fall 2022,GOVT,2306,2,11071,US and Texas Const/Politics,Cole,Jeffrey Bryan,83,95,19,19,21,0,8,2.813
+Fall 2022,POLS,4390,1,11072,Government Internship,Cross,Renee D,30,0,0,0,1,0,1,3.86
+Fall 2022,PSYC,2305,1,11073,Intro to Methods in Psychology,Ravey,Eriksen,16,11,7,1,4,0,1,2.897
+Fall 2022,PSYC,4344,1,11075,Cultural Psychology,Agan,Herb W,43,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,3310,2,11076,Indstrl-Orgnztnl Psy,Zamanipour,Tina,42,4,6,2,1,0,0,3.527
+Fall 2022,PSYC,2316,1,11077,Psychology of Personality,Fetterman,Adam Kent,23,13,5,3,1,0,0,3.266
+Fall 2022,PSYC,2330,1,11078,Biological Psychology,Leasure,Jennifer Leigh,12,16,7,3,4,0,7,2.69
+Fall 2022,PSYC,6317,1,11079,Psychopathology I,Alfano,Candice A,11,5,0,0,0,0,0,3.564
+Fall 2022,SOCI,1301,3,11080,Introduction To Sociology,Nelson,Steven M,29,20,4,3,3,0,1,3.13
+Fall 2022,SOCI,1301,1,11082,Introduction To Sociology,Nelson,Steven M,33,15,5,4,2,0,0,3.215
+Fall 2022,SOCI,1301,5,11083,Introduction To Sociology,Dorsey,Patricia Lynne,19,20,8,6,5,0,0,2.662
+Fall 2022,SOC,3400,1,11084,Intro To Social Statistics,Hwang,Hyunseok,15,12,7,2,1,0,2,2.956
+Fall 2022,SOC,6300,1,11087,Sem-Sociological Theory,Lee,Shayne,9,0,0,0,0,0,0,4.0
+Fall 2022,SOC,6304,1,11088,Social Statistics,Anderson,Kathryn,5,4,0,0,0,0,0,3.519
+Fall 2022,SOC,7399,4,11090,Masters Thesis,Monserud,Maria Aleksandrovna,0,0,0,0,0,1,0,
+Fall 2022,SPAN,1501,1,11091,Elementary Spanish I,Perez Vigil De Mostaccero,Sylvia Rossana,6,8,6,0,0,0,3,2.918
+Fall 2022,SPAN,1501,7,11093,Elementary Spanish I,Sanchez,Deyanira Dolores,10,9,3,0,1,0,2,3.117
+Fall 2022,SPAN,1501,9,11095,Elementary Spanish I,Cervantes Figueroa,Ana Silvia,15,10,1,0,1,0,0,3.322
+Fall 2022,SPAN,1501,11,11097,Elementary Spanish I,Martinez,Carlos David,10,7,0,2,0,0,2,3.246
+Fall 2022,SPAN,1501,13,11099,Elementary Spanish I,Patterson,Haley F,6,5,7,3,2,0,1,2.377
+Fall 2022,SPAN,1502,5,11101,Elementary Spanish II,Sanchez Carbajo,Maria,7,13,4,0,1,0,1,3.053
+Fall 2022,SPAN,1502,11,11103,Elementary Spanish II,Besovic,Helena,14,5,8,0,1,0,0,3.095
+Fall 2022,SPAN,1502,15,11107,Elementary Spanish II,Ruffino,Maythe,8,11,2,0,1,0,3,3.106
+Fall 2022,SPAN,1505,1,11109,Intensive Elementary Spanish,Hernandez,Stephanie,8,17,5,0,2,0,0,2.865
+Fall 2022,SPAN,2311,4,11111,Intermediate Spanish I,Benalcazar Astudillo,Diana Salome,5,5,3,1,1,0,2,2.712
+Fall 2022,SPAN,2311,7,11113,Intermediate Spanish I,Morales Utria,Yordanis,7,10,5,1,1,0,1,2.834
+Fall 2022,SPAN,2312,1,11114,Intermediate Spanish II,Reyes Ferrufino,Diana Eufemia,8,15,3,0,1,0,1,3.037
+Fall 2022,SPAN,2312,2,11115,Intermediate Spanish II,Martinez,Carlos David,10,3,0,4,0,0,0,3.059
+Fall 2022,SPAN,2307,1,11116,Span for Heritage Learners I,Ferrer,Tatiana Ines,15,4,3,1,1,0,1,3.25
+Fall 2022,SPAN,2308,2,11117,Span for Heritage Learners II,Martinez,Raquel,2,4,2,1,1,0,0,2.533
+Fall 2022,SPAN,3301,2,11118,Span Oral Comm for Crit Think,Serrano,Paloma A,18,0,1,0,0,0,0,3.738
+Fall 2022,SPAN,3302,1,11119,Adv Span for Non-Heritage,Cuesta,Mabel,12,4,1,0,0,0,3,3.511
+Fall 2022,SPAN,3307,1,11120,Public Speaking in Spanish,Quintanilla,Guadalupe C,16,4,0,0,0,0,0,3.751
+Fall 2022,SPAN,3307,3,11121,Public Speaking in Spanish,Quintanilla,Guadalupe C,15,2,0,0,0,0,2,3.805
+Fall 2022,SPAN,3308,2,11122,Written Com-Hisp Herit Learner,Quintanilla,Guadalupe C,16,1,0,0,0,0,3,3.825
+Fall 2022,SPAN,3308,1,11123,Written Com-Hisp Herit Learner,Hasbun,Rodrigo,12,2,2,0,1,0,0,3.315
+Fall 2022,SPAN,3384,2,11124,Intro To Hispanic Literature,Gutierrez,Pedro Revuelta,8,5,2,0,2,0,2,2.903
+Fall 2022,SPAN,8399,1,11133,Dissertation,Gutierrez,Manuel J,1,0,0,0,0,2,0,4.0
+Fall 2022,SPAN,8399,2,11134,Dissertation,Fairclough,Marta A,0,0,0,0,0,5,0,
+Fall 2022,SPAN,8399,4,11136,Dissertation,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,0,0,3.67
+Fall 2022,SPAN,8399,6,11137,Dissertation,Solino,Maria Elena,0,0,0,0,0,2,0,
+Fall 2022,SPAN,8699,1,11138,Dissertation,Solino,Maria Elena,0,0,0,0,0,2,0,
+Fall 2022,SPAN,8699,4,11140,Dissertation,Gutierrez,Manuel J,1,0,0,0,0,1,0,4.0
+Fall 2022,SPAN,8699,5,11141,Dissertation,Fairclough,Marta A,0,0,0,0,0,1,0,
+Fall 2022,THEA,1332,1,11142,Fundamentals of Theatre,Bush,Rachel R,23,5,0,0,0,0,2,3.821
+Fall 2022,DRAM,1330,1,11143,Scenic Technology,Ramos,Emili,11,5,1,0,0,0,2,3.472
+Fall 2022,THEA,2373,1,11145,Costume Technology,Meckley,Teresa L,1,10,7,0,0,0,0,2.685
+Fall 2022,THEA,3335,1,11147,History of the Theatre I,Shimko,Robert B,17,6,4,0,2,0,1,3.253
+Fall 2022,THEA,6301,1,11148,Acting,Young,John M,0,8,0,0,0,0,0,3.124
+Fall 2022,VIET,2301,1,11149,Intermediate Vietnamese I,DANG,THONG Q,17,2,0,0,0,0,0,3.877
+Fall 2022,WGSS,2350,3,11150,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,23,5,0,0,2,0,0,3.556
+Fall 2022,MUSI,8106,2,11152,Doctoral Large Ensemble,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,3361,1,11154,Advertising Copywriting,Clark,Thomas R,23,1,3,0,1,0,2,3.607
+Fall 2022,SPAN,3305,1,11156,Spanish Grammar Review,Gutierrez,Manuel J,8,6,3,0,2,0,0,2.965
+Fall 2022,VIET,1501,1,11157,Elementary Vietnamese I,DANG,THONG Q,26,3,0,0,0,0,1,3.908
+Fall 2022,PSYC,2305,3,11159,Intro to Methods in Psychology,Ravey,Eriksen,17,10,5,2,6,0,0,2.692
+Fall 2022,ENGL,1301,101,11161,First Year Writing I,Chatham,Donna Marie,7,7,1,2,5,0,3,2.364
+Fall 2022,ENGL,1301,103,11162,First Year Writing I,Braniger,Leslie,2,9,5,3,5,0,1,2.0
+Fall 2022,ENGL,1301,109,11179,First Year Writing I,Anderson,Claire F,13,2,0,0,3,0,1,3.149
+Fall 2022,HON,4398,3,11197,Independent Study,Barnes,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,2316,3,11206,Fundamentals of Painting,Foutz,Madelyn Mairie,15,2,1,2,0,0,0,3.5
+Fall 2022,MUSI,2181,4,11211,Group Piano III,Van Kekerix,Todd Evan,8,4,3,0,1,0,0,3.125
+Fall 2022,MUSI,3303,1,11212,Pop Music of Americas Sn 1840,Garza,Paul Victor,17,8,10,2,2,0,2,2.881
+Fall 2022,SOC,3351,1,11214,Soc Class&Mobilty in Am,Lorence,Jon P,17,16,5,0,2,0,0,3.158
+Fall 2022,GERM,1501,1,11215,Beginning German I,Bandmann,Tanya,4,3,3,0,0,0,0,2.968
+Fall 2022,GERM,1501,3,11217,Beginning German I,Bandmann,Tanya,8,1,1,1,0,0,1,3.395
+Fall 2022,GERM,1501,5,11219,Beginning German I,Bandmann,Tanya,3,0,0,0,0,0,0,4.0
+Fall 2022,FREN,1502,3,11221,Elementary French II,Green,Viola V,7,5,3,0,1,0,1,2.98
+Fall 2022,CHIN,1501,5,11223,Elementary Chinese I,McArthur,Charles M,11,6,0,0,0,0,0,3.647
+Fall 2022,SPAN,3341,1,11224,Language of Business and Trade,Serrano,Paloma A,15,7,1,0,0,0,2,3.523
+Fall 2022,CHIN,4301,1,11226,Public Speaking in Chinese,Li,Melody Yunzi,9,0,0,0,1,0,0,3.6
+Fall 2022,AFSC,4301,3,11228,National Security Affairs I,Curiel,Ernesto F,4,0,0,0,0,0,0,3.918
+Fall 2022,SOC,6399,1,11229,Masters Thesis,Karner,Tracy Xavia,0,0,1,0,0,0,0,2.0
+Fall 2022,POLS,6380,1,11230,Quantitative Methods I,Basinger,Scott J,9,3,0,0,0,0,0,3.723
+Fall 2022,CHIN,3360,1,11231,A Look Into Modern China,McArthur,Charles M,6,13,3,1,2,0,1,2.853
+Fall 2022,WGSS,2350,4,11232,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,25,3,0,0,1,0,0,3.713
+Fall 2022,DRAM,1310,4,11233,Introduction to Theatre,Verheyen PhD,Claremarie H,22,14,3,3,3,0,4,3.074
+Fall 2022,ENGL,6300,1,11234,College Tchg-Lang & Lit in Eng,Salome,Melanie Rebecca,11,1,0,0,0,0,1,3.834
+Fall 2022,THEA,7303,1,11235,Graduate Acting III,Young,John M,2,3,0,0,0,0,0,3.334
+Fall 2022,THEA,7313,1,11236,Graduate Movement III,Noble,Adam S,4,2,0,0,0,0,0,3.557
+Fall 2022,ENGL,1302,42,11237,First Year Writing II,Long,Steven A.,11,4,0,0,2,0,1,3.294
+Fall 2022,ENGL,1302,43,11238,First Year Writing II,Dykes,Justin,10,6,5,0,0,0,3,3.222
+Fall 2022,ENGL,1302,44,11239,First Year Writing II,Coleman,Quintin,13,2,1,0,3,0,0,3.071
+Fall 2022,ENGL,1301,110,11240,First Year Writing I,Fretwell,Leah M,7,8,0,0,2,0,1,3.098
+Fall 2022,ENGL,1301,111,11241,First Year Writing I,Braniger,Leslie,0,8,9,3,3,0,2,2.028
+Fall 2022,DANC,3310,1,11242,Dance History I,Estrada,Maria Gabriela,38,6,4,0,0,0,6,3.695
+Fall 2022,THEA,7323,1,11243,Graduate Voice/Speech III,Wetzel,Molly Elizabeth,3,2,0,0,0,0,0,3.666
+Fall 2022,MUSA,4400,1,11244,Applied Voice,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,2188,1,11245,Keybd Skills & Collab Technqs,Hester,Timothy E,4,1,0,0,0,0,0,3.8
+Fall 2022,WCL,2352,2,11246,World Cinema,Centeno,Daniel,11,15,2,1,0,0,0,3.162
+Fall 2022,COMD,7391,11,11249,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,3,1,0,0,0,0,0,3.585
+Fall 2022,ENGL,1302,46,11262,First Year Writing II,Brooks,Stuart,10,6,1,0,2,0,0,3.106
+Fall 2022,SOCI,1301,11,11264,Introduction To Sociology,Davis,Mary A,34,11,4,4,5,0,1,3.064
+Fall 2022,ENGL,1301,120,11265,First Year Writing I,Spencer,Jaxson Matthew,16,2,1,0,0,0,0,3.755
+Fall 2022,ENGL,1301,121,11266,First Year Writing I,Spencer,Jaxson Matthew,14,3,1,0,1,0,0,3.492
+Fall 2022,SGNL,1301,3,11267,Elementary Sign Language I,Brittain,Robyn Michelle,7,6,3,1,4,0,0,2.414
+Fall 2022,ENGL,1301,122,11268,First Year Writing I,Zachow,Alix V,8,9,1,0,1,0,0,3.211
+Fall 2022,ENGL,1301,123,11269,First Year Writing I,Koulen,Marisa Theresa,13,2,0,0,3,0,1,3.222
+Fall 2022,MUSI,4120,2,11271,Percussion Ensemble,Warren,Paul Alexander,13,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1301,124,11272,First Year Writing I,Murray,Christopher Brean,14,4,4,0,2,0,1,3.112
+Fall 2022,ENGL,1301,125,11273,First Year Writing I,Julian,Jennifer La'Vonne,19,3,0,1,2,0,0,3.374
+Fall 2022,BCHS,3304,1,11280,General Biochemistry I,Amaral Antunes,Dinler,24,18,22,3,2,0,3,2.951
+Fall 2022,BCHS,3304,2,11281,General Biochemistry I,Scott,Sean-Patrick,35,75,55,8,21,0,15,2.479
+Fall 2022,BCHS,3305,1,11282,General Biochemistry II,Fujita,Masaya,45,18,6,0,0,0,5,3.527
+Fall 2022,BCHS,4306,1,11283,Nucleic Acids,Gunaratne,Preethi H,32,26,9,1,0,0,1,3.285
+Fall 2022,BCHS,4313,1,11284,Cell Biochemistry,Rea,Michael A,16,8,8,0,0,0,4,3.26
+Fall 2022,BCHS,6113,1,11285,Graduate Biochemistry Seminar,Briggs,James M,0,0,0,0,0,22,0,
+Fall 2022,BCHS,6398,1,11287,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8399,1,11291,Doctoral Dissertation,Widger,William R,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,8598,1,11293,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8698,1,11294,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8999,1,11296,Doctoral Dissertation,Briggs,James M,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,2101,1,11297,Anatomy & Physiology Lab I,Gill,Tejendra,2,12,3,3,1,0,2,2.445
+Fall 2022,BIOL,2101,2,11298,Anatomy & Physiology Lab I,Gill,Tejendra,7,12,2,1,0,0,2,3.031
+Fall 2022,BIOL,2101,3,11299,Anatomy & Physiology Lab I,Gill,Tejendra,8,10,4,0,0,0,2,3.092
+Fall 2022,BIOL,2101,4,11300,Anatomy & Physiology Lab I,Gill,Tejendra,2,11,5,1,0,0,4,2.685
+Fall 2022,BIOL,2101,5,11301,Anatomy & Physiology Lab I,Gill,Tejendra,5,12,5,0,1,0,0,2.798
+Fall 2022,BIOL,2101,6,11302,Anatomy & Physiology Lab I,Gill,Tejendra,7,11,4,0,0,0,1,3.046
+Fall 2022,BIOL,2101,7,11303,Anatomy & Physiology Lab I,Gill,Tejendra,8,13,2,0,1,0,0,3.098
+Fall 2022,BIOL,2101,8,11304,Anatomy & Physiology Lab I,Gill,Tejendra,5,12,3,0,0,0,2,3.084
+Fall 2022,BIOL,2101,9,11305,Anatomy & Physiology Lab I,Gill,Tejendra,11,10,2,0,1,0,0,3.181
+Fall 2022,BIOL,2120,1,11306,Microbiology for Non-Science,Knapp,Richard D,19,2,1,0,0,0,2,3.833
+Fall 2022,BIOL,2120,2,11307,Microbiology for Non-Science,Knapp,Richard D,18,4,2,0,0,0,0,3.653
+Fall 2022,BIOL,1106,1,11308,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,1,0,1,0,0,3.528
+Fall 2022,BIOL,1106,2,11309,Biol for Science Majors I(Lab),Medrano,Ana I,11,4,3,1,0,0,3,3.316
+Fall 2022,BIOL,1106,3,11310,Biol for Science Majors I(Lab),Medrano,Ana I,13,7,1,1,0,0,1,3.425
+Fall 2022,BIOL,1106,4,11311,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,3,0,1,0,0,3.32
+Fall 2022,BIOL,1106,6,11312,Biol for Science Majors I(Lab),Medrano,Ana I,12,8,0,2,0,0,1,3.379
+Fall 2022,BIOL,1106,7,11313,Biol for Science Majors I(Lab),Medrano,Ana I,8,8,1,1,1,0,4,3.053
+Fall 2022,BIOL,1106,8,11314,Biol for Science Majors I(Lab),Medrano,Ana I,12,6,1,1,1,0,2,3.317
+Fall 2022,BIOL,1106,9,11315,Biol for Science Majors I(Lab),Medrano,Ana I,17,6,0,1,0,0,0,3.625
+Fall 2022,BIOL,1106,10,11316,Biol for Science Majors I(Lab),Medrano,Ana I,14,6,1,1,0,0,2,3.515
+Fall 2022,BIOL,1106,11,11317,Biol for Science Majors I(Lab),Medrano,Ana I,12,4,2,0,0,0,6,3.519
+Fall 2022,BIOL,1106,12,11318,Biol for Science Majors I(Lab),Medrano,Ana I,17,3,0,0,1,0,2,3.682
+Fall 2022,BIOL,1106,13,11319,Biol for Science Majors I(Lab),Medrano,Ana I,10,8,1,1,2,0,2,3.03
+Fall 2022,BIOL,1106,14,11320,Biol for Science Majors I(Lab),Medrano,Ana I,15,1,2,1,2,0,2,3.222
+Fall 2022,BIOL,1106,15,11321,Biol for Science Majors I(Lab),Medrano,Ana I,10,8,3,0,1,0,2,3.197
+Fall 2022,BIOL,1106,16,11322,Biol for Science Majors I(Lab),Medrano,Ana I,9,7,3,2,2,0,1,2.797
+Fall 2022,BIOL,1106,17,11323,Biol for Science Majors I(Lab),Medrano,Ana I,15,6,1,0,1,0,1,3.478
+Fall 2022,BIOL,1106,18,11324,Biol for Science Majors I(Lab),Medrano,Ana I,16,3,1,1,1,0,1,3.425
+Fall 2022,BIOL,1106,19,11325,Biol for Science Majors I(Lab),Medrano,Ana I,15,4,2,0,1,0,2,3.395
+Fall 2022,BIOL,1106,20,11326,Biol for Science Majors I(Lab),Medrano,Ana I,12,6,2,1,2,0,0,3.116
+Fall 2022,BIOL,1106,21,11327,Biol for Science Majors I(Lab),Medrano,Ana I,13,7,0,2,0,0,2,3.319
+Fall 2022,BIOL,1106,22,11328,Biol for Science Majors I(Lab),Medrano,Ana I,9,7,0,0,4,0,3,2.801
+Fall 2022,BIOL,1308,1,11329,Biology for Non-Science Majors,Ibrahim,Abdalla Zanouny,41,61,32,14,13,0,17,2.623
+Fall 2022,BIOL,2301,1,11330,Anatomy & Physiology I (lect),Wayne,Chad M,40,111,119,14,55,0,55,2.172
+Fall 2022,BIOL,2320,1,11331,Microbiology for Non-Science,Knapp,Richard D,73,78,69,46,37,0,31,2.343
+Fall 2022,BIOL,1306,1,11332,Biology for Science Majors I,Farmer,Lisa M,49,63,65,36,23,0,12,2.366
+Fall 2022,BIOL,1306,2,11333,Biology for Science Majors I,Cheek,Ann Oliver,46,52,65,45,31,0,33,2.247
+Fall 2022,BIOL,1306,3,11334,Biology for Science Majors I,Cheek,Ann Oliver,47,47,54,35,43,0,16,2.166
+Fall 2022,BIOL,1306,4,11335,Biology for Science Majors I,Gifford,Jenifer,70,83,58,47,18,0,10,2.475
+Fall 2022,BIOL,3306,1,11339,Evolutionary Biology,Azevedo,Ricardo,7,27,63,17,8,0,11,2.044
+Fall 2022,BIOL,3324,1,11340,Human Physiology,Wayne,Chad M,22,40,65,0,3,0,21,2.663
+Fall 2022,BIOL,3341,1,11341,Human Genetics,Feng,Qin,67,38,9,1,0,0,1,3.467
+Fall 2022,BIOL,3396,1,11342,Senior Research Project,Frankino,William A,10,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,4320,1,11343,Molecular Biology,Chung,Sanghyuk,8,5,10,2,2,0,5,2.531
+Fall 2022,BIOL,6110,1,11344,Biology Seminar,Sater,Amy,0,0,0,0,0,29,0,
+Fall 2022,BIOL,6298,1,11346,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6498,1,11347,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6598,1,11348,Special Problems,Graur,Dan,0,0,0,0,0,1,0,
+Fall 2022,BIOL,7167,1,11349,Population Biology Seminar,Zufall,Rebecca A,0,0,0,0,0,12,0,
+Fall 2022,BIOL,8398,1,11351,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8399,1,11352,Doctoral Dissertation,Pennings,Steven C,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,8598,1,11354,Doctoral Research,Sater,Amy,0,0,0,0,0,1,0,
+Fall 2022,CHEM,1105,1,11355,Foundations of Chem Lab,Zaitsev,Vladimir G,8,6,2,2,0,0,1,3.074
+Fall 2022,CHEM,1105,2,11356,Foundations of Chem Lab,Zaitsev,Vladimir G,2,15,0,0,0,0,0,3.156
+Fall 2022,CHEM,1111,1,11357,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,2,1,0,0,0,3.033
+Fall 2022,CHEM,1111,2,11358,Fundamentals of Chm Lab,Zaitsev,Vladimir G,9,3,4,2,0,0,1,3.019
+Fall 2022,CHEM,1111,5,11359,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,1,0,0,0,3,3.154
+Fall 2022,CHEM,1111,4,11360,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,5,0,0,0,2,3.02
+Fall 2022,CHEM,1111,9,11361,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,8,7,0,2,0,1,2.473
+Fall 2022,CHEM,1111,12,11362,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,3,0,0,0,2,3.021
+Fall 2022,CHEM,1111,7,11363,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,9,1,1,0,0,2,3.159
+Fall 2022,CHEM,1111,10,11364,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,17,0,1,0,0,0,3.11
+Fall 2022,CHEM,1111,11,11365,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,2,1,0,0,2,2.895
+Fall 2022,CHEM,1111,13,11366,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,2,0,0,0,0,3.101
+Fall 2022,CHEM,1111,14,11367,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,6,1,2,2,0,1,2.825
+Fall 2022,CHEM,1111,15,11368,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,0,0,0,1,3.111
+Fall 2022,CHEM,1111,16,11369,Fundamentals of Chm Lab,Zaitsev,Vladimir G,10,5,0,2,0,0,2,3.217
+Fall 2022,CHEM,1111,17,11370,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,4,5,0,1,0,0,2.853
+Fall 2022,CHEM,1111,19,11372,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,1,0,1,0,2,2.904
+Fall 2022,CHEM,1111,20,11373,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,0,2,0,0,1,3.176
+Fall 2022,CHEM,1111,22,11374,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,17,0,0,0,0,0,3.272
+Fall 2022,CHEM,1111,23,11375,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,15,1,0,0,0,1,3.092
+Fall 2022,CHEM,1111,25,11376,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,6,7,0,0,0,2,2.871
+Fall 2022,CHEM,1111,26,11377,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,4,0,1,0,1,2.912
+Fall 2022,CHEM,1111,28,11378,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,8,1,0,0,0,2,3.354
+Fall 2022,CHEM,1111,29,11379,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,10,1,0,0,0,0,3.352
+Fall 2022,CHEM,1111,31,11380,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,4,4,1,1,0,2,2.844
+Fall 2022,CHEM,1111,32,11381,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,1,0,0,0,1,3.204
+Fall 2022,CHEM,1111,34,11382,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,1,0,0,0,0,3.088
+Fall 2022,CHEM,1111,35,11383,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,15,1,1,0,0,0,2.913
+Fall 2022,CHEM,1111,37,11384,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,1,0,2,0,2,2.896
+Fall 2022,CHEM,1111,40,11386,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,1,0,1,0,3,2.942
+Fall 2022,CHEM,1111,41,11387,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,4,1,0,0,2,2.999
+Fall 2022,CHEM,1111,43,11388,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,5,0,0,0,3,2.967
+Fall 2022,CHEM,1111,44,11389,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,6,2,0,3,0,2,2.759
+Fall 2022,CHEM,1111,46,11390,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,8,2,1,1,0,4,2.619
+Fall 2022,CHEM,1112,1,11391,Fundamentals of Chm Lab,Zaitsev,Vladimir G,9,5,0,3,1,0,0,3.037
+Fall 2022,CHEM,1112,2,11392,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,8,7,0,0,0,2,2.877
+Fall 2022,CHEM,1112,3,11393,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,3,0,2,0,1,2.733
+Fall 2022,CHEM,1112,5,11394,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,2,0,0,0,3,3.157
+Fall 2022,CHEM,1112,6,11395,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,3,0,0,0,2,3.079
+Fall 2022,CHEM,1112,7,11396,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,0,1,0,0,1,3.104
+Fall 2022,CHEM,1112,8,11397,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,3,1,1,0,1,2.756
+Fall 2022,CHEM,1112,9,11398,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,14,1,0,0,0,1,3.148
+Fall 2022,CHEM,1112,10,11399,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,4,0,0,0,3,3.136
+Fall 2022,CHEM,1112,12,11400,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,7,1,1,0,0,1,3.25
+Fall 2022,CHEM,1112,13,11401,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,3,4,1,1,0,1,2.528
+Fall 2022,CHEM,1305,1,11402,Foundations of Chemistry,Czernuszewicz,Roman S,52,67,71,47,56,0,42,2.015
+Fall 2022,CHEM,1311,1,11403,Fundamentals of Chemistry,Larsen,Russell Gene,95,116,99,74,70,0,64,2.198
+Fall 2022,CHEM,1311,2,11404,Fundamentals of Chemistry,Carrasquillo M,Edwin,38,41,32,25,38,0,21,2.045
+Fall 2022,CHEM,1312,1,11405,Fundamentals of Chemistry 2,Larsen,Russell Gene,68,107,81,58,94,0,74,1.976
+Fall 2022,CHEM,3133,1,11406,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,6,6,0,0,0,0,1,3.39
+Fall 2022,CHEM,3133,2,11407,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,3,6,0,0,1,0,1,3.0
+Fall 2022,CHEM,3119,1,11408,Anlytical Chemistry Lab,Czader,Arkadiusz,5,2,0,0,0,0,1,3.62
+Fall 2022,CHEM,3119,2,11409,Anlytical Chemistry Lab,Czader,Arkadiusz,6,3,2,0,0,0,3,3.334
+Fall 2022,CHEM,2123,1,11410,Organic Chemistry Lab I,Bean,Mary B,3,12,6,1,0,0,0,2.773
+Fall 2022,CHEM,2123,2,11411,Organic Chemistry Lab I,Bean,Mary B,1,14,7,0,0,0,1,2.727
+Fall 2022,CHEM,2123,3,11412,Organic Chemistry Lab I,Bean,Mary B,3,12,8,1,0,0,0,2.777
+Fall 2022,CHEM,2123,4,11413,Organic Chemistry Lab I,Bean,Mary B,2,12,9,0,0,0,0,2.696
+Fall 2022,CHEM,2123,5,11414,Organic Chemistry Lab I,Bean,Mary B,4,4,11,1,1,0,1,2.507
+Fall 2022,CHEM,2123,6,11415,Organic Chemistry Lab I,Bean,Mary B,1,13,5,1,1,0,1,2.587
+Fall 2022,CHEM,2123,7,11416,Organic Chemistry Lab I,Bean,Mary B,3,7,9,2,0,0,1,2.618
+Fall 2022,CHEM,2123,8,11417,Organic Chemistry Lab I,Bean,Mary B,2,11,6,1,0,0,1,2.75
+Fall 2022,CHEM,2123,9,11418,Organic Chemistry Lab I,Bean,Mary B,4,6,7,1,0,0,5,2.667
+Fall 2022,CHEM,2123,10,11419,Organic Chemistry Lab I,Bean,Mary B,5,7,8,1,0,0,2,2.699
+Fall 2022,CHEM,2123,11,11420,Organic Chemistry Lab I,Bean,Mary B,2,15,5,1,0,0,1,2.768
+Fall 2022,CHEM,2123,12,11421,Organic Chemistry Lab I,Bean,Mary B,2,11,10,0,0,0,1,2.724
+Fall 2022,CHEM,2123,17,11422,Organic Chemistry Lab I,Bean,Mary B,2,8,8,1,1,0,0,2.5
+Fall 2022,CHEM,2123,14,11423,Organic Chemistry Lab I,Bean,Mary B,4,7,7,1,0,0,1,2.719
+Fall 2022,CHEM,2123,15,11424,Organic Chemistry Lab I,Bean,Mary B,2,8,5,3,1,0,2,2.368
+Fall 2022,CHEM,2123,16,11425,Organic Chemistry Lab I,Bean,Mary B,3,4,5,3,1,0,4,2.271
+Fall 2022,CHEM,2123,21,11426,Organic Chemistry Lab I,Bean,Mary B,2,13,7,0,1,0,0,2.609
+Fall 2022,CHEM,2123,18,11427,Organic Chemistry Lab I,Bean,Mary B,2,12,5,0,0,0,1,2.842
+Fall 2022,CHEM,2123,19,11428,Organic Chemistry Lab I,Bean,Mary B,5,6,6,2,2,0,2,2.413
+Fall 2022,CHEM,2123,20,11429,Organic Chemistry Lab I,Bean,Mary B,3,8,9,0,1,0,2,2.65
+Fall 2022,CHEM,2123,25,11430,Organic Chemistry Lab I,Bean,Mary B,4,8,5,2,0,0,2,2.615
+Fall 2022,CHEM,2123,22,11431,Organic Chemistry Lab I,Bean,Mary B,4,5,6,1,2,0,1,2.408
+Fall 2022,CHEM,2123,23,11432,Organic Chemistry Lab I,Bean,Mary B,2,7,7,1,2,0,1,2.368
+Fall 2022,CHEM,2123,24,11433,Organic Chemistry Lab I,Bean,Mary B,3,3,6,1,0,0,7,2.666
+Fall 2022,CHEM,2125,2,11434,Organic Chemistry Lab II,Bean,Mary B,7,9,5,0,0,0,1,3.017
+Fall 2022,CHEM,2125,3,11435,Organic Chemistry Lab II,Bean,Mary B,4,11,7,1,0,0,0,2.797
+Fall 2022,CHEM,2125,4,11436,Organic Chemistry Lab II,Bean,Mary B,5,5,9,3,0,0,0,2.53
+Fall 2022,CHEM,2125,7,11437,Organic Chemistry Lab II,Bean,Mary B,4,5,8,2,0,0,3,2.579
+Fall 2022,CHEM,2125,6,11438,Organic Chemistry Lab II,Bean,Mary B,4,11,6,1,1,0,0,2.724
+Fall 2022,CHEM,2323,1,11439,Organic Chemistry I,Bean,Mary B,79,71,66,13,22,0,39,2.676
+Fall 2022,CHEM,2323,3,11440,Organic Chemistry I,Miljanic,Ognjen S,15,32,46,37,40,0,34,1.653
+Fall 2022,CHEM,2323,4,11441,Organic Chemistry I,Gilbertson,Scott R,10,8,5,2,0,0,6,3.08
+Fall 2022,CHEM,2323,2,11442,Organic Chemistry I,Bean,Mary B,75,48,74,19,27,0,48,2.482
+Fall 2022,CHEM,2325,1,11443,Organic Chemistry II,Do,Loi H,27,21,36,30,13,0,57,2.113
+Fall 2022,CHEM,3369,1,11444,Analytical Chemistry 1,Czader,Arkadiusz,8,15,17,7,4,0,13,2.255
+Fall 2022,CHEM,4229,2,11446,Instrmntl Mthd-Anly Lab,Czader,Arkadiusz,13,4,2,1,0,0,0,3.368
+Fall 2022,CHEM,4272,1,11447,Physical Chemistry Lab II,Czader,Arkadiusz,4,8,0,0,0,0,0,3.223
+Fall 2022,CHEM,4369,1,11448,Analytical Chemistry 2,Chiang,Naihao,4,15,8,0,0,0,0,2.779
+Fall 2022,CHEM,4372,1,11449,Physical Chemistry II,Xu,Shoujun,7,7,12,1,1,0,1,2.702
+Fall 2022,CHEM,4373,1,11450,Survey of Physical Chemistry,Lubchenko,Vassiliy,7,22,14,0,1,0,2,2.788
+Fall 2022,CHEM,6111,1,11451,Graduate Colloquium,Comito,Robert Joseph,0,0,0,0,0,34,0,
+Fall 2022,CHEM,6112,1,11452,Graduate Seminar,Daugulis,Olafs,0,0,0,0,0,20,0,
+Fall 2022,CHEM,6112,2,11453,Graduate Seminar,Baldelli,Steve,0,0,0,0,0,5,0,
+Fall 2022,CHEM,6112,3,11454,Graduate Seminar,Brgoch,Jakoah,0,0,0,0,0,9,0,
+Fall 2022,CHEM,6115,3,11455,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,5,0,
+Fall 2022,CHEM,6115,1,11456,Sem in Chm Lab Instruct,Zaitsev,Vladimir G,0,0,0,0,0,21,0,
+Fall 2022,CHEM,6198,2,11458,Special Problems,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6198,4,11459,Special Problems,Bittner,Eric R,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6198,5,11460,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6313,1,11473,Thermodynamcs & Kinects,Chen,Tai-Yen,6,3,0,0,0,0,1,3.667
+Fall 2022,CHEM,6321,1,11474,Quantum Chemistry,Bittner,Eric R,3,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,6352,1,11475,Orgnc React & Synthesis,May,Jeremy A,2,8,2,0,0,0,0,3.028
+Fall 2022,CHEM,6374,1,11476,Physical Inorganic Chem I,Teets,Thomas,6,12,0,0,0,0,1,3.425
+Fall 2022,CHEM,6398,19,11482,Special Problems,Harth,Eva M,0,0,0,0,0,2,0,
+Fall 2022,CHEM,6698,2,11485,Special Problems,Harth,Eva M,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6698,4,11486,Special Problems,Do,Loi H,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6698,5,11487,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6698,6,11488,Special Problems,Xu,Shoujun,0,0,0,0,0,3,0,
+Fall 2022,CHEM,6698,7,11489,Special Problems,Gilbertson,Scott R,0,0,0,0,0,4,0,
+Fall 2022,CHEM,6698,13,11493,Special Problems,Zastrow,Melissa L,0,0,0,0,0,2,0,
+Fall 2022,CHEM,6698,16,11495,Special Problems,Baldelli,Steve,0,0,0,0,0,3,0,
+Fall 2022,CHEM,6698,19,11496,Special Problems,Teets,Thomas,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6998,1,11497,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6998,5,11500,Special Problems,May,Jeremy A,0,0,0,0,0,3,0,
+Fall 2022,CHEM,6998,6,11501,Special Problems,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Fall 2022,CHEM,6998,7,11502,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2022,CHEM,6998,10,11505,Special Problems,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Fall 2022,CHEM,8399,6,11519,Doctoral Dissertation,Miljanic,Ognjen S,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,8399,16,11524,Doctoral Dissertation,Chen,Tai-Yen,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,8998,2,11543,Doctoral Research,Harth,Eva M,0,0,0,0,0,3,0,
+Fall 2022,CHEM,8998,4,11544,Doctoral Research,Teets,Thomas,0,0,0,0,0,4,0,
+Fall 2022,CHEM,8998,5,11545,Doctoral Research,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2022,CHEM,8998,7,11547,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Fall 2022,CHEM,8998,10,11549,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Fall 2022,CHEM,8998,15,11553,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2022,CHEM,8998,19,11555,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,3,0,
+Fall 2022,CHEM,8999,2,11557,Doctoral Dissertation,Chen,Tai-Yen,2,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,8999,11,11560,Doctoral Dissertation,Guloy,Arnold M,0,0,0,0,0,2,0,
+Fall 2022,CHEM,8999,13,11561,Doctoral Dissertation,Lee,T Randall,2,0,0,0,0,1,0,4.0
+Fall 2022,CHEM,8999,15,11562,Doctoral Dissertation,Teets,Thomas,0,0,0,0,0,2,0,
+Fall 2022,COSC,3340,1,11563,Intro. to Automata and Comp.,Verma,Rakesh M,7,28,23,16,3,0,20,2.315
+Fall 2022,COSC,6110,1,11564,Graduate Colloquium,Leiss,Ernst L,0,0,0,0,0,8,0,
+Fall 2022,GEOL,1103,1,11565,Physical Geology Lab,Hauptvogel,Daniel William,16,2,0,0,1,0,1,3.545
+Fall 2022,GEOL,1103,2,11566,Physical Geology Lab,Hauptvogel,Daniel William,15,3,2,1,1,0,1,3.319
+Fall 2022,GEOL,1103,4,11567,Physical Geology Lab,Hauptvogel,Daniel William,12,7,1,2,0,0,2,3.303
+Fall 2022,GEOL,1103,5,11568,Physical Geology Lab,Hauptvogel,Daniel William,19,2,1,0,0,0,1,3.788
+Fall 2022,GEOL,1103,12,11569,Physical Geology Lab,Hauptvogel,Daniel William,15,5,1,2,0,0,0,3.478
+Fall 2022,GEOL,1340,1,11570,Earth Systems,Lytwyn,Jennifer N,15,17,15,12,10,0,5,2.198
+Fall 2022,MATH,1314,1,11571,College Algebra,Constante,Beatrice,108,65,47,23,36,0,22,2.661
+Fall 2022,MATH,1314,2,11572,College Algebra,Chang,James A,108,61,36,22,44,0,27,2.605
+Fall 2022,MATH,1314,5,11573,College Algebra,Xhabli,Blerina,98,57,34,20,69,0,52,2.298
+Fall 2022,MATH,1332,2,11574,Contemporary Mathematics,Hafeez,Shahinda,63,56,42,17,18,0,14,2.626
+Fall 2022,MATH,2312,1,11575,Precalculus,May,Jennifer Ruhnow,156,112,52,24,22,0,54,2.965
+Fall 2022,MATH,2312,2,11576,Precalculus,Bhullar,Jasmine,94,54,44,28,30,0,48,2.619
+Fall 2022,MATH,2312,3,11577,Precalculus,Perepelitsa,Irina,270,136,78,46,46,0,56,2.921
+Fall 2022,MATH,2312,5,11578,Precalculus,Almus,Melahat,250,116,56,32,38,0,40,3.016
+Fall 2022,MATH,2312,7,11579,Precalculus,Almus,Melahat,20,12,6,4,6,0,12,2.723
+Fall 2022,MATH,2413,1,11580,Calculus I,Perepelitsa,Irina,180,90,68,22,82,0,44,2.608
+Fall 2022,MATH,2413,11,11584,Calculus I,Almus,Melahat,306,102,74,62,58,0,40,2.887
+Fall 2022,MATH,2413,21,11591,Calculus I,Perepelitsa,Irina,194,82,34,22,62,0,28,2.809
+Fall 2022,MATH,2413,31,11596,Calculus I,Sosa,Moses,148,92,52,42,54,0,52,2.61
+Fall 2022,MATH,2413,41,11600,Calculus I,Douglas,Casey,118,66,54,50,96,0,80,2.136
+Fall 2022,MATH,2414,1,11602,Calculus II,May,Jennifer Ruhnow,68,60,50,31,30,0,29,2.408
+Fall 2022,MATH,2414,11,11605,Calculus II,Xhabli,Blerina,99,56,44,25,44,0,20,2.494
+Fall 2022,MATH,2414,21,11608,Calculus II,West,James David,36,20,23,15,41,0,42,1.961
+Fall 2022,MATH,1342,1,11610,Elementary Statistical Methods,Hong,Yuqi,20,28,42,34,40,0,30,1.683
+Fall 2022,MATH,1342,2,11611,Elementary Statistical Methods,Weber,Thomas Christian,88,94,68,40,50,0,50,2.38
+Fall 2022,MATH,1342,4,11612,Elementary Statistical Methods,Caputo,Matthew G,82,100,68,48,42,0,58,2.33
+Fall 2022,MATH,1342,5,11613,Elementary Statistical Methods,Weber,Thomas Christian,130,146,98,64,142,0,80,2.056
+Fall 2022,MATH,2415,1,11614,Calculus III,Weber,Thomas Christian,69,40,32,29,22,0,28,2.547
+Fall 2022,MATH,2415,11,11617,Calculus III,Pan,Tsorng-Whay,57,34,31,8,19,0,14,2.665
+Fall 2022,MATH,3303,1,11621,Elts Algebra & Numb Thy,George,Rebecca Ann,31,7,2,0,2,0,2,3.508
+Fall 2022,MATH,3321,2,11622,Engineering Mathematics,Etgen,Garret J,53,37,41,43,46,0,40,2.02
+Fall 2022,MATH,3321,3,11623,Engineering Mathematics,West,James David,10,17,24,18,16,0,14,1.839
+Fall 2022,MATH,3330,2,11624,Abstract Algebra,Leger,Nicholas M,4,8,6,4,5,0,2,2.074
+Fall 2022,MATH,3331,1,11625,Differential Equations,Sanders,Richard,7,1,8,2,6,0,2,2.042
+Fall 2022,MATH,3333,2,11626,Intermediate Analysis,Winkle,James J,7,9,3,3,1,0,1,2.697
+Fall 2022,MATH,3363,1,11627,Introduction To Pde,Caglar,Atife,29,20,12,14,10,0,12,2.533
+Fall 2022,MATH,3364,1,11629,Intro Complex Analysis,Haynes,Alan K,20,9,4,2,2,0,0,3.135
+Fall 2022,MATH,4320,1,11630,Intro To Stochastic Processes,Kao,Edward P,9,15,5,0,0,0,2,2.956
+Fall 2022,MATH,6302,1,11631,Modern Algebra,Heier,Gordon,7,1,0,0,0,0,0,3.793
+Fall 2022,MATH,6315,1,11632,Masters Tutorial,Fu,Wenjiang,2,0,0,0,0,0,0,3.835
+Fall 2022,MATH,6315,2,11633,Masters Tutorial,Ji,Shanyu,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,6315,5,11636,Masters Tutorial,Ru,Min,2,0,0,0,0,0,0,3.67
+Fall 2022,MATH,6315,7,11638,Masters Tutorial,Nicol,Matthew J.,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,6320,1,11658,Func Real Variable,Vershynina,Anna,5,5,2,0,1,0,0,2.949
+Fall 2022,MATH,6342,1,11659,Topology,Torok,Andrei S,3,3,2,0,0,0,0,3.208
+Fall 2022,MATH,6366,1,11660,Optimization Theory,Mang,Andreas,11,8,1,0,0,0,0,3.566
+Fall 2022,MATH,6370,1,11661,Numerical Analysis,Olshanskiy,Maxim Alexandrovich,7,12,3,0,0,0,0,3.182
+Fall 2022,MATH,6398,2,11663,Special Problems,Papadakis,Emanuel Ioannis,0,0,0,0,0,2,0,
+Fall 2022,MATH,6398,3,11664,Special Problems,Vershynina,Anna,0,0,0,0,0,1,0,
+Fall 2022,MATH,6398,6,11666,Special Problems,Mang,Andreas,0,0,0,0,0,1,0,
+Fall 2022,MATH,6398,9,11669,Special Problems,Ru,Min,0,0,0,0,0,2,0,
+Fall 2022,MATH,8398,6,11703,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Fall 2022,MATH,8398,9,11705,Doctoral Research,Heier,Gordon,0,0,0,0,0,2,0,
+Fall 2022,MATH,8398,11,11707,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Fall 2022,MATH,8398,12,11708,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,0,0,
+Fall 2022,MATH,8398,15,11711,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,2,0,
+Fall 2022,MATH,8398,16,11712,Doctoral Research,Ru,Min,0,0,0,0,0,2,0,
+Fall 2022,MATH,8398,18,11714,Doctoral Research,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Fall 2022,MATH,8398,20,11716,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,2,0,
+Fall 2022,MATH,8398,22,11718,Doctoral Research,Labate,Demetrio,0,0,0,0,0,2,0,
+Fall 2022,PHYS,1301,1,11726,College Physics I (lecture),McElhenny,Brian Patrick,10,10,20,9,4,0,11,2.227
+Fall 2022,PHYS,1302,1,11727,College Physics II (lecture),Curran,Seamus A,20,35,40,17,8,0,11,2.35
+Fall 2022,PHYS,1304,1,11728,Solar System,Li,Liming,87,49,19,2,0,0,1,3.361
+Fall 2022,PHYS,1303,1,11729,Stars and Galaxies,Pinsky,Lawrence S,22,16,30,2,7,0,19,2.606
+Fall 2022,PHYS,2326,3,11731,University Physics II(lecture),Forrest,Rebecca L,30,22,68,14,18,0,13,2.158
+Fall 2022,PHYS,8398,3,11745,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,4,11746,Doctoral Research,Bering,Edgar A,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,5,11747,Doctoral Research,Chen,Shuo,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,8,11750,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,9,11751,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,10,11752,Doctoral Research,Curran,Seamus A,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,12,11754,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,16,11757,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,18,11759,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,22,11763,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8398,27,11767,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8398,28,11768,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8399,1,11773,Doctoral Dissertation,Cardoso Barato,Andre,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8399,14,11785,Doctoral Dissertation,Stokes,Donna,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8399,21,11789,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2022,ENGL,2306,4,11808,Intro To Poetry,Bradley,Jari,21,0,0,0,0,0,1,4.0
+Fall 2022,HIST,1301,2,11811,The U.S. to 1877,Hopkins,Kelly Y,152,93,60,20,25,0,4,2.917
+Fall 2022,PHYS,1102,1,11839,College Physics II (lab),Wood,Lowell T,1,17,4,0,0,0,2,2.729
+Fall 2022,PHYS,1101,1,11840,College Physics I (lab),Wood,Lowell T,4,12,7,1,0,0,0,2.737
+Fall 2022,PHYS,1101,2,11841,College Physics I (lab),Wood,Lowell T,0,9,4,0,0,0,3,2.718
+Fall 2022,PHYS,1101,3,11842,College Physics I (lab),Wood,Lowell T,2,15,2,2,0,0,3,2.7
+Fall 2022,PHYS,1101,4,11843,College Physics I (lab),Wood,Lowell T,2,5,9,0,0,0,0,2.686
+Fall 2022,PHYS,1101,5,11844,College Physics I (lab),Wood,Lowell T,1,9,5,0,0,0,7,2.667
+Fall 2022,PHYS,1101,6,11845,College Physics I (lab),Wood,Lowell T,1,5,7,0,0,0,2,2.615
+Fall 2022,PHYS,1101,7,11846,College Physics I (lab),Wood,Lowell T,1,11,11,0,0,0,1,2.694
+Fall 2022,PHYS,1101,8,11847,College Physics I (lab),Wood,Lowell T,0,14,1,0,0,0,0,2.713
+Fall 2022,PHYS,1101,9,11848,College Physics I (lab),Wood,Lowell T,3,9,9,1,0,0,1,2.636
+Fall 2022,PHYS,1101,10,11849,College Physics I (lab),Wood,Lowell T,1,8,4,0,0,0,1,2.693
+Fall 2022,PHYS,1102,2,11850,College Physics II (lab),Wood,Lowell T,0,17,5,1,0,0,1,2.667
+Fall 2022,PHYS,1102,3,11851,College Physics II (lab),Wood,Lowell T,2,13,6,0,1,0,0,2.727
+Fall 2022,PHYS,1102,4,11852,College Physics II (lab),Wood,Lowell T,4,9,7,1,0,0,3,2.699
+Fall 2022,PHYS,1102,5,11853,College Physics II (lab),Wood,Lowell T,3,9,10,0,1,0,1,2.637
+Fall 2022,PHYS,1102,6,11854,College Physics II (lab),Wood,Lowell T,2,10,11,1,0,0,0,2.652
+Fall 2022,PHYS,1102,7,11855,College Physics II (lab),Wood,Lowell T,3,14,6,0,0,0,0,2.783
+Fall 2022,PHYS,1102,8,11856,College Physics II (lab),Wood,Lowell T,2,9,10,0,0,0,1,2.682
+Fall 2022,COSC,3380,1,11857,Database Systems,Hilford,Victoria,94,25,0,0,0,0,1,3.732
+Fall 2022,COSC,4393,1,11858,Digital Image Processing,Mantini,Pranav,70,31,0,1,1,0,2,3.602
+Fall 2022,COSC,6309,1,11861,Intro Automata & Computability,Verma,Rakesh M,3,3,2,0,0,0,0,3.125
+Fall 2022,CHEM,4272,2,11862,Physical Chemistry Lab II,Czader,Arkadiusz,4,5,3,0,0,0,2,3.083
+Fall 2022,MATH,3340,1,11863,Intro To Fixed Income Math,Timofeyev,Ilya,6,11,7,8,0,0,4,2.489
+Fall 2022,BIOL,3306,2,11864,Evolutionary Biology,Azevedo,Ricardo,4,12,20,4,6,0,4,2.101
+Fall 2022,COSC,6358,1,11879,Interactive Game Development,Yun,Changhoon,5,5,0,0,0,0,0,3.467
+Fall 2022,COSC,4358,1,11880,Intro to Interactive Game Dev.,Yun,Changhoon,86,25,0,1,0,0,1,3.779
+Fall 2022,COSC,6355,1,11881,Ubiquitous Computing,Pavlidis,Ioannis T,6,3,0,0,0,0,0,3.52
+Fall 2022,COSC,4355,1,11882,Intro to Ubiquitous Computing,Pavlidis,Ioannis T,9,12,5,1,3,0,3,2.745
+Fall 2022,COSC,6380,1,11883,Digital Image Processing,Mantini,Pranav,52,20,0,0,0,0,0,3.663
+Fall 2022,BIOL,2120,3,11884,Microbiology for Non-Science,Knapp,Richard D,15,7,1,0,0,0,0,3.594
+Fall 2022,BIOL,2120,4,11885,Microbiology for Non-Science,Knapp,Richard D,10,8,2,0,0,0,3,3.318
+Fall 2022,BIOL,8999,1,11886,Doctoral Dissertation,Sater,Amy,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,2415,21,11891,Calculus III,West,James David,13,17,15,8,21,0,38,1.883
+Fall 2022,OPTO,5111,1,11894,Optics Lab I,Coates,Daniel R,14,8,2,0,0,0,0,3.5
+Fall 2022,OPTO,5111,2,11895,Optics Lab I,Coates,Daniel R,17,6,3,0,0,0,0,3.538
+Fall 2022,OPTO,5111,3,11896,Optics Lab I,Coates,Daniel R,11,11,1,0,0,0,0,3.435
+Fall 2022,OPTO,5111,4,11897,Optics Lab I,Coates,Daniel R,16,6,2,0,0,0,0,3.583
+Fall 2022,OPTO,5133,3,11898,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,15,8,0,0,0,0,0,3.652
+Fall 2022,OPTO,5133,4,11899,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,16,7,1,0,0,0,0,3.625
+Fall 2022,OPTO,5134,1,11900,Neuroanatomy Laboratory,Cheng,Han,21,3,0,0,0,0,0,3.875
+Fall 2022,OPTO,5134,2,11901,Neuroanatomy Laboratory,Cheng,Han,23,3,0,0,0,0,0,3.885
+Fall 2022,OPTO,5134,3,11902,Neuroanatomy Laboratory,Cheng,Han,16,6,1,0,0,0,0,3.652
+Fall 2022,OPTO,5134,4,11903,Neuroanatomy Laboratory,Cheng,Han,22,1,1,0,0,0,0,3.875
+Fall 2022,OPTO,5171,1,11904,Clinic Practicum I,Berntsen,David A,11,12,1,0,0,0,0,3.417
+Fall 2022,OPTO,5171,2,11905,Clinic Practicum I,Kehinde,Lucy,12,10,4,0,0,0,0,3.308
+Fall 2022,OPTO,5171,3,11906,Clinic Practicum I,Kehinde,Lucy,7,13,3,0,0,0,0,3.174
+Fall 2022,OPTO,5171,4,11907,Clinic Practicum I,Berntsen,David A,9,12,3,0,0,0,0,3.25
+Fall 2022,OPTO,5233,1,11908,Adv Human Anatomy and Hist,Coulson-Thomas,Vivien J,48,34,9,6,0,0,0,3.278
+Fall 2022,OPTO,5271,1,11909,Optometry I,Dempsey,Robert L.,61,30,6,0,0,0,0,3.516
+Fall 2022,OPTO,5314,1,11910,Optics I,Marsack,Jason,55,31,10,0,1,0,0,3.433
+Fall 2022,OPTO,5320,1,11911,Vision Science I,Stevenson,Scott Bailli,39,44,13,1,0,0,0,3.247
+Fall 2022,OPTO,5334,1,11912,Neuroanat and Physio,Cheng,Han,60,24,12,1,0,0,0,3.474
+Fall 2022,OPTO,5344,1,11913,Adv Physiol and Molecular Biol,Frishman,Laura J,34,40,18,5,0,0,0,3.116
+Fall 2022,OPTO,6132,1,11914,Med Laboratory Proced,Garza,Janet,22,1,0,0,0,0,1,3.957
+Fall 2022,OPTO,6132,2,11915,Med Laboratory Proced,Garza,Janet,21,3,0,0,0,0,0,3.875
+Fall 2022,OPTO,6132,3,11916,Med Laboratory Proced,Garza,Janet,19,3,0,0,0,0,1,3.864
+Fall 2022,OPTO,6132,4,11917,Med Laboratory Proced,Garza,Janet,21,2,1,0,0,0,0,3.833
+Fall 2022,OPTO,6163,1,11918,Primary Opt Lab,Chandler,Moriah Adine,16,8,0,0,0,0,1,3.667
+Fall 2022,OPTO,6163,2,11919,Primary Opt Lab,Chandler,Moriah Adine,18,6,0,0,0,0,0,3.75
+Fall 2022,OPTO,6163,3,11920,Primary Opt Lab,Chandler,Moriah Adine,15,6,1,0,0,0,1,3.636
+Fall 2022,OPTO,6163,4,11921,Primary Opt Lab,Chandler,Moriah Adine,11,14,0,0,0,0,0,3.44
+Fall 2022,OPTO,6173,1,11922,Clinic Practicum III,Giannoni,Amber Gaume,14,8,2,0,0,0,1,3.5
+Fall 2022,OPTO,6173,2,11923,Clinic Practicum III,Giannoni,Amber Gaume,20,4,0,0,0,0,0,3.833
+Fall 2022,OPTO,6173,3,11924,Clinic Practicum III,Giannoni,Amber Gaume,15,6,1,0,0,0,1,3.636
+Fall 2022,OPTO,6173,4,11925,Clinic Practicum III,Giannoni,Amber Gaume,15,9,0,0,1,0,0,3.48
+Fall 2022,OPTO,6190,1,11926,Ophthalmic Optics Laboratory,Tucker,Ashley,21,3,0,0,0,0,1,3.875
+Fall 2022,OPTO,6190,2,11927,Ophthalmic Optics Laboratory,Tucker,Ashley,18,6,0,0,0,0,0,3.75
+Fall 2022,OPTO,6190,3,11928,Ophthalmic Optics Laboratory,Tucker,Ashley,21,1,0,0,0,0,1,3.955
+Fall 2022,OPTO,6190,4,11929,Ophthalmic Optics Laboratory,Tucker,Ashley,18,6,1,0,0,0,0,3.68
+Fall 2022,OPTO,6219,1,11930,Vision Science III,Das,Vallabh E,32,46,16,1,0,0,2,3.147
+Fall 2022,OPTO,6231,1,11931,Corneal Disease,Bergmanson,Jan Pg,0,0,0,0,0,26,0,
+Fall 2022,OPTO,6234,1,11932,Ocular Pathology I,Ketcham,Tonya G,15,70,10,0,0,0,2,3.063
+Fall 2022,OPTO,6251,1,11934,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,27,0,
+Fall 2022,OPTO,6311,1,11935,Optics III,Ritchey,Eric R,62,28,6,0,0,0,2,3.583
+Fall 2022,OPTO,6363,1,11936,Primary Optometry,Stevenson,Scott Bailli,56,34,4,1,0,0,2,3.526
+Fall 2022,OPTO,6434,1,11937,General Pharmacology,Rump,Rachel,23,47,22,0,2,0,2,2.943
+Fall 2022,OPTO,7152,1,11938,Pediatric Optometry II Lab,Martinez,Muriel L,8,15,0,0,0,0,0,3.348
+Fall 2022,OPTO,7152,2,11939,Pediatric Optometry II Lab,Martinez,Muriel L,14,11,1,0,1,0,0,3.37
+Fall 2022,OPTO,7152,3,11940,Pediatric Optometry II Lab,Martinez,Muriel L,10,11,0,0,0,0,0,3.476
+Fall 2022,OPTO,7152,4,11941,Pediatric Optometry II Lab,Martinez,Muriel L,13,7,1,0,0,0,0,3.571
+Fall 2022,OPTO,7252,1,11942,Pediatric Optometry II,Duong,Kim,33,51,8,0,0,0,0,3.272
+Fall 2022,OPTO,7361,1,11943,Geriatric Optometry,Dempsey,Robert L.,38,50,1,0,0,0,0,3.416
+Fall 2022,OPTO,7494,1,11944,General Clinic IIIb,Dempsey,Robert L.,0,0,0,0,0,85,0,
+Fall 2022,OPTO,8990,1,11945,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,33,0,
+Fall 2022,OPTO,8991,1,11946,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,33,0,
+Fall 2022,OPTO,8992,1,11947,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,28,0,
+Fall 2022,OPTO,8993,1,11948,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,28,0,
+Fall 2022,PHOP,6160,1,11949,Gen Sem Visual Sciences,Coates,Daniel R,23,1,0,0,0,0,0,3.972
+Fall 2022,PHOP,6241,1,11952,Vision Science Core-Part 1,Frishman,Laura J,4,1,0,0,0,0,0,3.866
+Fall 2022,PHOP,6242,1,11953,Vision Science Core-Part 2,Frishman,Laura J,4,1,0,0,0,0,0,3.536
+Fall 2022,OPTO,5198,2,11956,Spec Prob - Clerkship,Dempsey,Robert L.,0,0,0,0,0,1,0,
+Fall 2022,PCEU,6341,1,11957,Advanced Pharmacokinetics,Chow,Diana Shu-Lian,3,0,0,0,0,0,0,4.0
+Fall 2022,PCEU,8399,1,11959,Doctoral Dissertation,Hu,Ming,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6370,1,11960,Advanced Pharmacology I,Boini,Krishna M,9,3,0,0,0,0,0,3.75
+Fall 2022,PCOL,7180,1,11961,Pharmacology Seminar,McConnell,Bradley K,0,0,0,0,0,19,0,
+Fall 2022,PHAR,4270,1,11963,Communication Aspects of Pharm,Gee,Jodie Sue,66,41,4,0,0,0,1,3.559
+Fall 2022,PHAR,4320,1,11964,Physiology I,Salim,Samina,36,54,25,4,0,0,1,3.025
+Fall 2022,PHAR,4330,1,11965,Pharmaceutics I & Calculations,Guo,Bin,33,51,27,3,0,0,1,3.0
+Fall 2022,PHAR,5332,1,11966,Pharmacokinetics,Chow,Diana Shu-Lian,20,56,33,0,2,0,0,2.829
+Fall 2022,PHAR,5642,1,11967,Emergency Medicine,Truong,Mabel,4,3,0,0,0,0,0,3.571
+Fall 2022,PHAR,5643,1,11968,Neurology,Truong,Mabel,0,0,0,0,0,0,0,
+Fall 2022,PHAR,5662,1,11969,Academic Scholarship,Surati,Dhara Divyang,5,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5663,1,11970,Pharmacy Management,Truong,Mabel,7,2,0,0,0,0,0,3.778
+Fall 2022,PHAR,5664,1,11971,Legal & Regulatory Affairs,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5670,1,11972,Community Pharmaceutical Care,Tolleson,Shane Russell,13,4,0,0,0,0,0,3.765
+Fall 2022,PHAR,5673,1,11973,Veterinary Pharmaceutical Care,Tolleson,Shane Russell,0,2,0,0,0,0,0,3.0
+Fall 2022,PHAR,5675,1,11974,Disease State Management,Tolleson,Shane Russell,37,4,1,0,0,0,0,3.857
+Fall 2022,PHAR,5678,1,11975,Transplant Therapeutics,Truong,Mabel,4,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5680,1,11977,Oncology,Truong,Mabel,4,2,0,0,0,0,0,3.667
+Fall 2022,PHAR,5681,2,11978,Infectious Diseases,Sofjan,Amelia Kartikasari,2,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5685,1,11979,Critical Care,Truong,Mabel,13,8,1,0,0,0,0,3.545
+Fall 2022,PHAR,5686,1,11980,Psychiatry,Tolleson,Shane Russell,1,1,0,0,0,0,0,3.5
+Fall 2022,PHAR,5687,1,11981,Nuclear Pharmacy,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5690,1,11982,Internal Medicine,Sherer,Jeffrey T,4,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5690,2,11983,Internal Medicine,Truong,Mabel,20,16,1,0,0,0,0,3.514
+Fall 2022,PHAR,5692,1,11985,Advanced Hospital Pharmacy,Truong,Mabel,45,5,0,0,0,0,0,3.9
+Fall 2022,PHAR,5693,1,11986,Advanced Community Pharmacy,Tolleson,Shane Russell,24,2,1,0,0,0,0,3.852
+Fall 2022,PHAR,5694,1,11987,Pediatrics,Truong,Mabel,8,3,0,0,0,0,0,3.727
+Fall 2022,PHAR,5695,1,11988,Geriatrics,Tolleson,Shane Russell,4,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5696,3,11990,Ambulatory Care - Primary Care,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,6398,5,11992,SP- Outcomes Research,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,3354,1,11997,Nonprofit Management,Battle,Jennifer Alene,5,2,0,1,0,0,0,3.375
+Fall 2022,SOCW,6354,1,11998,Managing Human Services Orgs,Battle,Jennifer Alene,17,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7356,1,11999,Groups in Clinical Settings,Burkley,Casondra,19,3,0,0,0,0,0,3.864
+Fall 2022,SOCW,7384,2,12000,Field Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,141,0,
+Fall 2022,SOCW,7385,1,12001,Field Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,10,0,
+Fall 2022,SOCW,7388,3,12002,Field Practicum III Macro,Gonzales,Shelley A,0,0,0,0,0,32,0,
+Fall 2022,SOCW,7389,1,12003,Field Practicum IV Macro,Gonzales,Shelley A,0,0,0,0,0,3,0,
+Fall 2022,CNST,1301,1,12007,Constructn Materials & Methods,Zaheri,Mohammad J,37,53,4,1,2,0,0,3.278
+Fall 2022,CNST,2341,1,12008,Construction Documents,Vecera,Robert Gerard,20,36,15,0,0,0,2,3.029
+Fall 2022,CNST,4331,1,12009,Construction Management II,Khan,Taimoor,22,17,0,0,1,0,1,3.318
+Fall 2022,ELET,2101,1,12010,Poly-Phase Circuits Laboratory,Fan,Lei,12,1,0,0,0,0,0,3.847
+Fall 2022,ELET,2101,2,12011,Poly-Phase Circuits Laboratory,Fan,Lei,7,1,2,0,1,0,0,3.122
+Fall 2022,ELET,2300,1,12012,Introductn To C++ Programming,Lent,Marino Ricardo,11,11,16,5,13,0,15,2.071
+Fall 2022,ELET,2303,1,12013,Digital Systems,Abdelhadi,Ahmed,9,22,19,0,0,0,0,2.76
+Fall 2022,ELET,2307,1,12014,Electrical-Electronic Circuits,Abraham,Yonas B,11,13,7,1,0,0,5,3.083
+Fall 2022,ELET,3107,1,12015,Electrical Mach & Control Lab,Fan,Lei,11,5,1,1,1,0,0,3.315
+Fall 2022,ELET,3107,2,12016,Electrical Mach & Control Lab,Fan,Lei,2,2,1,2,1,0,0,2.333
+Fall 2022,ELET,3307,1,12017,Electrical Machines & Controls,Fan,Lei,4,10,11,1,1,0,0,2.47
+Fall 2022,ELET,3405,1,12018,Microprocessor Architecture,Soneja,Chandrayee,15,7,5,0,0,0,1,3.297
+Fall 2022,ELET,3425,1,12019,Embedded Systems,Moges,Mequanint A,3,10,8,1,1,0,0,2.522
+Fall 2022,ELET,4208,1,12021,Senior Project Laboratory,Moges,Mequanint A,10,6,4,0,0,0,0,3.234
+Fall 2022,ELET,4300,1,12022,Unix Operating System,Lent,Marino Ricardo,8,9,4,4,0,0,0,2.932
+Fall 2022,ELET,4308,1,12023,Senior Project,Moges,Mequanint A,5,25,3,0,0,0,0,3.161
+Fall 2022,ELET,4310,1,12024,Alternative Energy Sources,Shireen,Wajiha,9,14,0,0,0,0,1,3.363
+Fall 2022,ELET,4317,1,12025,Elec Sys Safety & Protection,Shi,Jian,25,2,0,0,0,0,0,3.755
+Fall 2022,ELET,4421,1,12026,Computer Networks,Gurkan,Deniz,1,9,24,5,5,0,1,1.834
+Fall 2022,HDCS,1300,1,12028,Human Ecosystems & Tech Change,Mudd,Blake Stevens,32,15,5,2,4,0,2,3.201
+Fall 2022,HDCS,1300,2,12029,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,49,7,0,1,0,0,3,3.767
+Fall 2022,HDCS,1300,3,12030,Human Ecosystems & Tech Change,Gatterson,Beverly,40,10,7,1,1,0,1,3.435
+Fall 2022,HDCS,3300,1,12031,Org Decisions,Stewart,Quentin K,23,13,5,2,7,0,0,2.801
+Fall 2022,HDCS,2301,1,12032,Consumer Science,Stewart,Juliana Floriene,44,7,0,0,3,0,1,3.648
+Fall 2022,HDCS,3303,1,12033,Retailing and Consumer Science,Jacobs,Karen S,13,6,4,0,0,0,1,3.248
+Fall 2022,HDCS,3303,2,12034,Retailing and Consumer Science,Rifai,Rana Ihsan,24,12,1,3,4,0,4,3.009
+Fall 2022,HDCS,3304,1,12035,Visual Merchandising,Mudd,Blake Stevens,15,21,5,4,2,0,3,2.88
+Fall 2022,HDCS,4300,1,12036,Research Concepts in Hdcs,Gatterson,Beverly,13,18,12,3,5,0,1,2.588
+Fall 2022,HDCS,4302,1,12037,Apparel Analysis,Gatterson,Beverly,31,14,4,0,4,0,2,3.258
+Fall 2022,HDCS,4380,2,12038,Merchandising,Jacobs,Karen S,10,14,16,0,5,0,0,2.467
+Fall 2022,HDCS,4386,1,12039,Communication Strategies,Hitchman Sr,Cal M,12,11,8,2,3,0,1,2.759
+Fall 2022,HDCS,4394,1,12040,Internship in RCS,Ezell,Shirley D,1,1,0,0,0,0,0,3.665
+Fall 2022,HRD,6304,30,12041,Research in Human Resource Dev,Nery-Kjerfve,Tania,5,1,0,0,0,0,0,3.833
+Fall 2022,ITEC,1301,1,12042,Intro To Computer Appl Tech,Schroeder,Susan L,10,15,12,5,3,0,3,2.526
+Fall 2022,MECT,3155,1,12043,Strength Materials Lab,Basaran,Burak,11,3,1,0,1,0,0,3.417
+Fall 2022,MECT,3331,1,12045,Applied Thermodynamics,El Nahas,Medhat A,0,12,3,2,13,0,1,1.423
+Fall 2022,MECT,4172,1,12046,Materials Tech Lab,Taylor,Gordon D,6,4,2,1,0,0,1,3.078
+Fall 2022,MECT,4372,1,12047,Materials Technology,Robles Hernandez,Francisco C,4,4,4,2,1,0,0,2.401
+Fall 2022,TECH,3365,1,12048,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,34,4,4,0,0,0,6,3.73
+Fall 2022,TECH,3365,2,12049,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,29,9,2,1,3,0,3,3.409
+Fall 2022,TLIM,3360,30,12050,Law & Ethics-Tech & Innovation,Soliz,Rudy,50,1,6,1,2,0,0,3.6
+Fall 2022,TLIM,4341,1,12051,Production & Service Operation,Chance,Michael Dean,16,11,3,0,0,0,1,3.334
+Fall 2022,TMTH,3360,20,12052,Applied Technical Statistics,Dick,Deanna L,0,7,9,9,9,0,5,1.392
+Fall 2022,TMTH,3360,2,12053,Applied Technical Statistics,Schroeder,Susan L,9,17,9,3,8,0,3,2.362
+Fall 2022,CNST,1330,1,12054,Graphics I,Lyon,Eva Yaneth,14,20,14,4,4,0,2,2.596
+Fall 2022,MECT,1364,33,12055,Materials & Processes,Wari,Ezra Tsegaye,12,12,9,5,3,0,2,2.561
+Fall 2022,MECT,4275,1,12059,Senior Design Project I,Zhu,Weihang,27,17,1,0,0,0,0,3.556
+Fall 2022,ELET,3402,1,12062,Communications Circuits,Velusamy,Gandhimathi,4,10,10,3,0,0,0,2.592
+Fall 2022,MECT,3118,2,12066,Fluid Mechanic Application Lab,Taylor,Gordon D,4,5,5,0,1,0,4,2.645
+Fall 2022,TEPM,6395,20,12069,Integration Project,Carden,Lila L,2,0,0,0,0,0,0,4.0
+Fall 2022,TEPM,6302,20,12070,Leadership and Team Building,Hopkins,Ronald K.,10,3,0,0,0,0,0,3.642
+Fall 2022,CNST,1361,1,12071,Construction Management I,Beadle,Dwight D,123,30,5,4,7,0,0,3.527
+Fall 2022,CNST,2321,1,12072,Mechanical & Electrical System,Beadle,Dwight D,35,25,15,2,1,0,0,3.167
+Fall 2022,CNST,3155,1,12074,Const Materials & Testing,Meyer,Joseph Ray,54,15,5,1,0,0,0,3.539
+Fall 2022,CNST,3185,1,12075,Construction Experience,Beadle,Dwight D,29,11,4,0,0,0,1,3.568
+Fall 2022,MECT,4276,1,12076,Senior Design Project II,Zhu,Weihang,17,4,0,0,0,0,0,3.637
+Fall 2022,MECT,1330,1,12078,Engineering Graphics,Fan,Zheng,1,14,14,2,0,0,7,2.366
+Fall 2022,HRD,6305,1,12079,Organizational Learning,Greer,Tomika,15,3,1,0,0,0,0,3.667
+Fall 2022,HDCS,4372,1,12080,Forecasting for Tech Entrep.,Breaux,James William,22,1,3,1,3,0,2,3.289
+Fall 2022,BTEC,3200,30,12081,Biotech Research Methods,Iken,Brian N,9,2,0,0,0,0,0,3.758
+Fall 2022,MECT,3341,1,12082,Computer-Aided Drafting,Ray,Kyle A,140,39,6,4,2,0,5,3.563
+Fall 2022,ECON,3334,1,12084,Intermediate Macroeconomics,Cubas Norando,German,3,11,2,0,0,0,4,3.124
+Fall 2022,GEOL,1103,6,12085,Physical Geology Lab,Hauptvogel,Daniel William,18,3,1,0,1,0,0,3.623
+Fall 2022,ACCT,5331,1,12086,Federal Income Tax-Individual,Fernandez,Ramon,2,8,3,1,0,0,2,2.809
+Fall 2022,MATH,3339,2,12087,Statistics for the Sciences,Kwon,Junhyeon,29,46,2,7,2,0,11,3.135
+Fall 2022,MATH,3363,3,12088,Introduction To Pde,Cappanera,Loic,11,6,9,1,0,0,7,3.0
+Fall 2022,PSYC,3350,1,12089,Intro to Cognitive Psychology,Anderson,Jill Annette,3,27,19,1,0,0,0,2.594
+Fall 2022,MATH,4389,1,12090,Survey of Undergraduate Math,Blecher,David P,6,10,9,0,0,0,0,2.774
+Fall 2022,MARK,4389,5,12091,Marketing Strategy & Planning,Lish,Alan D,28,7,3,2,0,0,0,3.492
+Fall 2022,ECE,5113,1,12092,Microwave Engineering Lab,Chen,Ji,3,3,0,0,0,0,0,3.445
+Fall 2022,HRD,3310,1,12094,Talent Management,Edwards,Malaika,18,26,3,2,0,0,0,3.137
+Fall 2022,HDCS,1300,4,12095,Human Ecosystems & Tech Change,Selzer,Lori Michele,6,19,12,8,1,0,12,2.421
+Fall 2022,COMM,3303,1,12096,Health Literacy,Xiao,Zhiwen,25,4,1,0,1,0,0,3.582
+Fall 2022,COMM,4363,1,12097,Integrated Comm. Campaigns,Thorp,Charles Arthur,12,0,1,0,0,0,0,3.795
+Fall 2022,COMM,4366,1,12098,Advertising Account Planning,Kelley,Larry D.,17,10,2,0,0,0,0,3.506
+Fall 2022,SOCW,6201,1,12100,Foundation of Social Work Prof,Boyd,Reiko K,0,0,0,0,0,149,0,
+Fall 2022,GHL,4132,1,12107,Bev Mgmt & Mktg Internship,Taylor,David C,4,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,6396,1,12108,Graduate Seminar,Wang,Yuxuan,14,0,0,0,0,0,0,4.0
+Fall 2022,GHL,4336,1,12109,Beverage Marketing,Taylor,David C,12,6,4,1,1,0,0,3.056
+Fall 2022,GHL,6330,1,12110,Statistical Analysis in Hosp.,Shin,Min Jung,17,6,0,0,0,0,2,3.71
+Fall 2022,GHL,7353,1,12111,Services Management in Hosp.,Boger Jr,Carl A,17,8,0,0,0,0,0,3.706
+Fall 2022,MIS,3360,1,12112,Systems Analysis and Design,Knighton,William B,47,13,3,0,0,0,1,3.698
+Fall 2022,MIS,3360,2,12113,Systems Analysis and Design,Knighton,William B,34,23,8,0,0,0,0,3.4
+Fall 2022,FREN,2311,3,12115,Intermediate French I,Wilson,Celine Madeleine Alice,4,15,6,1,0,0,0,2.783
+Fall 2022,AFSC,3301,3,12116,Air Force Leadership I,Whitfield,David,3,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3350,2,12117,Knowing/Learning Science-Math,Latiolais,Cheryl S,9,0,0,0,0,0,1,3.89
+Fall 2022,CUIN,3351,2,12118,Class Interact Science-Math,Latiolais,Cheryl S,7,3,0,0,0,0,2,3.766
+Fall 2022,BIOL,2101,10,12119,Anatomy & Physiology Lab I,Gill,Tejendra,9,12,3,0,0,0,0,3.181
+Fall 2022,BIOL,2101,11,12120,Anatomy & Physiology Lab I,Gill,Tejendra,5,11,5,1,0,0,2,2.804
+Fall 2022,ARCH,3354,1,12121,The Culture of Architecture,Turner,Drexel,11,7,0,0,0,0,1,3.611
+Fall 2022,ARCH,4351,1,12122,Readings & Criticism in Arch,Turner,Drexel,13,5,0,0,0,0,0,3.759
+Fall 2022,ARCH,6351,1,12123,Criticism in Architecture,Turner,Drexel,1,0,0,0,0,0,0,3.67
+Fall 2022,ARCH,4355,1,12124,Houston Architecture,Fox,Stephen,13,1,1,0,0,0,3,3.756
+Fall 2022,LAW,5408,1,12126,Property,Warren,Gina S,18,19,3,0,0,0,0,3.367
+Fall 2022,LAW,5371,1,12127,Int'l Petroleum Transaction,Wright,Denney L,9,12,1,0,0,2,0,3.334
+Fall 2022,LAW,6355,1,12128,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,1,0,
+Fall 2022,LAW,5382,1,12130,Administrative Law,Duke,Brandon W,6,12,0,0,0,2,0,3.388
+Fall 2022,SOCW,6306,1,12133,Social Work Practice Skills,Gonzales,Shelley A,21,0,0,0,0,0,1,4.0
+Fall 2022,LAW,5410,1,12134,Law Review,Sanders,Joseph,0,0,0,0,0,5,0,
+Fall 2022,PUBL,6310,1,12136,Administrative Theory,Koelling,Peter,11,1,0,0,0,0,0,3.779
+Fall 2022,PHLS,8361,1,12137,Eco-Behavioral Interventions,Gonzalez,Jorge E,4,2,0,0,0,0,0,3.612
+Fall 2022,PHLS,8363,1,12138,Research in School Psych,Smith,Bradley,3,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3111,3,12139,Educational Tech Elem Teachers,Tran,Hien Thi,23,3,0,0,0,0,0,3.796
+Fall 2022,ELED,3320,2,12140,Survey Literature Child Adol,Louis,Sarah Lenore,19,2,1,0,0,0,0,3.728
+Fall 2022,CUIN,4350,1,12141,Multiple Teaching Strategies,Segura,Perri F,14,0,0,0,0,0,0,3.953
+Fall 2022,PSYC,4344,2,12142,Cultural Psychology,Agan,Herb W,40,2,1,0,0,0,1,3.915
+Fall 2022,SOCW,6306,2,12143,Social Work Practice Skills,Gonzales,Shelley A,24,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,6306,3,12144,Social Work Practice Skills,Parker,Jamie Lynne,22,0,0,0,0,0,0,4.0
+Fall 2022,DRAM,2351,1,12145,Acting III,Pistorius,Allison Marie,12,0,0,0,0,0,0,3.973
+Fall 2022,THEA,2332,1,12146,Voice & Mvmnt for the Actor I,Johnson,James B,11,4,0,0,0,0,0,3.733
+Fall 2022,DRAM,2331,1,12147,Lighting and Sound Technology,Giannelli,Christina Rose,9,7,3,1,0,0,0,3.167
+Fall 2022,DANC,4305,1,12149,Senior Project with Career Mgt,Valle,Toni Leago,8,3,1,0,0,0,0,3.418
+Fall 2022,DANC,4307,1,12150,Teaching Dance in Education,Sommers,Jennifer,3,5,1,0,0,0,0,3.222
+Fall 2022,ACCT,3371,5,12153,Accounting Information Systems,Seijas,Nuria S,28,31,12,3,1,0,0,3.067
+Fall 2022,CUIN,8377,1,12154,Qualitative Inquiry in Educ I,Thomas,Dustine J,16,0,0,0,0,0,0,4.0
+Fall 2022,CNST,6310,1,12155,Construction Contract Administ,Eldin,Neil N,2,2,3,1,1,0,1,2.333
+Fall 2022,TEPM,6303,2,12157,Risk Assessment in Project Mgm,Carden,Lila L,8,0,0,0,0,0,0,4.0
+Fall 2022,COMD,2338,2,12158,Phonetics,Townsend,Alayna,21,6,3,0,0,0,0,3.6
+Fall 2022,COMD,1333,1,12159,Intro to Comm Sci & Disorders,Ross,Byron L,12,11,6,2,0,0,4,3.096
+Fall 2022,PHCA,8298,1,12161,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,8398,3,12162,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Fall 2022,ENTR,3310,3,12164,Entrepreneurship,Ortega,Carlos Alberto,132,55,9,3,0,0,0,3.59
+Fall 2022,ENGL,1301,115,12165,First Year Writing I,Box,Anthony Joseph,10,5,0,1,2,0,0,3.019
+Fall 2022,FREN,1501,3,12166,Elementary French I,Wilson,Celine Madeleine Alice,6,7,4,3,0,0,3,2.817
+Fall 2022,FREN,1501,5,12168,Elementary French I,Gnanwo Hounfodji,Raymond,5,4,7,0,3,0,2,2.317
+Fall 2022,SOCW,6305,1,12170,Social Work Research,Acquati,Chiara,19,3,0,0,0,0,0,3.864
+Fall 2022,SOCW,6305,2,12171,Social Work Research,Acquati,Chiara,21,3,0,0,0,0,0,3.875
+Fall 2022,SOCW,6305,3,12172,Social Work Research,Leung,Yuk-Hi Patrick,21,0,0,0,0,0,1,4.0
+Fall 2022,PSYC,3310,1,12174,Indstrl-Orgnztnl Psy,Zamanipour,Tina,38,5,4,4,4,0,0,3.255
+Fall 2022,HDFS,3300,2,12175,Educational Psychology,Conston,Toya,160,0,0,0,0,0,2,4.0
+Fall 2022,DRAM,1310,2,12176,Introduction to Theatre,Ostrow,Stuart,19,2,0,0,0,0,0,3.905
+Fall 2022,ACCT,6331,3,12179,Financial Accounting,Lobo,Gerald,8,12,0,0,0,0,0,3.384
+Fall 2022,BIOL,2120,5,12185,Microbiology for Non-Science,Knapp,Richard D,16,3,2,2,0,0,1,3.42
+Fall 2022,HON,3399,6,12186,Senior Honors Thesis,Stelzig,Donaji,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,2318,3,12190,Linear Algebra,Kalantar,Mehrdad,21,20,16,2,5,0,16,2.776
+Fall 2022,ENTR,3310,5,12194,Entrepreneurship,Ortega,Carlos Alberto,117,61,10,1,6,0,4,3.441
+Fall 2022,ARCH,5500,7,12195,Architecture Design Studio IX,Jacobs,Daniel,10,5,0,0,0,0,0,3.579
+Fall 2022,PHLS,7393,1,12197,Internship and Practicum,Margulis,Milena A,0,0,0,0,0,3,0,
+Fall 2022,BIOL,8698,1,12210,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6498,1,12211,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2022,PUBL,6325,1,12212,Capstone Problem Project,Koelling,Peter,0,0,0,0,0,0,0,
+Fall 2022,MUSI,6102,1,12213,Acting for Opera,Edelson,Lawrence Michael,4,0,0,0,0,0,2,3.918
+Fall 2022,CUIN,8398,8,12215,Independent Study,Hale,Margaret Ann,0,1,0,0,0,0,0,3.0
+Fall 2022,CUIN,8398,9,12222,Independent Study,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,1311,4,12224,Music Theory I,Lee,Ji Yeon,6,5,2,1,2,0,0,2.709
+Fall 2022,MUSI,1116,4,12226,Aural Skills I,Lee,Ji Yeon,4,6,1,0,5,0,0,2.271
+Fall 2022,MUSI,2210,3,12228,Theory III,Guez,Jonathan Charles,8,10,2,0,2,0,3,2.895
+Fall 2022,MUSI,2210,4,12229,Theory III,Guez,Jonathan Charles,8,14,4,0,1,0,0,2.964
+Fall 2022,MUSI,2116,3,12231,Aural Skills III,Guez,Jonathan Charles,10,4,7,0,2,0,2,2.798
+Fall 2022,MUSI,2116,4,12232,Aural Skills III,Guez,Jonathan Charles,7,11,7,1,0,0,0,2.898
+Fall 2022,ENGL,1302,52,12233,First Year Writing II,Wolfe,Steven R.,8,4,1,0,3,0,3,2.772
+Fall 2022,GEOL,1103,3,12252,Physical Geology Lab,Hauptvogel,Daniel William,13,5,1,2,2,0,1,3.044
+Fall 2022,GEOL,1347,1,12254,Introduction To Meteorology,Rappenglueck,Bernhard,54,33,20,9,11,0,24,2.856
+Fall 2022,ECON,2301,1,12255,Principles of Macroeconomics,Salinas Huerta,Luis Eduardo,40,27,15,5,3,0,0,3.085
+Fall 2022,FINA,4320,1,12257,Investment Management,Doshi,Hitesh B,14,16,1,0,0,0,0,3.473
+Fall 2022,ARTS,2348,1,12259,Digital Tools,Scott,Caitlin,5,7,2,0,0,0,0,3.238
+Fall 2022,MIS,3370,2,12261,Info Systems Development Tools,Oladeji,Oyebisi Olufoyeke,15,20,8,5,2,0,14,2.82
+Fall 2022,ITAL,1501,1,12262,Elementary Italian I,Ercolani,Monica,15,2,1,0,4,0,1,3.046
+Fall 2022,ITAL,1501,5,12264,Elementary Italian I,Ercolani,Monica,15,2,3,0,0,0,3,3.534
+Fall 2022,ECON,6475,1,12266,Macroeconomic Analysis,Thornton,Rebecca Achee,11,1,1,0,0,0,0,3.693
+Fall 2022,ECON,6485,1,12267,Microeconomic Analysis,Craig,Steven G,6,5,0,0,0,0,0,3.605
+Fall 2022,ECON,6465,1,12268,Econometrics,Chin,Aimee,5,6,0,0,0,0,0,3.545
+Fall 2022,COSC,6310,1,12269,Fundamentals of Operating Syst,Rincon Castro,Carlos Alberto,0,3,0,0,0,0,0,2.89
+Fall 2022,ARTS,2356,1,12271,Fundamentals of Photo/DM,Politzer,David,7,6,2,0,1,0,1,3.043
+Fall 2022,ARTS,2356,2,12272,Fundamentals of Photo/DM,Krouba,Blya Ange Ernestine,10,5,0,0,1,0,2,3.438
+Fall 2022,ARTS,2356,3,12273,Fundamentals of Photo/DM,Duron-Larson,Angela Marie,12,1,1,0,2,0,1,3.333
+Fall 2022,FINA,4341,1,12275,Commercial Bank Management,Lara,Alexander J,40,7,1,2,0,0,0,3.687
+Fall 2022,CUIN,3351,3,12276,Class Interact Science-Math,Mateer,Ramona Caravella,6,3,0,0,0,0,0,3.63
+Fall 2022,MUSA,1176,1,12277,Applied Jazz Percussion,Hubley,Robert L,3,3,1,0,0,0,0,3.38
+Fall 2022,MANA,3335,2,12278,Intro Org Behavior and Mgmt,Currie,Daniel David,171,92,24,6,3,0,1,3.398
+Fall 2022,EDUC,4314,3,12279,Student Teaching Sec,Evans,Paige K,15,1,1,0,0,0,1,3.824
+Fall 2022,EDUC,4315,3,12280,Student Teaching Sec,Evans,Paige K,18,0,0,0,0,0,1,4.0
+Fall 2022,ELED,3322,2,12281,Elem Reading Phonics Instructn,Westfall,Dawn Marie,31,2,0,0,0,0,0,3.899
+Fall 2022,EDUC,4324,1,12282,Student Teaching Tech Middle,Culpepper,Shea Mosley,35,4,0,0,0,0,0,3.847
+Fall 2022,MUSI,3215,4,12283,Introduction To Large Forms,Garza,Paul Victor,10,7,1,0,0,0,0,3.518
+Fall 2022,MUED,4343,1,12284,Choral Materials Grades 4-12,Mueller,Jebediah Lee,7,1,1,0,0,0,0,3.74
+Fall 2022,HDFS,1311,1,12285,Personal Dev and College Succ,Kamdar-Sharif,Amber,33,4,4,3,1,0,0,3.349
+Fall 2022,GHL,6355,1,12286,Event Administration,Draper,Jason A,6,0,0,0,0,0,0,4.0
+Fall 2022,LAW,5488,1,12287,Constitutional Law,Knake,Renee N,23,14,5,0,0,0,0,3.397
+Fall 2022,PHYS,4321,1,12288,Int Electromagnetic Theory I,Cherdack,Daniel David,8,9,6,2,0,0,1,2.867
+Fall 2022,LAW,5357,3,12289,Evidence,Janicke,Paul,20,45,5,0,0,0,0,3.37
+Fall 2022,HON,3310,1,12290,Creativity at Work,Rayneard,Max James Anthony,34,14,0,0,0,0,2,3.612
+Fall 2022,LAW,5183,1,12291,Mediation Process,Willis,Tasha L,0,7,0,0,0,0,0,3.33
+Fall 2022,LAW,5283,1,12292,Mediation Externship,Willis,Tasha L,0,0,0,0,0,7,0,
+Fall 2022,BIOL,1106,5,12294,Biol for Science Majors I(Lab),Medrano,Ana I,12,6,2,1,1,0,0,3.302
+Fall 2022,COSC,6370,1,12295,Fundamental of Medical Imaging,Tsekos,Nikolaos V,31,0,0,0,0,0,0,3.904
+Fall 2022,ELET,4326,1,12297,Power Converter Circuits,Shireen,Wajiha,3,9,0,0,0,0,1,3.168
+Fall 2022,CNST,4381,1,12298,Reinforced Conc & Bldg Codes,Elzafraney,Mohamed,34,30,1,0,0,0,0,3.477
+Fall 2022,CNST,2351,1,12299,Construction Estimating I,Liggin,Gregory G,11,31,21,4,2,0,1,2.652
+Fall 2022,FINA,7371,1,12300,Energy Value Chain,Slaughter,Andrew Jeremy,6,5,0,0,0,0,0,3.545
+Fall 2022,CNST,6310,2,12301,Construction Contract Administ,Eldin,Neil N,2,2,3,0,11,0,0,1.111
+Fall 2022,COSC,4372,1,12302,Fundamental of Medical Imaging,Tsekos,Nikolaos V,49,5,0,0,1,0,2,3.77
+Fall 2022,CNST,6350,1,12304,Decision Making and Risk Mgmt,Gao,Lu,34,5,0,0,0,0,0,3.863
+Fall 2022,THEA,3320,1,12305,Acting V,Pistorius,Allison Marie,8,5,0,0,0,0,0,3.438
+Fall 2022,THEA,3350,1,12306,Movement for the Actor III,Bronfenbrenner,Skye,9,4,0,0,0,0,0,3.642
+Fall 2022,THEA,3380,1,12307,Voice for the Actor III,Johnson,James B,10,3,0,0,0,0,0,3.668
+Fall 2022,POLS,3390,1,12308,Women in Politics,Sims,Nancy Lou,26,13,4,0,2,0,1,3.297
+Fall 2022,THEA,1111,1,12309,Production,Vintu,Tatiana,14,4,0,0,0,0,1,3.796
+Fall 2022,THEA,1111,2,12310,Production,Vintu,Tatiana,19,1,0,0,0,0,1,3.95
+Fall 2022,THEA,1112,1,12311,Production,Vintu,Tatiana,8,2,0,0,0,0,0,3.767
+Fall 2022,THEA,2390,1,12312,Technical Drawing,Vintu,Tatiana,7,2,1,0,0,0,0,3.468
+Fall 2022,THEA,3387,1,12313,Lighting Design,Giannelli,Christina Rose,3,5,2,1,0,0,0,2.999
+Fall 2022,WGSS,2350,5,12314,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,25,3,2,0,0,0,0,3.756
+Fall 2022,MECE,4340,1,12315,Mechanical Engr Capstone I,Baxevanis,Theocharis,104,28,0,0,0,0,0,3.79
+Fall 2022,MIS,7376,1,12316,Systems Analysis and Design,Johnson,Glynn L,19,6,0,0,0,0,0,3.734
+Fall 2022,CUIN,4361,1,12317,Second Language Methodology,Leon,Maredil Josefina,22,6,3,0,1,0,1,3.428
+Fall 2022,WGSS,2350,7,12318,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,2,0,1,0,0,1,3.816
+Fall 2022,GEOL,1104,1,12319,Historical Geology Lab,Hauptvogel,Daniel William,16,3,0,0,2,0,1,3.382
+Fall 2022,ANTH,2351,1,12320,Intro to Cultural Anthropology,Gordon,Andrew J,87,31,8,1,8,0,7,3.261
+Fall 2022,MUSA,4400,5,12321,Applied Voice,Jones,Timothy J,2,0,0,0,0,0,0,3.835
+Fall 2022,PUBL,6410,1,12322,Quantitative Methods I,Yuasa,Toshiyuki,1,4,4,0,0,0,0,2.593
+Fall 2022,PHAR,5668,1,12323,Managed Care Pharmacy,Tolleson,Shane Russell,8,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1301,127,12327,First Year Writing I,Brown,Erika J,15,3,3,1,2,0,1,3.125
+Fall 2022,ELET,4126,1,12328,Power Converter Circuits Lab,Shireen,Wajiha,11,0,0,0,0,0,0,3.7
+Fall 2022,BIOL,2101,12,12329,Anatomy & Physiology Lab I,Gill,Tejendra,7,10,3,2,2,0,0,2.571
+Fall 2022,BIOL,2101,13,12330,Anatomy & Physiology Lab I,Gill,Tejendra,11,7,6,0,0,0,0,3.071
+Fall 2022,GHL,6290,1,12331,Professional Paper I,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Fall 2022,CNST,1315,1,12333,Project Drawings and Graphics,Clark,Peter J,18,21,8,0,1,0,0,3.098
+Fall 2022,CNST,1325,1,12334,Process & Industrial Construct,Ponnusamy,Ravi Chandran,7,3,1,0,0,0,1,3.545
+Fall 2022,CNST,4341,1,12335,Project Controls,Bouhou,Nour-El Imane,6,11,3,0,0,0,0,3.134
+Fall 2022,ENGL,1301,128,12336,First Year Writing I,Murray,Christopher Brean,8,9,1,0,7,0,0,2.466
+Fall 2022,ENGL,1302,1,12337,First Year Writing II,Jones,Baylea,8,6,2,0,2,0,1,2.872
+Fall 2022,SOC,6399,5,12339,Masters Thesis,Anderson,Kathryn,2,0,0,0,0,0,0,4.0
+Fall 2022,MANA,6332,2,12340,Organiztnl Behavior & Mangemnt,Werner,Steve,12,1,0,0,0,0,0,3.923
+Fall 2022,PSYC,2320,1,12342,Abnormal Psychology,Venta,Amanda Cristina,17,16,10,3,2,0,1,2.903
+Fall 2022,ENGL,1301,129,12343,First Year Writing I,Brown,Erika J,5,10,5,0,1,0,2,2.92
+Fall 2022,ENGL,1301,130,12344,First Year Writing I,Rajkumar,Nidhi,8,9,2,1,2,0,3,2.894
+Fall 2022,COMD,7392,4,12346,Adv Pract Sp & Lang Dis,Tragesser,Bridgid Jane,3,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,1501,17,12348,Elementary Spanish I,Torres-Calle,Maria Jose,4,8,6,0,3,0,3,2.46
+Fall 2022,MATH,3331,2,12360,Differential Equations,Winkle,James J,13,0,7,5,1,0,3,2.667
+Fall 2022,MUSI,6106,1,12361,Grad Large Ensemble,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1302,40,12363,First Year Writing II,Long,Steven A.,14,2,0,0,3,0,0,3.263
+Fall 2022,ENGL,1302,3,12365,First Year Writing II,Garcia,Serena Mari,10,6,3,0,3,0,3,2.834
+Fall 2022,PHAR,5660,1,12366,Pharmaceutical Industry,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Fall 2022,SOC,6399,7,12369,Masters Thesis,Baumle,Amanda K,0,0,0,0,0,0,0,
+Fall 2022,SOC,6399,8,12371,Masters Thesis,Tuthill,Zelma,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1301,26,12388,First Year Writing I,Hiers,Maria,10,1,0,2,6,0,0,2.403
+Fall 2022,ECON,3332,3,12396,Intermediate Microeconomics,Saboury,Piruz,10,5,12,6,3,0,3,2.324
+Fall 2022,MUSI,6300,1,12397,Intro Res Method in Musicology,Caton,Kathryn L.,8,1,0,0,0,0,0,3.889
+Fall 2022,MUSI,6300,2,12398,Intro Res Method in Musicology,Lange,Barbara Rose,6,1,0,0,0,0,0,3.716
+Fall 2022,BIOL,2321,1,12399,Microbiology for Science Major,Knapp,Richard D,67,96,84,66,33,0,42,2.281
+Fall 2022,BCHS,4304,1,12400,Biophysics,Fox,Robert O,20,16,15,0,0,0,1,3.007
+Fall 2022,SCM,4330,1,12404,Bus Modeling and Dec Analysis,Cossick,Kathy L,31,8,16,3,0,0,2,3.155
+Fall 2022,SCM,4301,1,12405,Logistics Management,Tibodeau,Dale,18,33,14,6,0,0,3,2.869
+Fall 2022,SCM,4330,2,12406,Bus Modeling and Dec Analysis,Cossick,Kathy L,15,11,2,5,0,0,6,3.091
+Fall 2022,INDE,2331,1,12408,Computer Applications for IE,Chung,Christopher,7,7,2,0,1,0,2,3.118
+Fall 2022,INDE,6339,1,12409,Materials Handling,Keedy,Elias,15,17,4,0,2,0,1,3.097
+Fall 2022,CHEE,3321,1,12410,Analytical Methods Chem Engr,Grabow,Lars C,5,9,11,4,10,0,3,1.796
+Fall 2022,KIN,1304,1,12411,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,490,61,23,6,8,0,5,3.753
+Fall 2022,KIN,3304,1,12412,Human Structure & Phys Perform,LaVoy,Emily Claire-Pyle,32,45,35,16,8,0,8,2.556
+Fall 2022,KIN,3305,1,12413,Sport Sociology,Graham,Marilynn Hadassah,142,35,14,4,2,0,2,3.54
+Fall 2022,KIN,3350,1,12414,Psych Aspects Sport Exercise,Gray,Jon Phillip,194,38,10,1,2,0,1,3.667
+Fall 2022,KIN,3360,1,12415,Professional Prep for Sp Admin,Pearson,Demetrius W,2,13,16,18,7,0,3,1.773
+Fall 2022,KIN,3370,1,12416,Sport Facility Management,Cho,Minseok,22,17,2,0,0,0,0,3.536
+Fall 2022,KIN,4190,1,12417,Sport Administration Seminar,Walsh,David W,11,14,3,0,0,0,0,3.321
+Fall 2022,KIN,4345,1,12418,Econ and Finc Aspects of Sport,Lee,Dong Hun,21,11,5,4,1,0,0,3.088
+Fall 2022,KIN,4355,1,12419,Adm of Sport & Phys Activity,Walsh,David W,9,30,16,1,0,0,1,2.792
+Fall 2022,KIN,4390,1,12420,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,1,4.0
+Fall 2022,KIN,4690,1,12421,Internship in Sport Admin 1,Walsh,David W,22,8,0,0,0,0,0,3.711
+Fall 2022,NUTR,2133,1,12422,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,9,8,0,0,0,0,0,3.51
+Fall 2022,NUTR,2133,3,12423,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,12,5,0,0,0,0,1,3.628
+Fall 2022,NUTR,2332,2,12424,Intro To Human Nutrition,Alastuey,Lisa L,70,54,36,13,17,0,7,2.716
+Fall 2022,NUTR,2333,1,12425,Comm Food Prod I,Svendsen-Sanchez,Ann Carol,21,12,1,0,1,0,1,3.467
+Fall 2022,NUTR,3101,1,12426,Dietetics As a Profession,Scott,Claudia W,21,12,3,2,0,0,1,3.386
+Fall 2022,NUTR,3330,1,12427,Mgmt in Food & Nutr Systems,Haubrick,Kevin,8,10,0,0,0,0,1,3.334
+Fall 2022,LAW,5406,6,12428,Civil Procedure,Hoffman,Lonny,19,27,4,0,0,0,0,3.366
+Fall 2022,ARTS,3371,1,12429,Photo-Dig Media Portfolio Dev,Molina,Lorena Guadalupe,4,2,4,1,0,0,2,2.818
+Fall 2022,ARTS,3372,1,12430,Intermediate Video Art,Majithia,Maria Jacinta,9,4,4,0,0,0,0,3.236
+Fall 2022,NUTR,3334,1,12431,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,84,75,23,2,10,0,5,3.109
+Fall 2022,NUTR,4312,1,12432,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,13,15,13,6,1,0,0,2.722
+Fall 2022,NUTR,4333,1,12433,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,19,9,7,1,0,0,0,3.204
+Fall 2022,NUTR,4334,1,12434,Community Nutrition,Cepni,Aliye Beyza,64,45,19,10,7,0,4,2.921
+Fall 2022,NUTR,4346,1,12435,Research in Nutrition,Ledoux,Tracey A,16,32,16,2,1,0,0,2.861
+Fall 2022,NUTR,4348,1,12436,Intro to NUTR Counseling,Honig,Caryn A,12,9,2,0,0,0,3,3.363
+Fall 2022,PEP,6305,1,12438,Measurmnt Hlt & Phys Educ,Lee,Dong Hun,14,0,0,0,0,0,0,3.929
+Fall 2022,PEP,7306,1,12439,Adm Princs of Sprts/Exer Prgms,Pearson,Demetrius W,4,6,3,0,0,0,0,3.128
+Fall 2022,PEP,7393,1,12440,Internship & Practicum,Walsh,David W,4,1,2,0,0,0,0,3.286
+Fall 2022,GEOL,7324,1,12441,Rock Physics,Chesnokov,Evgeni M,4,2,0,0,0,0,0,3.612
+Fall 2022,SPAN,1502,3,12443,Elementary Spanish II,Said White,Erika,8,10,6,0,1,0,2,3.013
+Fall 2022,BUSI,1301,1,12448,Business Principles,Thompson,Joseph Lee,24,0,0,0,0,0,0,4.0
+Fall 2022,SCM,4350,1,12449,Strategic Supply Management,Wayhan,Victor Brian,65,52,7,1,1,0,3,3.4
+Fall 2022,FREN,2312,2,12450,Intermediate French II,Chalhoub,Rania Maria,6,2,1,0,0,0,0,3.556
+Fall 2022,CHEM,4340,1,12451,Research Methods,Ekeoba,Jacqueline Njideka,3,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,4340,1,12453,Research Methods,Ekeoba,Jacqueline Njideka,4,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8198,1,12459,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Fall 2022,BIOE,8298,1,12460,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Fall 2022,BIOE,8298,2,12461,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8398,4,12462,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,3,0,
+Fall 2022,BIOE,8598,1,12464,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Fall 2022,ECE,3355,1,12466,Electronics,Litvinov,Dmitri,21,10,14,8,7,0,2,2.495
+Fall 2022,ITAL,3303,1,12467,Italian Convers&Compos,Nicosia,Alda,1,0,0,0,0,0,0,4.0
+Fall 2022,MARK,4362,1,12468,Applied Buyer Behavior,Rudd,Melanie R,15,22,2,0,0,0,0,3.283
+Fall 2022,CUIN,3321,1,12470,Intro to Teaching Middle Grade,Pauloski,Gwendolyn Jordan,18,8,0,0,0,0,0,3.515
+Fall 2022,CUIN,3352,1,12471,Perspectives Math and Science,Wong,Sissy S,7,0,0,0,0,0,0,4.0
+Fall 2022,MATH,4388,1,12472,History of Mathematics,Ji,Shanyu,21,16,5,1,2,0,0,3.156
+Fall 2022,HLT,3301,2,12473,Health Behavior Theories,Drenner,Kelli Linn,3,11,0,0,0,0,0,3.167
+Fall 2022,PHYS,1102,9,12474,College Physics II (lab),Wood,Lowell T,2,11,10,0,0,0,0,2.681
+Fall 2022,TEPM,6301,4,12476,Project Management Principles,Sherman,Dennis Louis,42,2,0,0,1,0,0,3.874
+Fall 2022,TEPM,6301,20,12477,Project Management Principles,Sherman,Dennis Louis,47,7,0,0,0,0,0,3.87
+Fall 2022,ARTS,3301,1,12478,Life Drawing,Barrera,Debra,17,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,2333,1,12479,Fundamentals of Printmaking,Christlieb,Lauren Nicole,12,0,1,0,0,0,0,3.846
+Fall 2022,TEPM,6302,1,12480,Leadership and Team Building,Hopkins,Ronald K.,12,1,0,0,0,0,0,3.872
+Fall 2022,ARTS,1311,1,12481,Fundamentals of Graphic Design,Hamouda,Salma Mohamed Ashraf Moussad Mohamed,16,6,1,0,0,0,1,3.595
+Fall 2022,ARTS,1311,3,12482,Fundamentals of Graphic Design,Flores,Rachel Kam,5,11,4,0,0,0,1,3.05
+Fall 2022,PSYC,2317,1,12483,Intro to Psychology Statistics,Ng,Vincent,11,8,10,2,2,0,1,2.677
+Fall 2022,PSYC,2317,3,12484,Intro to Psychology Statistics,Steinberg,Lynne,3,9,6,4,3,0,14,2.2
+Fall 2022,ARTS,2326,2,12486,Fundamentals of Sculpture,Long,Randi Rochelle,12,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,2121,1,12487,Microbiology for Science Major,Knapp,Richard D,9,10,2,2,0,0,1,3.188
+Fall 2022,BIOL,2121,2,12488,Microbiology for Science Major,Knapp,Richard D,10,10,2,1,0,0,0,3.29
+Fall 2022,BIOL,2121,3,12489,Microbiology for Science Major,Knapp,Richard D,14,6,3,1,0,0,0,3.43
+Fall 2022,BIOL,2121,4,12490,Microbiology for Science Major,Knapp,Richard D,16,4,2,0,0,0,0,3.576
+Fall 2022,BIOL,2121,5,12491,Microbiology for Science Major,Knapp,Richard D,14,5,3,0,1,0,1,3.348
+Fall 2022,ARTS,2311,1,12492,"Color, Materials and Methods",Switzer,Christopher P,11,10,2,0,0,0,0,3.363
+Fall 2022,ARTS,2311,2,12493,"Color, Materials and Methods",Williams,Celeste,14,6,0,0,0,0,2,3.667
+Fall 2022,ARTS,3313,1,12494,Silkscreen,Masterson,Patrick D,13,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,3314,1,12495,Lithography,Masterson,Patrick D,11,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7324,3,12496,Clinical Apps of DSM in SW,Maldonado-Morales,Maria Ximena,19,0,0,0,0,0,1,3.948
+Fall 2022,SOCW,7305,1,12497,Evaluation of SW Practice,Miyawaki,Christina E,12,16,0,0,0,0,0,3.429
+Fall 2022,SOCW,7305,2,12498,Evaluation of SW Practice,Webb,Ann E,17,4,0,0,0,0,1,3.81
+Fall 2022,ARTS,3334,1,12499,Introduction to Typography,Hagmann,Sibylle,7,10,3,0,0,0,4,3.25
+Fall 2022,ARCH,5500,5,12500,Architecture Design Studio IX,Smith,Joshua S,9,5,1,0,0,0,0,3.489
+Fall 2022,ARCH,5500,9,12503,Architecture Design Studio IX,Jackson,Megan H,7,8,0,0,0,0,0,3.313
+Fall 2022,ARCH,4327,1,12505,Technology 5,Taylor,Rives,51,49,3,1,0,0,1,3.439
+Fall 2022,FINA,4330,2,12506,Corporate Finance,Roshak,Kevin T,8,11,3,0,1,0,1,3.03
+Fall 2022,FINA,4330,4,12507,Corporate Finance,Berger,Elizabeth,16,16,6,2,0,0,1,3.142
+Fall 2022,CIS,2337,30,12508,Fund of Information Security,Peddoju,Suresh Kumar,49,37,5,3,3,0,6,3.279
+Fall 2022,CIS,2332,30,12509,Info Tech Hdwr & Systems Sftwr,Ratner,Edward,129,58,15,6,14,0,6,3.211
+Fall 2022,CIS,2336,30,12511,Internet Application Developmt,Faiyaz,Sajida,12,12,5,0,1,0,0,3.243
+Fall 2022,CIS,2336,31,12512,Internet Application Developmt,Viseh,Mehran,16,16,10,0,3,0,3,2.977
+Fall 2022,CIS,3343,1,12513,Info Systems Analysis & Design,Faiyaz,Sajida,2,17,20,0,2,0,1,2.471
+Fall 2022,CIS,3351,1,12514,Intrusion Detect & Incid Resp,Conklin,William A,17,38,8,3,5,0,7,2.868
+Fall 2022,CIS,3365,1,12515,Database Management,Wu,Xuqing,11,9,12,0,0,0,0,2.948
+Fall 2022,CIS,4338,1,12516,Database Admin & Implementatn,Miertschin,Susan L,16,29,26,0,7,0,3,2.577
+Fall 2022,CIS,4375,1,12517,Project Management & Practice,Martinez,Jose C,2,24,4,0,0,0,0,2.933
+Fall 2022,CIS,6321,1,12518,Principles of Cybersecurity,Bronk,Robert C.,69,12,4,0,1,0,0,3.679
+Fall 2022,CIS,6323,1,12519,Applied Cryptography,Zhang,Yunpeng,36,2,0,0,0,0,0,3.878
+Fall 2022,SCLT,4312,30,12523,Inventory & Materials Handling,Hu,Minxiang,29,19,8,2,1,0,1,3.181
+Fall 2022,SCLT,4375,30,12524,Global Supply Chain,Velarde,Jose Manuel,30,16,3,2,5,0,2,3.113
+Fall 2022,SCLT,4380,31,12525,Quality Systems,Hu,Minxiang,32,24,2,0,1,0,1,3.363
+Fall 2022,ELET,2103,1,12526,Digital Systems Laboratory,Abdelhadi,Ahmed,6,12,5,1,1,0,0,2.761
+Fall 2022,ELET,3403,1,12527,Sensor Applications,Yuan,Xiaojing,6,8,15,2,0,0,0,2.549
+Fall 2022,NUTR,4347,1,12529,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,12,10,3,1,1,0,0,3.148
+Fall 2022,TEPM,6307,1,12531,Advanced Project Management,Sherman,Dennis Louis,3,0,0,0,0,0,0,4.0
+Fall 2022,TEPM,6307,20,12532,Advanced Project Management,Sherman,Dennis Louis,3,1,0,0,1,0,0,3.0
+Fall 2022,MIS,3376,1,12533,Busn Appls Database Mgmt I,Grimes,George M,21,25,14,3,0,0,0,3.016
+Fall 2022,MIS,4374,1,12534,Info Technology Project Mgmt,Scott,Carl P,21,16,0,0,0,0,0,3.505
+Fall 2022,MIS,4374,2,12535,Info Technology Project Mgmt,Scott,Carl P,24,14,2,0,0,0,0,3.542
+Fall 2022,BIOL,1308,2,12536,Biology for Non-Science Majors,Gifford,Jenifer,50,92,78,38,20,0,27,2.403
+Fall 2022,ARCH,3393,1,12537,Thesis Preparation,Johnson,Matthew W,11,2,0,0,0,0,0,3.643
+Fall 2022,THEA,3332,1,12539,Directing I,Watt,Sophia M,11,5,0,0,0,0,1,3.688
+Fall 2022,THEA,4320,1,12540,Acting VII,Pistorius,Allison Marie,9,0,0,0,0,0,0,4.0
+Fall 2022,PHYS,1101,11,12541,College Physics I (lab),Wood,Lowell T,1,19,3,0,1,0,0,2.792
+Fall 2022,MATH,3321,5,12542,Engineering Mathematics,Ryan,John M,25,21,18,4,7,0,4,2.768
+Fall 2022,PHYS,1101,12,12543,College Physics I (lab),Wood,Lowell T,1,6,6,0,0,0,3,2.666
+Fall 2022,HLT,4317,1,12544,Found of Epi in Public Health,Drenner,Kelli Linn,26,44,16,6,4,0,4,2.844
+Fall 2022,FINA,4320,2,12545,Investment Management,Doshi,Hitesh B,15,6,1,0,0,0,1,3.621
+Fall 2022,MUSI,8106,4,12546,Doctoral Large Ensemble,Krager,Franz A,14,0,0,0,0,0,1,4.0
+Fall 2022,PHLS,8324,1,12547,Multivar Analy in Psy/Educ Res,Wiesner,Margit F,11,0,0,0,0,0,0,3.97
+Fall 2022,MUSI,6106,4,12548,Grad Large Ensemble,Krager,Franz A,26,1,0,0,0,0,1,3.914
+Fall 2022,CNST,2325,1,12550,Process and Industrial Subsyst,Zayas,Frederick A,0,5,3,0,0,0,0,2.666
+Fall 2022,CNST,2345,1,12551,Contract Doc Capital Projects,Beadle,Dwight D,8,12,4,0,0,0,0,3.167
+Fall 2022,ENGL,2305,4,12552,Intro To Fiction,Kelly,Hannah Elizabeth,25,3,0,0,1,0,1,3.759
+Fall 2022,PSYC,2317,2,12553,Intro to Psychology Statistics,Ng,Vincent,10,5,8,4,0,0,4,2.741
+Fall 2022,THEA,4693,1,12554,Stage Management Internship,Bush,Rachel R,0,0,0,0,0,5,0,
+Fall 2022,PHAR,5662,3,12555,Academic Scholarship,Wallace,David A,4,2,0,0,0,0,0,3.667
+Fall 2022,FINA,4320,3,12564,Investment Management,Vasu,Rajkamal Kamaladevi,17,15,10,0,0,0,2,3.23
+Fall 2022,SOCW,7319,1,12572,SW Practice in Organizations,Pang,Melanie Espinosa,24,0,0,0,0,0,0,4.0
+Fall 2022,INDE,6365,1,12579,Engineering Economy II,Schulze,Lawrence John Henry,34,45,13,1,0,0,1,3.208
+Fall 2022,BIOL,1106,23,12580,Biol for Science Majors I(Lab),Medrano,Ana I,8,4,4,1,2,0,4,2.772
+Fall 2022,BIOL,1106,24,12581,Biol for Science Majors I(Lab),Medrano,Ana I,16,5,1,0,2,0,0,3.389
+Fall 2022,BIOL,1106,25,12582,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,1,0,0,0,1,3.651
+Fall 2022,BIOL,1106,26,12583,Biol for Science Majors I(Lab),Medrano,Ana I,15,8,0,0,0,0,1,3.595
+Fall 2022,PSYC,2317,4,12587,Intro to Psychology Statistics,Steinberg,Lynne,3,6,3,2,4,0,18,2.111
+Fall 2022,ELET,2300,2,12588,Introductn To C++ Programming,Hu,Bin,11,19,8,9,8,0,3,2.285
+Fall 2022,ECON,8362,1,12590,Workshop Research Methods IV,Liu,Elaine Meichen,9,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,8180,1,12597,Advanced Seminar,Varisco,Tyler J,7,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,1106,27,12598,Biol for Science Majors I(Lab),Medrano,Ana I,9,10,2,1,1,0,1,3.087
+Fall 2022,BIOL,1106,28,12599,Biol for Science Majors I(Lab),Medrano,Ana I,17,6,0,0,0,0,1,3.653
+Fall 2022,BIOL,2101,14,12608,Anatomy & Physiology Lab I,Gill,Tejendra,4,15,4,0,1,0,0,2.875
+Fall 2022,BIOL,1106,29,12610,Biol for Science Majors I(Lab),Medrano,Ana I,15,6,1,1,0,0,1,3.522
+Fall 2022,BIOL,1106,30,12611,Biol for Science Majors I(Lab),Medrano,Ana I,21,2,1,0,0,0,0,3.833
+Fall 2022,BIOL,1106,31,12613,Biol for Science Majors I(Lab),Medrano,Ana I,12,9,1,1,1,0,0,3.181
+Fall 2022,BIOL,1106,32,12614,Biol for Science Majors I(Lab),Medrano,Ana I,13,4,2,2,1,0,2,3.137
+Fall 2022,BIOL,1306,5,12615,Biology for Science Majors I,Medrano,Ana I,53,79,61,41,15,0,27,2.462
+Fall 2022,COMD,7391,9,12616,Clinic in Speech Lang Disorder,Degge,Mary Chistine,1,2,0,0,0,0,0,3.223
+Fall 2022,ENGL,1301,119,12618,First Year Writing I,Kroger,Ann Gabriel,13,3,1,0,3,0,0,3.084
+Fall 2022,DRAM,1310,7,12619,Introduction to Theatre,Young,Courtney Leigh,40,9,1,0,0,0,0,3.787
+Fall 2022,ENGL,1301,30,12624,First Year Writing I,Pan,Weijia,12,4,0,1,1,0,0,3.297
+Fall 2022,ENTR,4340,1,12625,Entrepreneurial Capital,Blair,Edward A,11,16,3,0,0,0,0,3.212
+Fall 2022,BTEC,1322,30,12635,Introduction to Biotechnology,Iken,Brian N,21,6,1,0,2,0,1,3.467
+Fall 2022,BTEC,3200,31,12636,Biotech Research Methods,Iken,Brian N,12,9,1,0,0,0,1,3.53
+Fall 2022,PSYC,2305,5,12639,Intro to Methods in Psychology,Yoruk,Harun,20,15,3,1,1,0,0,3.259
+Fall 2022,ECON,2301,2,12640,Principles of Macroeconomics,Vidogbena,Yabo Gwladys,21,39,47,13,20,0,13,2.209
+Fall 2022,ECON,3334,3,12641,Intermediate Macroeconomics,Jiu,Haibin Brett,4,4,1,1,0,0,2,3.034
+Fall 2022,GEOL,1103,7,12642,Physical Geology Lab,Hauptvogel,Daniel William,16,3,2,0,0,0,1,3.635
+Fall 2022,GEOL,1103,8,12643,Physical Geology Lab,Hauptvogel,Daniel William,16,4,2,0,0,0,1,3.636
+Fall 2022,GEOL,1103,9,12644,Physical Geology Lab,Hauptvogel,Daniel William,20,1,1,0,0,0,2,3.819
+Fall 2022,CHEM,1111,49,12646,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,1,1,2,0,1,2.729
+Fall 2022,CHEM,1112,14,12648,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,2,2,0,0,1,2.871
+Fall 2022,CHEM,1112,15,12649,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,6,3,2,0,0,2,2.822
+Fall 2022,CHEM,1112,16,12650,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,10,1,1,0,0,3,2.978
+Fall 2022,CHEM,1112,17,12651,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,5,2,1,1,0,3,2.665
+Fall 2022,CHEM,1105,4,12652,Foundations of Chem Lab,Zaitsev,Vladimir G,4,12,2,0,0,0,1,3.184
+Fall 2022,CHEM,1105,3,12653,Foundations of Chem Lab,Zaitsev,Vladimir G,7,8,2,1,0,0,0,3.13
+Fall 2022,MARK,3365,2,12654,Intro to Digital Marketing,Tirunillai,Seshadri N,73,48,17,2,4,0,0,3.246
+Fall 2022,CHEM,2125,5,12655,Organic Chemistry Lab II,Bean,Mary B,4,7,6,1,0,0,2,2.741
+Fall 2022,BIOL,2302,1,12656,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,44,49,67,37,12,0,44,2.356
+Fall 2022,MUSI,6350,1,12657,Applied Music Pedagogy,Evans,Joseph,4,1,0,0,0,0,0,3.8
+Fall 2022,PHAR,5663,2,12658,Pharmacy Management,Tolleson,Shane Russell,7,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5683,2,12659,Cardiology,Truong,Mabel,10,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,3378,1,12660,Principles of Atmospheric Sci.,Choi,Yunsoo,14,9,3,1,0,0,0,3.272
+Fall 2022,ELED,4310,3,12662,Reading/Language in Elementary,Tyson,Eleanore S,25,4,1,0,0,0,0,3.789
+Fall 2022,ELED,4310,4,12663,Reading/Language in Elementary,Tyson,Eleanore S,24,2,0,0,0,0,0,3.86
+Fall 2022,EDUC,1301,1,12664,Intro to Teaching Profession,Larry,Frederick,25,0,0,0,0,0,0,4.0
+Fall 2022,RELS,2310,1,12665,Bible and Western Culture I,Tamber-Rosenau,Caryn M,22,14,6,2,3,0,1,3.071
+Fall 2022,PETR,6368,1,12667,Well Drilling and Completion I,Samuel,Robello,3,6,1,3,0,0,0,2.667
+Fall 2022,ARAB,3301,1,12668,Adv Modern Standard Arabic I,Taha,Asmaa,5,1,0,0,0,0,0,3.778
+Fall 2022,PETR,5350,1,12669,Natural Gas Engineering,Farouq-Ali,Syed,8,2,0,0,0,0,0,3.767
+Fall 2022,PETR,6328,1,12670,Petro Fluid Prop & Phase Equil,Dindoruk,Birol,3,1,0,0,0,0,0,3.75
+Fall 2022,BIOL,4354,1,12672,Endocrinology,Warner,Margaret,31,10,6,1,0,0,1,3.479
+Fall 2022,BIOL,4374,1,12673,Cell Biology,Rea,Michael A,28,10,13,4,3,0,8,2.971
+Fall 2022,BCHS,4313,2,12674,Cell Biochemistry,Rea,Michael A,7,1,4,0,0,0,2,3.25
+Fall 2022,BIOL,6374,1,12675,Cell Biology,Rea,Michael A,3,1,0,0,0,0,0,3.75
+Fall 2022,AAS,2320,3,12676,Intro To African American Stdy,Wiggins,Gretchen Flowers,17,7,1,0,1,0,4,3.449
+Fall 2022,ECE,4119,1,12677,Solid State Devices Lab,Pei,Shin-Shem Steven,16,0,0,0,0,0,0,3.711
+Fall 2022,SOCW,7305,4,12678,Evaluation of SW Practice,Webb,Ann E,25,3,0,0,0,0,0,3.893
+Fall 2022,SOCW,7305,5,12679,Evaluation of SW Practice,Miyawaki,Christina E,15,13,0,0,0,0,0,3.536
+Fall 2022,SOCW,7367,1,12680,Social Policy Analysis,Pang,Melanie Espinosa,26,1,0,0,0,0,0,3.963
+Fall 2022,ECE,5356,1,12681,Cmos Analog Integrated Circuit,Chen,Jinghong,11,0,0,0,0,0,0,3.82
+Fall 2022,ECE,6328,1,12682,Cmos Analog Integrated Circuit,Chen,Jinghong,9,14,1,0,0,0,1,3.375
+Fall 2022,ASLI,2233,1,12683,History of Interpreting,Hill,Sharon Grigsby,2,11,1,1,1,0,0,2.709
+Fall 2022,CUIN,4350,2,12684,Multiple Teaching Strategies,Latiolais,Cheryl S,11,2,0,0,0,0,0,3.821
+Fall 2022,MANA,4348,1,12685,Global Leadership,Walker,William A,26,7,2,0,0,0,0,3.714
+Fall 2022,SCM,4380,1,12686,Enterprise Resource Planning,Miller,Bradley D,33,43,10,1,0,0,0,3.219
+Fall 2022,MUSI,6200,1,12690,Accompanying Seminar,Hester,Timothy E,3,0,0,0,0,0,0,4.0
+Fall 2022,MANA,4346,1,12691,Leadership Development,Evans,Klavdia Markelova,37,7,3,0,0,0,0,3.716
+Fall 2022,FINA,4358,1,12692,Commercial Property,Kapatos,Nick Gus,4,5,2,0,0,0,0,3.182
+Fall 2022,SOCW,7367,4,12693,Social Policy Analysis,Pang,Melanie Espinosa,28,0,0,0,0,0,0,4.0
+Fall 2022,CIS,2348,30,12694,Info Systems Appl Development,Ratner,Edward,15,21,9,1,12,0,4,2.408
+Fall 2022,CIS,3343,2,12695,Info Systems Analysis & Design,Faiyaz,Sajida,4,21,14,0,2,0,0,2.674
+Fall 2022,ELET,2103,2,12697,Digital Systems Laboratory,Abdelhadi,Ahmed,13,10,5,0,0,0,0,3.286
+Fall 2022,ELET,2105,1,12698,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,15,3,3,0,1,0,0,3.409
+Fall 2022,MUSI,2302,1,12699,Listening to Jazz,Garza,Paul Victor,71,14,4,2,3,0,2,3.546
+Fall 2022,HLT,2320,2,12700,Introduction to Public Health,Proctor,Robin Ann,73,20,3,0,0,0,4,3.657
+Fall 2022,SOCI,1301,15,12701,Introduction To Sociology,Cooper,Chelsey Wells,33,11,9,4,0,0,2,3.246
+Fall 2022,ARTS,1372,1,12702,Fundamentals of Video Art,Majithia,Maria Jacinta,16,1,0,0,0,0,0,3.805
+Fall 2022,ARTS,3309,1,12703,Jr Painting Major,Frankfort,Dana M,9,1,0,0,0,0,0,3.9
+Fall 2022,ARTS,3310,1,12704,Jr Painting Major,Hecker,Rachel G,9,1,0,0,0,0,0,3.9
+Fall 2022,ARTS,3311,1,12705,Jr Painting Major,Frankfort,Dana M,9,1,0,0,0,0,0,3.9
+Fall 2022,ARTS,3335,1,12706,Junior Graphic Design Major,Kim,Yoonkyung,11,10,1,0,1,0,1,3.304
+Fall 2022,ARTS,3336,1,12707,Junior Graphic Design Major,Beckett,Cheryl A,13,8,1,0,1,0,1,3.363
+Fall 2022,ARTS,3337,1,12708,Junior Graphic Design Major,Unikel,Joshua,19,3,0,0,0,0,1,3.849
+Fall 2022,ARTS,3365,1,12709,Jr Sculpture Major,Hawk,Ryan,4,1,0,0,0,0,0,3.734
+Fall 2022,ARTS,3366,1,12710,Jr Sculpture Major,Mayer,Anna W,4,1,0,0,0,0,0,3.734
+Fall 2022,ARTS,3367,1,12711,Jr Sculpture Major,Giampietro,Francis A,4,1,0,0,0,0,0,3.8
+Fall 2022,ARTS,4300,1,12712,Senior Painting Major I,Ledvina,Cody,8,0,2,0,0,0,0,3.6
+Fall 2022,ARTS,4301,1,12713,Senior Painting Major I,Ledvina,Cody,8,0,2,0,0,0,0,3.6
+Fall 2022,ARTS,4302,1,12714,Senior Painting Major I,Parazette,Aaron,8,0,2,0,0,0,0,3.6
+Fall 2022,ARTS,4303,1,12715,Senior Painting Major II,Parazette,Aaron,12,1,1,0,0,0,0,3.762
+Fall 2022,ARTS,4304,1,12716,Senior Painting Major II,Parazette,Aaron,12,1,1,0,0,0,0,3.762
+Fall 2022,ARTS,4305,1,12717,Senior Painting Major II,Parazette,Aaron,12,1,1,0,0,0,0,3.762
+Fall 2022,ARTS,4330,1,12718,Senior Graphic Design Major I,Beckett,Cheryl A,15,8,0,1,0,0,0,3.514
+Fall 2022,ARTS,4331,1,12719,Senior Graphic Design Major I,Unikel,Joshua,23,0,1,0,0,0,0,3.917
+Fall 2022,ARTS,4332,1,12720,Senior Graphic Design Major I,Suryadi,Adry,12,9,1,2,0,0,0,3.25
+Fall 2022,ARTS,4360,1,12721,Senior Sculpture Major I,Hawk,Ryan,3,1,0,0,0,0,0,3.668
+Fall 2022,ARTS,4361,1,12722,Senior Sculpture Major I,Mayer,Anna W,3,1,0,0,0,0,0,3.668
+Fall 2022,ARTS,4362,1,12723,Senior Sculpture Major I,Mayer,Anna W,3,1,0,0,0,0,0,3.833
+Fall 2022,ARTS,4363,1,12724,Senior Sculpture Major II,Hawk,Ryan,3,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,4364,1,12725,Senior Sculpture Major II,Mayer,Anna W,3,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,4365,1,12726,Senior Sculpture Major II,Mayer,Anna W,3,0,0,0,0,0,0,4.0
+Fall 2022,GOVT,2306,3,12727,US and Texas Const/Politics,Davis,Sharon M,36,62,71,28,37,0,14,2.156
+Fall 2022,INDE,4370,1,12729,Discrete Event Simulation,Khator,Suresh K,5,20,10,3,0,0,3,2.658
+Fall 2022,INDE,4320,1,12731,Computer-Integrated Manufactur,Chang,Feng-Chang Roger,20,16,1,0,0,0,1,3.478
+Fall 2022,MIS,4390,1,12732,Energy Trading Systems,Pena,Juan F,102,5,4,0,0,0,1,3.874
+Fall 2022,MIS,4386,1,12733,Busn Appls Database Mgmt II,Scamell,Richard W,12,17,1,2,1,0,5,3.091
+Fall 2022,ELET,1400,1,12735,Circuit Theory and Lab I,Soneja,Chandrayee,5,22,5,5,9,0,6,2.188
+Fall 2022,PETR,1111,1,12736,Intro to Petroleum Engineering,Farouq-Ali,Syed,2,1,0,0,0,0,0,3.667
+Fall 2022,HRD,6353,1,12737,Methods of Adult Learning,Shirmohammadi,Melika,21,1,0,0,0,0,0,3.895
+Fall 2022,ASLI,3430,1,12738,Consecutive Interpreting,Hill,Sharon Grigsby,3,4,1,0,0,0,0,3.003
+Fall 2022,MUSI,6330,1,12740,Adv Instrumental Conducting,Krager,Franz A,3,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6300,1,12741,Drawing Studio,Parazette,Aaron,9,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6305,1,12742,Painting Studio,Lowe,Rick,8,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6330,1,12743,Graphic Design Studio,Hagmann,Sibylle,3,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6360,1,12744,Sculpture Studio,Kittelson,Paul A,8,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6370,1,12745,Photography Studio,Hillerbrand,Stephan C,8,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6385,1,12746,IPEF Studio,Lowe,Rick,6,0,0,0,0,0,0,4.0
+Fall 2022,PETR,3362,1,12747,Reservoir Engineering I,Hatzignatiou,Dimitrios Georgios,2,6,12,1,0,0,1,2.24
+Fall 2022,FINA,7376,1,12749,Energy Trading,Smith III,Edwin A,5,3,0,0,0,0,0,3.584
+Fall 2022,ARTS,4370,1,12750,Sr Photo/Digital Media Major I,Politzer,David,4,4,4,1,0,0,0,2.872
+Fall 2022,ARTS,4371,1,12751,Sr Photo/Digital Media Major I,Chen,Shang-Yee Mark,13,0,0,0,0,0,0,3.975
+Fall 2022,ARTS,4372,1,12752,Sr Photo/Digital Media Major I,Molina,Lorena Guadalupe,6,4,3,0,0,0,0,3.155
+Fall 2022,SPAN,3306,1,12753,Intro Study Span Language,Lopez Otero,Julio Cesar,8,5,2,0,1,0,1,3.126
+Fall 2022,PHAR,5672,3,12754,Clinical Pharmaceutical Resch,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5675,2,12755,Disease State Management,Asias-Dinh,Bernadette De Leon,2,1,0,0,0,0,0,3.667
+Fall 2022,PHAR,5675,3,12756,Disease State Management,De La Cruz,Austin Isaac,2,1,0,0,0,0,0,3.667
+Fall 2022,HIST,3327,1,12757,Houston Since 1836,Harwell,Debbie Z,7,6,4,2,2,0,2,2.62
+Fall 2022,GHL,6190,1,12758,Hospitality Research Proposal,Back,KiJoon,0,0,0,0,0,4,0,
+Fall 2022,SPAN,7398,10,12760,Reading & Research,Gutierrez,Manuel J,0,0,0,0,0,1,0,
+Fall 2022,ENGL,1301,31,12762,First Year Writing I,Colchado,Lea,13,2,1,1,1,0,0,3.297
+Fall 2022,ENGL,1301,32,12763,First Year Writing I,Koulen,Marisa Theresa,15,2,0,0,2,0,0,3.474
+Fall 2022,ENGL,1301,36,12764,First Year Writing I,Hiers,Maria,15,1,1,0,0,0,2,3.824
+Fall 2022,ENGL,1301,41,12765,First Year Writing I,Alcorn III,Charles William,12,5,3,0,0,0,0,3.483
+Fall 2022,MUSI,3303,2,12767,Pop Music of Americas Sn 1840,Caton,Kathryn L.,23,11,4,0,0,0,2,3.465
+Fall 2022,IDNS,1101,1,12768,Physics 1301 Workshop,Pattison,Donna,16,7,6,1,0,0,0,3.289
+Fall 2022,CHEM,2132,1,12769,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,7,0,
+Fall 2022,CHEM,2131,1,12770,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,4,1,
+Fall 2022,CHEM,2131,2,12771,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,6,0,
+Fall 2022,ARTS,3361,1,12773,Wood and Metal Fabrication,Giampietro,Francis A,13,2,0,0,0,0,0,3.889
+Fall 2022,COMD,2376,2,12774,Anatomy for Communication,Daniels,Stephanie K,14,13,9,6,2,0,5,2.72
+Fall 2022,BIOL,2120,6,12776,Microbiology for Non-Science,Knapp,Richard D,16,7,1,0,0,0,0,3.625
+Fall 2022,BIOL,2121,6,12777,Microbiology for Science Major,Knapp,Richard D,13,7,3,0,0,0,0,3.449
+Fall 2022,ELCS,8399,1,12778,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,2,0,
+Fall 2022,MTLS,6111,1,12779,Materials Engineering Seminar,Yao,Yan,0,0,0,0,0,28,1,
+Fall 2022,BIOL,1106,33,12780,Biol for Science Majors I(Lab),Medrano,Ana I,8,11,1,2,0,0,2,3.136
+Fall 2022,BIOL,1106,34,12781,Biol for Science Majors I(Lab),Medrano,Ana I,17,4,1,0,1,0,1,3.522
+Fall 2022,BIOL,1106,35,12782,Biol for Science Majors I(Lab),Medrano,Ana I,16,3,0,0,2,0,0,3.508
+Fall 2022,BIOL,1106,36,12783,Biol for Science Majors I(Lab),Medrano,Ana I,18,5,0,1,0,0,0,3.584
+Fall 2022,HON,3361,1,12786,Global Engagement and Research,Miljanic,Andra Olivia,7,5,0,0,0,0,0,3.556
+Fall 2022,PHAR,5644,1,12788,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,9,1,0,0,0,0,0,3.9
+Fall 2022,PHAR,5645,1,12789,Pharmacy Informatics,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Fall 2022,SCM,4351,1,12792,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,30,24,0,0,0,0,0,3.507
+Fall 2022,BIOL,1106,37,12793,Biol for Science Majors I(Lab),Medrano,Ana I,15,8,0,0,0,0,1,3.652
+Fall 2022,BIOL,1106,38,12794,Biol for Science Majors I(Lab),Medrano,Ana I,13,6,1,0,3,0,1,3.073
+Fall 2022,BIOL,1106,39,12795,Biol for Science Majors I(Lab),Medrano,Ana I,18,2,0,0,0,0,3,3.9
+Fall 2022,BIOL,1106,40,12796,Biol for Science Majors I(Lab),Medrano,Ana I,13,9,1,0,1,0,0,3.348
+Fall 2022,CUIN,8398,3,12798,Independent Study,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,2120,7,12808,Microbiology for Non-Science,Knapp,Richard D,11,6,3,2,0,0,0,3.137
+Fall 2022,BIOL,2121,7,12809,Microbiology for Science Major,Knapp,Richard D,8,6,7,1,0,0,0,2.955
+Fall 2022,BIOL,2101,15,12810,Anatomy & Physiology Lab I,Gill,Tejendra,4,12,4,1,1,0,2,2.698
+Fall 2022,BIOL,2101,16,12811,Anatomy & Physiology Lab I,Gill,Tejendra,6,8,6,1,1,0,1,2.713
+Fall 2022,BIOL,1106,41,12812,Biol for Science Majors I(Lab),Medrano,Ana I,12,6,3,2,1,0,0,3.042
+Fall 2022,BIOL,1106,42,12813,Biol for Science Majors I(Lab),Medrano,Ana I,13,7,1,0,1,0,1,3.364
+Fall 2022,HDFS,4316,1,12815,Dynamics of Family Relations,Schoger,Kimberly,25,5,1,0,4,0,6,3.343
+Fall 2022,COMD,1333,3,12821,Intro to Comm Sci & Disorders,Ross,Byron L,9,11,11,3,1,0,0,2.695
+Fall 2022,BIOL,1106,43,12823,Biol for Science Majors I(Lab),Medrano,Ana I,11,5,2,1,1,0,4,3.101
+Fall 2022,CHEM,1111,3,12824,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,6,2,3,1,0,2,2.501
+Fall 2022,CHEM,1111,8,12825,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,6,2,1,1,0,1,2.896
+Fall 2022,CHEM,1111,21,12826,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,0,0,2,0,1,2.723
+Fall 2022,CHEM,1111,33,12827,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,2,0,0,0,3,3.187
+Fall 2022,CHEM,1111,42,12828,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,6,3,1,0,0,2,3.0
+Fall 2022,HON,3301,2,12830,Readings in Medicine & Society,Brown,Erika J,21,2,0,0,0,0,1,3.899
+Fall 2022,CHEM,1112,4,12834,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,6,4,1,0,0,1,2.786
+Fall 2022,CHEM,1112,11,12835,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,6,0,1,0,0,2,3.212
+Fall 2022,MATH,2450,1,12836,Accelerated Calculus I,Wu,Yingying,20,4,0,0,0,0,4,3.806
+Fall 2022,BIOL,1106,46,12837,Biol for Science Majors I(Lab),Medrano,Ana I,18,3,2,1,0,0,0,3.515
+Fall 2022,CHEE,8498,17,12839,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8398,14,12842,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8398,15,12843,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,3,0,
+Fall 2022,CHEE,8298,15,12844,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,3,0,
+Fall 2022,BTEC,1322,1,12845,Introduction to Biotechnology,Khan,Abdul Latif,8,14,19,14,5,0,12,2.133
+Fall 2022,DANC,3302,1,12864,Int. Technique and Theory,Chapman,Teresa Lynn,11,1,0,0,0,0,0,3.862
+Fall 2022,CHEM,2123,13,12865,Organic Chemistry Lab I,Bean,Mary B,4,10,9,0,0,0,1,2.697
+Fall 2022,ENGL,2360,1,12867,Western World Lit I--Honors,Barnes,Michael,10,1,0,0,0,0,1,3.789
+Fall 2022,ENGL,2360,2,12868,Western World Lit I--Honors,Barnes,Michael,7,1,0,0,0,0,0,3.751
+Fall 2022,HIST,8677,4,12870,Reading for Comps Exams,Young,Nancy Beck,0,0,0,0,0,0,0,
+Fall 2022,COMM,6398,1,12872,Special Problems,Harlow,Summer D,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,8398,1,12875,Special Problems,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Fall 2022,ECON,7301,1,12883,Seminar in Microecon Research,Chin,Aimee,0,0,0,0,0,11,0,
+Fall 2022,ECON,7302,1,12884,Seminar in Macroecon Research,Cubas Norando,German,0,0,0,0,0,10,0,
+Fall 2022,MATH,2318,4,12885,Linear Algebra,Sanders,Richard,30,18,15,2,11,0,4,2.784
+Fall 2022,MATH,3333,3,12886,Intermediate Analysis,Leger,Nicholas M,4,3,6,4,5,0,2,1.909
+Fall 2022,MATH,3339,4,12887,Statistics for the Sciences,Wang,Wenshuang,170,55,25,17,16,0,14,3.204
+Fall 2022,GEOL,1103,10,12889,Physical Geology Lab,Hauptvogel,Daniel William,14,8,1,0,0,0,1,3.58
+Fall 2022,GEOL,1304,1,12890,Historical Geology,Copeland,Peter,17,11,10,0,0,0,2,3.132
+Fall 2022,GEOL,3373,1,12891,Igneous & Met. Petrogenesis,Oostingh,Kornelia Fieneke,4,7,10,0,0,0,0,2.667
+Fall 2022,SPAN,3343,1,12893,Span for the Health Profession,Zubiate,Maria Laura,11,3,1,0,0,0,0,3.689
+Fall 2022,CHEM,6311,1,12894,Mechanisms,Comito,Robert Joseph,7,15,2,0,0,0,0,3.153
+Fall 2022,HDFS,1311,2,12895,Personal Dev and College Succ,Kamdar-Sharif,Amber,25,8,1,0,3,0,2,3.298
+Fall 2022,HDFS,4318,2,12896,Parent-Child Relationships,Jordan,Erica F,33,17,4,3,2,0,1,3.283
+Fall 2022,PHYS,2326,5,12898,University Physics II(lecture),Bellwied,Rene,7,5,5,1,0,0,1,3.0
+Fall 2022,ECE,4335,1,12899,Electrical Comp Engr Design I,Contreras-Vidal,Jose Luis,43,31,0,0,0,0,0,3.621
+Fall 2022,HLT,1353,2,12901,Personal Health,Rafique,Kiran Sajid,96,15,4,0,1,0,3,3.71
+Fall 2022,HLT,3306,2,12902,Environmental Health,Behjat,Amirmohsen,6,16,6,2,2,0,2,2.739
+Fall 2022,HLT,3381,2,12903,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,68,16,3,0,1,0,2,3.667
+Fall 2022,HLT,4307,1,12904,Research and Eval in Health,Fedor Amador,Theresa Marie,20,9,5,0,1,0,0,3.315
+Fall 2022,PHAR,5681,3,12905,Infectious Diseases,Truong,Mabel,15,2,0,0,0,0,0,3.882
+Fall 2022,PSYC,4344,3,12906,Cultural Psychology,Ochoa Lopez,Andrea Pilar,45,17,9,7,4,0,1,3.17
+Fall 2022,SCM,4351,2,12907,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,9,3,0,0,0,0,0,3.64
+Fall 2022,ENGL,1301,20,12909,First Year Writing I,Pan,Weijia,12,6,2,1,0,0,3,3.302
+Fall 2022,MANA,3335,3,12910,Intro Org Behavior and Mgmt,Carlin,Barbara A,23,74,50,9,5,0,2,2.648
+Fall 2022,MANA,4338,1,12911,Performance Management Systems,Sullivan,David Walter,28,10,1,1,2,0,1,3.46
+Fall 2022,ENGL,1302,14,12912,First Year Writing II,Long,Steven A.,11,3,3,2,0,0,0,3.211
+Fall 2022,ENGL,1302,20,12913,First Year Writing II,Campese,Kathleen Ann,16,3,2,2,1,0,1,3.264
+Fall 2022,ENGL,1302,22,12914,First Year Writing II,Garcia,Serena Mari,8,5,4,1,6,0,1,2.306
+Fall 2022,ENGL,2305,3,12915,Intro To Fiction,Christensen,Ann C,8,8,3,4,1,0,5,2.736
+Fall 2022,INTB,3355,1,12916,Global Environment of Business,Thompson,Joseph Lee,219,15,9,1,4,0,1,3.776
+Fall 2022,INTB,3355,2,12917,Global Environment of Business,Pennebaker,Matt,231,11,2,1,2,0,3,3.884
+Fall 2022,CNST,4385,1,12919,Field Operations Capital Proj,Molina,Mariel,8,6,1,0,0,0,0,3.467
+Fall 2022,BUSI,1301,2,12921,Business Principles,Thompson,Joseph Lee,21,2,0,0,0,0,0,3.942
+Fall 2022,BUSI,1301,3,12922,Business Principles,Thompson,Joseph Lee,224,13,3,4,4,0,2,3.8
+Fall 2022,TMTH,3360,4,12923,Applied Technical Statistics,Daniel,Patrick Nathanial,8,14,9,0,0,0,7,2.968
+Fall 2022,PSYC,6303,1,12924,Foundation-Clinical Interven I,Babcock,Julia,13,3,0,0,0,0,0,3.771
+Fall 2022,EDUC,1301,2,12925,Intro to Teaching Profession,Ronduen,Lionnel Ganir,24,6,3,1,2,0,3,3.279
+Fall 2022,CIS,3365,2,12926,Database Management,Sadeghi,Abdi,2,10,18,1,0,0,2,2.473
+Fall 2022,CIS,4338,2,12927,Database Admin & Implementatn,Miertschin,Susan L,12,20,21,0,3,0,3,2.673
+Fall 2022,CIS,4339,1,12928,Enterprise Appls Development,Lindner,Peggy,57,42,15,6,4,0,5,3.156
+Fall 2022,HDCS,3300,2,12929,Org Decisions,Hitchman Sr,Cal M,33,7,5,0,5,0,0,3.194
+Fall 2022,GEOL,6324,1,12930,Sat. Positioning & Geodesy,Wang,Guoquan,10,2,0,0,0,0,0,3.778
+Fall 2022,FINA,7372,1,12932,Upstream Economics,Berta,Dom,5,2,1,0,0,0,0,3.5
+Fall 2022,FINA,4372,1,12933,Upstream Economics,Berta,Dom,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,4352,1,12934,Fin Planning for Professionals,Lopez,John C,3,14,8,0,0,0,0,2.919
+Fall 2022,LAW,5409,1,12935,Contracts,Bush,Darren,14,20,0,0,0,0,0,3.402
+Fall 2022,ENRG,3310,1,12936,Intro to Energy & Sustainblty,Miljanic,Ognjen S,23,17,4,1,0,0,0,3.378
+Fall 2022,ACCT,5375,1,12937,Internl Audit-Entity Ctrl Env,Brant Jr.,Robert Edward,2,0,3,0,0,0,0,2.866
+Fall 2022,HLT,4320,1,12939,Admin of Health Services,Markowitz,Eliz,29,9,2,1,1,0,0,3.398
+Fall 2022,ELED,4314,2,12940,Mathematics in Elem School I,Cutler,Carrie Sybil,20,3,2,0,0,0,0,3.641
+Fall 2022,BTEC,3320,30,12941,Intro to QA/QC in BTEC,Flavier,Albert B,9,20,10,1,1,0,3,2.878
+Fall 2022,ELED,4314,4,12942,Mathematics in Elem School I,Cutler,Carrie Sybil,25,2,0,0,0,0,0,3.865
+Fall 2022,ARCH,4510,1,12943,Integrated Arch Solutions,Peters,Patrick A,6,11,0,0,0,0,1,3.411
+Fall 2022,ARCH,4510,3,12945,Integrated Arch Solutions,Lutz,Shawn M,8,6,4,0,0,0,0,3.296
+Fall 2022,ARCH,4510,5,12947,Integrated Arch Solutions,Story,Jon Kevin,4,14,0,0,0,0,0,3.296
+Fall 2022,INAR,3500,1,12949,Interior Arch Design Studio V,Mantz,Ophelia,8,15,0,0,0,0,0,3.305
+Fall 2022,ASLI,4346,1,12951,ASL Translit & Educ Interpret,Gietz,Merrilee Ruth,1,4,2,0,0,0,0,2.716
+Fall 2022,ASLI,3434,1,12952,Simultaneous Interpreting II,Hill,Sharon Grigsby,1,6,0,0,0,0,0,3.001
+Fall 2022,SGNL,2302,1,12953,Intermediate Sign Language II,Gietz,Merrilee Ruth,1,1,9,3,0,0,1,1.976
+Fall 2022,HON,3330,1,12954,Leadership Theory and Practice,Rhoden,Brenda,10,5,0,0,0,0,0,3.777
+Fall 2022,ECE,3337,1,12955,Signals and Systems Analysis,Roysam,Badrinath,8,6,8,2,0,0,2,2.778
+Fall 2022,ECE,3364,1,12956,Circuits and Systems,Hebert,Thomas James,6,12,11,0,1,0,3,2.81
+Fall 2022,TECH,6360,1,12958,Exp Design & Data Analysis,Schroeder,Susan L,22,2,1,0,0,0,0,3.8
+Fall 2022,MATH,3325,1,12959,Transition to Advanced Math,Ott,William R,19,4,6,2,2,0,2,3.081
+Fall 2022,COMD,6334,1,12960,Aphasia & Related Com Disorder,Maher,Lynn M,9,10,2,1,0,0,0,3.287
+Fall 2022,ACCT,4105,1,12962,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,4,1,
+Fall 2022,NUTR,3336,1,12963,Nutritional Pathophysiology,Vollrath,Kirstin,29,28,8,2,0,0,1,3.145
+Fall 2022,CUIN,3302,3,12964,Social Education,Thomas,Dustine J,19,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,1360,1,12965,Architectural Sketching I,Williams,Celeste,12,7,0,0,1,0,0,3.401
+Fall 2022,BCIS,1305,3,12966,Business Computer Applications,Felvegi,Emese,159,52,22,4,6,0,5,3.423
+Fall 2022,MUSA,4440,2,12967,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Fall 2022,MIS,4378,1,12968,Admin of Computer-Based MIS,Skinner,Richard James,13,37,1,0,0,0,0,3.235
+Fall 2022,MIS,4378,2,12969,Admin of Computer-Based MIS,Skinner,Richard James,20,31,0,0,0,0,1,3.392
+Fall 2022,SCM,4367,1,12970,Process and Quality Management,Miller,Bradley D,13,18,7,3,0,0,2,3.0
+Fall 2022,SCM,4367,2,12971,Process and Quality Management,Miller,Bradley D,16,28,10,1,0,0,0,3.085
+Fall 2022,MUSI,6370,1,12972,Art Song Repertoire,Sonnenberg,Melanie,7,0,0,0,0,0,0,3.906
+Fall 2022,HDFS,4315,1,12973,Culture and Diversity,Rab,Saira,32,7,3,1,3,0,1,3.37
+Fall 2022,ARED,4365,1,12975,Integrative Art Teaching,Boyaki Wilson,Amanda R,11,0,1,0,0,0,0,3.778
+Fall 2022,SEDE,4312,1,12976,Teaching English in Sec School,Russell IV,Glen Curtis,30,0,0,0,0,0,1,3.956
+Fall 2022,MARK,4362,2,12977,Applied Buyer Behavior,Rudd,Melanie R,20,19,0,0,0,0,0,3.42
+Fall 2022,MARK,4362,3,12978,Applied Buyer Behavior,Rudd,Melanie R,12,21,2,1,1,0,2,3.135
+Fall 2022,CUIN,7303,1,12980,Professional Seminar I,Leon,Maredil Josefina,20,2,0,0,0,0,0,3.909
+Fall 2022,CUIN,7303,3,12981,Professional Seminar I,Brower,Samuel Richard,19,4,0,1,1,0,0,3.586
+Fall 2022,CUIN,7303,2,12982,Professional Seminar I,Gist,Conra D.,28,7,0,1,1,0,1,3.631
+Fall 2022,PHYS,1101,13,12984,College Physics I (lab),Wood,Lowell T,1,12,10,0,0,0,0,2.637
+Fall 2022,PHYS,1101,14,12985,College Physics I (lab),Wood,Lowell T,0,8,5,1,0,0,2,2.571
+Fall 2022,SCM,7380,1,12987,Analytics & Enterprise Opertns,Murray,Michael J,22,2,0,0,0,0,0,3.834
+Fall 2022,COSC,4315,901,12989,Programming Languages and Para,Subramaniam,Venkat,15,7,2,0,0,0,3,3.583
+Fall 2022,COSC,6345,901,12990,Programming Languages,Subramaniam,Venkat,3,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8699,1,12993,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,1,0,
+Fall 2022,LAW,5314,1,12994,Lawyering Skills & Strategy I,Gomez,Alissa R,7,13,0,0,0,0,0,3.367
+Fall 2022,LAW,5314,2,12995,Lawyering Skills & Strategy I,Gomez,Alissa R,4,13,0,0,0,0,0,3.371
+Fall 2022,LAW,5314,4,12996,Lawyering Skills & Strategy I,Brantley,Maikieta Antoinette,7,9,0,0,0,0,0,3.396
+Fall 2022,LAW,5314,5,12997,Lawyering Skills & Strategy I,Swift,Kenneth Richard,8,8,1,0,0,0,0,3.392
+Fall 2022,LAW,5314,6,12998,Lawyering Skills & Strategy I,Heard,Whitney W,6,12,1,0,0,0,0,3.246
+Fall 2022,LAW,5314,8,12999,Lawyering Skills & Strategy I,Heard,Whitney W,8,9,1,0,0,0,1,3.389
+Fall 2022,LAW,5314,9,13000,Lawyering Skills & Strategy I,Brantley,Maikieta Antoinette,9,9,0,0,0,0,0,3.408
+Fall 2022,LAW,5314,10,13001,Lawyering Skills & Strategy I,Reed,Hilary S,8,10,0,0,0,0,0,3.389
+Fall 2022,LAW,5314,12,13002,Lawyering Skills & Strategy I,Swift,Kenneth Richard,9,10,1,0,0,0,0,3.4
+Fall 2022,LAW,5314,13,13003,Lawyering Skills & Strategy I,Reed,Hilary S,8,9,1,0,0,0,1,3.389
+Fall 2022,LAW,5314,14,13004,Lawyering Skills & Strategy I,Brem,Katherine B,6,7,1,0,0,0,1,3.381
+Fall 2022,LAW,5314,16,13005,Lawyering Skills & Strategy I,Brem,Katherine B,8,9,1,0,0,0,0,3.389
+Fall 2022,THEA,4345,1,13006,Dramaturgy Practicum,Shimko,Robert B,2,0,0,0,0,0,0,4.0
+Fall 2022,GRET,6336,1,13007,Global Retail Analysis,Johnson,Olivia,1,4,3,2,0,0,1,2.4
+Fall 2022,GRET,6332,1,13008,Consumer Issues and Apps.,Stewart,Barbara L,7,2,0,0,1,0,0,3.301
+Fall 2022,GRET,6334,1,13010,Global E-Tailing Systems,Ezell,Shirley D,10,0,1,0,0,0,0,3.818
+Fall 2022,ARLD,6310,1,13011,Fundraising for the Arts,Hays,Carolyn Jane,5,5,1,0,0,0,0,3.274
+Fall 2022,FORE,6331,20,13012,Social Change,Frewen-Wuellner PhD,Cynthia S,19,7,0,0,0,0,2,3.705
+Fall 2022,FORE,6351,20,13013,Futures Research,Hines,Andrew Lewis,17,1,0,0,0,0,0,3.926
+Fall 2022,ENGL,1301,131,13014,First Year Writing I,Rajkumar,Nidhi,11,7,0,1,5,0,1,2.709
+Fall 2022,ENGI,1100,2,13015,Introduction To Engineering,Kowal,Marsha Christine,16,5,3,0,0,0,1,3.487
+Fall 2022,ENGI,1100,3,13016,Introduction To Engineering,Landon,Alexandra Maley,20,3,2,0,0,0,1,3.694
+Fall 2022,KIN,1352,1,13017,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,228,19,14,4,3,0,0,3.706
+Fall 2022,KIN,1352,2,13018,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,223,21,5,1,5,0,3,3.758
+Fall 2022,KIN,1352,3,13019,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,210,27,10,5,3,0,3,3.654
+Fall 2022,PHYS,8399,40,13029,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,2,0,
+Fall 2022,MUSI,6106,3,13036,Grad Large Ensemble,Weber,Mary E,2,0,0,0,0,0,0,3.835
+Fall 2022,SOC,6399,9,13037,Masters Thesis,Katz,Sheila,2,0,0,0,0,0,0,4.0
+Fall 2022,SOC,6302,1,13038,Research and Writing,Baumle,Amanda K,8,2,0,0,0,0,0,3.668
+Fall 2022,PHYS,6303,1,13039,Methods of Math Physics I,Weglein,Arthur B,18,5,1,0,1,0,0,3.6
+Fall 2022,FINA,4326,1,13042,Private Equity & Inv. Banking,Stewart,Marcus,16,14,1,0,0,0,2,3.473
+Fall 2022,MUSI,8296,5,13043,Doctoral Essay,Bertagnolli,Paul A,0,0,0,0,0,2,0,
+Fall 2022,HRD,4344,1,13044,Designing E-Learning,Bennett,LaTasha,47,6,0,1,1,0,0,3.722
+Fall 2022,POLS,8999,19,13046,Doctoral Dissertation,Chatagnier,John Tyson,1,0,0,0,0,2,0,4.0
+Fall 2022,COMD,6261,1,13047,Research and Critical Thinking,Blake,Margaret T,7,13,2,1,0,0,0,3.173
+Fall 2022,HIST,8688,1,13051,Dissertation Proposal,Clavin,Matthew J,0,0,0,0,0,0,0,
+Fall 2022,ENGL,1301,132,13058,First Year Writing I,Rajkumar,Nidhi,9,7,0,4,5,0,0,2.466
+Fall 2022,ENGL,1301,133,13059,First Year Writing I,Stewart-Steele,Heather Marie,5,14,1,0,1,0,4,2.938
+Fall 2022,ENGL,1302,32,13060,First Year Writing II,Shepley,Nathan,5,8,3,2,0,0,1,2.852
+Fall 2022,MARK,4396,1,13063,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,11,1,
+Fall 2022,POLS,8999,22,13076,Doctoral Dissertation,Kennedy,Ryan P,0,0,0,0,0,1,0,
+Fall 2022,POLS,8999,24,13077,Doctoral Dissertation,Marinov,Nikolay,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8999,5,13079,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,0,0,
+Fall 2022,HIST,8999,6,13083,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,1,0,
+Fall 2022,GOVT,2305,8,13084,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,58,93,50,34,6,0,7,2.654
+Fall 2022,POLS,8399,20,13086,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,1,0,
+Fall 2022,POLS,8699,6,13088,Doctoral Dissertation,Rottinghaus,Brandon J,0,0,0,0,0,1,0,
+Fall 2022,SPAN,8699,6,13090,Dissertation,Kanellos,Nicolas,0,0,0,0,0,0,0,
+Fall 2022,CHEM,6698,20,13091,Special Problems,Bittner,Eric R,0,0,0,0,0,1,0,
+Fall 2022,THEA,7221,1,13094,Graduate Voice I,Johnson,James B,7,0,0,0,0,0,0,4.0
+Fall 2022,THEA,7251,1,13095,Graduate Speech I,Wetzel,Molly Elizabeth,6,1,0,0,0,0,0,3.857
+Fall 2022,THEA,7211,1,13096,Graduate Movement I,Noble,Adam S,5,2,0,0,0,0,0,3.62
+Fall 2022,IRW,1300,1,13100,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,58,0,
+Fall 2022,IRW,1300,2,13101,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,54,3,
+Fall 2022,POLS,8399,23,13104,Doctoral Dissertation,Clark,Jennifer H,0,0,0,0,0,1,0,
+Fall 2022,MANA,4396,1,13105,Management Internship,Carlin,Barbara A,0,0,0,0,0,8,0,
+Fall 2022,SPAN,8399,9,13106,Dissertation,Goodin-Mayeda,Carrie Elizabeth,0,0,0,0,0,0,0,
+Fall 2022,FINA,4396,1,13108,Finance Internship,Kumar,Praveen,0,0,0,0,0,18,0,
+Fall 2022,BIOE,8298,4,13109,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Fall 2022,POLS,8399,24,13110,Doctoral Dissertation,Zhu,Ling,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,1340,2,13112,Earth Systems,Lytwyn,Jennifer N,36,70,51,24,17,0,16,2.444
+Fall 2022,CHEE,8298,16,13114,Doctoral Research,Robertson,Megan L,0,0,0,0,0,2,0,
+Fall 2022,MATH,8399,31,13117,Doctoral Dissertation,Perepelitsa,Mikhail Antolyevic,1,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8399,8,13119,Doctoral Dissertation,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Fall 2022,MANA,8399,3,13120,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8598,6,13123,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Fall 2022,COMM,6399,2,13126,Masters Thesis,Huang,Yan,0,0,0,0,0,1,0,
+Fall 2022,BIOE,6398,8,13130,Research,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Fall 2022,GOVT,2306,6,13131,US and Texas Const/Politics,Jefferies,Kevin E,100,95,15,16,20,0,3,2.946
+Fall 2022,KIN,3303,1,13133,Sports Communication,Walsh,David W,2,14,11,1,0,0,1,2.595
+Fall 2022,KIN,4302,1,13134,Fitness and Human Sexuality,Alastuey,Lisa L,35,29,28,8,11,0,6,2.553
+Fall 2022,SPAN,3312,1,13135,English/Spanish Translation,Arboleda,Paola,18,4,1,1,0,0,0,3.57
+Fall 2022,MUSI,8106,3,13137,Doctoral Large Ensemble,Weber,Mary E,4,0,0,0,0,0,0,4.0
+Fall 2022,MATH,2318,5,13138,Linear Algebra,Perepelitsa,Mikhail Antolyevic,21,42,24,16,7,0,7,2.44
+Fall 2022,MATH,4331,2,13140,Intro to Real Analysis I,Kalantar,Mehrdad,5,5,1,2,0,0,4,2.975
+Fall 2022,MATH,6312,2,13141,Introduction to Real Analysis,Kalantar,Mehrdad,0,7,0,0,0,0,0,3.047
+Fall 2022,MATH,4377,4,13142,Advanced Linear Algebra I,Haynes,Alan K,10,10,1,1,0,0,2,3.318
+Fall 2022,MATH,6308,4,13143,Advanced Linear Algebra I,Haynes,Alan K,17,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,6398,10,13145,Research,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2022,BIOE,6398,11,13146,Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2022,BIOE,6398,13,13148,Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Fall 2022,CNST,4315,1,13152,Steel Construction,Chang,Chi Chung,13,23,10,2,0,0,0,2.952
+Fall 2022,BIOE,8298,8,13154,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8298,9,13155,Doctoral Research,Larin,Kirill,0,0,0,0,0,6,0,
+Fall 2022,BIOE,8298,10,13156,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8298,11,13157,Doctoral Research,May,Elebeoba E,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8298,12,13158,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8298,13,13159,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,5,0,
+Fall 2022,FINA,3332,4,13160,Prin of Financial Management,Chisholm,Darla,15,22,30,14,9,0,20,2.175
+Fall 2022,NUTR,4349,1,13161,Public Policy in Nutrition,Vollrath,Kirstin,40,55,22,1,1,0,4,3.095
+Fall 2022,BIOE,8398,5,13162,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Fall 2022,BIOE,8398,8,13164,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8398,9,13165,Doctoral Research,Larin,Kirill,0,0,0,0,0,5,0,
+Fall 2022,BIOE,8398,10,13166,Doctoral Research,Majd,Sheereen,0,0,0,0,0,0,0,
+Fall 2022,BIOE,8398,11,13167,Doctoral Research,May,Elebeoba E,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8398,12,13168,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8398,13,13169,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,2,0,
+Fall 2022,PSYC,3339,1,13170,Intro To Clinical Psychology,Szafranski,Derek D,72,18,8,0,0,0,3,3.623
+Fall 2022,PSYC,2301,1,13171,Introduction to Psychology,Agan,Herb W,124,44,17,5,5,0,0,3.373
+Fall 2022,PSYC,2301,2,13172,Introduction to Psychology,Agan,Herb W,139,33,11,2,0,0,3,3.66
+Fall 2022,PSYC,2301,3,13173,Introduction to Psychology,Gehm,Kevan H,49,20,6,0,1,0,3,3.518
+Fall 2022,GEOL,1340,3,13174,Earth Systems,Lytwyn,Jennifer N,46,71,46,21,13,0,15,2.58
+Fall 2022,SCM,4301,2,13175,Logistics Management,Tibodeau,Dale,16,32,22,7,0,0,1,2.727
+Fall 2022,BIOL,4374,2,13176,Cell Biology,Rea,Michael A,48,25,31,17,6,0,10,2.737
+Fall 2022,FORE,6395,1,13177,Master's Project in Foresight,Hines,Andrew Lewis,5,0,0,0,0,0,0,4.0
+Fall 2022,FORE,6398,1,13178,Special Problems in Foresight,Hines,Andrew Lewis,3,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7329,1,13179,Behavioral Finance,Rude,Dale,2,3,1,0,0,0,0,3.222
+Fall 2022,BIOE,8498,11,13184,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8598,8,13188,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,3,0,
+Fall 2022,BIOE,8598,10,13190,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8598,11,13191,Doctoral Research,Majd,Sheereen,0,0,0,0,0,0,0,
+Fall 2022,BIOE,8598,13,13193,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Fall 2022,COMM,6310,1,13194,Mass Comm Theory and Research,Camaj,Lindita,6,2,0,0,0,0,1,3.709
+Fall 2022,FINA,7329,1,13195,Behavioral Finance,Rude,Dale,8,4,0,0,0,0,0,3.612
+Fall 2022,GEOL,3383,1,13196,Remote Sensing,Khan,Shuhab D.,11,9,3,1,2,0,0,2.937
+Fall 2022,GEOL,6325,1,13198,Remote Sensing,Khan,Shuhab D.,4,5,0,0,0,0,0,3.518
+Fall 2022,ACCT,3367,2,13200,Intermediate Accounting I,Gamble,George O,3,8,1,0,0,0,8,3.222
+Fall 2022,HDFS,2320,1,13201,Research Methods in HDFS,Rab,Saira,25,9,1,1,0,0,0,3.556
+Fall 2022,PHYS,1302,2,13202,College Physics II (lecture),Maric,Sladjana,15,18,17,4,7,0,4,2.503
+Fall 2022,PETR,6399,3,13209,Masters Thesis,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2022,PHYS,3315,1,13214,Modern Physics,Das,Mini,6,10,2,0,1,0,4,3.035
+Fall 2022,PETR,6362,1,13215,Reservoir Engineering I,Sakhaee Pour,Ahmad,1,1,0,0,0,0,0,3.5
+Fall 2022,PHYS,3309,1,13216,Intermediate Mechanics,Wood,Lowell T,2,10,7,1,1,0,4,2.555
+Fall 2022,PHYS,4421,1,13217,Elec Devices & Applic,Freelon,Byron Kendall,2,5,0,0,0,0,0,3.239
+Fall 2022,PHYS,6309,1,13218,Advanced Mechanics I,Gunaratne,Gemunu,11,16,2,0,0,0,0,3.344
+Fall 2022,MIS,4477,3,13219,Network & Security Infrastruct,Messinger,Jacob Nelson,27,10,0,0,0,0,0,3.614
+Fall 2022,HDFS,4315,3,13222,Culture and Diversity,Rab,Saira,34,8,3,2,0,0,2,3.546
+Fall 2022,ELED,4312,2,13225,Science in the Elem School II,Domjan,Heather N.,23,1,0,0,0,0,0,3.917
+Fall 2022,ECE,4336,1,13226,Electrical Comp Engr Design II,Pei,Shin-Shem Steven,44,4,0,0,0,0,0,3.827
+Fall 2022,MECE,3345,1,13228,Materials Science,Sun,Li,12,21,18,0,2,0,3,2.711
+Fall 2022,MIS,3370,3,13229,Info Systems Development Tools,Hossain,Nahid,13,14,13,4,3,0,14,2.638
+Fall 2022,MECT,3331,2,13233,Applied Thermodynamics,El Nahas,Medhat A,0,4,9,4,10,0,8,1.125
+Fall 2022,LAW,5383,1,13235,Family Law,Oldham,J Thomas,27,38,0,0,0,4,0,3.375
+Fall 2022,LAW,5418,7,13237,Torts,Mantel,Jessica,20,53,3,0,0,0,0,3.328
+Fall 2022,LAW,5332,1,13238,Patent Law,Michaels,Andrew Charles,13,23,0,0,0,1,0,3.425
+Fall 2022,FINA,4320,4,13239,Investment Management,Vasu,Rajkamal Kamaladevi,14,16,2,0,0,0,1,3.282
+Fall 2022,ENGL,2330,1,13240,Writing Discipline English,Wolfe,Steven R.,8,6,3,0,3,0,0,2.718
+Fall 2022,POLS,3311,1,13241,Intro Compar Politics,Hanna,Tom Leard,27,5,8,0,1,0,4,3.358
+Fall 2022,POLS,3312,1,13242,"Arguments, Data, Politics",Zhou,Hui,16,9,4,4,4,0,1,2.677
+Fall 2022,POLS,3358,1,13243,Judicial Behavior,Badas,Alex,2,8,15,3,4,0,4,2.093
+Fall 2022,CHEM,1311,4,13244,Fundamentals of Chemistry,Guloy,Arnold M,31,43,56,44,53,0,41,1.77
+Fall 2022,SUBS,6320,1,13245,Riser Design,Sun,Li,1,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,3361,1,13246,Behavior: Interventions,Carp,Charlotte Lynn,2,0,0,0,0,0,0,3.835
+Fall 2022,SPEC,4363,2,13247,Instructional Interventions,Rigby-Wills,Hope,6,8,2,1,1,0,1,2.889
+Fall 2022,PSYC,2301,5,13248,Introduction to Psychology,Capuozzo,Kristen Irene,14,11,3,2,0,0,1,3.233
+Fall 2022,PSYC,2301,4,13249,Introduction to Psychology,Capuozzo,Kristen Irene,14,10,5,0,0,0,1,3.344
+Fall 2022,CUIN,3111,4,13250,Educational Tech Elem Teachers,Tran,Hien Thi,20,1,2,0,0,0,0,3.74
+Fall 2022,PHYS,1101,15,13251,College Physics I (lab),Wood,Lowell T,0,18,6,0,0,0,0,2.654
+Fall 2022,PHYS,1101,16,13252,College Physics I (lab),Wood,Lowell T,0,13,2,0,0,0,1,2.779
+Fall 2022,PHYS,1102,10,13253,College Physics II (lab),Wood,Lowell T,2,9,6,1,0,0,3,2.667
+Fall 2022,PHYS,1102,11,13254,College Physics II (lab),Wood,Lowell T,3,9,6,0,0,0,3,2.778
+Fall 2022,INAR,4500,1,13255,Interior Arch Studio VII,Handanovic,Dijana,9,6,1,0,0,0,0,3.335
+Fall 2022,ARCH,3327,1,13257,Technology 3,Vanlandingham,Joshua J,68,42,3,0,1,0,2,3.466
+Fall 2022,GHL,2350,2,13261,Mgmt Principles in Hospitality,Haskell,Rebecca Erin,34,7,4,4,0,0,0,3.361
+Fall 2022,GHL,3341,2,13262,Hospitality Managerial Acct,Johnson,Tucker A,15,5,7,1,0,0,0,3.155
+Fall 2022,PHYS,1102,12,13263,College Physics II (lab),Wood,Lowell T,1,8,6,0,0,0,0,2.667
+Fall 2022,PETR,4301,1,13264,Resvr Character and Modeling,Lee,Kyung Jae,7,4,1,0,0,0,0,3.583
+Fall 2022,PHAR,5683,3,13266,Cardiology,Wanat,Matthew A,4,0,0,0,0,0,0,4.0
+Fall 2022,GHL,2340,1,13268,System of Accts in Hospitality,DeFranco,Agnes L,10,17,9,5,0,0,1,2.756
+Fall 2022,GHL,2340,2,13269,System of Accts in Hospitality,Ramirez,Arlene D,10,13,5,0,4,0,1,2.678
+Fall 2022,PHYS,1302,3,13270,College Physics II (lecture),Portillo Vazquez,Israel,37,29,43,23,5,0,10,2.477
+Fall 2022,MARK,7362,1,13271,Mgmt of Marketing Information,Hui,Kachuen Sam,8,2,0,0,0,0,0,3.8
+Fall 2022,MARK,4338,1,13272,Marketing Research,Hui,Kachuen Sam,13,8,2,0,2,0,2,3.134
+Fall 2022,MECE,4331,1,13273,Design of Machine Elements,Baxevanis,Theocharis,25,43,52,12,0,0,2,2.471
+Fall 2022,MUED,2342,1,13274,Music for Children,Riddle,Mary Colleen,17,1,1,0,1,0,0,3.535
+Fall 2022,MUED,2342,2,13275,Music for Children,Riddle,Mary Colleen,20,0,0,0,0,0,0,3.967
+Fall 2022,DANC,2304,1,13276,Dance Kinesiology,Chapman,Teresa Lynn,4,3,1,0,0,0,0,3.416
+Fall 2022,HDFS,3300,1,13277,Educational Psychology,Conston,Toya,158,0,0,0,0,0,2,3.998
+Fall 2022,TLIM,3340,30,13278,Org Leadership & Supervision,Evans,Gerald S,174,12,4,3,0,0,1,3.793
+Fall 2022,TLIM,3340,2,13279,Org Leadership & Supervision,Evans,Gerald S,134,9,8,0,3,0,4,3.738
+Fall 2022,HLT,3325,1,13280,Medical Terminology,Bloom,Joel A,122,22,2,0,1,0,2,3.731
+Fall 2022,BIOE,4115,1,13282,Intro Bioinstrumentation Lab,Ince,Nuri Firat,18,1,0,0,1,0,0,3.734
+Fall 2022,BIOE,4315,1,13283,Bioinstrumentation,Ince,Nuri Firat,33,7,3,1,1,0,0,3.541
+Fall 2022,BIOE,4335,1,13284,Capstone Design I,Akay PhD,Metin,40,0,0,0,0,0,0,4.0
+Fall 2022,MECT,4188,1,13285,Ethics in Engineering Tech,Bose,Anima B,30,11,0,0,0,0,0,3.659
+Fall 2022,MECT,4188,2,13286,Ethics in Engineering Tech,Bose,Anima B,11,13,1,0,0,0,0,3.347
+Fall 2022,TLIM,4341,2,13287,Production & Service Operation,Lattier,Gregory Jeff,14,19,2,0,0,0,0,3.352
+Fall 2022,TLIM,4342,32,13288,Quality Improvement Methods,O'Kelley,Donna K,23,12,9,1,0,0,3,3.201
+Fall 2022,TLIM,4372,30,13290,Proposal and Project Writing,Thomas,Jamie M,8,11,8,0,2,0,3,2.793
+Fall 2022,ARCH,7600,3,13296,Architecture Design Studio V,Longoria,Rafael R,6,0,0,0,0,0,0,3.78
+Fall 2022,ARLD,6320,1,13298,Financial Management for Arts,Townsend,Justine M,9,2,1,0,0,0,0,3.667
+Fall 2022,ENGL,1301,13,13302,First Year Writing I,Bose,Godhuly,14,4,1,2,2,0,2,3.087
+Fall 2022,ENGL,1301,105,13303,First Year Writing I,Braniger,Leslie,3,11,3,3,0,0,3,2.634
+Fall 2022,COSC,6344,1,13304,Visualization,Chen,Guoning,18,21,1,0,0,0,0,3.392
+Fall 2022,CNST,4335,1,13305,Capital Projects Development,Bolander,Larry A,3,5,0,0,1,0,1,3.037
+Fall 2022,ACCT,3367,3,13306,Intermediate Accounting I,Gamble,George O,3,5,1,0,0,0,1,3.259
+Fall 2022,ARTS,3313,2,13310,Silkscreen,Masterson,Patrick D,13,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,6347,1,13315,Intro Opt Sense & Biophotonics,Larin,Kirill,5,0,1,0,1,0,0,3.19
+Fall 2022,INDE,6333,1,13317,Probability Stat For Engineers,Feng,Qianmei,17,36,8,1,3,0,10,2.995
+Fall 2022,ARTH,7380,1,13318,Graduate Art History Methods I,Tejada,Roberto Jose,6,0,0,0,0,0,0,4.0
+Fall 2022,FORE,6311,20,13321,Introduction to Foresight,Schultz,Wendy L,13,2,0,0,0,0,0,3.889
+Fall 2022,COMM,3320,1,13322,Audio Production,Maratea,Brian Michael,26,0,0,0,0,0,2,4.0
+Fall 2022,BZAN,6310,3,13326,Quant Analysis for Busn Dec,Wiley,Briceon C,9,5,1,0,1,0,1,3.23
+Fall 2022,WGSS,2350,6,13327,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,0,1,2,0,0,0,3.703
+Fall 2022,CHEE,8398,16,13328,Doctoral Research,Robertson,Megan L,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8398,17,13331,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Fall 2022,MATH,8698,2,13334,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Fall 2022,FINA,4380,1,13335,R E Fin & Investment,Adams,James S,10,18,10,0,0,0,2,3.0
+Fall 2022,CUIN,3350,3,13336,Knowing/Learning Science-Math,Segura,Perri F,15,2,0,1,0,0,0,3.612
+Fall 2022,ARTS,3383,1,13337,Digital Fabrication,Scott,Caitlin,6,7,0,1,0,0,0,3.191
+Fall 2022,MUSI,6101,1,13339,Opera Role Performance,Edelson,Lawrence Michael,19,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6140,1,13341,Graduate Recital I,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6140,2,13342,Graduate Recital I,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6142,1,13343,Graduate Recital III,Sonnenberg,Melanie,0,0,0,0,0,0,0,
+Fall 2022,MUSI,4370,1,13344,Art Song Repertoire,Sonnenberg,Melanie,6,0,0,0,0,0,0,3.89
+Fall 2022,MUSI,6340,1,13345,Graduate Music History Review,Caton,Kathryn L.,18,8,1,0,0,0,1,3.569
+Fall 2022,MUSI,6341,1,13346,Graduate Music Theory Review,Koozin,Timothy,10,7,0,0,0,0,1,3.53
+Fall 2022,POLS,4398,10,13350,Independent Study,Aleman,Eduardo,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3400,4,13352,Applied Voice,Evans,Joseph,3,0,0,0,0,0,0,4.0
+Fall 2022,ECON,3370,3,13353,Introduction To Econometrics,Zhivan,Natalia A.,11,6,8,2,2,0,1,2.736
+Fall 2022,ATP,6311,1,13354,Research in Athletic Training,Knoblauch,Mark Alan,11,5,0,0,0,0,0,3.688
+Fall 2022,ATP,6312,1,13355,Therapeutic Intervention 1,Yellen,Joshua B,14,2,0,0,0,0,0,3.875
+Fall 2022,ATP,6192,1,13356,Clinical Experience II,Harrison,Layci,16,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6275,1,13359,Professional Development,Porter,Jason,5,0,0,0,0,0,0,4.0
+Fall 2022,LAW,5314,18,13361,Lawyering Skills & Strategy I,Simpson,Lauren J,7,13,0,0,0,0,0,3.383
+Fall 2022,LAW,5314,22,13362,Lawyering Skills & Strategy I,Simpson,Lauren J,6,11,0,0,0,0,0,3.372
+Fall 2022,CHEE,3399,1,13363,Senior Honors Thesis,Grabow,Lars C,0,0,0,0,0,0,0,
+Fall 2022,MECT,4172,2,13365,Materials Tech Lab,Taylor,Gordon D,11,8,1,1,0,0,0,3.24
+Fall 2022,THEA,7141,1,13368,Grad Direct/Design Collaboratn,Rigdon,Kevin L,6,0,0,0,0,0,0,4.0
+Fall 2022,ARLD,6691,1,13369,Internship in Arts Organizatn,Luks Jacobs,Joel,5,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8303,1,13370,Seminar in Music Theory,Snyder,John L,4,0,0,0,0,0,0,4.0
+Fall 2022,WGSS,2350,8,13376,Intro To Women's Studies,Pegoda,Andrew Joseph,13,5,3,2,3,0,2,2.834
+Fall 2022,CHEM,6698,24,13385,Special Problems,Carrow,Bradley,0,0,0,0,0,4,0,
+Fall 2022,PHYS,1102,13,13386,College Physics II (lab),Wood,Lowell T,2,13,8,1,0,0,0,2.694
+Fall 2022,PHLS,7393,2,13387,Internship and Practicum,Margulis,Milena A,7,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,1106,47,13390,Biol for Science Majors I(Lab),Medrano,Ana I,13,6,3,1,0,0,0,3.333
+Fall 2022,BIOL,1106,48,13391,Biol for Science Majors I(Lab),Medrano,Ana I,7,12,1,0,2,0,0,3.06
+Fall 2022,CHEM,1111,52,13392,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,2,0,0,0,1,3.118
+Fall 2022,CHEM,1111,55,13395,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,11,1,0,0,0,0,3.316
+Fall 2022,CHEM,1112,18,13398,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,2,1,2,0,2,2.686
+Fall 2022,CHEM,1112,19,13399,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,8,4,0,1,0,3,2.755
+Fall 2022,ARCH,1500,17,13401,Design Studio I,Gonzales,Michael A,7,4,1,1,0,0,1,3.232
+Fall 2022,MECT,3118,3,13404,Fluid Mechanic Application Lab,Taylor,Gordon D,2,4,8,0,0,0,0,2.43
+Fall 2022,MECT,3155,3,13405,Strength Materials Lab,Basaran,Burak,18,1,1,0,0,0,0,3.834
+Fall 2022,MATH,8698,3,13412,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Fall 2022,SPAN,6305,1,13414,Teaching Span. for Acquisition,Gellon,Sofia,3,3,0,0,0,0,0,3.61
+Fall 2022,ECON,8363,1,13415,Workshop in Research Methods V,Cubas Norando,German,13,0,0,0,0,0,0,4.0
+Fall 2022,PHIL,1321,2,13416,Logic I,Haaga,Curtis W,39,14,6,11,8,0,20,2.778
+Fall 2022,ECON,8399,3,13417,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,4,0,
+Fall 2022,PHOP,6257,5,13418,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2022,HRD,3340,2,13419,Principles of HRD,Greer,Tomika,21,25,11,3,2,0,2,2.915
+Fall 2022,PEP,8699,1,13422,Doctoral Dissertation,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1301,22,13425,First Year Writing I,Martinez,Jorge,1,10,4,3,4,0,3,2.09
+Fall 2022,ENGL,1301,25,13426,First Year Writing I,Presswood,Phillip Hilliard,20,1,0,0,3,0,0,3.403
+Fall 2022,BIOL,2101,17,13427,Anatomy & Physiology Lab I,Gill,Tejendra,7,13,1,0,0,0,2,3.27
+Fall 2022,BIOL,2101,18,13428,Anatomy & Physiology Lab I,Gill,Tejendra,8,9,4,0,1,0,1,2.955
+Fall 2022,BIOL,2101,19,13429,Anatomy & Physiology Lab I,Gill,Tejendra,5,14,2,0,0,0,3,3.19
+Fall 2022,ECON,8399,2,13434,Doctoral Dissertation,Craig,Steven G,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8598,14,13435,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,2,0,
+Fall 2022,THEA,6294,3,13436,Design and Production Studio,Willson,Paige A,3,0,0,0,0,0,0,4.0
+Fall 2022,THEA,6294,5,13437,Design and Production Studio,Niederer,Barbara,2,0,0,0,0,0,0,3.835
+Fall 2022,THEA,6294,7,13438,Design and Production Studio,Rigdon,Kevin L,3,0,1,0,0,0,0,3.5
+Fall 2022,THEA,6171,1,13439,Techniques and Styles,Niederer,Barbara,3,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8298,17,13442,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,3,0,
+Fall 2022,SOC,7399,8,13445,Masters Thesis,Savage,Scott Vandenburgh,0,0,0,0,0,1,0,
+Fall 2022,HIST,8399,1,13446,Doctoral Dissertation,Clavin,Matthew J,0,0,0,0,0,0,0,
+Fall 2022,HIST,8399,4,13448,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,0,0,
+Fall 2022,ELCS,6301,1,13462,Leadership for Equity,Lopez,Ruth Maria,12,0,1,0,0,0,1,3.821
+Fall 2022,BCHS,3304,3,13465,General Biochemistry I,Scott,Sean-Patrick,30,59,39,7,13,0,12,2.579
+Fall 2022,BIOE,6351,1,13466,Diseases and Biomarkers,Mohan,Chandra,14,0,0,0,0,0,1,3.882
+Fall 2022,BIOE,6350,1,13467,Genomic and Proteomic Engr,Wu,Tianfu,13,0,0,0,0,0,0,4.0
+Fall 2022,SCM,4390,1,13469,Supply Chain Strategy,Smith,Gordon D,9,29,15,1,0,0,0,2.815
+Fall 2022,PETR,4311,1,13471,Petroleum Capstone Project I,Zargar,Zeinab,10,0,0,0,0,0,0,3.868
+Fall 2022,SPAN,3339,1,13472,Span for Global Professions,Zubiate,Maria Laura,14,2,0,0,1,0,0,3.492
+Fall 2022,ARTS,3374,3,13474,Computer Imaging,Shon,Jean Young,11,5,0,0,0,0,1,3.708
+Fall 2022,PETR,7399,2,13477,Masters Thesis,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2022,PETR,7399,3,13478,Masters Thesis,Ehlig-Economides,Christine A.,1,0,0,0,0,0,0,3.67
+Fall 2022,PETR,8298,1,13482,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,2,0,
+Fall 2022,PETR,8399,1,13483,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Fall 2022,PETR,8699,1,13486,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,2,0,
+Fall 2022,CHEM,4365,1,13487,Inorganic Chemistry II,Hoffman,David M,5,8,13,0,0,0,0,2.667
+Fall 2022,PSYC,3350,2,13488,Intro to Cognitive Psychology,Anderson,Jill Annette,1,23,21,1,2,0,0,2.375
+Fall 2022,BIOE,4115,2,13489,Intro Bioinstrumentation Lab,Ince,Nuri Firat,16,2,0,0,0,0,0,3.852
+Fall 2022,GEOL,1147,1,13490,Introductory Meteorology Lab,Rappenglueck,Bernhard,6,8,1,1,0,0,0,3.105
+Fall 2022,CUIN,8341,1,13491,Crit Issues & Research Urb Ed,Cole,Mikel Walker,8,0,0,0,0,0,0,3.918
+Fall 2022,COSC,4351,2,13493,Fundamentals of Software Engr,Singh,Raj Kumar,80,5,0,0,0,0,0,3.941
+Fall 2022,ECE,2100,1,13494,Circuit Analysis Laboratory,Ramachandran,Deepa,21,2,0,0,0,0,2,3.913
+Fall 2022,ECE,2201,1,13495,Circuit Analysis I,Ramachandran,Deepa,10,17,20,9,7,0,5,2.175
+Fall 2022,ECE,3340,1,13496,Numerical Methods for ECE,Li,Xingpeng,15,10,9,1,0,0,2,3.095
+Fall 2022,ECE,3155,1,13497,Electronics Laboratory,Wolfe,John C,56,5,0,0,0,0,2,3.875
+Fall 2022,COMM,2320,1,13498,Fundamentals Media Production,Crowe,Craig Warren,66,12,4,0,2,0,1,3.592
+Fall 2022,COMM,2322,1,13499,Television Production I,Crowe,Craig Warren,12,5,2,0,0,0,1,3.457
+Fall 2022,ECE,6340,1,13500,Interm Electromag Waves,Chen,Jiefu,18,1,0,0,0,0,0,3.895
+Fall 2022,GEOL,3370,1,13501,Mineralogy,Fu,Qi,21,9,14,3,4,0,0,2.752
+Fall 2022,ACCT,2302,3,13504,Prin of Managerial Accounting,Weber,Catherine K,27,20,8,6,1,0,6,3.134
+Fall 2022,ACCT,2302,8,13505,Prin of Managerial Accounting,Weber,Catherine K,27,31,16,2,1,0,3,3.112
+Fall 2022,ACCT,5379,1,13506,Enterprise Risk Management,Neely,Gregory Wayne,1,0,0,0,0,0,0,4.0
+Fall 2022,POLS,3310,2,13507,Intro to Political Theory,Vassiliou,Constantine,5,18,6,2,8,0,5,2.223
+Fall 2022,ENGI,1100,8,13510,Introduction To Engineering,Aksu,Gulin Tulunay,21,21,9,2,3,0,3,2.947
+Fall 2022,PHLS,8393,1,13511,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,9,0,
+Fall 2022,PHLS,8393,3,13512,Doctoral Practicum in Psy,Fein,Rachel,0,0,0,0,0,12,0,
+Fall 2022,AAMS,2300,1,13513,Intro Asian American Studies,Nguyen,An,5,6,0,0,1,0,1,3.139
+Fall 2022,PETR,8198,4,13517,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2022,PETR,8298,4,13521,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2022,PETR,8398,3,13524,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,1,0,
+Fall 2022,PETR,8398,4,13525,Doctoral Research,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Fall 2022,MUSI,4198,2,13531,Research in Chamber Music,Lo,Mann-Wen,8,0,0,0,0,0,0,3.918
+Fall 2022,MUSI,4198,3,13532,Research in Chamber Music,Cho,Eunghee,7,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4198,5,13533,Research in Chamber Music,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2022,SOC,4394,1,13534,Internship in Sociology,Karner,Tracy Xavia,4,1,0,1,0,0,0,3.388
+Fall 2022,ELET,1401,1,13535,Circuit Theory and Lab II,Moges,Mequanint A,8,20,8,1,3,0,0,2.618
+Fall 2022,FINA,4329,1,13538,Life Insurance and Annuities,Hong,James,28,35,2,0,0,0,1,3.415
+Fall 2022,FINA,4343,1,13539,Credit Analysis,Welch III,John Clifton,12,4,0,0,0,0,2,3.729
+Fall 2022,PETR,8598,2,13540,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Fall 2022,PETR,8598,3,13541,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,2,0,
+Fall 2022,PETR,8598,4,13542,Doctoral Research,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Fall 2022,PETR,8399,2,13544,Doctoral Dissertation,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2022,PETR,8399,3,13545,Doctoral Dissertation,Ehlig-Economides,Christine A.,0,0,0,0,0,1,0,
+Fall 2022,PETR,8399,4,13546,Doctoral Dissertation,Farouq-Ali,Syed,0,0,0,0,0,0,0,
+Fall 2022,BCHS,3201,1,13548,Biochemistry I Laboratory,Pattison,Donna,10,9,2,0,1,0,2,3.167
+Fall 2022,BCHS,3201,2,13549,Biochemistry I Laboratory,Pattison,Donna,4,11,2,0,0,0,1,3.079
+Fall 2022,BCHS,3201,4,13551,Biochemistry I Laboratory,Pattison,Donna,6,3,5,0,0,0,2,3.071
+Fall 2022,BCHS,3201,5,13552,Biochemistry I Laboratory,Pattison,Donna,7,9,1,1,0,0,0,3.112
+Fall 2022,BCHS,3201,6,13553,Biochemistry I Laboratory,Pattison,Donna,4,10,3,2,2,0,2,2.509
+Fall 2022,BCHS,3201,7,13554,Biochemistry I Laboratory,Pattison,Donna,6,4,3,0,0,0,0,3.231
+Fall 2022,BCHS,3201,8,13555,Biochemistry I Laboratory,Pattison,Donna,13,6,3,0,2,0,0,3.153
+Fall 2022,BCHS,3201,9,13556,Biochemistry I Laboratory,Pattison,Donna,4,15,1,0,0,0,1,3.167
+Fall 2022,BCHS,3201,10,13557,Biochemistry I Laboratory,Pattison,Donna,6,5,0,1,1,0,3,3.026
+Fall 2022,BIOL,4103,1,13559,Integration Biol Knowledge,Wayne,Chad M,35,17,12,0,2,0,0,3.278
+Fall 2022,BIOL,4103,2,13560,Integration Biol Knowledge,Wayne,Chad M,63,12,6,0,3,0,0,3.603
+Fall 2022,COSC,4353,901,13561,Software Design,Subramaniam,Venkat,8,14,2,0,0,0,1,3.319
+Fall 2022,PETR,8699,4,13564,Doctoral Dissertation,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Fall 2022,PETR,8699,6,13565,Doctoral Dissertation,Hatzignatiou,Dimitrios Georgios,0,0,0,0,0,1,0,
+Fall 2022,COMM,3360,1,13566,Principles of Strategic Comm,Choi,Ho Joon,13,8,3,0,1,0,0,3.293
+Fall 2022,COMM,3360,2,13567,Principles of Strategic Comm,Clark,Thomas R,23,2,2,0,1,0,1,3.643
+Fall 2022,COMM,4360,2,13568,Media Planning & Placement,Tinnel,Jason Wayne,1,6,2,1,0,0,0,2.733
+Fall 2022,COMM,4368,1,13569,Public Relations Campaigns,Paisley,Kimberly A,14,3,0,0,0,0,0,3.785
+Fall 2022,POLS,3348,1,13571,"Left, Right, and Center",McDonald,John Terrence George,15,12,8,6,3,0,1,2.682
+Fall 2022,COSC,3360,1,13572,Operating Systems,Rincon Castro,Carlos Alberto,31,30,18,7,19,0,21,2.429
+Fall 2022,HDCS,3300,3,13573,Org Decisions,Stewart,Quentin K,23,8,4,4,1,0,0,3.167
+Fall 2022,MECE,3363,1,13574,Intro To Fluid Mechanics,Floryan,Daniel,16,33,10,1,0,0,5,3.05
+Fall 2022,ARCH,6359,1,13575,Modern Architecture & Urbanism,Ramaswamy,Deepa,9,15,2,0,0,0,0,3.257
+Fall 2022,ECE,3317,2,13576,Applied Electromagnetic Waves,Long,Stuart A,5,8,3,0,0,0,2,3.146
+Fall 2022,COMD,4489,1,13577,Clinical Procedures,Ivey,Michelle L,23,1,0,0,0,0,0,3.89
+Fall 2022,MARK,3336,1,13578,Introduction to Marketing,Koch,Steven F.,14,10,0,0,0,0,0,3.57
+Fall 2022,MARK,3336,2,13579,Introduction to Marketing,Ahearne,Michael,180,250,79,17,7,0,13,3.075
+Fall 2022,MARK,3336,3,13580,Introduction to Marketing,Koch,Steven F.,67,151,77,22,11,0,12,2.728
+Fall 2022,MARK,3336,4,13581,Introduction to Marketing,Ahearne,Michael,84,144,50,16,11,0,6,2.862
+Fall 2022,HON,3301,3,13582,Readings in Medicine & Society,Liddell,Robert B,16,8,1,0,0,0,1,3.587
+Fall 2022,MATH,1324,1,13584,Finite Math with Applications,Sosa,Moses,142,120,62,36,120,0,104,2.249
+Fall 2022,MATH,1324,2,13585,Finite Math with Applications,Hong,Yuqi,74,110,86,44,70,0,42,2.188
+Fall 2022,MATH,1324,3,13586,Finite Math with Applications,Caglar,Atife,230,148,64,26,48,0,40,2.92
+Fall 2022,MATH,1324,5,13587,Finite Math with Applications,Caglar,Atife,186,168,74,38,52,0,38,2.758
+Fall 2022,MATH,1324,6,13588,Finite Math with Applications,Sosa,Moses,262,132,62,50,42,0,48,2.925
+Fall 2022,MATH,1325,2,13589,Calc for Bus & Social Sciences,Constante,Beatrice,82,60,42,14,32,0,38,2.612
+Fall 2022,MATH,4364,1,13590,Intro to Numerical Analysis,Pan,Tsorng-Whay,25,13,14,0,0,0,3,3.205
+Fall 2022,BUSI,3302,1,13591,Connecting Bauer to Business,Belinne,Jamie King,287,90,37,4,7,0,4,3.52
+Fall 2022,BUSI,3302,2,13592,Connecting Bauer to Business,Belinne,Jamie King,274,96,39,5,7,0,3,3.485
+Fall 2022,COSC,4353,1,13594,Software Design,Alipour,Mohammad Amin,6,8,0,1,0,0,0,3.157
+Fall 2022,COSC,6353,901,13595,Software Design,Subramaniam,Venkat,5,0,0,0,0,0,0,3.802
+Fall 2022,BIOL,4272,1,13596,Cell and Develop Biol Lab,Gifford,Jenifer,21,1,1,0,0,0,0,3.827
+Fall 2022,COMM,3314,1,13597,Intermediate Reporting,Sewing,Joy,4,17,2,0,0,0,1,3.073
+Fall 2022,THEA,4307,1,13599,Intro to Educational Theatre,Chuter,Frank Philip,10,1,2,0,1,0,0,3.334
+Fall 2022,THEA,4305,1,13600,Theatre in Elem & Sec Schools,Chuter,Frank Philip,6,1,0,0,0,0,0,3.716
+Fall 2022,MSCI,1210,4,13601,Introduction to the Army,Thomas,Roland,1,1,1,0,0,0,0,3.11
+Fall 2022,SOCW,8311,1,13602,Research Methods I,Narendorf,Sarah C.,4,1,0,0,0,0,1,3.8
+Fall 2022,MSCI,4398,1,13603,Independent Study,Sanders,Ronyel D,13,0,0,0,0,0,0,3.949
+Fall 2022,BIOL,4272,2,13604,Cell and Develop Biol Lab,Gifford,Jenifer,13,7,4,0,0,0,0,3.293
+Fall 2022,SOCW,8424,1,13605,Statistics and Data Analysis I,Leung,Yuk-Hi Patrick,6,1,0,0,0,0,1,3.857
+Fall 2022,DIGM,3353,32,13606,Visual Communications Tech,Dozier,Devin K,28,8,4,4,8,0,0,2.732
+Fall 2022,COMM,6305,1,13607,Qualitative Research Methods,Harlow,Summer D,13,3,2,0,0,0,1,3.556
+Fall 2022,PSYC,2319,1,13608,Intro to Social Psychology,Fetterman,Adam Kent,18,18,7,1,1,0,0,3.192
+Fall 2022,GHL,1301,1,13609,Hospitality Technology,Morosan,Cristian,17,25,9,1,4,0,3,2.887
+Fall 2022,GHL,1301,2,13610,Hospitality Technology,Lee,Minwoo,19,10,6,2,4,0,2,2.87
+Fall 2022,GHL,2160,1,13611,Professional Development,Doudna,Simone P,63,7,2,0,2,0,5,3.641
+Fall 2022,PSYC,6300,1,13612,Stat for Psy,Mehta,Paras D,12,10,0,0,0,0,0,3.59
+Fall 2022,GHL,8303,1,13614,Multivariate Anal. in Hosp. Ad,Guchait,Priyanko,3,0,0,0,0,0,0,4.0
+Fall 2022,GHL,3348,1,13615,Principles of Hosp Revenue Mgt,Kazemi Zarkouei,Mohammad Sadegh,18,10,5,4,9,0,4,2.5
+Fall 2022,COMD,3381,2,13616,Audiology,Andrews,Chereece N,33,7,0,0,0,0,0,3.858
+Fall 2022,COMD,4489,3,13617,Clinical Procedures,Ermgodts,Katherine Natalie,19,4,1,1,0,0,0,3.627
+Fall 2022,FINA,4351,1,13618,"Derivs II: Frwds, Futrs&Swaps",Rabinovitch,Ramon,12,11,10,1,0,0,3,2.971
+Fall 2022,LAW,5314,23,13619,Lawyering Skills & Strategy I,Simmons,Laurel Ellis Parker,15,18,1,0,0,0,0,3.373
+Fall 2022,LAW,5108,1,13620,Advanced Health Law,Ewer,Michael S,2,2,0,0,0,0,0,3.583
+Fall 2022,LAW,5325,1,13622,National Security Law,Berman,Emily,8,11,0,0,0,0,0,3.386
+Fall 2022,THEA,2383,1,13623,Stage Management II,Bush,Rachel R,2,0,0,0,0,0,0,4.0
+Fall 2022,THEA,3283,1,13624,Stage Management III,Bush,Rachel R,4,1,0,0,0,0,0,3.866
+Fall 2022,LAW,5600,1,13630,Judicial Externship I,Powers,William,0,0,0,0,0,1,0,
+Fall 2022,COMM,4392,1,13632,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,13,0,
+Fall 2022,TLIM,3355,31,13633,Project Management Principles,Chance,Michael Dean,34,13,9,2,4,0,4,3.108
+Fall 2022,CIVE,6111,1,13634,Graduate Seminar,Li,Hongyi,0,0,0,0,0,16,0,
+Fall 2022,MECT,3367,1,13635,Quality Control Technology,Rypien,David V,24,14,2,0,1,0,2,3.544
+Fall 2022,MECT,3342,1,13636,Elements of Plant Design,El Nahas,Medhat A,1,18,7,0,0,0,0,2.782
+Fall 2022,MECT,3358,1,13638,Dynamics of Mechanisms,Basaran,Burak,0,12,24,8,2,0,8,1.993
+Fall 2022,MECT,3365,1,13640,Computer-Aided Design I,El Nahas,Medhat A,1,8,27,8,4,0,1,1.82
+Fall 2022,PHYS,2326,1,13642,University Physics II(lecture),Forrest,Rebecca L,15,22,52,5,6,0,9,2.268
+Fall 2022,PHYS,1101,17,13644,College Physics I (lab),Wood,Lowell T,4,11,8,0,0,0,0,2.754
+Fall 2022,PHYS,1101,18,13645,College Physics I (lab),Wood,Lowell T,1,13,7,0,0,0,1,2.761
+Fall 2022,ENGL,3322,1,13646,Contemporary Novel,Majumder,Auritro,17,8,0,0,1,0,2,3.5
+Fall 2022,PHYS,1102,14,13647,College Physics II (lab),Wood,Lowell T,0,11,4,0,1,0,0,2.542
+Fall 2022,ACCT,2301,12,13649,Prin of Financial Accounting,Goble,Samuel,44,65,39,5,5,0,8,2.957
+Fall 2022,ACCT,3366,1,13650,Financial Reporting Frameworks,Harris,Kathleen L,10,8,7,1,0,0,4,3.051
+Fall 2022,ECE,3457,1,14155,Digital Electronics,Bao,Jiming,61,10,3,2,1,0,1,3.645
+Fall 2022,PETR,2111,1,14157,Petroleum Petrophysics Lab,Myers,Michael Tolbert,3,0,0,0,0,0,0,4.0
+Fall 2022,MECE,3400,1,14158,Intro To Mechanics,Wang,Su Su,5,6,13,0,1,0,8,2.441
+Fall 2022,INDE,2333,4,14160,Engineering Statistics I,Wang,Yaping,19,26,18,1,2,0,4,2.934
+Fall 2022,SPAC,6201,1,14162,Man Systems Integration,Toups,Larry David,16,0,0,0,0,0,0,4.0
+Fall 2022,SPAC,6401,1,14163,Space Systems Tech Studio,Bannova,Olga,6,8,0,0,0,0,0,3.405
+Fall 2022,BIOE,8298,14,14164,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8298,16,14165,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8298,17,14166,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8398,16,14168,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8398,17,14169,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8598,15,14173,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8399,6,14183,Doctoral Dissertation,Al-Ubaidi,Muayyad,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8399,7,14184,Doctoral Dissertation,Francis,Joseph Thachil,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8399,8,14185,Doctoral Dissertation,Gifford,Howard,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8399,9,14186,Doctoral Dissertation,Ince,Nuri Firat,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8399,10,14187,Doctoral Dissertation,Larin,Kirill,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8399,12,14189,Doctoral Dissertation,May,Elebeoba E,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8399,15,14191,Doctoral Dissertation,Romero Ortega,Mario Ignacio,2,0,0,0,0,0,0,3.67
+Fall 2022,BIOE,8699,2,14193,Doctoral Dissertation,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8399,14,14198,Doctoral Dissertation,Palmer,Jeremy,3,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8398,18,14199,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Fall 2022,BIOE,6398,17,14200,Research,Zhang,Yingchun,0,0,0,0,0,2,0,
+Fall 2022,PETR,8598,7,14202,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2022,INDE,3310,1,14203,Quality Control & Improvement,Wang,Yaping,16,9,7,1,0,0,0,3.192
+Fall 2022,CHEE,8598,12,14204,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8298,18,14207,Doctoral Research,Vekilov,Peter,0,0,0,0,0,1,0,
+Fall 2022,ENGI,1331,2,14208,Computing for Engineers,Kota,Venkata Krishna Tulasi,8,10,6,3,7,0,10,2.226
+Fall 2022,ENGI,1331,6,14209,Computing for Engineers,Burleson,Daniel W,18,15,10,2,3,0,11,2.848
+Fall 2022,ENGI,1100,9,14210,Introduction To Engineering,Luna Singh,Jennifer Austin,16,25,13,4,2,0,0,2.861
+Fall 2022,ENGI,1100,11,14211,Introduction To Engineering,Luna Singh,Jennifer Austin,24,19,7,3,4,0,2,2.977
+Fall 2022,ENGI,1100,12,14212,Introduction To Engineering,Metrovich,Brian,27,18,9,1,2,0,2,3.106
+Fall 2022,PETR,8298,7,14214,Doctoral Research,Ehlig-Economides,Christine A.,0,0,0,0,0,1,0,
+Fall 2022,PETR,8399,7,14217,Doctoral Dissertation,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Fall 2022,PETR,8699,7,14218,Doctoral Dissertation,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2022,ENGR,2301,2,14219,Mechanics I,Nakshatrala,Kalyana,12,22,18,0,0,0,2,2.866
+Fall 2022,PETR,4312,1,14220,Petroleum Capstone Project II,Zargar,Zeinab,0,5,0,0,0,0,0,3.264
+Fall 2022,MECE,2334,2,14221,Thermodynamics,Love,Holley Carole,13,23,25,12,0,0,6,2.48
+Fall 2022,MECE,3336,2,14222,Mechanics II,Cescon,Marzia,7,30,33,10,6,0,8,2.191
+Fall 2022,MECE,3369,1,14223,Solid Mechanics,Chen,Tian,41,46,29,12,0,0,7,2.917
+Fall 2022,MECE,3381,1,14224,Finite Elements for Mech Engr,Rao,Jagannatha R,15,17,24,8,2,0,6,2.435
+Fall 2022,ECE,3436,3,14225,Microprocessor Systems,Le,Hung Quang,4,3,1,2,0,0,2,2.834
+Fall 2022,BIOE,3351,1,14227,Introduction to Diseases,Mohan,Chandra,23,1,0,0,0,0,0,3.958
+Fall 2022,CIVE,6355,1,14229,Intro-Dynamics of Structures,Mo,Larry Yi-Lung,13,11,1,0,1,0,0,3.308
+Fall 2022,CIVE,6355,2,14230,Intro-Dynamics of Structures,Mo,Larry Yi-Lung,3,4,1,0,1,0,0,2.852
+Fall 2022,CIVE,6362,1,14231,Water Quality Engineering,Pena Bahamonde,Janire,2,1,0,0,0,0,0,3.777
+Fall 2022,ECE,4339,2,14232,Phy Prin of Solid State Device,Pei,Shin-Shem Steven,8,9,0,0,0,0,0,3.432
+Fall 2022,MECE,3338,1,14234,Dynamic & Control of Mech Syst,Grigoriadis,Karolos,31,39,43,12,12,0,8,2.419
+Fall 2022,MECE,4343,1,14235,Thermal Design,Zhao,Bo,24,65,31,2,0,0,3,2.918
+Fall 2022,CHEE,6335,1,14237,Classicl-Statist Thermo,Palmer,Jeremy,25,10,0,0,0,0,0,3.743
+Fall 2022,CHEE,6333,1,14238,Transport Processes,Karim,Alamgir,20,8,1,0,0,0,0,3.644
+Fall 2022,INDE,3432,1,14239,Manufacturing Processes,Kamrani,Ali K,36,8,1,0,0,0,1,3.638
+Fall 2022,SPAC,6405,1,14241,Advanced Design and Analysis,Bannova,Olga,0,2,0,0,0,0,1,3.33
+Fall 2022,SPAC,7410,1,14242,Master's Project: Space Arch,Bell,Larry S,2,1,0,0,0,0,0,3.447
+Fall 2022,BIOE,8298,18,14243,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8298,22,14247,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8399,16,14252,Doctoral Dissertation,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8399,17,14253,Doctoral Dissertation,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8399,18,14254,Doctoral Dissertation,Zhang,Yingchun,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8399,22,14258,Doctoral Dissertation,Willson,Richard,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8598,18,14265,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8598,19,14266,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8598,20,14267,Doctoral Research,Das,Mini,0,0,0,0,0,3,0,
+Fall 2022,BIOE,8699,11,14274,Doctoral Dissertation,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8699,13,14276,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8699,14,14277,Doctoral Dissertation,Romero Ortega,Mario Ignacio,1,1,0,0,0,0,0,3.5
+Fall 2022,BIOE,8699,15,14278,Doctoral Dissertation,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Fall 2022,CHEE,8399,15,14285,Doctoral Dissertation,Rimer,Jeffrey,0,0,0,0,0,4,0,
+Fall 2022,CHEE,8399,16,14286,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8399,17,14287,Doctoral Dissertation,Varadarajan,Navin,5,0,0,0,0,2,0,4.0
+Fall 2022,CHEE,8399,18,14288,Doctoral Dissertation,Vekilov,Peter,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8399,19,14289,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2022,PETR,3315,1,14297,Introduction to Well Logging,Hathon,Lori A,8,7,3,4,0,0,0,2.864
+Fall 2022,PETR,7399,7,14298,Masters Thesis,Lee,Kyung Jae,1,0,0,0,0,0,0,4.0
+Fall 2022,PETR,7399,8,14299,Masters Thesis,Myers,Michael Tolbert,0,0,0,0,0,2,0,
+Fall 2022,PETR,6398,9,14306,Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2022,ENGI,1100,15,14308,Introduction To Engineering,Aksu,Gulin Tulunay,21,20,10,4,2,0,2,2.942
+Fall 2022,ENGI,1331,3,14309,Computing for Engineers,Kowal,Marsha Christine,6,12,4,2,3,0,17,2.531
+Fall 2022,ENGI,1331,7,14310,Computing for Engineers,Aksu,Gulin Tulunay,13,16,5,2,1,0,8,2.947
+Fall 2022,BIOE,4307,1,14311,Optical Imaging,Larin,Kirill,1,1,0,0,0,0,0,3.5
+Fall 2022,BIOE,6305,1,14313,Brain Machine Interfacing,Francis,Joseph Thachil,2,3,0,1,1,0,0,2.713
+Fall 2022,ENGI,2304,5,14314,Technical Communications,Padilla,Monica Sanchez,14,7,4,0,1,0,3,3.231
+Fall 2022,CHEE,3367,1,14315,Process Modeling and Control,Kaspar,Michael,8,6,5,2,0,0,0,2.874
+Fall 2022,CHEE,3369,1,14316,Chemical Engr Transport Proc,Harold,Michael P,4,6,4,0,1,0,1,2.646
+Fall 2022,CHEE,3466,1,14317,Bio & Physical Chemistry,Vekilov,Peter,6,1,10,1,0,0,1,2.538
+Fall 2022,CHEE,4321,2,14318,Chemical Engineering Design I,Smith,Christopher Michael,32,12,0,0,0,0,0,3.712
+Fall 2022,MECE,4341,1,14319,Mechanical Engr Capstone II,Chang,Christiana,29,21,1,0,0,0,0,3.555
+Fall 2022,ECE,2100,2,14320,Circuit Analysis Laboratory,Pan,Miao,14,0,0,0,0,0,2,3.906
+Fall 2022,ECE,2202,1,14321,Circuit Analysis II,Trombetta,Leonard P,9,12,21,8,7,0,11,2.135
+Fall 2022,ECE,4115,1,14323,Control Systems Laboratory I,Provence,Robert S,18,7,2,0,2,0,2,3.311
+Fall 2022,ECE,4375,1,14324,Automatic Control Systems,Provence,Robert S,9,11,15,0,1,0,2,2.723
+Fall 2022,ECE,4437,2,14326,Embedded Microcomputer Systems,Le,Hung Quang,47,20,5,5,0,0,1,3.347
+Fall 2022,PETR,6332,1,14327,Deterministic Reserves Estimat,Zargar,Zeinab,2,5,0,0,0,0,0,3.286
+Fall 2022,ECE,5335,2,14328,State-Space Control Systems,Ortiz,James Norman,6,6,2,0,0,0,0,3.309
+Fall 2022,ECE,6325,2,14329,State-Space Control Systems,Ortiz,James Norman,7,7,6,3,0,0,1,2.783
+Fall 2022,MECE,2336,1,14330,Mechanics I,Hammami,Farah,8,7,4,3,0,0,1,2.864
+Fall 2022,CHEE,6331,1,14331,Math Mtds in Chem Engr,Mountziaris,Triantafillos John,20,11,0,0,0,0,0,3.592
+Fall 2022,PETR,8298,9,14337,Doctoral Research,Hatzignatiou,Dimitrios Georgios,0,0,0,0,0,1,0,
+Fall 2022,PETR,8398,8,14338,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2022,PETR,8398,9,14339,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,2,0,
+Fall 2022,PETR,8298,10,14345,Doctoral Research,Wong,George K,0,0,0,0,0,2,0,
+Fall 2022,POLC,6313,1,14346,Policy Analysis I: Microecon,Wong,Man Chiu,10,5,0,0,2,0,1,3.216
+Fall 2022,POLC,6316,1,14347,Pol Res III: Adv Quant Mod,Wong,Man Chiu,14,6,0,0,0,0,0,3.667
+Fall 2022,POLC,6331,1,14348,Philosophy and Pub Policy II,Engster,Daniel A,16,5,1,1,1,0,0,3.362
+Fall 2022,POLC,6312,1,14351,Public Finance,Zhu,Ling,9,2,0,0,0,0,0,3.758
+Fall 2022,POLC,6314,1,14352,Pol Res I: Intro to Statistics,Buttorff,Gail J.,8,5,3,0,1,0,1,3.001
+Fall 2022,POLC,6311,2,14353,Leader and Prof Development,Witt,Lawrence A,26,2,0,0,2,0,0,3.656
+Fall 2022,HDFS,2314,1,14355,Human Dev and Interventions,Rab,Saira,138,18,5,0,0,0,2,3.828
+Fall 2022,HDFS,2314,8,14360,Human Dev and Interventions,Dunsmore,Julie C,12,8,7,0,1,0,7,3.001
+Fall 2022,CUIN,8390,4,14362,Doctoral Thesis,McNeil,Sara G,2,0,0,0,0,3,0,4.0
+Fall 2022,CUIN,8390,6,14363,Doctoral Thesis,Hausmann,Robert Carl,0,0,0,0,0,2,0,
+Fall 2022,CUIN,8690,1,14364,Doctoral Thesis,Hausmann,Robert Carl,0,0,0,0,0,2,0,
+Fall 2022,CUIN,8690,2,14365,Doctoral Thesis,McNeil,Sara G,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8699,2,14366,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Fall 2022,PHLS,8393,2,14367,Doctoral Practicum in Psy,Smith,Nathan G,0,0,0,0,0,12,0,
+Fall 2022,CUIN,7358,1,14368,Educ Uses Digital Storytelling,Dogan,Bulent,10,0,1,0,0,0,0,3.788
+Fall 2022,PHLS,8193,1,14369,Internship in Psychology,Allan,Blake A,0,0,0,0,0,8,0,
+Fall 2022,PHLS,8193,2,14370,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,2,0,
+Fall 2022,CUIN,6320,1,14372,Tech in Learning Environments,Dogan,Bulent,17,0,0,0,1,0,0,3.778
+Fall 2022,ELCS,8301,1,14373,Leadership Theory School Admin,Davis,Bradley,2,2,0,0,0,0,0,3.5
+Fall 2022,CUIN,3111,1,14375,Educational Tech Elem Teachers,Tran,Hien Thi,31,1,1,0,0,0,0,3.899
+Fall 2022,CUIN,3302,4,14376,Social Education,Thomas,Dustine J,34,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,4375,5,14377,Classroom Management,Snead,Lauren Oropeza,29,2,0,0,0,0,0,3.935
+Fall 2022,ELED,3320,1,14378,Survey Literature Child Adol,Ely,Lauren,27,0,0,0,0,0,0,4.0
+Fall 2022,ELED,3322,1,14379,Elem Reading Phonics Instructn,Alba,Celeste,14,0,0,1,0,0,0,3.778
+Fall 2022,ELED,4310,1,14380,Reading/Language in Elementary,Tyson,Eleanore S,13,2,0,0,0,0,0,3.867
+Fall 2022,ELED,4312,1,14381,Science in the Elem School II,Bailer,Jill,20,2,0,0,0,0,0,3.894
+Fall 2022,ELED,4314,3,14382,Mathematics in Elem School I,Cutler,Carrie Sybil,22,4,0,0,0,0,0,3.808
+Fall 2022,EDUC,2301,2,14383,Intro to Special Populations,McCormick,Marina,21,20,8,4,7,0,0,2.772
+Fall 2022,EDUC,2301,1,14384,Intro to Special Populations,McKee,Shannon,40,18,7,3,3,0,3,3.226
+Fall 2022,ARED,3305,1,14385,Art in Elementary Schools,Allen,Andrea E,30,0,0,0,0,0,0,3.989
+Fall 2022,ELED,4314,5,14386,Mathematics in Elem School I,Culpepper,Shea Mosley,19,3,3,0,0,0,1,3.6
+Fall 2022,SEDE,7335,1,14387,Literature for Adolescents,Burren,Roni Leigh,7,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8302,1,14388,Research Meth in Psych/Educ,Kim,Han Joe,8,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8371,1,14389,Introduction to Quant Research,Weiland,Travis,5,2,0,0,1,0,0,3.25
+Fall 2022,HLT,4307,2,14390,Research and Eval in Health,Fedor Amador,Theresa Marie,12,18,2,0,0,0,2,3.343
+Fall 2022,PHLS,8241,1,14391,Prof Seminar in School Psych,Margulis,Milena A,3,3,0,0,0,0,0,3.5
+Fall 2022,PHLS,8341,1,14392,Professional Seminar,Allan,Blake A,4,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,7372,1,14393,Expert Teaching Methods,Auzenne-Curl,Chestin,3,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8345,1,14396,CUIN Seminar,Hutchison,Laveria F,8,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8320,1,14397,C&I Doctoral Rsch Sem,Hausmann,Robert Carl,7,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,2314,10,14401,Human Dev and Interventions,Schoger,Kimberly,24,22,8,6,6,0,0,2.768
+Fall 2022,HLT,3301,3,14403,Health Behavior Theories,Correa-Fernandez,Virmarie,37,22,6,1,2,0,1,3.295
+Fall 2022,HLT,3325,2,14404,Medical Terminology,Bloom,Joel A,126,15,3,1,2,0,1,3.719
+Fall 2022,HDFS,3350,1,14405,Observation and Assessment,Schroder,Kathleen Anne,34,6,2,0,2,0,0,3.538
+Fall 2022,HDFS,4316,2,14406,Dynamics of Family Relations,Schroder,Kathleen Anne,31,8,1,0,0,0,0,3.651
+Fall 2022,HDFS,2320,2,14407,Research Methods in HDFS,Rab,Saira,25,6,3,0,2,0,0,3.426
+Fall 2022,HDFS,3317,1,14408,Prenatal and Infant Developmt,Wang,Jennifer L,37,8,1,1,2,0,0,3.497
+Fall 2022,HDFS,3318,1,14409,Human Ecol of Adult Developmt,Schoger,Kimberly,52,7,0,0,0,0,0,3.848
+Fall 2022,HLT,3325,3,14410,Medical Terminology,Burk,Kelly Ann,121,20,6,0,1,0,0,3.697
+Fall 2022,PHLS,8324,2,14411,Multivar Analy in Psy/Educ Res,Fan,Weihua,7,1,0,0,0,0,0,3.834
+Fall 2022,PHLS,6325,2,14412,Theories of Counseling,Lee,Jungeun,7,1,0,0,0,0,0,3.793
+Fall 2022,ELED,4312,3,14413,Science in the Elem School II,Domjan,Heather N.,31,0,0,0,0,0,0,3.989
+Fall 2022,AAMS,2300,2,14414,Intro Asian American Studies,Nguyen,An,8,9,5,0,0,0,2,3.151
+Fall 2022,ELCS,8191,1,14415,Special Field Projects,Shockley,Gerald,9,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,4317,1,14416,Intro to Early Child Dev,Storch,Jill Frenchman,10,17,7,4,3,0,3,2.626
+Fall 2022,CUIN,4303,1,14418,Sec Language Acq,Burgess Monroy,Miguel,26,0,1,0,1,0,0,3.786
+Fall 2022,ELCS,6302,1,14420,Decision Making School Ldrs,Butcher,Keith,5,2,0,0,0,0,0,3.761
+Fall 2022,ELCS,6302,2,14421,Decision Making School Ldrs,Ude,Audra Diane,17,0,0,0,1,0,0,3.686
+Fall 2022,HLT,4310,1,14422,Program Planning for Hlt Prof,Bennett,Kristin C,27,6,1,1,0,0,0,3.563
+Fall 2022,HLT,4310,2,14423,Program Planning for Hlt Prof,Bennett,Kristin C,23,8,1,1,0,0,0,3.526
+Fall 2022,EDUC,2301,3,14426,Intro to Special Populations,Christensen,Caroline,18,12,5,1,0,0,0,3.223
+Fall 2022,CUIN,8999,3,14427,Doctoral Dissertation,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Fall 2022,CUIN,8690,4,14429,Doctoral Thesis,Hutchison,Laveria F,0,0,0,0,0,1,0,
+Fall 2022,ELED,7320,1,14430,Foundations of Literacy Instru,Oliver,Patricia Ann,18,0,1,0,0,0,0,3.825
+Fall 2022,CUIN,8398,6,14431,Independent Study,Li,Miao,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8699,1,14432,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Fall 2022,CUIN,8399,1,14434,Doctoral Dissertation,Zhang,Jie,0,0,0,0,0,1,0,
+Fall 2022,SPEC,6361,1,14436,Behavior: Interventions,Carp,Charlotte Lynn,10,1,0,0,0,0,0,3.789
+Fall 2022,SPEC,6363,1,14437,Instructional Interventions,Rigby-Wills,Hope,12,0,0,0,0,0,0,3.89
+Fall 2022,SPEC,6360,1,14438,Individuals with Disabilities,Rigby-Wills,Hope,6,1,0,0,0,0,0,3.857
+Fall 2022,SPEC,7340,1,14439,Assessment of Acad Achievement,Cole,Jana Belinda,17,0,0,0,0,0,0,4.0
+Fall 2022,EDUC,2301,4,14441,Intro to Special Populations,Rigby-Wills,Hope,38,21,7,5,0,0,3,3.273
+Fall 2022,HLT,4320,2,14442,Admin of Health Services,Markowitz,Eliz,21,16,5,0,0,0,2,3.295
+Fall 2022,CUIN,1350,1,14444,Mathematics for Teachers 1,Burris,Justin T,25,10,3,0,0,0,0,3.509
+Fall 2022,ELED,4314,1,14445,Mathematics in Elem School I,Cutler,Carrie Sybil,19,3,1,0,0,0,0,3.74
+Fall 2022,SEDE,4311,2,14446,Teaching Social Studie Sec Sch,Brower,Samuel Richard,11,3,2,0,0,0,0,3.439
+Fall 2022,ELED,3320,5,14447,Survey Literature Child Adol,Black,Misty Paul,6,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,4375,4,14448,Classroom Management,Snead,Lauren Oropeza,29,1,0,0,0,0,0,3.945
+Fall 2022,ELED,3322,5,14449,Elem Reading Phonics Instructn,Alba,Celeste,19,8,1,0,0,0,0,3.466
+Fall 2022,ELED,3322,6,14450,Elem Reading Phonics Instructn,Alba,Celeste,4,5,0,0,0,0,0,3.444
+Fall 2022,PHLS,6330,2,14451,Human Growth-Developmnt,Whitaker,Rachael Gwin,7,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3312,1,14453,Educational Technology,Hebert,Waneta Suzanne,17,6,0,0,0,0,0,3.653
+Fall 2022,PHLS,8321,1,14455,Struct Equ Mod in Psy/Educ Res,Wiesner,Margit F,6,0,0,0,0,0,0,3.945
+Fall 2022,PHLS,8329,1,14456,Moderation & Mediation Anlysis,Kim,Han Joe,12,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,4341,1,14457,Teaching Math Problem Solving,Mitchell,Morgan Love,21,10,1,0,1,0,0,3.525
+Fall 2022,CUIN,4101,3,14459,Content for Teaching,Ford,Haley Michelle Grimland,47,2,1,1,1,0,1,3.776
+Fall 2022,CUIN,1103,1,14460,Educator Dispositions,Culpepper,Shea Mosley,98,16,4,2,1,0,1,3.645
+Fall 2022,CUIN,8368,1,14461,Curriculum Leadership,McNeil,Sara G,7,1,0,0,0,0,0,3.875
+Fall 2022,PHLS,7193,2,14462,Internship and Practicum,Margulis,Milena A,5,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8312,1,14463,Lab of Practice-Res Meth Devel,Hawkins,Jacqueline McLean,0,0,0,0,0,4,0,
+Fall 2022,ELCS,8312,3,14464,Lab of Practice-Res Meth Devel,Santi,Kristi L,4,2,0,0,2,0,0,2.75
+Fall 2022,ELCS,8311,10,14465,Lab of Practice-Lit Revw Devel,Peters-Hawkins,April,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8340,1,14466,Organizatn & Admin Curriculum,Gillman-Rich,Lynn,9,0,0,0,0,0,1,4.0
+Fall 2022,CUIN,3312,2,14468,Educational Technology,Nguyen,Phuong Thi Mai,24,5,1,0,0,0,0,3.756
+Fall 2022,CUIN,4331,2,14469,Adolescent Literature,Hale,Margaret Ann,27,1,0,0,1,0,0,3.771
+Fall 2022,CUIN,3302,1,14470,Social Education,Thomas,Dustine J,24,1,0,0,0,0,0,3.973
+Fall 2022,CUIN,4375,6,14471,Classroom Management,Snead,Lauren Oropeza,33,4,0,0,0,0,0,3.883
+Fall 2022,CUIN,3111,2,14472,Educational Tech Elem Teachers,Tran,Hien Thi,37,1,0,0,0,0,1,3.948
+Fall 2022,CUIN,8393,3,14473,Adv Internship & Prac,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,3317,2,14475,Prenatal and Infant Developmt,Wang,Jennifer L,36,9,2,0,1,0,2,3.577
+Fall 2022,ELED,3320,4,14477,Survey Literature Child Adol,Tyson,Eleanore S,9,2,0,0,0,0,0,3.848
+Fall 2022,CUIN,8393,6,14478,Adv Internship & Prac,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8199,1,14481,Dissertation,Smith,Bradley,0,0,0,0,0,3,0,
+Fall 2022,CUIN,8398,10,14482,Independent Study,Thomas,Dustine J,0,0,0,0,1,0,0,0.0
+Fall 2022,HLT,4307,3,14483,Research and Eval in Health,Dao,Tam K,16,3,2,5,0,0,1,3.052
+Fall 2022,CUIN,8393,7,14484,Adv Internship & Prac,Lee,Mimi Miyoung,0,0,0,0,0,0,0,
+Fall 2022,CUIN,8399,5,14486,Doctoral Dissertation,Wong,Sissy S,0,0,0,0,0,2,0,
+Fall 2022,CUIN,4350,3,14489,Multiple Teaching Strategies,Ekeoba,Jacqueline Njideka,9,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3351,1,14490,Class Interact Science-Math,Manuel,Mariam A,14,2,2,1,0,0,1,3.596
+Fall 2022,CUST,8375,1,14491,Hist & Phil of Higher Educ,McKinney,Lonnie Lyle,11,2,0,0,0,0,0,3.846
+Fall 2022,ELED,4312,4,14492,Science in the Elem School II,Domjan,Heather N.,26,0,0,0,0,0,1,3.975
+Fall 2022,ELED,4315,1,14494,Mathematics in Elem School II,Cutler,Carrie Sybil,21,3,0,0,0,0,0,3.82
+Fall 2022,ELED,4315,3,14495,Mathematics in Elem School II,Burris,Justin T,21,3,1,0,0,0,0,3.76
+Fall 2022,ELED,4315,4,14496,Mathematics in Elem School II,Burris,Justin T,24,1,1,0,0,0,1,3.847
+Fall 2022,ELED,4320,1,14497,Social Studies Ele Sch,Ford,Haley Michelle Grimland,27,0,0,0,0,0,0,3.988
+Fall 2022,ELED,4320,2,14498,Social Studies Ele Sch,Ford,Haley Michelle Grimland,24,2,0,0,0,0,0,3.91
+Fall 2022,ELED,4320,3,14499,Social Studies Ele Sch,Ford,Haley Michelle Grimland,14,0,1,0,0,0,0,3.867
+Fall 2022,ELED,4310,2,14500,Reading/Language in Elementary,Jerasa,Sarah E,19,1,0,0,0,0,0,3.95
+Fall 2022,SPEC,4364,1,14502,Ed Students Giifts and Talents,Govan,Kordney J,27,2,0,1,0,0,0,3.833
+Fall 2022,SPEC,7341,1,14503,Assessment of Learning Diff,Cole,Jana Belinda,8,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,7394,1,14504,Diagnostician Practicum I,Hassett,Kristen Spring,0,0,0,0,0,6,0,
+Fall 2022,SPEC,7395,1,14505,Diagnostician Practicum II,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Fall 2022,SPEC,8375,2,14506,Research for Special Pops,Santi,Kristi L,4,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,4325,1,14507,Theory to Practice in HDFS,Frankel,Leslie Ann,27,9,2,0,0,0,1,3.667
+Fall 2022,CUIN,4344,1,14508,Teaching Math in Grades 4-8,Weiland,Travis,15,8,2,0,1,0,0,3.334
+Fall 2022,ELCS,8310,1,14509,The Superintendency,Klussmann,Duncan Foster,8,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,7392,1,14510,Internship in Superintendent,Horner,Glenda Sue,5,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,6350,1,14511,School Leadership-Principalshp,Butcher,Keith,15,1,0,0,0,0,0,3.917
+Fall 2022,ELCS,6350,2,14512,School Leadership-Principalshp,Brosnahan,Carla,16,0,0,0,0,0,0,3.979
+Fall 2022,ELCS,6304,1,14513,Law & Policy for School Leader,Simpson,Susan Collins,14,1,0,0,0,0,1,3.867
+Fall 2022,PHLS,6345,2,14514,Atypical Growth & Behavior,Hurt,Kara Marie,14,0,0,0,0,0,0,4.0
+Fall 2022,HLT,3380,1,14515,Culture and Health,Fedor Amador,Theresa Marie,35,18,5,1,0,0,0,3.475
+Fall 2022,HDFS,3350,3,14516,Observation and Assessment,Schroder,Kathleen Anne,30,10,0,1,3,0,1,3.402
+Fall 2022,HDFS,3320,1,14520,Careers in HDFS,Jordan,Erica F,31,5,4,2,3,0,1,3.26
+Fall 2022,PHLS,8306,1,14521,Health Psych Res Prev Interv,Carmack,Chakema,8,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8393,8,14525,Adv Internship & Prac,Alarcon,Jeannette Driscoll,1,0,0,0,0,0,0,4.0
+Fall 2022,EDUC,4511,1,14526,Student Teaching - Elementary,Culpepper,Shea Mosley,116,8,2,0,0,0,2,3.884
+Fall 2022,CUIN,8393,9,14528,Adv Internship & Prac,Cole,Mikel Walker,1,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3350,1,14529,Knowing/Learning Science-Math,McAlister,Leah Yvette,9,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,7347,1,14531,"Sem in Learning, Design & Tech",Dogan,Bulent,23,0,1,0,0,0,0,3.93
+Fall 2022,HDFS,3300,3,14532,Educational Psychology,Kamdar-Sharif,Amber,12,14,2,4,1,0,2,2.93
+Fall 2022,CUIN,7398,1,14533,Independent Study,Brower,Samuel Richard,1,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8398,5,14535,Independent Study,Lee,Mimi Miyoung,2,1,0,0,0,0,1,3.447
+Fall 2022,EDUC,4512,1,14539,Student Teaching - Elementary,Thompson,Amber M,100,8,0,0,0,0,0,3.898
+Fall 2022,CUIN,4331,1,14540,Adolescent Literature,Dokes,Rosa Mack,19,0,0,0,0,0,1,4.0
+Fall 2022,CUIN,3311,1,14541,Methods/Tech in Bilingual Educ,Burgess Monroy,Miguel,14,0,0,0,0,0,0,4.0
+Fall 2022,EDUC,3101,1,14542,Practicum for Preservice Tchrs,Thompson,Amber M,93,6,1,0,0,0,0,3.913
+Fall 2022,CUIN,3333,1,14546,Differentiating Diverse Learn,Dokes,Rosa Mack,16,1,0,0,0,0,0,3.922
+Fall 2022,CUIN,6375,2,14548,Classroom Mgt,Snead,Lauren Oropeza,4,1,0,0,0,0,0,3.602
+Fall 2022,CUIN,6375,3,14549,Classroom Mgt,Snead,Lauren Oropeza,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,7317,1,14551,Cog. & Affective Bases of Beh,Kahn,David Andrew,21,1,0,0,1,0,0,3.797
+Fall 2022,PHLS,6343,1,14552,Ethical Legal Issues in Counsl,Hurt,Kara Marie,17,3,0,0,0,0,0,3.9
+Fall 2022,PHLS,6343,2,14553,Ethical Legal Issues in Counsl,Hurt,Kara Marie,16,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,6311,1,14554,Introduction to Counseling,Lee,Jungeun,10,1,1,0,0,0,0,3.778
+Fall 2022,PHLS,6311,2,14555,Introduction to Counseling,Lee,Jungeun,6,1,0,0,0,0,0,3.763
+Fall 2022,HLT,4303,1,14556,The Obesity Epidemic,Olvera,Norma E,19,29,3,5,4,0,0,2.845
+Fall 2022,EDRS,8381,1,14557,Rsch Mthds in Educ,Hawkins,Jacqueline McLean,7,2,0,0,2,0,0,3.091
+Fall 2022,CUIN,4332,4,14558,Literacy Assess Rdg Writing,Louis,Sarah Lenore,33,2,0,0,0,0,0,3.924
+Fall 2022,ELED,4315,2,14559,Mathematics in Elem School II,Burris,Justin T,31,1,0,0,0,0,0,3.907
+Fall 2022,PHLS,8369,1,14560,Program Evaluation,Gonzalez,Jorge E,7,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8337,2,14561,Multicul Iss Coun Psych,McCain,Morgan,16,3,0,0,0,0,0,3.807
+Fall 2022,CUIN,4375,10,14562,Classroom Management,Mateer,Ramona Caravella,11,0,0,0,0,0,0,4.0
+Fall 2022,HLT,3301,4,14565,Health Behavior Theories,Correa-Fernandez,Virmarie,43,25,1,0,0,0,0,3.585
+Fall 2022,CUIN,4304,3,14566,La/Read Meth in Span,Burgess Monroy,Miguel,18,0,1,0,0,0,0,3.895
+Fall 2022,ELCS,8311,3,14567,Lab of Practice-Lit Revw Devel,Shockley,Gerald,0,0,0,0,0,0,0,
+Fall 2022,ELCS,8311,4,14568,Lab of Practice-Lit Revw Devel,Butcher,Keith,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8311,5,14569,Lab of Practice-Lit Revw Devel,Davis,Bradley,4,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8311,6,14570,Lab of Practice-Lit Revw Devel,Freelon,Rhoda,0,0,0,0,0,4,0,
+Fall 2022,ELCS,8311,9,14573,Lab of Practice-Lit Revw Devel,Lopez,Ruth Maria,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8311,11,14574,Lab of Practice-Lit Revw Devel,Snodgrass Rangel,Virginia Walker,3,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,6320,1,14575,Instructional Supervision,Butcher,Keith,11,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,8375,3,14576,Research for Special Pops,Hawkins,Jacqueline McLean,3,0,0,0,1,0,0,3.0
+Fall 2022,PHLS,6324,1,14577,Addictions Counseling,Lukingbeal,Patrick Livingston,24,0,0,0,0,0,0,3.986
+Fall 2022,PHLS,6324,2,14578,Addictions Counseling,Lukingbeal,Patrick Livingston,15,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,6301,2,14579,Leadership for Equity,Lopez,Ruth Maria,6,0,2,0,0,0,0,3.294
+Fall 2022,ELCS,8399,3,14581,Doctoral Dissertation,McKinney,Lonnie Lyle,1,0,0,0,0,1,0,4.0
+Fall 2022,ELCS,8399,4,14582,Doctoral Dissertation,Zou,Yali,1,0,0,0,0,1,0,4.0
+Fall 2022,ELCS,8699,2,14584,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Fall 2022,SPEC,6340,1,14585,Learning & Education Sciences,Santi,Kristi L,19,3,0,0,1,0,0,3.638
+Fall 2022,EDRS,8380,1,14586,Rsch Mthds in Educ,Johnson PhD,Detra DeVerne,5,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3316,1,14588,Prekindergarten Curr & Instr,Katz,Denise Annette,13,2,0,0,0,0,0,3.911
+Fall 2022,CUIN,3317,1,14589,Kindergarten/Elem Curr & Instr,Edgar,Teresa A,23,7,1,0,0,0,0,3.646
+Fall 2022,CUIN,4315,1,14590,Assessment of Children,Katz,Denise Annette,25,4,1,0,0,0,0,3.789
+Fall 2022,CUIN,8398,1,14591,Independent Study,Alarcon,Jeannette Driscoll,2,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,4315,5,14593,Assessment of Children,Harris,Deborah,8,6,0,0,0,0,0,3.454
+Fall 2022,CUIN,7358,2,14594,Educ Uses Digital Storytelling,Dogan,Bulent,18,0,1,0,0,0,0,3.877
+Fall 2022,PHED,1306,1,14595,Emergency Care & First Aid,Brown,Korey J,31,4,0,0,0,0,0,3.886
+Fall 2022,PHED,1306,3,14596,Emergency Care & First Aid,Monreal,Daniel Joseph,32,3,0,0,0,0,0,3.914
+Fall 2022,PHLS,7193,1,14599,Internship and Practicum,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Fall 2022,CUIN,8303,1,14600,Seminal Thinkers,Santi,Kristi L,7,1,0,0,0,0,1,3.793
+Fall 2022,ELCS,6393,1,14602,Practicum,Klussmann,Duncan Foster,16,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8393,10,14604,Adv Internship & Prac,Chung,Sheng Kuan,1,0,0,0,0,0,0,4.0
+Fall 2022,HLT,4310,3,14605,Program Planning for Hlt Prof,Behjat,Amirmohsen,3,8,14,2,1,0,3,2.334
+Fall 2022,CUIN,8699,9,14608,Doctoral Dissertation,Li,Miao,1,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8399,6,14609,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,1,0,
+Fall 2022,PHLS,8999,1,14615,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,
+Fall 2022,ELCS,6393,2,14616,Practicum,Klussmann,Duncan Foster,17,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,2314,14,14617,Human Dev and Interventions,Fernandez,Elaine C,53,11,8,1,2,0,0,3.419
+Fall 2022,CUIN,6380,1,14622,Teaching Young Children,Phipps,Stephanie,6,4,0,0,0,0,0,3.6
+Fall 2022,CUIN,1350,2,14624,Mathematics for Teachers 1,Burris,Justin T,9,9,2,0,1,0,1,3.175
+Fall 2022,CUIN,6318,1,14625,Approaches in 2nd Lang Teach,Burgess Monroy,Miguel,5,0,0,0,0,0,0,4.0
+Fall 2022,SAER,8321,1,14626,Survey Mthds in Educ,Zhang,Jie,7,0,0,0,0,0,0,3.953
+Fall 2022,CUIN,7366,1,14627,Sci instruct in Middle Grades,Rodriguez,Alberto J,18,1,2,0,1,0,0,3.591
+Fall 2022,CUIN,2300,1,14628,Introduction to STEM Teaching,Campos,Amanda Renee,7,1,1,0,0,0,0,3.63
+Fall 2022,CUIN,2300,2,14629,Introduction to STEM Teaching,Manuel,Mariam A,21,0,0,0,0,0,1,4.0
+Fall 2022,CUIN,2300,3,14630,Introduction to STEM Teaching,Segura,Perri F,12,2,0,0,1,0,2,3.468
+Fall 2022,CUIN,2300,4,14631,Introduction to STEM Teaching,Manuel,Mariam A,17,4,1,0,0,0,2,3.787
+Fall 2022,CUIN,4332,9,14632,Literacy Assess Rdg Writing,Reis,Nancy,14,1,0,0,0,0,0,3.933
+Fall 2022,CUIN,4332,5,14633,Literacy Assess Rdg Writing,Ely,Lauren,28,1,0,0,0,0,0,3.954
+Fall 2022,CUIN,4332,7,14635,Literacy Assess Rdg Writing,Reis,Nancy,22,1,2,0,0,0,0,3.734
+Fall 2022,CUIN,3302,2,14636,Social Education,Thomas,Dustine J,30,1,0,0,0,0,0,3.978
+Fall 2022,CUIN,3316,2,14637,Prekindergarten Curr & Instr,Katz,Denise Annette,30,4,1,0,0,0,0,3.838
+Fall 2022,CUIN,3316,3,14638,Prekindergarten Curr & Instr,Katz,Denise Annette,31,5,1,1,0,0,0,3.685
+Fall 2022,CUIN,3316,4,14639,Prekindergarten Curr & Instr,Siller Escudero,Patricia,8,1,0,0,0,0,0,3.742
+Fall 2022,CUIN,3317,2,14640,Kindergarten/Elem Curr & Instr,Edgar,Teresa A,24,4,0,0,0,0,0,3.81
+Fall 2022,CUIN,3317,3,14641,Kindergarten/Elem Curr & Instr,Edgar,Teresa A,15,5,1,0,0,0,0,3.525
+Fall 2022,CUIN,3317,4,14642,Kindergarten/Elem Curr & Instr,Nurre,Irma Linda,11,3,0,0,0,0,0,3.668
+Fall 2022,CUIN,3347,2,14643,Reading in the Content Area,Morris,Alana,33,6,1,0,1,0,0,3.595
+Fall 2022,CUIN,4315,2,14645,Assessment of Children,Edgar,Teresa A,23,6,0,0,0,0,0,3.782
+Fall 2022,CUIN,4315,3,14646,Assessment of Children,Wilson,Jahnette,12,8,1,0,0,0,0,3.508
+Fall 2022,CUIN,4361,3,14648,Second Language Methodology,Leon,Maredil Josefina,10,6,4,0,0,0,1,3.218
+Fall 2022,CUIN,4351,1,14649,Develop Proportional Reasoning,Chauvot,Jennifer B,16,3,0,1,0,0,0,3.733
+Fall 2022,CUIN,4375,1,14650,Classroom Management,Thompson,Alan M,8,0,0,0,0,0,0,4.0
+Fall 2022,ARED,2310,1,14652,Intro Critical Visual Culture,Chung,Sheng Kuan,24,1,1,0,1,0,2,3.692
+Fall 2022,SPEC,2350,1,14658,RBT Training,Carp,Charlotte Lynn,7,1,0,0,1,0,0,3.408
+Fall 2022,SPEC,6349,1,14659,Intro to Educ of Gifted/Talent,Carp,Charlotte Lynn,3,0,0,0,1,0,0,3.0
+Fall 2022,EDRS,8382,1,14665,Statistical Analyses in Eductn,Davis,Bradley,7,2,1,0,0,0,0,3.6
+Fall 2022,ELCS,8356,1,14666,Program Policy Evaluation,Causey,Ashley,6,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4198,1,14668,Research in Chamber Music,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,3366,2,14671,Financial Reporting Frameworks,Harris,Kathleen L,24,9,7,3,3,0,3,3.036
+Fall 2022,ACCT,4331,1,14673,Federal Income Tax-Individual,Meade,Janet,3,5,14,13,1,0,8,1.825
+Fall 2022,MARK,4389,6,14674,Marketing Strategy & Planning,Muschalik,Monica Harper,24,5,0,0,0,0,0,3.702
+Fall 2022,TLIM,3363,1,14676,Technical Communications,Piercy,Penelope Junker,30,16,5,2,2,0,5,3.231
+Fall 2022,TLIM,3363,2,14678,Technical Communications,Piercy,Penelope Junker,33,10,6,3,7,0,1,2.95
+Fall 2022,BTEC,3317,30,14680,Biotech Regulatory Environment,Flavier,Albert B,16,23,11,5,2,0,4,2.738
+Fall 2022,BTEC,3301,30,14681,Genomics/Proteomics & Bioinfo.,Flavier,Albert B,13,13,13,5,0,0,4,2.758
+Fall 2022,BTEC,3321,30,14682,Good Manufacturing Practices,Gerwin,Ashley Sarah,15,16,2,2,1,0,1,3.148
+Fall 2022,BTEC,4350,30,14683,Biotech Capstone Experience,Khan,Abdul Latif,26,2,0,0,0,0,0,3.917
+Fall 2022,ELET,2301,1,14684,Poly-Phase Circuits & Trans,Fan,Lei,4,12,7,2,1,0,0,2.539
+Fall 2022,ELET,2305,1,14685,Semicond Devices & Circuits,Talusani,Pratap Reddy,18,17,2,0,1,0,0,3.368
+Fall 2022,ENTR,7339,1,14686,Venture Fund,Rassin,Keith David,8,0,0,0,0,0,0,4.0
+Fall 2022,MARK,4376,1,14687,Sales CRM,Suki,Yara D,24,4,0,0,0,0,0,3.822
+Fall 2022,MARK,4376,2,14688,Sales CRM,Suki,Yara D,26,3,1,0,0,0,1,3.789
+Fall 2022,ELET,3301,1,14691,Linear Systems Analysis,Barbieri,Enrique,2,0,23,6,5,0,3,1.603
+Fall 2022,PHAR,5691,2,14692,Drug Information,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5646,1,14694,Medication Safety,Truong,Mabel,5,0,0,0,0,0,0,4.0
+Fall 2022,SGNL,1301,6,14695,Elementary Sign Language I,Brittain,Terrell,4,6,6,0,2,0,3,2.519
+Fall 2022,BUSI,4335,1,14696,Brainstorming to Bankrolling,Khumawala,Saleha B,3,2,0,0,0,0,0,3.6
+Fall 2022,GENB,7334,1,14697,Brainstorming to Bankrolling,Khumawala,Saleha B,3,0,0,0,0,0,0,3.89
+Fall 2022,MATH,2318,1,14698,Linear Algebra,Cappanera,Loic,37,20,13,5,2,0,2,3.044
+Fall 2022,MECT,3318,1,14699,Fluid Mechanics Applications,Alba,Kamran,3,15,7,11,10,0,8,1.79
+Fall 2022,MECT,3355,1,14700,Strength of Materials,Basaran,Burak,0,5,5,3,9,0,1,1.138
+Fall 2022,MATH,1332,4,14703,Contemporary Mathematics,Namakforoosh,Navid,28,24,6,10,8,0,9,2.693
+Fall 2022,LAW,5339,1,14706,Trusts and Wills,Tamborello,Gus Gerard,13,34,3,0,0,0,0,3.193
+Fall 2022,ENGL,3327,1,14707,Masterpieces of British Lit I,Mazella,David S,18,6,0,0,2,0,2,3.487
+Fall 2022,MECT,1330,4,14708,Engineering Graphics,Fan,Zheng,4,3,0,1,1,0,0,2.742
+Fall 2022,ARCH,4510,7,14709,Integrated Arch Solutions,Tucker de Vazquez,Sheryl,10,4,1,0,0,0,0,3.512
+Fall 2022,ARCH,2500,3,14711,Arc/Int Arc Design Studio III,Lee,Seo Hee,3,6,2,1,0,0,3,2.917
+Fall 2022,CNST,3265,1,14713,Construction Layout & Site Dvp,Moghaddam,Hassan,4,14,19,1,0,0,1,2.553
+Fall 2022,ACCT,5376,1,14714,Adv Fin Statement Auditing,Zhao,Yuping,4,1,2,0,0,0,0,3.333
+Fall 2022,WGSS,3350,1,14715,Feminist Theory,Gregory,Elizabeth,12,5,0,0,0,0,0,3.589
+Fall 2022,HDCS,4393,1,14717,Internship in RCS,Ezell,Shirley D,17,4,2,0,0,0,0,3.652
+Fall 2022,SOCW,8999,1,14719,Dissertation,Leung,Yuk-Hi Patrick,2,0,0,0,0,0,0,4.0
+Fall 2022,CNST,3205,1,14720,Construction Safety Management,Hart,Lee J,40,6,1,0,1,0,1,3.75
+Fall 2022,CNST,3331,1,14722,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,25,26,6,0,0,0,1,3.333
+Fall 2022,CNST,3355,1,14723,Strength of Construction Mtrls,Senouci,Ahmed,28,24,24,2,7,0,1,2.753
+Fall 2022,CNST,3351,1,14724,Construction Estimating II,Siddiqui,Muhammad Ali,33,17,4,1,0,0,2,3.473
+Fall 2022,CNST,3365,1,14725,Cost Estimating Capital Projec,Glumac,Carmel,5,7,4,1,1,0,2,2.814
+Fall 2022,CNST,3372,1,14726,Soil Mechanics & Foundations,Meyer,Joseph Ray,29,19,11,3,1,0,0,3.164
+Fall 2022,ATP,7311,1,14727,Human Performance,Knoblauch,Mark Alan,8,6,1,0,0,0,0,3.467
+Fall 2022,DANC,2303,2,14728,Introduction to Dance,Bobet,Jacqueline A,48,20,6,4,22,0,18,2.588
+Fall 2022,RELS,3370,1,14730,The Bible and Modern Science,Ott,Aaron Frederick,16,6,3,0,7,0,7,2.668
+Fall 2022,TECH,3365,3,14732,Appl of Discrete Mthds in Tech,Telles,John E,10,7,5,4,3,0,1,2.598
+Fall 2022,GHL,8310,1,14733,Teaching Methods in Hosp. Adm.,DeFranco,Agnes L,3,0,0,0,0,0,0,3.89
+Fall 2022,ARCH,6A48,1,14734,Environmental Technology 3,Kyropoulou,Amygdalia,15,11,1,0,0,0,0,3.457
+Fall 2022,ARCH,6A20,1,14735,Environmental Technology 1,Kyropoulou,Amygdalia,8,3,0,0,0,0,0,3.727
+Fall 2022,ARCH,6A50,1,14736,Construction Technology 3,Thaddeus,David,14,9,3,0,0,0,0,3.258
+Fall 2022,ARCH,6A22,1,14737,Construction Technology I,Thaddeus,David,8,3,0,0,0,0,0,3.517
+Fall 2022,NAVY,1301,1,14738,Naval Orientation,Winters,Adam W,4,0,0,0,0,0,1,4.0
+Fall 2022,NAVY,2302,1,14740,Naval Engineering-Ship Sys I,Konoza,Emily M,1,0,0,0,0,0,0,4.0
+Fall 2022,LATI,1301,4,14741,Elementary Latin I,Behr,Francesca D.,11,5,2,0,2,0,7,3.15
+Fall 2022,DRAM,1310,20,14742,Introduction to Theatre,Brincks,Alan,34,9,4,1,2,0,0,3.4
+Fall 2022,SPAN,2610,1,14743,Intensive Intermediate Spanish,Santos-Guevara,Criseida,3,10,6,0,3,0,1,2.395
+Fall 2022,SPAN,2610,2,14744,Intensive Intermediate Spanish,Romero Jurado,Neysi,5,6,9,0,3,0,0,2.363
+Fall 2022,CHEM,6698,25,14749,Special Problems,Chiang,Naihao,0,0,0,0,0,2,0,
+Fall 2022,BTEC,6304,30,14751,Computational Methods in BTEC,Balan,Venkatesh,4,2,0,0,0,0,0,3.612
+Fall 2022,BTEC,6302,30,14752,Intro to Regulatory Affairs,Flavier,Albert B,4,1,1,0,0,0,0,3.445
+Fall 2022,DANC,1309,1,14753,Dance Production,Valle,Toni Leago,5,3,2,0,0,0,0,3.267
+Fall 2022,ATP,7195,1,14754,Clinical Experience 5,Knoblauch,Mark Alan,13,2,0,0,0,0,0,3.867
+Fall 2022,ATP,7312,1,14755,Therapeutic Intervention 2,Yellen,Joshua B,13,2,0,0,0,0,0,3.867
+Fall 2022,ARTS,3304,2,14757,Intermediate Painting,Frankfort,Dana M,18,1,0,0,0,0,1,3.93
+Fall 2022,COMM,6399,3,14758,Masters Thesis,Liu,Wenlin,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,7399,1,14759,Masters Thesis,Olson,Beth M,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6338,1,14760,Fndtns of Social Psyc,Derrick,Jaye L,21,0,0,0,0,0,0,3.796
+Fall 2022,CHEM,8998,21,14761,Doctoral Research,Do,Loi H,0,0,0,0,0,1,0,
+Fall 2022,SCM,4390,2,14772,Supply Chain Strategy,Smith,Gordon D,11,25,6,0,0,0,1,3.111
+Fall 2022,ENGL,1302,6,14774,First Year Writing II,Wolfe,Steven R.,6,4,4,1,1,0,3,2.813
+Fall 2022,ENGL,1302,7,14775,First Year Writing II,Long,Steven A.,12,4,2,1,0,0,0,3.421
+Fall 2022,ENGL,1302,8,14776,First Year Writing II,Kozma,Andrew,14,5,0,1,0,0,3,3.551
+Fall 2022,ENGL,1302,9,14777,First Year Writing II,Kozma,Andrew,12,6,2,2,1,0,0,3.13
+Fall 2022,PHYS,3396,1,14779,Senior Research Project,Ratti,Claudia,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,8998,22,14780,Doctoral Research,May,Jeremy A,0,0,0,0,0,3,0,
+Fall 2022,MATH,8698,6,14781,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Fall 2022,CNST,6335,1,14782,Intro to Oil and Gas Industry,Ritchie Jr,Earl James,25,4,3,0,0,0,3,3.43
+Fall 2022,MATH,8698,7,14783,Doctoral Research,Josic,Kresimir,0,0,0,0,0,1,0,
+Fall 2022,ACCT,2301,13,14784,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,18,28,9,2,2,0,4,3.095
+Fall 2022,ENGL,1301,112,14786,First Year Writing I,Anderson,Claire F,11,4,2,0,1,0,2,3.297
+Fall 2022,ENGL,1301,113,14787,First Year Writing I,Kroger,Ann Gabriel,12,5,0,0,3,0,0,3.101
+Fall 2022,ENGL,3301,1,14788,Intro To Literary Studies,Yang,Sunny Chen,17,2,0,0,0,0,1,3.808
+Fall 2022,CHEM,1111,61,14789,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,16,1,0,0,0,1,3.07
+Fall 2022,CHEM,1111,62,14790,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,1,0,0,0,2,3.059
+Fall 2022,CHEM,1111,63,14791,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,9,1,0,0,0,3,3.372
+Fall 2022,CHEM,1111,64,14792,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,3,2,0,0,0,2.877
+Fall 2022,CHEM,1111,65,14793,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,1,1,0,0,2,3.157
+Fall 2022,CHEM,1111,67,14795,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,2,0,0,0,3,3.313
+Fall 2022,CHEM,1111,69,14797,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,10,0,1,0,0,2,3.223
+Fall 2022,CHEM,1111,70,14798,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,3,0,0,0,2,3.098
+Fall 2022,CHEM,1111,71,14799,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,11,2,0,2,0,0,2.817
+Fall 2022,PSYC,4344,4,14801,Cultural Psychology,Martinez,Anjelica M,48,12,6,6,5,0,2,3.178
+Fall 2022,BIOL,1306,50,14802,Biology for Science Majors I,Cheek,Ann Oliver,12,6,13,1,0,0,2,2.958
+Fall 2022,AAS,3348,1,14803,African Americans and the Law,Putman,Eronn A,9,10,1,0,0,0,0,3.334
+Fall 2022,PHOP,6243,1,14806,Vision Science Core-Part 3,Frishman,Laura J,5,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2319,2,14815,Intro to Social Psychology,Osika,Matylda Maria,16,34,6,4,3,0,6,2.81
+Fall 2022,PHLA,6100,1,14816,Leadership Seminar,Varkey,Divya A,14,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,2101,20,14823,Anatomy & Physiology Lab I,Gill,Tejendra,6,12,1,1,1,0,2,2.89
+Fall 2022,ELET,2300,4,14826,Introductn To C++ Programming,Tsegaye,Mikias,49,12,2,0,6,0,4,3.42
+Fall 2022,CHEM,1111,73,14827,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,15,0,1,0,0,0,3.216
+Fall 2022,CHEM,1111,74,14828,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,4,4,0,0,0,4,3.112
+Fall 2022,CHEM,1111,75,14829,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,1,3,0,0,1,2.964
+Fall 2022,CHEM,1111,76,14830,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,1,0,0,0,1,3.228
+Fall 2022,MATH,8698,8,14832,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,2,0,
+Fall 2022,CHEM,2123,26,14834,Organic Chemistry Lab I,Bean,Mary B,3,7,5,3,0,0,1,2.482
+Fall 2022,CHEM,2123,27,14835,Organic Chemistry Lab I,Bean,Mary B,4,5,6,0,1,0,3,2.523
+Fall 2022,POLS,8399,12,14839,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,1,0,
+Fall 2022,CIS,3343,3,14840,Info Systems Analysis & Design,Faiyaz,Sajida,3,23,15,0,0,0,1,2.691
+Fall 2022,TLIM,4341,32,14845,Production & Service Operation,Lattier,Gregory Jeff,25,12,1,1,4,0,3,3.233
+Fall 2022,ENGL,1302,11,14848,First Year Writing II,Sicinski,Michael J,9,6,0,0,3,0,6,2.945
+Fall 2022,MATH,8698,9,14849,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,3,0,
+Fall 2022,MATH,8698,10,14850,Doctoral Research,Cappanera,Loic,0,0,0,0,0,1,0,
+Fall 2022,CNST,3301,1,14851,Constructn Equipment & Methods,Al-Nahhas,Amer Faisal,23,28,25,10,9,0,1,2.484
+Fall 2022,CHEM,8999,20,14852,Doctoral Dissertation,Comito,Robert Joseph,0,0,0,0,0,5,0,
+Fall 2022,MATH,6315,6,14854,Masters Tutorial,Morgan,Jeffrey,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1300,8,14855,Applied Voice,Jones,Timothy J,1,1,0,0,0,0,0,3.665
+Fall 2022,SPAN,8699,8,14858,Dissertation,Goodin-Mayeda,Carrie Elizabeth,0,0,0,0,0,0,0,
+Fall 2022,MATH,8698,11,14859,Doctoral Research,Mang,Andreas,0,0,0,0,0,3,0,
+Fall 2022,PHAR,5681,5,14865,Infectious Diseases,Tam,Vincent H,0,2,0,0,0,0,0,3.0
+Fall 2022,MAS,2340,2,14868,Intro Mexican American Studies,Pino,Diana,16,16,3,2,6,0,1,2.714
+Fall 2022,ARTS,2326,3,14869,Fundamentals of Sculpture,Martinez,Catherine Ruth,10,1,0,0,1,0,0,3.501
+Fall 2022,PHIL,1305,2,14873,Intro To Ethics,Coates,Daniel J,128,50,21,6,4,0,3,3.437
+Fall 2022,DIGM,3354,30,14874,Video Production 1,Snyder,Philip Charles,43,25,10,4,7,0,4,3.03
+Fall 2022,COMM,2328,2,14878,Broadcast Writing Basics,Trigg,Katishia Leonna,3,4,4,0,0,0,3,2.849
+Fall 2022,COMM,2370,1,14879,Introduction to Motion Picture,Houk,Keith R,21,4,0,0,4,0,1,3.276
+Fall 2022,COMM,3316,1,14881,Electronic News,Perez,Felicia Russell,8,1,2,0,0,0,1,3.395
+Fall 2022,COMM,3316,2,14882,Electronic News,Perez,Felicia Russell,8,9,1,0,0,0,0,3.334
+Fall 2022,COMM,3353,1,14883,Information & Comm Tech I,Liu,Youmei,32,11,3,0,3,0,3,3.408
+Fall 2022,COMM,3353,2,14884,Information & Comm Tech I,McCombs,Shawn,11,3,2,0,0,0,0,3.563
+Fall 2022,COMM,4378,1,14887,Social Impact of Info Tech,Gonzalez,David De Jesus,57,0,0,0,0,0,1,4.0
+Fall 2022,DIGM,4372,30,14888,Costing in Digital Media,Snyder,Karen Yvonne,24,47,18,2,1,0,2,2.978
+Fall 2022,DIGM,3351,30,14891,Individ Comm Processes,Waite,Jerry J,40,24,6,1,0,0,0,3.423
+Fall 2022,DIGM,3353,31,14893,Visual Communications Tech,Bravo,Gina C,41,9,1,1,0,0,0,3.686
+Fall 2022,PSYC,2307,1,14894,Psychology of Adolescence,Martin,Rebecca B,68,15,8,4,3,0,1,3.412
+Fall 2022,HRD,3351,30,14895,Instructional Design for HRD,Pereira-Leon,Maura Josefina,5,16,14,0,0,0,1,2.743
+Fall 2022,PSYC,2319,3,14896,Intro to Social Psychology,Shepherd,Justin M,28,11,5,0,2,0,0,3.355
+Fall 2022,GHL,4355,1,14897,Event Administration,Kenyan,Erin Oeser,13,3,2,0,0,0,0,3.519
+Fall 2022,MATH,2312,6,14898,Precalculus,May,Jennifer Ruhnow,154,94,70,52,116,0,118,2.232
+Fall 2022,SOC,3342,1,14899,Sociology of Work,Lorence,Jon P,10,25,10,0,2,0,0,2.858
+Fall 2022,NURS,3735,1,14902,Clinical Nursing Practice III,Quintana,Danielle,59,3,0,0,0,0,0,3.952
+Fall 2022,NURS,3737,1,14903,Nurs Proc Collabrtive Prac II,Quintana,Danielle,19,43,0,0,0,0,0,3.306
+Fall 2022,POLS,3357,1,14904,Constitutnl Law-Civ Lib,Wall,Kenneth S,5,4,3,5,0,0,4,2.471
+Fall 2022,SCLT,3389,31,14905,Transportation Law,Blount,James,48,8,4,1,0,0,0,3.586
+Fall 2022,SCLT,4387,30,14906,Financial Evaluation For SCM,Reyes,Jorge,41,13,5,0,0,0,1,3.577
+Fall 2022,SCLT,4389,30,14907,Practicum in Supply Chain,Kidd,Margaret A,4,13,6,0,0,0,1,2.913
+Fall 2022,SCLT,3387,30,14908,Procurement,Elliott,Stephen Dwight,35,14,4,2,1,0,4,3.387
+Fall 2022,MATH,3339,3,14909,Statistics for the Sciences,Papadakis,Emanuel Ioannis,4,2,9,3,6,0,7,1.778
+Fall 2022,PSYC,3350,3,14910,Intro to Cognitive Psychology,Hernandez,Arturo E,65,19,3,2,1,0,4,3.567
+Fall 2022,BCHS,3304,4,14912,General Biochemistry I,Liu,Yu,8,18,12,3,2,0,6,2.62
+Fall 2022,COMM,3368,1,14913,Principles of Public Relations,Ashley,Laura B,18,6,1,0,0,0,0,3.64
+Fall 2022,COMM,3369,2,14915,Strategic Comm. Writing,Rougeau,Rose,12,6,0,2,0,0,0,3.351
+Fall 2022,COMM,3383,1,14916,Non-linear Editing,Newlin,Julye G,43,1,9,0,2,0,1,3.509
+Fall 2022,COMM,4303,3,14918,Communication Law and Ethics,Perin,Monica Wilch,18,7,4,2,2,0,1,3.121
+Fall 2022,MATH,2131,2,14920,Linear Alg Labs w/MATLAB,Vu,An Thuy,25,3,2,0,5,0,4,3.181
+Fall 2022,COMM,4370,1,14922,Social Aspects of Film,Vaughan,Thomas Michael,6,6,3,1,0,0,1,3.001
+Fall 2022,BIOL,3304,1,14924,The Biology of Social Behavior,Cole,Blaine J,13,17,15,8,3,0,3,2.418
+Fall 2022,GOVT,2305,9,14926,"US Govt: Congress,Pres & Crts",Contractor,Cyrus Ali,7,10,5,3,6,0,1,2.269
+Fall 2022,GOVT,2305,11,14927,"US Govt: Congress,Pres & Crts",Clark,Jennifer H,74,106,46,8,5,0,5,2.95
+Fall 2022,POLS,3316,1,14928,Stats for Political Scientists,Kennedy,Ryan P,17,10,5,2,0,0,4,3.187
+Fall 2022,CHEM,4364,1,14929,Advanced Organic Chem,Wu,Judy,2,4,0,0,0,0,0,3.278
+Fall 2022,PHYS,1301,2,14930,College Physics I (lecture),Portillo Vazquez,Israel,17,26,25,12,6,0,23,2.373
+Fall 2022,PHYS,3313,1,14931,Advanced Laboratory I,Forrest,Rebecca L,5,3,2,1,1,0,0,2.861
+Fall 2022,RELS,3366,1,14932,Magic and Occult,Allen,Paul J,31,0,0,0,1,0,2,3.875
+Fall 2022,PSYC,7306,1,14933,Adv. Stats: Multilevel Model.,Francis,David J,3,2,0,0,0,0,0,3.402
+Fall 2022,COSC,1336,1,14934,Computer Science & Program,Hilford,Victoria,45,32,15,13,7,0,11,2.792
+Fall 2022,COSC,1336,2,14935,Computer Science & Program,Hilford,Victoria,56,28,17,7,6,0,7,3.044
+Fall 2022,COSC,2436,1,14938,Programming and Data Structure,Mukherjee,Arjun,43,19,9,5,6,0,25,3.057
+Fall 2022,SOCW,8335,1,14941,Teaching in Higher Education,Lucas,Virginia,6,0,0,0,0,0,0,4.0
+Fall 2022,MATH,4366,1,14942,Numerical Linear Algebra,He,Jiwen,10,4,1,2,2,0,3,2.791
+Fall 2022,ENTR,3311,1,14943,Technology Entrepreneurship,McCormick,Kelly,9,2,0,1,2,0,1,3.024
+Fall 2022,MARK,4332,1,14944,Social Media Marketing,Noriega,Jaime L,25,11,7,2,1,0,2,3.153
+Fall 2022,POLS,3310,3,14947,Intro to Political Theory,Vassiliou,Constantine,10,14,9,0,5,0,5,2.527
+Fall 2022,SCM,3301,4,14949,SCM Fundamentals,Miller,Bradley D,262,221,43,12,4,0,5,3.304
+Fall 2022,SCM,4385,1,14950,Supply Chain Analytics,Murray,Michael J,7,2,1,0,0,0,2,3.435
+Fall 2022,BIOL,6374,2,14951,Cell Biology,Rea,Michael A,4,3,3,0,0,0,0,3.133
+Fall 2022,MANA,3335,9,14953,Intro Org Behavior and Mgmt,Kim,Jaewoo,30,11,5,1,2,0,0,3.253
+Fall 2022,POLS,6344,1,14954,Dissertation Prospectus,Scarrow,Susan E,5,0,0,0,0,0,0,4.0
+Fall 2022,POLS,3322,1,14955,Intro Latin-Am Politics,Aleman,Eduardo,9,17,9,7,1,0,1,2.582
+Fall 2022,MARK,7333,1,14956,Search Engine Marketing,Gavin,Daniel Yaakov,19,14,1,0,0,0,0,3.539
+Fall 2022,HON,3303,1,14957,Mental Health & Society,Valier,Helen K,18,5,0,0,0,0,0,3.74
+Fall 2022,HON,3301,4,14958,Readings in Medicine & Society,Valier,Helen K,21,5,0,0,0,0,0,3.795
+Fall 2022,GHL,1345,2,14959,"Safety, Sanitation in Hosp Ind",Sirsat,Sujata Ashok,14,14,10,2,2,0,3,2.771
+Fall 2022,GHL,3348,2,14961,Principles of Hosp Revenue Mgt,Kazemi Zarkouei,Mohammad Sadegh,19,12,3,5,4,0,8,2.822
+Fall 2022,HRD,4396,30,14962,Internship in HRD,Polesello,Daiane,22,7,5,1,2,0,1,3.261
+Fall 2022,GHL,6368,1,14963,Career Capstone Project,Legendre,Jungyoung Shin,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,7361,1,14964,Hospitality Marketing Analysis,Shin,Min Jung,18,0,0,0,0,0,1,3.927
+Fall 2022,MIS,4378,3,14966,Admin of Computer-Based MIS,Skinner,Richard James,25,22,2,0,0,0,0,3.469
+Fall 2022,GOVT,2306,11,14969,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,68,84,71,19,2,0,2,2.779
+Fall 2022,SPAN,1507,1,14970,Intns Elem Span Heritage Learn,Monarrez Martinez,Sendy Patricia,7,5,1,2,3,0,1,2.483
+Fall 2022,LAW,5421,1,14972,Business Organizations,Moll,Douglas Keith,11,18,1,0,0,9,0,3.41
+Fall 2022,LAW,5203,1,14973,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,5,0,
+Fall 2022,LAW,5228,1,14975,Judicial Externship I,Powers,William,0,0,0,0,0,5,0,
+Fall 2022,LAW,7334,1,14977,WRS: Int'l Law & Use of Force,Foteh,Samir Jabra,5,6,1,0,0,0,0,3.388
+Fall 2022,HRD,3351,1,14978,Instructional Design for HRD,Pereira-Leon,Maura Josefina,16,12,8,1,0,0,2,3.091
+Fall 2022,COMM,3377,1,14979,Strategic PR Planning,Uhrick,Jan,16,9,0,0,0,0,0,3.68
+Fall 2022,KIN,1304,2,14980,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,427,86,31,15,28,0,8,3.512
+Fall 2022,KIN,3301,1,14981,Design/Eval Phys Activity Prog,Gray,Jon Phillip,41,5,1,1,0,0,0,3.778
+Fall 2022,LAW,5361,1,14982,Financial Statement Analysis,Brennan,Daniel,8,13,0,0,0,3,0,3.365
+Fall 2022,PSYC,2316,4,14983,Psychology of Personality,Inman,Tonya N,38,24,6,2,3,0,2,3.256
+Fall 2022,IDNS,1111,1,14984,Physics 1321 Workshop,Pattison,Donna,10,1,0,3,0,0,0,3.239
+Fall 2022,IDNS,1112,1,14985,Physics 1322 Workshop,Pattison,Donna,5,7,10,0,1,0,1,2.638
+Fall 2022,WGSS,4360,1,14986,Capstone Internship Course,Gregory,Elizabeth,4,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,3368,2,14987,Intermediate Accounting II,Muslu,Volkan,26,22,6,2,0,0,0,3.156
+Fall 2022,KIN,3306,2,14988,Physiology-Human Performance,Breslin,Whitney L,39,46,39,14,5,0,4,2.685
+Fall 2022,KIN,3309,2,14989,Biomechanics,Gorniak,Stacey,18,15,12,2,1,0,0,2.979
+Fall 2022,KIN,4301,1,14990,Workplace Wellness,Alastuey,Lisa L,10,14,5,1,2,0,0,2.896
+Fall 2022,KIN,4310,1,14991,Measurement Tech Human Perf,Thrasher,Timothy Adam,22,30,26,10,11,0,2,2.421
+Fall 2022,MARK,3337,3,14992,Professional Selling,Vandaveer,Amy L,193,83,7,2,5,0,8,3.529
+Fall 2022,BTEC,6101,30,14993,Biotechnology Techniques Metho,Iken,Brian N,3,0,0,0,0,0,0,4.0
+Fall 2022,BTEC,3302,30,14995,Molecular Genetics and Biotech,Lin,Yuheng,33,13,6,0,0,0,0,3.545
+Fall 2022,BTEC,6300,30,14996,Standards in Biotechnology,Iken,Brian N,17,0,0,0,0,0,0,3.961
+Fall 2022,TLIM,3345,30,15000,Human Resources in Technology,Malik,Sarah A,6,6,7,4,4,0,2,2.161
+Fall 2022,TLIM,3363,31,15002,Technical Communications,Tangeman,Anthony C,24,19,8,1,4,0,0,3.077
+Fall 2022,TLIM,3363,32,15003,Technical Communications,Tangeman,Anthony C,29,18,8,0,4,0,0,3.192
+Fall 2022,TLIM,3363,33,15004,Technical Communications,Tangeman,Anthony C,34,23,1,0,2,0,0,3.439
+Fall 2022,TLIM,3365,30,15005,Team Leadership,Burns,Maria,48,0,0,0,0,0,1,3.993
+Fall 2022,TLIM,4341,31,15007,Production & Service Operation,Cao,Shun,8,4,4,0,2,0,0,2.907
+Fall 2022,TLIM,4342,30,15008,Quality Improvement Methods,Chance,Michael Dean,18,12,5,1,2,0,1,3.123
+Fall 2022,TLIM,4390,30,15009,Current Issues Ldshp & Innov,Mehring,Brian George,16,6,2,2,0,0,0,3.296
+Fall 2022,MATH,3363,4,15010,Introduction To Pde,Onofrei,Daniel T,28,15,13,4,1,0,7,3.06
+Fall 2022,ENGL,3301,2,15011,Intro To Literary Studies,Wong,Karen Y,2,8,5,1,0,0,3,2.708
+Fall 2022,ENGL,7390,1,15012,Intro to Doctoral Studies,Ehlers,Sarah E,10,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,3350,1,15013,Am Lit To 1865,Snediker,Michael,16,7,3,0,1,0,0,3.346
+Fall 2022,ENTR,4110,1,15014,Entrepren Values & Leadership,Cook,David B,23,7,0,0,0,0,0,3.767
+Fall 2022,SCLT,3376,30,15015,Global Trade Intermediaries,Crockett,Brianne,11,6,5,0,1,0,0,3.016
+Fall 2022,SCLT,6318,1,15016,Supply Chain Strategies,Bian,Zheyong,63,4,0,0,0,0,0,3.96
+Fall 2022,MARK,4333,1,15017,Search Engine Marketing,Zahn,William J,19,9,1,1,0,0,1,3.533
+Fall 2022,SOCW,7324,2,15018,Clinical Apps of DSM in SW,Charles,Janea,13,3,0,0,0,0,0,3.813
+Fall 2022,WGSS,3321,1,15020,Gender in Transnational Persp,Al-Sowayel,Dina,13,3,3,3,6,0,2,2.488
+Fall 2022,MATH,1332,1,15021,Contemporary Mathematics,Hafeez,Shahinda,36,41,19,19,49,0,31,1.953
+Fall 2022,MATH,1351,1,15022,Intro to Geometric Reasoning,Douglas,Casey,130,112,78,58,100,0,62,2.233
+Fall 2022,HRD,3346,30,15023,Performance Assessment & Eval,Clancy,James Patrick,9,4,4,0,0,0,1,3.236
+Fall 2022,PHYS,3110,1,15024,Sem-Adv Lab Analysis,Forrest,Rebecca L,7,2,0,0,1,0,0,3.4
+Fall 2022,ECON,2302,3,15026,Principles of Microeconomics,Blanchfield,Craig,22,2,0,0,0,0,0,3.889
+Fall 2022,ARCH,3374,1,15028,World Cities,Adams,Vera A,10,5,3,0,0,0,0,3.297
+Fall 2022,SCM,7350,1,15030,Strategic Supply Management,Wayhan,Victor Brian,34,0,0,0,0,0,1,3.961
+Fall 2022,PSYC,6392,1,15031,Intervention Practicum,Vincent,John P,6,0,0,0,0,8,0,4.0
+Fall 2022,PSYC,8321,1,15033,Clinical Psyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8399,1,15034,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,1,0,
+Fall 2022,GHL,3341,3,15035,Hospitality Managerial Acct,Johnson,Tucker A,25,26,7,1,4,0,1,3.063
+Fall 2022,GHL,3358,1,15036,Hospitality Industry Law,Barth,Stephen C,30,7,1,1,6,0,2,3.171
+Fall 2022,MARK,4379,1,15037,Personal Branding,Suki,Yara D,47,12,0,0,0,0,0,3.769
+Fall 2022,MATH,3305,2,15038,Formal & Informal Geometry,George,Rebecca Ann,27,2,3,0,3,0,1,3.4
+Fall 2022,PSYC,6399,1,15039,Masters Thesis,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8399,2,15040,Doctoral Dissertation,Vujanovic,Anka Anna,0,0,0,0,0,4,0,
+Fall 2022,ENGL,8322,1,15042,Master Workshop: Poetry,Tejada,Roberto Jose,8,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,7399,1,15043,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2022,COMM,4328,1,15046,Broadcast & Film Writing,Vaughan,Thomas Michael,12,5,3,0,0,0,0,3.302
+Fall 2022,PSYC,8399,3,15048,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,4,0,
+Fall 2022,CHEM,4115,2,15050,Inorganic Chem Laboratory II,Zaitsev,Vladimir G,3,10,2,0,0,0,0,3.067
+Fall 2022,PSYC,6352,1,15053,Directed Rsch in I/O Psyc,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,6322,1,15054,Poetry Workshop,Belieu,Erin Colleen,9,0,0,0,0,0,0,4.0
+Fall 2022,THEA,6362,1,15055,Dramatic Thry&Criticism,Coen,Elizabeth Manya,9,5,0,1,0,0,0,3.423
+Fall 2022,SPAN,8699,9,15057,Dissertation,Hasbun,Rodrigo,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2306,1,15058,Psychology of Human Sexuality,Keo-Meier,Colton Lawrence,33,30,16,10,4,0,8,2.803
+Fall 2022,CHEM,1112,20,15060,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,4,7,0,1,0,0,2.825
+Fall 2022,CHEM,1112,21,15061,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,2,0,0,0,1,3.018
+Fall 2022,CHEM,1112,22,15062,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,3,0,1,0,0,2.888
+Fall 2022,COMM,1307,1,15065,Media and Society,Olson,Beth M,49,86,49,28,24,0,9,2.414
+Fall 2022,PSYC,7393,1,15066,Field Practicum in Psychology,Vincent,John P,0,0,0,0,0,24,0,
+Fall 2022,COMM,3311,1,15067,Editing Print & Digital Media,Crixell,Charles A,4,12,1,0,2,0,1,2.807
+Fall 2022,COMM,3311,2,15068,Editing Print & Digital Media,Crixell,Charles A,8,5,6,0,1,0,0,3.033
+Fall 2022,COMM,3311,3,15069,Editing Print & Digital Media,Crixell,Charles A,6,10,4,0,0,0,0,3.051
+Fall 2022,PSYC,3399,1,15071,Senior Honors Thesis,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6298,1,15074,Special Problems,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6336,1,15075,Directed Rsch in Social Psyc,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2022,PSYC,3399,2,15076,Senior Honors Thesis,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1302,55,15077,First Year Writing II,Rizzo,Kaitlin M,15,0,0,1,1,0,1,3.53
+Fall 2022,ENGL,1302,56,15078,First Year Writing II,Rizzo,Kaitlin M,16,1,1,0,0,0,1,3.778
+Fall 2022,ENGL,1302,57,15079,First Year Writing II,Rizzo,Kaitlin M,11,1,2,2,0,0,1,3.23
+Fall 2022,SOCW,6201,2,15080,Foundation of Social Work Prof,Lucas,Virginia,0,0,0,0,0,80,0,
+Fall 2022,MATH,2450,7,15081,Accelerated Calculus I,Wang,Min,6,4,6,0,0,0,12,3.083
+Fall 2022,ARTH,3332,1,15084,20th Century Design,Orto,Luisa,19,6,2,0,0,0,1,3.593
+Fall 2022,ARTH,6332,1,15085,20th Century Design,Orto,Luisa,3,1,0,0,0,0,0,3.833
+Fall 2022,PSYC,8399,4,15086,Doctoral Dissertation,Viana,Andres G,0,0,0,0,0,3,0,
+Fall 2022,CHIN,3360,2,15088,A Look Into Modern China,McArthur,Charles M,6,15,3,0,1,0,2,3.053
+Fall 2022,MUSA,6140,3,15089,Graduate Recital I,Brooks,Wayne A,0,0,0,0,0,0,0,
+Fall 2022,POLS,4391,1,15090,Internships in Intl Affairs,Sisman,Ozlem,5,1,1,0,0,0,0,3.666
+Fall 2022,PSYC,8121,1,15091,Clinical Psychology Internship,Vincent,John P,0,0,0,0,0,10,0,
+Fall 2022,GEOL,3330,1,15092,Paleobiology,Maddocks,Rosalie F,2,11,12,2,1,0,1,2.358
+Fall 2022,PSYC,7399,5,15093,Masters Thesis,Neighbors,Clayton T,0,0,0,0,0,0,0,
+Fall 2022,PSYC,7393,2,15095,Field Practicum in Psychology,Witt,Lawrence A,0,0,0,0,0,0,0,
+Fall 2022,MUSI,6200,2,15096,Accompanying Seminar,Suits,Brian J,5,0,0,0,0,0,0,3.934
+Fall 2022,CHEM,8998,25,15097,Doctoral Research,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2022,SPAN,2312,4,15098,Intermediate Spanish II,Miranda Moreno,Sujaila Abigail,5,11,1,0,0,0,2,3.119
+Fall 2022,PSYC,6398,2,15104,Independent Studies,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Fall 2022,HON,3399,5,15109,Senior Honors Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6498,3,15110,Special Problems,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2022,AAS,2320,4,15114,Intro To African American Stdy,Poindexter-Sylvers,Carole Jean,8,14,1,0,1,0,7,3.112
+Fall 2022,MUSI,1181,3,15125,Group Piano I,Van Kekerix,Todd Evan,7,3,1,0,0,0,0,3.425
+Fall 2022,PSYC,8399,5,15129,Doctoral Dissertation,Alfano,Candice A,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7399,6,15130,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,4,0,
+Fall 2022,PSYC,8390,1,15131,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7399,7,15132,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Fall 2022,CHEM,8399,20,15135,Doctoral Dissertation,Cai,Chengzhi,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6257,14,15136,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,1306,54,15138,Biology for Science Majors I,Sirrieh,Rita Evelyn,14,10,4,2,1,0,1,2.98
+Fall 2022,PSYC,7390,1,15139,Clin Neuropsychology Practicum,Woods,Steven Paul,7,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6398,2,15140,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8399,6,15142,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2022,MUSI,6352,1,15143,Group Piano Pedagogy,Van Kekerix,Todd Evan,6,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6260,1,15144,Internship in Piano Teaching I,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,8399,11,15149,Dissertation,Kanellos,Nicolas,0,0,0,0,0,0,0,
+Fall 2022,SPAN,8699,10,15150,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Fall 2022,POLS,8999,15,15152,Doctoral Dissertation,Clifford,Scott,0,0,0,0,0,0,0,
+Fall 2022,ENGL,1301,92,15153,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,11,4,3,0,1,0,0,3.263
+Fall 2022,PEP,8399,3,15155,Doctoral Dissertation,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,8399,7,15161,Doctoral Dissertation,Walker,Rheeda L,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,13,15167,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,3,0,
+Fall 2022,PSYC,8190,1,15169,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,2,0,
+Fall 2022,PSYC,6398,4,15170,Independent Studies,Spitzmuller,Christiane,3,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1302,58,15173,First Year Writing II,Dykes,Justin,10,6,4,0,3,0,2,2.884
+Fall 2022,PSYC,8399,9,15175,Doctoral Dissertation,Medina PhD,Luis Daniel,0,0,0,0,0,2,0,
+Fall 2022,MATH,8698,14,15176,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6352,3,15177,Directed Rsch in I/O Psyc,Ng,Vincent,0,0,0,0,0,3,0,
+Fall 2022,PSYC,6498,5,15179,Special Problems,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2022,ENGL,1302,59,15184,First Year Writing II,Cooper-Edwards,Jacquelyn,19,2,0,0,1,0,3,3.652
+Fall 2022,WGSS,2350,9,15185,Intro To Women's Studies,Norquist,Grete A,16,8,2,0,1,0,3,3.297
+Fall 2022,COSC,1336,3,15187,Computer Science & Program,Subhlok,Jaspal,64,23,20,1,14,0,7,2.997
+Fall 2022,PSYC,6498,6,15188,Special Problems,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,2123,28,15198,Organic Chemistry Lab I,Bean,Mary B,4,7,3,1,1,0,5,2.688
+Fall 2022,CHEM,2125,8,15199,Organic Chemistry Lab II,Bean,Mary B,4,11,5,2,0,0,0,2.728
+Fall 2022,ECON,8399,4,15200,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,4,0,
+Fall 2022,PSYC,8399,10,15201,Doctoral Dissertation,Spitzmuller,Christiane,0,0,0,0,0,0,0,
+Fall 2022,PSYC,6398,5,15202,Independent Studies,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6352,4,15203,Directed Rsch in I/O Psyc,Spitzmuller,Christiane,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,8399,13,15205,Doctoral Dissertation,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2022,WGSS,2360,3,15206,Introduction to LGBT Studies,Stone,Lauren Michelle,21,2,0,1,2,0,3,3.449
+Fall 2022,CHEM,1111,77,15207,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,2,0,0,0,1,3.123
+Fall 2022,PSYC,6398,6,15209,Independent Studies,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6398,9,15210,Independent Studies,Yoshida,Hanako,0,0,0,0,0,2,0,
+Fall 2022,PSYC,8399,14,15211,Doctoral Dissertation,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6399,7,15212,Masters Thesis,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Fall 2022,DRAM,1310,9,15214,Introduction to Theatre,Young,Courtney Leigh,42,5,3,0,1,0,0,3.661
+Fall 2022,ENGL,1301,93,15215,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,11,5,1,1,1,0,0,3.263
+Fall 2022,ENGL,1301,94,15216,First Year Writing I,Dykes,Justin,8,7,5,0,4,0,1,2.584
+Fall 2022,PSYC,6398,10,15221,Independent Studies,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Fall 2022,CHEM,1111,78,15222,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,7,7,0,1,0,3,2.626
+Fall 2022,CHEM,1112,24,15224,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,7,2,1,0,0,0,2.751
+Fall 2022,GEOL,3150,2,15225,Prin-Stratigraphy Lab,Carlson,Brandee Nicole,9,3,1,0,0,0,0,3.438
+Fall 2022,PSYC,8399,15,15226,Doctoral Dissertation,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,15,15227,Doctoral Research,Papadakis,Emanuel Ioannis,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6398,12,15233,Independent Studies,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2022,INDS,6398,1,15234,Independent Study,Chow,George K,2,0,0,0,0,0,0,3.835
+Fall 2022,PSYC,6399,8,15235,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6393,6,15238,Clinical Research Practicum,Vujanovic,Anka Anna,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6393,5,15239,Clinical Research Practicum,Viana,Andres G,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6393,7,15240,Clinical Research Practicum,Zvolensky,Michael J,3,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,16,15247,Doctoral Research,Nicol,Matthew J.,0,0,0,0,0,2,0,
+Fall 2022,ECON,8361,1,15257,Workshop Research Methods III,Maheshri,Vikram,8,0,0,0,0,0,0,4.0
+Fall 2022,ECON,3332,4,15258,Intermediate Microeconomics,Saboury,Piruz,4,4,5,1,1,0,5,2.446
+Fall 2022,ECON,4374,1,15259,Behavioral Economics,Friedman,Willa H,22,18,5,0,2,0,2,3.255
+Fall 2022,PHIL,1301,1,15260,Intro To Philosophy,Hattab,Helen,2,12,10,12,18,0,53,1.42
+Fall 2022,PHIL,1301,2,15261,Intro To Philosophy,Oliveira,Luis RG,90,84,10,5,7,0,3,3.245
+Fall 2022,WCL,3366,1,15262,Latin American and Latino Film,Centeno,Daniel,13,11,1,0,0,0,0,3.427
+Fall 2022,GERM,3330,1,15263,Reading German Texts,Kleinheider,Julia D,4,1,1,0,0,0,3,3.555
+Fall 2022,GEOL,1102,1,15264,Intro to Climate Change Lab,Choi,Yunsoo,22,1,0,0,0,0,0,3.928
+Fall 2022,GEOL,1103,11,15265,Physical Geology Lab,Hauptvogel,Daniel William,14,6,0,2,0,0,0,3.365
+Fall 2022,MATH,1314,6,15266,College Algebra,Hafeez,Shahinda,100,55,34,19,48,0,20,2.526
+Fall 2022,MATH,2131,1,15271,Linear Alg Labs w/MATLAB,Panagopoulos,Nikolaos,12,3,4,0,1,0,3,3.168
+Fall 2022,POLS,3312,2,15272,"Arguments, Data, Politics",Zhou,Hui,14,6,2,4,4,0,9,2.667
+Fall 2022,POLS,3313,1,15273,Intro Internatl Relatns,Chatagnier,John Tyson,28,9,4,2,0,0,1,3.396
+Fall 2022,MATH,3336,4,15274,Discrete Mathematics,Winkle,James J,19,14,21,1,1,0,7,2.822
+Fall 2022,BIOL,3345,1,15275,Plant Physiology,Farmer,Lisa M,28,11,3,0,1,0,1,3.473
+Fall 2022,COSC,3380,2,15277,Database Systems,Ramamurthy,Uma,7,27,22,19,18,0,1,1.786
+Fall 2022,POLS,3310,1,15278,Intro to Political Theory,Koganzon,Rita,7,12,11,3,8,0,3,2.147
+Fall 2022,FINA,4381,1,15279,Essentials of Real Estate,Madison,Necitha,10,26,3,0,0,0,1,3.137
+Fall 2022,PSYC,2307,2,15280,Psychology of Adolescence,Cifre,Anthony Ballachie,34,27,11,2,4,0,1,3.014
+Fall 2022,PSYC,4344,5,15281,Cultural Psychology,Hernandez Ortiz,Jessica G,37,19,14,4,3,0,2,3.116
+Fall 2022,PSYC,2308,1,15282,Child Development,Yoshida,Hanako,36,19,6,0,2,0,2,3.36
+Fall 2022,PSYC,2330,2,15284,Biological Psychology,Maynard,Mark Eugene,8,11,9,3,1,0,4,2.77
+Fall 2022,PSYC,2330,3,15285,Biological Psychology,Williams,Michael W,17,17,4,2,0,0,0,3.233
+Fall 2022,MANA,4385,1,15286,Intro to Strategic Management,Chiu,Shih-chi,12,7,0,1,1,0,0,3.333
+Fall 2022,CNST,4302,2,15288,Construction Law and Ethics,Ducran,Denis George,9,46,12,1,4,0,2,2.709
+Fall 2022,CNST,4331,2,15289,Construction Management II,Menendez,Daniel,21,4,0,0,0,0,1,3.734
+Fall 2022,ANTH,4393,1,15290,Research Practicum,Brown,Kenneth L,2,0,0,0,0,0,0,4.0
+Fall 2022,MATH,4335,1,15291,Partial Diff  Equations I,Jaramillo,Gabriela T,4,4,3,2,0,0,1,2.642
+Fall 2022,BCIS,1305,4,15292,Business Computer Applications,Felvegi,Emese,268,110,29,5,25,0,12,3.325
+Fall 2022,MARK,3337,4,15293,Professional Selling,Vandaveer,Amy L,160,107,18,0,5,0,8,3.409
+Fall 2022,POLS,3318,1,15294,Intro To Public Policy,Davis,Sharon M,19,14,2,0,3,0,2,3.193
+Fall 2022,PSYC,4343,1,15295,Perception,Tamber-Rosenau,Benjamin J,9,20,10,2,0,0,5,2.91
+Fall 2022,COMD,3381,1,15296,Audiology,Andrews,Chereece N,66,9,1,1,1,0,1,3.773
+Fall 2022,FINA,4328,1,15297,Principles of Personal Finance,Coleman,Alfred G,34,12,4,2,0,0,1,3.449
+Fall 2022,TEPM,6305,20,15298,Project Manager Tools,Sherman,Dennis Louis,7,1,0,0,0,0,0,3.875
+Fall 2022,KIN,4360,1,15299,Adaptive Athletics Management,Cottingham,Michael,12,0,0,0,0,0,0,3.89
+Fall 2022,TEPM,6304,20,15300,Quality Improvemnt in Proj Mgt,Kovach,Jamison,4,0,0,0,0,0,1,4.0
+Fall 2022,HRD,6352,1,15301,Inst Design for Training Envir,Waight,Consuelo L,16,1,0,0,0,0,0,3.961
+Fall 2022,HRD,6356,1,15302,Consulting & Prof. Practice,Salomon,Lauren Manning,15,9,0,0,0,0,0,3.598
+Fall 2022,ACCT,2301,16,15304,Prin of Financial Accounting,Sykes,Mary Reeves,27,28,6,2,2,0,3,3.266
+Fall 2022,HIST,3316,1,15305,Race & Racism in Amer Sci/Med,Mizelle Jr,Richard M.,19,9,2,0,0,0,1,3.479
+Fall 2022,WGSS,2360,4,15306,Introduction to LGBT Studies,Pegoda,Andrew Joseph,20,4,0,2,0,0,2,3.565
+Fall 2022,KIN,3309,3,15309,Biomechanics,Lee,Beom Chan,27,31,16,11,5,0,9,2.656
+Fall 2022,NUTR,4353,1,15310,Cultural Comp for Nutr Prof,Yoon,Cynthia Yursun,47,23,4,0,0,0,0,3.492
+Fall 2022,SCLT,3340,30,15311,Geography for GSC,Henson,Alfred Bernard,24,12,3,2,1,0,1,3.215
+Fall 2022,SCLT,3375,30,15312,Maritime Operations,Chopra,Anuj,10,15,4,1,0,0,0,3.144
+Fall 2022,SCLT,3384,31,15313,Logistics Tech and Processes,Bian,Zheyong,46,8,1,0,2,0,3,3.713
+Fall 2022,GEOL,1102,2,15314,Intro to Climate Change Lab,Choi,Yunsoo,17,1,0,0,2,0,1,3.451
+Fall 2022,WCL,6356,1,15315,World Film and Film Theory,Carrera,Alessandro,3,0,0,0,0,0,0,4.0
+Fall 2022,WCL,4356,1,15316,World Film and Film Theory,Carrera,Alessandro,21,2,0,0,1,0,0,3.613
+Fall 2022,HON,4130,1,15317,E-Portfolio,Rayder,Benjamin Taylor,14,2,1,0,0,0,0,3.726
+Fall 2022,GHL,3352,2,15318,Human Resource Management,Madera,Juan Manuel,40,3,3,0,1,0,1,3.681
+Fall 2022,GHL,3357,1,15319,Gaming and Casino Managment,Kim,Jaewook,9,4,0,0,1,0,0,3.287
+Fall 2022,GHL,6357,1,15320,Gaming and Casino Mgmt,Kim,Jaewook,6,0,0,0,0,0,0,3.89
+Fall 2022,ARCH,3230,1,15323,Programming & Bldg Regulations,Tucker de Vazquez,Sheryl,25,39,44,18,12,0,1,2.293
+Fall 2022,PSYC,4344,6,15326,Cultural Psychology,Kilani,Mohamed Hechmi,20,9,4,2,2,0,3,3.135
+Fall 2022,DANC,1241,1,15327,Beginning Ballet,Estrada,Maria Gabriela,10,5,0,0,3,0,1,3.129
+Fall 2022,LAW,5199,1,15329,Special Problems,Vetter,Greg R,0,0,0,0,0,17,0,
+Fall 2022,LAW,5299,1,15331,Special Problems,Vetter,Greg R,0,0,0,0,0,28,0,
+Fall 2022,LAW,5299,2,15332,Special Problems,Alderman,Richard M,0,0,0,0,0,1,0,
+Fall 2022,LAW,6238,1,15334,International Risk Management,Rivero,Francisco,4,1,0,0,0,1,0,3.668
+Fall 2022,LAW,5363,1,15335,Securities Regulation,Ragazzo,Robert A,11,20,0,0,0,0,0,3.344
+Fall 2022,LAW,5403,1,15336,Street Law,Cohen,Lisa Elaine,2,4,0,0,0,0,0,3.388
+Fall 2022,LAW,5418,11,15338,Torts,Sanders,Joseph,22,48,4,0,0,0,2,3.341
+Fall 2022,LAW,6360,1,15339,Trial Advocy for NonLitigators,Lukin,Karen B,4,4,1,0,0,0,0,3.37
+Fall 2022,ENGL,3331,1,15340,Beg Creative Writing-Poetry,English,Joshua,19,1,0,0,0,0,0,3.934
+Fall 2022,HON,3307,1,15341,Narrative Medicine,Vollrath,Lesli A,20,1,0,0,0,0,2,3.89
+Fall 2022,LAW,6321,2,15342,Professional Responsibility,Murphy,Mary Ellen,19,40,0,0,0,0,0,3.328
+Fall 2022,COMM,3360,3,15343,Principles of Strategic Comm,Clark,Thomas R,9,4,5,0,1,0,0,3.053
+Fall 2022,COMM,3331,1,15344,Communication in the Family,Hudson-Gillan,Gail,17,10,3,0,0,0,0,3.445
+Fall 2022,PETR,8399,8,15345,Doctoral Dissertation,Myers,Michael Tolbert,1,0,0,0,0,5,0,3.67
+Fall 2022,PETR,8399,9,15346,Doctoral Dissertation,Qin,Guan,0,0,0,0,0,1,0,
+Fall 2022,PETR,8399,10,15347,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Fall 2022,PETR,8598,10,15352,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Fall 2022,PETR,8598,8,15353,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,5,0,
+Fall 2022,PETR,8699,8,15354,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2022,PETR,8699,10,15356,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,3,0,
+Fall 2022,ENTR,7390,1,15357,Technology Entrepreneurship,McCormick,Kelly,22,2,1,0,0,0,0,3.814
+Fall 2022,ENGL,1301,135,15358,First Year Writing I,Stewart-Steele,Heather Marie,5,11,6,0,2,0,1,2.598
+Fall 2022,PHYS,3316,1,15359,Quantum Mechanics,Miller,John H,7,3,0,0,0,0,0,3.733
+Fall 2022,ENGL,1301,136,15360,First Year Writing I,Seelen,William,14,5,0,0,0,0,0,3.737
+Fall 2022,ENGL,1301,137,15361,First Year Writing I,Downey,Carlton M,14,0,1,0,1,0,3,3.604
+Fall 2022,ENGL,1301,138,15362,First Year Writing I,English,Joshua,8,4,1,0,3,0,2,2.854
+Fall 2022,ENGL,1301,139,15363,First Year Writing I,Box,Anthony Joseph,14,2,0,0,2,0,1,3.371
+Fall 2022,ENGL,1301,140,15364,First Year Writing I,Stewart-Steele,Heather Marie,7,7,7,2,1,0,1,2.667
+Fall 2022,CIVE,3434,1,15365,Fluid Mech and Hydraulic Engr,Wang,Keh-Han,3,8,11,0,0,0,6,2.696
+Fall 2022,MATH,6382,2,15367,Probability,Ott,William R,12,1,0,0,0,0,0,3.847
+Fall 2022,TLIM,3345,1,15368,Human Resources in Technology,Evans,Ruth Ann,15,14,3,3,0,0,0,3.162
+Fall 2022,CIS,3368,1,15369,Adv Info Systems Development,Dobretsberger,Otto,19,8,6,0,5,0,5,2.939
+Fall 2022,TLIM,4350,30,15370,Occup Safety & Envir Health,Freedkin,Aaron Samuel,38,19,2,0,0,0,1,3.543
+Fall 2022,TLIM,4371,30,15371,Leading Change in the Wrkplace,Burns,Maria,25,2,0,0,0,0,0,3.926
+Fall 2022,KIN,4691,1,15373,Internship in Sport Admin 2,Walsh,David W,19,6,0,0,0,0,0,3.76
+Fall 2022,KIN,4391,1,15374,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Fall 2022,KIN,4398,1,15375,Independent Study,Cottingham,Michael,3,0,0,0,0,0,0,4.0
+Fall 2022,KIN,1304,3,15376,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,270,59,25,13,20,0,6,3.449
+Fall 2022,LAW,6365,1,15377,U.S. Health System: An Intro,Mantel,Jessica,10,9,1,0,0,0,0,3.417
+Fall 2022,MUED,2342,3,15378,Music for Children,Bigwood,Cora Morgan,19,0,0,0,0,0,0,3.931
+Fall 2022,MUED,2342,4,15379,Music for Children,Bigwood,Cora Morgan,10,7,0,0,0,0,2,3.472
+Fall 2022,MUSI,6198,1,15380,Research in Chamber Music,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2022,NUTR,2332,3,15383,Intro To Human Nutrition,Hughes,Lindsay,40,35,13,6,4,0,1,3.034
+Fall 2022,ARTS,3331,1,15385,Graphic Design Software,Phenneger,Mary Jo,3,2,1,0,1,0,1,2.951
+Fall 2022,BTEC,4319,30,15387,Microbial Biotechnology,Flavier,Albert B,6,3,6,4,1,0,1,2.351
+Fall 2022,PSYC,2316,6,15388,Psychology of Personality,Westmoreland,Kirsten E,24,11,7,1,2,0,3,3.163
+Fall 2022,DRAM,1341,1,15389,Make up for Actors,Gardecki,Samantha Lauren,4,3,0,0,0,0,1,3.524
+Fall 2022,GOVT,2305,10,15391,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,47,78,68,17,21,0,14,2.483
+Fall 2022,THEA,3388,1,15392,Advanced Stagecraft,Bush,Rachel R,6,0,2,0,0,0,0,3.459
+Fall 2022,LAW,5370,1,15393,International Law,Jackson,Craig Leonard,7,13,2,0,0,4,0,3.212
+Fall 2022,ECE,4398,1,15394,Independent Study,Bering,Edgar A,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,3360,1,15395,Intermediate Sculpture,Kittelson,Paul A,9,9,1,0,0,0,0,3.421
+Fall 2022,MUED,3102,1,15396,Brasses,Bell,Priscilla Garrett,18,1,1,0,0,0,1,3.85
+Fall 2022,MUSA,3420,1,15397,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3420,2,15398,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,3.835
+Fall 2022,ARCH,1500,19,15401,Design Studio I,Handanovic,Dijana,4,4,0,0,0,0,2,3.459
+Fall 2022,DIGM,4381,30,15409,Mobile Application Design,Snyder,Karen Yvonne,6,3,4,2,0,0,0,2.823
+Fall 2022,PHYS,1101,19,15411,College Physics I (lab),Wood,Lowell T,0,12,10,0,0,0,2,2.65
+Fall 2022,MUSI,4230,2,15412,Instrumental Conducting I,Meals,Cory Dewitt,15,2,0,0,0,0,0,3.902
+Fall 2022,INAR,3300,1,15416,Hist of Interior Architecture,Thomas,James B,36,0,1,0,0,0,0,3.946
+Fall 2022,MUSA,3438,1,15418,Applied Saxophone,Witt,Woodrow W,2,0,0,0,0,0,0,4.0
+Fall 2022,POLS,8999,2,15419,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,1,0,
+Fall 2022,NURS,4521,1,15421,Community Health Nursing,McWilliams,Lenora A,15,30,0,2,0,0,0,3.234
+Fall 2022,BTEC,4300,31,15423,Principles of Bioinformatics,Balan,Venkatesh,1,5,1,0,0,0,0,3.0
+Fall 2022,MUSA,3424,1,15424,Applied Violoncello,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6324,1,15432,Applied Violoncello,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,1,15433,Doctoral Applied Music,Dorough,Aralee,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,3,15434,Doctoral Applied Music,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,8,15435,Doctoral Applied Music,Morgulis,Tali,3,0,0,0,0,0,0,3.89
+Fall 2022,MUSA,8320,9,15436,Doctoral Applied Music,Robinson,Daryl Allen,2,1,0,0,0,0,0,3.667
+Fall 2022,MUSA,8320,16,15438,Doctoral Applied Music,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6381,1,15440,Writing Seminar,Williams,Matthew Joseph,11,5,0,0,0,0,0,3.523
+Fall 2022,PHYS,3396,3,15441,Senior Research Project,Li,Liming,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,7399,1,15442,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,1,0,
+Fall 2022,PHIL,1321,1,15447,Logic I,Loewenstein,Yael R,29,30,24,16,8,0,13,2.489
+Fall 2022,ENGL,2305,1,15448,Intro To Fiction,Brooks,Stuart,17,2,0,1,4,0,2,3.084
+Fall 2022,ENGL,2315,1,15450,Literature and Film,Garcia,Sylvia A,23,6,0,1,0,0,0,3.579
+Fall 2022,ARTS,4398,1,15451,Independent Study,Hecker,Rachel G,1,2,0,0,0,0,0,3.333
+Fall 2022,COSC,4351,1,15466,Fundamentals of Software Engr,Singh,Raj Kumar,94,1,1,0,0,0,1,3.948
+Fall 2022,BIOL,6320,1,15469,Molecular Biology,Chung,Sanghyuk,1,0,0,0,0,0,0,3.67
+Fall 2022,CHEM,6498,34,15472,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Fall 2022,HON,4399,1,15473,Senior Honors Thesis,Kapral,Andrew J,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,8395,4,15484,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,2,0,
+Fall 2022,CHEM,6498,35,15485,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2022,ARTS,4398,2,15486,Independent Study,Frankfort,Dana M,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,4398,3,15487,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6356,1,15489,Clinical Assessment I,Cirino,Paul,11,5,0,0,0,0,0,3.688
+Fall 2022,MUSA,4410,3,15494,Applied Piano,Morgulis,Tali,3,0,0,0,0,0,0,3.78
+Fall 2022,PSYC,6399,12,15497,Masters Thesis,Fetterman,Adam Kent,3,0,0,0,0,0,0,4.0
+Fall 2022,LACP,2111,1,15503,Liberal Arts Career Planning,Thompson,Monica,0,0,0,0,0,33,2,
+Fall 2022,ACCT,4331,4,15504,Federal Income Tax-Individual,Fernandez,Ramon,12,27,8,0,0,0,2,3.197
+Fall 2022,HIST,8677,5,15506,Reading for Comps Exams,Mizelle Jr,Richard M.,0,0,0,0,0,1,0,
+Fall 2022,HDCS,1300,5,15509,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,37,7,3,3,3,0,6,3.284
+Fall 2022,COMM,1307,2,15510,Media and Society,Lyn,Robyn,47,4,2,0,2,0,2,3.679
+Fall 2022,CHEM,6498,36,15512,Special Problems,Harth,Eva M,0,0,0,0,0,1,0,
+Fall 2022,ENGL,4319,1,15514,English in Secondary Schools,Bachmann,Abbey M,32,1,0,0,0,0,0,3.9
+Fall 2022,MATH,6358,2,15515,Probability & Stat. Computing,Poliak,Cathy Dawn,17,4,0,0,1,0,0,3.606
+Fall 2022,BIOE,7399,6,15518,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2317,6,15526,Intro to Psychology Statistics,Saiyed,Amna Shabbir,63,5,1,0,0,0,0,3.875
+Fall 2022,BZAN,6310,4,15527,Quant Analysis for Busn Dec,Hou,Jinghui,50,8,0,1,1,0,0,3.712
+Fall 2022,MATH,8698,17,15536,Doctoral Research,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8320,20,15538,Doctoral Applied Music,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2022,HON,4399,2,15540,Senior Honors Thesis,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2022,MARK,4389,7,15545,Marketing Strategy & Planning,Randazzo,Gary W,25,6,0,0,0,0,0,3.711
+Fall 2022,SOCW,8999,3,15549,Dissertation,Cheung,Monit,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6393,8,15552,Clinical Research Practicum,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Fall 2022,NURS,3315,1,15553,Pathophysiology,Edwards-Maddox,Shermel Vinese,22,22,0,0,0,0,4,3.5
+Fall 2022,POLS,3313,2,15554,Intro Internatl Relatns,Marinov,Nikolay,6,18,8,4,4,0,3,2.475
+Fall 2022,PCOL,8399,1,15555,Doctoral Dissertation,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Fall 2022,PHOP,6257,11,15556,Research Practicum B,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5686,2,15562,Psychiatry,Truong,Mabel,3,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5695,2,15563,Geriatrics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,8399,16,15566,Doctoral Dissertation,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,2425,5,15568,Computer Org & Architecture,Johnsson,Lennart,41,34,12,2,2,0,7,3.187
+Fall 2022,PHOP,6257,2,15569,Research Practicum B,Harrison,Wendy W,2,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,19,15570,Doctoral Research,Heier,Gordon,0,0,0,0,0,2,0,
+Fall 2022,RELS,2310,2,15571,Bible and Western Culture I,Allen,Paul J,45,0,0,0,0,0,2,4.0
+Fall 2022,PSYC,6399,13,15572,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Fall 2022,POLS,3316,2,15573,Stats for Political Scientists,Konak Unal,Saadet,16,15,4,0,3,0,2,3.062
+Fall 2022,PSYC,7392,1,15574,Psychology Practicum,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2022,ASLI,3460,1,15575,Advanced ASL,Gietz,Merrilee Ruth,3,4,1,0,0,0,0,3.126
+Fall 2022,PSYC,7392,3,15576,Psychology Practicum,Fetterman,Adam Kent,4,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6567,1,15580,Research Practicum A,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,8998,1,15586,Doctoral Research,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2022,POLS,8399,28,15589,Doctoral Dissertation,Chatagnier,John Tyson,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLA,6221,1,15590,Adv Health System Mgmt,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,1106,45,15591,Biol for Science Majors I(Lab),Medrano,Ana I,14,6,1,1,1,0,1,3.305
+Fall 2022,BIOL,1106,44,15592,Biol for Science Majors I(Lab),Medrano,Ana I,13,5,1,0,3,0,1,3.106
+Fall 2022,PHOP,6257,1,15598,Research Practicum B,Bergmanson,Jan Pg,0,0,0,0,0,0,0,
+Fall 2022,PHOP,6257,7,15612,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8399,5,15617,Doctoral Dissertation,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6399,15,15618,Masters Thesis,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2022,PHLA,7299,1,15623,Masters Thesis,Varkey,Divya A,0,0,0,0,0,0,0,
+Fall 2022,MUSA,8320,25,15624,Doctoral Applied Music,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,ECON,3332,1,15627,Intermediate Microeconomics,Gosselin,Richard John,3,8,2,8,10,0,6,1.495
+Fall 2022,PSYC,6399,16,15628,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Fall 2022,POLS,8399,29,15629,Doctoral Dissertation,Rottinghaus,Brandon J,1,0,0,0,0,0,0,4.0
+Fall 2022,MANA,4356,1,15630,Managing Diversity,Fernandez,Alejandro,44,4,1,1,0,0,0,3.853
+Fall 2022,SGNL,1301,8,15631,Elementary Sign Language I,Brittain,Terrell,4,6,6,1,0,0,5,2.668
+Fall 2022,PHYS,3399,1,15633,Senior Honors Thesis,Bering,Edgar A,0,0,0,0,0,0,0,
+Fall 2022,PSYC,6336,2,15634,Directed Rsch in Social Psyc,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2022,HON,3399,4,15638,Senior Honors Thesis,Dunsmore,Julie C,0,0,0,0,0,0,0,
+Fall 2022,HON,4399,3,15639,Senior Honors Thesis,Stelzig,Donaji,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3426,1,15642,Applied Double Bass,Larson,Eric Amery,0,0,0,0,0,0,0,
+Fall 2022,MUSA,2350,1,15643,Applied Percussion,Warren,Paul Alexander,2,3,0,0,0,0,0,3.466
+Fall 2022,MSCI,1210,2,15645,Introduction to the Army,Thomas,Roland,2,3,2,0,0,0,1,3.047
+Fall 2022,ARCH,2500,17,15646,Arc/Int Arc Design Studio III,Sen,Ozan,11,4,0,0,0,0,2,3.711
+Fall 2022,PSYC,8999,1,15648,Doctoral Dissertation,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Fall 2022,POLS,6359,1,15651,Bibliographic Essay,Basinger,Scott J,2,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,6498,37,15653,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7392,4,15655,Psychology Practicum,Knee,Clifford R,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6598,5,15664,Special Problems,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6365,1,15665,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,3,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,6399,18,15667,Masters Thesis,Zhang,Yingchun,1,0,0,0,0,0,0,4.0
+Fall 2022,PETR,8298,11,15675,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2022,PETR,8398,11,15677,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Fall 2022,PETR,8398,12,15678,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2022,PETR,8399,12,15680,Doctoral Dissertation,Wong,George K,0,0,0,0,0,1,0,
+Fall 2022,PETR,8598,11,15683,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,2,0,
+Fall 2022,PETR,8699,12,15686,Doctoral Dissertation,Wong,George K,0,0,0,0,0,1,0,
+Fall 2022,MUSA,2202,1,15687,Applied Composition,Maroney,Marcus K,0,2,0,0,0,0,0,3.33
+Fall 2022,PSYC,6399,18,15688,Masters Thesis,Hernandez,Arturo E,0,0,0,0,0,0,0,
+Fall 2022,MUSA,2202,2,15689,Applied Composition,Smith,Robert Thomas,5,0,1,0,0,0,0,3.612
+Fall 2022,PSYC,7392,6,15690,Psychology Practicum,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1276,1,15692,Applied Jazz Percussion,Hubley,Robert L,0,1,0,0,0,0,0,3.33
+Fall 2022,PSYC,6365,2,15693,Dir Rsch in Dev Cog Beh Neuro,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,3396,2,15696,Senior Research Project,Frankino,William A,3,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,20,15698,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Fall 2022,HON,3399,7,15704,Senior Honors Thesis,Alward,Beau Andrew,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6498,1,15707,Special Problems,Das,Joydip,3,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,3399,1,15708,Senior Honors Thesis,McKeon,Frank D,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,8699,10,15710,Doctoral Dissertation,Parikh,Pranav J,0,0,0,0,0,1,0,
+Fall 2022,MUSI,6198,4,15711,Research in Chamber Music,Cho,Eunghee,4,0,0,0,0,0,1,4.0
+Fall 2022,PSYC,8399,18,15713,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,2,0,
+Fall 2022,CHEM,4396,1,15715,Senior Research Project,Meen,James K,1,0,0,0,0,0,0,4.0
+Fall 2022,PHIL,1361,2,15721,Philosophy and the Arts,Drapela,Nick Gerard,16,16,8,1,0,0,8,3.05
+Fall 2022,PHIL,1361,3,15722,Philosophy and the Arts,Drapela,Nick Gerard,12,15,13,2,4,0,4,2.652
+Fall 2022,ECON,2302,4,15723,Principles of Microeconomics,Lin,Shuan-Wen,28,29,18,3,11,0,4,2.622
+Fall 2022,ECON,3334,4,15724,Intermediate Macroeconomics,Nygaard,Vegard Mokleiv,26,10,5,0,2,0,7,3.318
+Fall 2022,MATH,1314,4,15725,College Algebra,Caputo,Matthew G,121,48,48,34,26,0,22,2.723
+Fall 2022,CLAS,3307,2,15728,Greek & Roman Myths of Heroes,Due Hackney,Casey L,23,5,1,0,1,0,0,3.622
+Fall 2022,ECON,6390,1,15729,Workshop Research Methods I,Prokopovych,Pavlo,1,5,0,0,0,0,0,3.112
+Fall 2022,SOCW,7304,1,15731,Brief Targeted Interventions,Parks,Steven Lee,26,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7304,2,15732,Brief Targeted Interventions,Walton,Quenette,17,2,0,1,0,0,0,3.75
+Fall 2022,SOCW,7304,3,15733,Brief Targeted Interventions,Gracely,Jill Marie,18,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7304,4,15734,Brief Targeted Interventions,McMorris,Saralyn Dionne,17,0,0,0,0,0,1,4.0
+Fall 2022,SOCW,7304,6,15735,Brief Targeted Interventions,Parks,Steven Lee,14,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,2615,1,15738,Intsve Inter Span Heritg Lrnrs,Ruiz,Eugenia Maria,11,6,6,0,1,0,0,3.07
+Fall 2022,HRD,6305,30,15741,Organizational Learning,Waight,Consuelo L,5,3,0,0,0,0,0,3.501
+Fall 2022,MIS,4477,1,15742,Network & Security Infrastruct,Messinger,Jacob Nelson,25,10,2,0,0,0,2,3.613
+Fall 2022,ENGL,1302,60,15744,First Year Writing II,Cooper-Edwards,Jacquelyn,11,2,1,2,2,0,1,2.927
+Fall 2022,ENGL,1301,141,15745,First Year Writing I,Stewart-Steele,Heather Marie,9,6,1,0,3,0,6,2.756
+Fall 2022,MANA,4330,3,15746,Intro to Strategic HR Mgt,Reinoso,Gaston,14,8,1,0,2,0,0,3.214
+Fall 2022,ENGL,3331,2,15747,Beg Creative Writing-Poetry,Priest,Joy M,17,1,0,0,2,0,0,3.55
+Fall 2022,ENGL,3301,3,15748,Intro To Literary Studies,Harrell,Haylee C,11,2,0,1,1,0,3,3.356
+Fall 2022,ENGL,3365,1,15750,Postcolonial Literature,Singh,Kavita Ashana,23,2,1,1,0,0,3,3.631
+Fall 2022,SOCW,7318,2,15751,Cognitive Behavioral Interven,Amtsberg,Donna K.,25,2,0,0,0,0,0,3.926
+Fall 2022,ENGL,4315,1,15752,Sociolinguistics,Lee,Eunjeong,21,1,1,0,0,0,0,3.827
+Fall 2022,MANA,4310,1,15754,Behavioral Finance,Rude,Dale,3,3,1,0,0,0,0,3.191
+Fall 2022,HON,3301,1,15755,Readings in Medicine & Society,Brown,Erika J,23,2,0,0,0,0,0,3.92
+Fall 2022,POLS,3311,2,15756,Intro Compar Politics,Hanna,Tom Leard,22,9,4,1,5,0,3,2.992
+Fall 2022,POLS,3312,3,15758,"Arguments, Data, Politics",Raychaudhuri,Tanika,15,11,10,0,1,0,3,3.009
+Fall 2022,PSYC,3350,4,15759,Intro to Cognitive Psychology,Saiyed,Amna Shabbir,86,8,2,1,0,0,3,3.832
+Fall 2022,GEOL,1102,3,15761,Intro to Climate Change Lab,Choi,Yunsoo,16,5,1,0,0,0,0,3.622
+Fall 2022,TEPM,6306,20,15762,Project Management Office,Sherman,Dennis Louis,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2316,7,15763,Psychology of Personality,Serrano Holden,Surizaday,51,9,5,2,4,0,1,3.423
+Fall 2022,PSYC,2316,8,15764,Psychology of Personality,Liu,Tingshu,23,17,10,7,2,0,0,2.853
+Fall 2022,PSYC,2330,4,15765,Biological Psychology,Zegel,Maya,36,4,0,0,0,0,0,3.851
+Fall 2022,BCHS,3304,5,15766,General Biochemistry I,Fox,Robert O,8,7,2,0,0,0,0,3.353
+Fall 2022,ACCT,2301,17,15767,Prin of Financial Accounting,Sykes,Mary Reeves,33,22,5,4,1,0,4,3.307
+Fall 2022,ACCT,2301,18,15768,Prin of Financial Accounting,Sykes,Mary Reeves,34,20,8,1,1,0,4,3.375
+Fall 2022,KIN,4315,1,15769,Motor Learning and Control,Layne,Charles S,16,60,43,5,0,0,1,2.707
+Fall 2022,COSC,3360,2,15772,Operating Systems,Rincon Castro,Carlos Alberto,35,38,23,7,10,0,28,2.691
+Fall 2022,ENTR,3312,5,15774,Corporate Entrepreneurship,Karonika,John R,28,9,4,0,3,0,4,3.273
+Fall 2022,ENTR,3312,6,15775,Corporate Entrepreneurship,Karonika,John R,28,11,2,0,4,0,3,3.216
+Fall 2022,CHIN,3350,2,15776,Chinese Culture Through Films,McArthur,Charles M,15,5,0,0,1,0,3,3.556
+Fall 2022,PSYC,4354,1,15777,Brain and Behavior,Leasure,Jennifer Leigh,6,13,7,4,1,0,1,2.624
+Fall 2022,COMM,3321,1,15778,Single Camera Studio Productn,Houk,Keith R,24,1,1,0,0,0,0,3.897
+Fall 2022,PETR,6322,1,15779,Integrated Reservoir Mgmt,Thakur,Ganesh Chandra,15,4,0,0,0,0,0,3.72
+Fall 2022,AAS,2320,2,15781,Intro To African American Stdy,Lyons,Da' Vonte,14,15,4,0,0,0,1,3.323
+Fall 2022,BIOL,6120,1,15782,Responsible Conduct Bio Rsrch,Sater,Amy,39,0,0,0,0,0,0,3.983
+Fall 2022,PETR,6111,1,15783,Petroleum Graduate Seminar,Qin,Guan,0,0,0,0,0,29,0,
+Fall 2022,COMM,3377,2,15785,Strategic PR Planning,Uhrick,Jan,14,4,0,0,0,0,0,3.741
+Fall 2022,COMM,3382,1,15786,TV II & Sports Production,Crowe,Craig Warren,12,5,0,0,0,0,0,3.725
+Fall 2022,BIOL,7124,1,15788,Cell Biology Seminar,Lin,Chin-Yo,0,0,0,0,0,12,0,
+Fall 2022,PSYC,2308,3,15790,Child Development,Griep,Christina Diaz,35,22,9,0,3,0,0,3.213
+Fall 2022,PSYC,4344,7,15791,Cultural Psychology,Beltran-Najera,Ilex,36,24,11,2,4,0,3,3.19
+Fall 2022,HRD,3350,1,15792,Workforce Diversity and Global,Lopez,Johana,22,11,3,1,3,0,0,3.159
+Fall 2022,POLS,3386,1,15793,Criminal Law,Martinez,Elizabeth Stukes,17,15,3,5,2,0,2,3.0
+Fall 2022,ENGL,1301,142,15795,First Year Writing I,Kelly,Hannah Elizabeth,14,0,2,0,2,0,1,3.26
+Fall 2022,ENGL,1301,143,15796,First Year Writing I,Khalil,Rand Omar,12,2,0,2,3,0,0,2.878
+Fall 2022,ENGL,1301,144,15797,First Year Writing I,Worley,Sharon J,10,9,2,1,1,0,2,3.03
+Fall 2022,ENGL,1301,145,15798,First Year Writing I,Worley,Sharon J,9,8,0,2,4,0,1,2.581
+Fall 2022,ENGL,1301,146,15799,First Year Writing I,Worley,Sharon J,14,2,1,1,5,0,3,2.683
+Fall 2022,ENGL,1301,147,15800,First Year Writing I,Presswood,Phillip Hilliard,17,0,1,0,1,0,0,3.615
+Fall 2022,INTB,3355,3,15801,Global Environment of Business,Miljanic,Andra Olivia,117,85,25,10,5,0,6,3.225
+Fall 2022,FINA,6387,3,15802,Managerial Analysis,Basu,Swati,9,0,0,0,0,0,0,3.89
+Fall 2022,ECE,6311,1,15807,Introduction to Robotics,Becker,Aaron T,10,11,1,0,2,0,0,3.056
+Fall 2022,BIOL,2315,1,15810,Biology of Food,Zufall,Rebecca A,35,11,1,3,0,0,0,3.567
+Fall 2022,MARK,3337,2,15812,Professional Selling,Ahearne,Michael,116,126,36,6,6,0,9,3.149
+Fall 2022,ENTR,3310,4,15819,Entrepreneurship,Ortega,Carlos Alberto,108,61,11,4,10,0,3,3.318
+Fall 2022,IDNS,1101,2,15820,Physics 1301 Workshop,Pattison,Donna,14,9,2,1,0,0,0,3.41
+Fall 2022,IDNS,1102,1,15821,Physics 1302 Workshop,Pattison,Donna,21,6,1,0,0,0,0,3.714
+Fall 2022,COMD,3301,1,15824,History and Culture of Deaf,Brittain,Terrell,12,6,2,1,0,0,1,3.35
+Fall 2022,ASLI,4210,1,15825,ASL Literature,Gietz,Merrilee Ruth,5,2,0,0,0,0,0,3.809
+Fall 2022,FINA,4320,5,15826,Investment Management,Vasu,Rajkamal Kamaladevi,9,5,4,0,1,0,2,3.071
+Fall 2022,BIOE,2331,1,15827,Biomedical Processes,Shevkoplyas,Sergey,13,5,3,0,0,0,3,3.398
+Fall 2022,BIOE,3340,1,15828,Quantitative Physiology,Roh,Jinsook,11,9,6,3,0,0,0,2.977
+Fall 2022,PSYC,2301,8,15829,Introduction to Psychology,Schoolfield,Lucy,44,22,6,3,3,0,0,3.286
+Fall 2022,GOVT,2306,50,15830,US and Texas Const/Politics,Belco,Michelle Helene,22,1,0,0,0,0,0,3.928
+Fall 2022,GOVT,2306,51,15831,US and Texas Const/Politics,Belco,Michelle Helene,21,2,1,0,0,0,0,3.847
+Fall 2022,GOVT,2306,52,15832,US and Texas Const/Politics,Leland,Alison W,11,9,0,0,0,0,1,3.534
+Fall 2022,GOVT,2306,53,15833,US and Texas Const/Politics,LeVeaux,Christine,14,10,0,0,0,0,0,3.597
+Fall 2022,GOVT,2306,54,15834,US and Texas Const/Politics,LeVeaux,Christine,11,8,3,0,0,0,1,3.319
+Fall 2022,GOVT,2305,50,15836,"US Govt: Congress,Pres & Crts",Belco,Michelle Helene,22,0,0,0,0,0,2,3.97
+Fall 2022,GHL,6380,1,15838,Business Analytics,Lee,Minwoo,15,4,1,0,0,0,0,3.651
+Fall 2022,CHEM,1312,2,15841,Fundamentals of Chemistry 2,Yang,Ding-Shyue,3,10,20,15,14,0,19,1.565
+Fall 2022,CHEM,1311,3,15842,Fundamentals of Chemistry,Carrasquillo M,Edwin,42,53,70,27,67,0,32,1.883
+Fall 2022,FINA,4310,1,15844,Behavioral Finance,Rude,Dale,18,14,2,0,0,0,1,3.471
+Fall 2022,ECE,6373,1,15847,Adv Computer Arch,Fu,Xin,40,22,1,1,0,0,1,3.521
+Fall 2022,DIGM,2353,30,15849,Page Layout and Design,De Vega,Jaime M,56,29,13,1,5,0,5,3.187
+Fall 2022,HON,4198,1,15852,Independent Study,Rayder,Benjamin Taylor,4,0,0,0,0,0,0,4.0
+Fall 2022,AAS,2396,1,15853,History of Black Education,Shockley,Gerald,15,4,1,1,1,0,2,3.364
+Fall 2022,THEA,4306,1,15856,Edu Thea & Prg Mngt in Schools,Miller,Destyne,7,1,0,0,0,0,0,3.875
+Fall 2022,LAW,5262,1,15858,Healthcare Compliance,Ingraham,Ryan,4,5,0,0,0,1,0,3.444
+Fall 2022,CHEM,6351,1,15860,Organic Structure Detrm,Carrow,Bradley,2,8,1,0,0,0,0,3.211
+Fall 2022,SOC,3395,1,15861,Careers in Sociology,Katz,Sheila,27,8,5,0,6,0,0,3.073
+Fall 2022,LAW,5357,7,15862,Evidence,Thompson,Sandra Guerra,26,54,0,0,0,0,0,3.383
+Fall 2022,LAW,6370,1,15863,Advanced Legal Research,Watson,Amanda,6,4,1,0,0,1,0,3.455
+Fall 2022,LAW,5330,1,15864,Anti-Trust Law,Bush,Darren,11,20,0,0,0,4,0,3.397
+Fall 2022,LAW,5300,1,15865,Criminal Defense Clinic,Locascio,Erik Matthew,0,3,0,0,0,0,0,3.33
+Fall 2022,LAW,6366,1,15866,Int'l Arbitration Advocacy,Carson,Derrick Bryan,3,8,0,0,0,0,0,3.153
+Fall 2022,LAW,5221,1,15867,Int'l Commercial Arbitration,Dimitroff,Sashe Dimanin,1,4,0,0,0,0,0,3.2
+Fall 2022,SOCW,6293,1,15869,Field Practicum I - Foundation,Gonzales,Shelley A,0,0,0,0,0,124,4,
+Fall 2022,FINA,4382,1,15871,Developing R E Project,Henning,Erica,18,14,1,1,0,0,0,3.334
+Fall 2022,FINA,4383,1,15872,R E Mkt Research & Valuation,Wright,Larry Thomas,27,8,0,0,0,0,0,3.771
+Fall 2022,CIVE,3337,1,15873,Structural Analysis,Herman,Reagan,12,7,20,7,5,0,0,2.203
+Fall 2022,CIVE,4311,1,15874,Prof Practice in Civil Engr,Herman,Reagan,6,22,14,0,0,0,0,2.802
+Fall 2022,CIVE,4312,1,15876,Civil Engr Design Project,Mo,Larry Yi-Lung,26,0,0,0,0,0,0,3.949
+Fall 2022,MECT,3355,2,15878,Strength of Materials,Basaran,Burak,0,4,11,12,8,0,2,1.267
+Fall 2022,PETR,8298,13,15889,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,2,0,
+Fall 2022,PETR,8398,13,15890,Doctoral Research,Wong,George K,0,0,0,0,0,5,0,
+Fall 2022,MUSI,1301,1,15895,Rudiments of Theory,Koozin,Timothy,7,7,5,0,0,0,0,3.105
+Fall 2022,PHYS,2126,2,15897,University Physics Lab II,Wood,Lowell T,1,10,7,0,0,0,1,2.758
+Fall 2022,PHYS,2126,3,15898,University Physics Lab II,Wood,Lowell T,1,11,7,0,0,0,0,2.684
+Fall 2022,PHYS,2126,4,15899,University Physics Lab II,Wood,Lowell T,4,7,5,0,1,0,0,2.629
+Fall 2022,PHYS,2126,5,15900,University Physics Lab II,Wood,Lowell T,3,9,5,2,0,0,0,2.667
+Fall 2022,PHYS,2126,6,15901,University Physics Lab II,Wood,Lowell T,2,10,7,0,0,0,1,2.685
+Fall 2022,COMM,1307,3,15902,Media and Society,Ashley,Laura B,16,30,8,4,0,0,3,3.023
+Fall 2022,PHYS,2126,7,15903,University Physics Lab II,Wood,Lowell T,2,10,8,0,0,0,0,2.7
+Fall 2022,PHYS,2125,1,15904,University Physics Lab I,Wood,Lowell T,3,8,5,1,0,0,2,2.726
+Fall 2022,PHYS,2125,2,15905,University Physics Lab I,Wood,Lowell T,0,12,6,0,0,0,1,2.685
+Fall 2022,PHYS,2125,3,15906,University Physics Lab I,Wood,Lowell T,2,9,8,1,0,0,1,2.633
+Fall 2022,PHYS,2125,4,15907,University Physics Lab I,Wood,Lowell T,1,12,5,1,0,0,1,2.684
+Fall 2022,PHYS,2125,5,15908,University Physics Lab I,Wood,Lowell T,1,13,5,0,0,0,1,2.807
+Fall 2022,PHYS,2125,6,15909,University Physics Lab I,Wood,Lowell T,0,11,6,1,0,0,2,2.666
+Fall 2022,POLS,3385,1,15910,Introduction to Law,Jackson,Jerald W,12,17,15,1,0,0,2,2.94
+Fall 2022,MUSI,3160,1,15911,Adv Sightrding for Kybrd Plyrs,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4104,1,15912,New Music Ensemble,Smith,Robert Thomas,3,0,0,0,0,0,0,4.0
+Fall 2022,MSCI,1131,1,15913,Intermediate Physical Fitness,Gilley,Timothy O,0,2,0,0,0,0,0,3.0
+Fall 2022,ARTS,1311,2,15914,Fundamentals of Graphic Design,Williams,Celeste,10,9,0,0,0,0,4,3.509
+Fall 2022,ARTS,2356,4,15915,Fundamentals of Photo/DM,Hillerbrand,Stephan C,23,0,0,0,0,0,2,4.0
+Fall 2022,INDE,6337,1,15916,Human Factors Syst Dsgn,Schulze,Lawrence John Henry,1,9,4,0,0,0,1,2.762
+Fall 2022,ARTS,3384,1,15917,Sound Art,Meza,Abinadi,17,3,0,0,1,0,0,3.667
+Fall 2022,LACP,2111,2,15918,Liberal Arts Career Planning,Espinosa,Adalia,0,0,0,0,0,24,1,
+Fall 2022,ARTH,3334,1,15920,History of Graphic Design,Orto,Luisa,23,9,4,1,1,0,1,3.212
+Fall 2022,ARTH,6331,1,15921,Contemporary Painting,Barrera,Debra,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTH,6334,1,15922,History of Graphic Design,Orto,Luisa,5,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6301,1,15923,Life Drawing Studio,Barrera,Debra,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,4305,1,15924,Brain Machine Interfacing,Francis,Joseph Thachil,9,2,0,0,0,0,0,3.818
+Fall 2022,INDE,6335,1,15929,Egr Administration,Chung,Christopher,5,16,11,0,0,0,7,2.813
+Fall 2022,MUSI,4298,1,15931,Special Problems in Pedagogy,Reed,Gavin Davis,5,0,0,0,0,0,0,3.934
+Fall 2022,MECE,6361,1,15933,Mechanical Behavior/Materials,Ryou,Jae-Hyun,23,13,5,0,0,0,1,3.342
+Fall 2022,MECE,6388,1,15934,Optimal Control Theory,Chen,Zheng,8,7,0,1,2,0,1,3.037
+Fall 2022,FINA,4330,1,15935,Corporate Finance,Roshak,Kevin T,9,9,1,0,1,0,1,3.25
+Fall 2022,TLIM,4342,31,15937,Quality Improvement Methods,Terrell,John Allen,33,10,3,0,0,0,0,3.609
+Fall 2022,TLIM,4342,2,15938,Quality Improvement Methods,Chance,Michael Dean,22,15,4,1,0,0,3,3.263
+Fall 2022,COMM,4335,1,15939,Crisis Communication,Hudson-Gillan,Gail,38,8,7,0,0,0,1,3.56
+Fall 2022,NAVY,2301,1,15940,Leadership Management,Kroeger,Eric J,0,2,0,1,0,0,0,2.443
+Fall 2022,CHEE,3399,2,15941,Senior Honors Thesis,Orman,Mehmet,0,0,0,0,0,0,0,
+Fall 2022,PHYS,1301,3,15942,College Physics I (lecture),McElhenny,Brian Patrick,37,49,50,14,9,0,23,2.541
+Fall 2022,MUSA,4432,1,15944,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,6307,1,15945,Cell Biology for BME,Al-Ubaidi,Muayyad,2,4,1,0,0,0,0,3.19
+Fall 2022,THEA,2334,1,15946,Fundamentals of Design,Willson,Paige A,13,2,0,0,0,0,1,3.779
+Fall 2022,PHAR,4300,1,15947,Biochemistry I,Hussain,Tahir,36,57,27,2,0,0,1,3.041
+Fall 2022,PHAR,4260,1,15948,Intro to the Healthcare System,Essien,Ekere James,59,52,1,0,0,0,1,3.518
+Fall 2022,PHAR,4250,1,15949,Pharmacy Skills Program I,Wollen,Joshua T,66,41,4,0,0,0,1,3.559
+Fall 2022,CHEE,2331,1,15950,Chemical Processes,Henderson,Jerrod A,14,10,13,3,6,0,3,2.5
+Fall 2022,CHEE,2331,2,15951,Chemical Processes,Kowal,Marsha Christine,3,6,1,0,0,0,1,3.167
+Fall 2022,MUSA,6334,1,15952,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3430,1,15955,Applied Flute,Russell,Peggy,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,3140,1,15956,Quantitative Physiology Lab,Roh,Jinsook,1,0,0,0,0,0,0,3.67
+Fall 2022,BIOE,3140,2,15957,Quantitative Physiology Lab,Roh,Jinsook,14,3,2,0,0,0,1,3.562
+Fall 2022,WGSS,2360,2,15959,Introduction to LGBT Studies,Stone,Lauren Michelle,21,4,2,1,1,0,1,3.483
+Fall 2022,MUSA,4424,2,15960,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2022,NUTR,2332,4,15962,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,33,10,4,1,0,0,1,3.508
+Fall 2022,ARTS,2333,2,15963,Fundamentals of Printmaking,Christlieb,Lauren Nicole,12,0,0,1,0,0,0,3.744
+Fall 2022,ARTS,3316,1,15964,Relief Printmaking,Gates,Elizabeth Ann,12,0,0,0,0,0,1,4.0
+Fall 2022,CNST,6340,1,15969,Best Practices in Construction,Song,Lingguang,11,1,0,0,2,0,2,3.286
+Fall 2022,CNST,6340,2,15970,Best Practices in Construction,Song,Lingguang,9,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,1372,2,15971,Fundamentals of Video Art,Chen,Shang-Yee Mark,12,3,0,0,1,0,0,3.501
+Fall 2022,ARTS,3374,1,15972,Computer Imaging,Gaona,Veronica,16,0,0,0,1,0,0,3.668
+Fall 2022,ARTS,3304,1,15973,Intermediate Painting,Hecker,Rachel G,17,2,1,0,0,0,1,3.817
+Fall 2022,ARTS,3334,2,15974,Introduction to Typography,Kim,Yoonkyung,7,9,3,0,0,0,3,3.141
+Fall 2022,ARTS,3330,1,15975,Intermediate Graphic Design,Stipeche,Cynthia,3,18,4,0,0,0,0,3.066
+Fall 2022,KIN,3304,2,15976,Human Structure & Phys Perform,Hunt,Rebekah,7,17,11,8,4,0,2,2.333
+Fall 2022,PSYC,8399,20,15978,Doctoral Dissertation,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,7342,1,15979,Bio Bases of Behav,Grigorenko,Elena L,21,0,0,0,0,0,0,3.937
+Fall 2022,MUSA,1340,1,15981,Applied Trumpet,Hughes,Mark Alan,4,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,2326,5,15983,Fundamentals of Sculpture,Vega,Zulma C.,10,1,1,0,0,0,0,3.723
+Fall 2022,PCOL,7360,1,15984,Current Topics in Med Chem,Das,Joydip,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6310,2,15985,Printmaking Studio,Masterson,Patrick D,2,0,0,0,0,0,0,4.0
+Fall 2022,THEA,2100,1,15986,Theatre Education Internship,Cooper,Charles G,0,2,0,0,0,0,0,2.835
+Fall 2022,NUTR,2332,5,15989,Intro To Human Nutrition,Hughes,Lindsay,15,19,15,5,1,0,0,2.74
+Fall 2022,WGSS,6398,1,15990,Special Probs in Women's Study,Miller,Audrey,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,3330,2,15993,Intermediate Graphic Design,Unikel,Joshua,4,14,2,0,0,0,3,3.117
+Fall 2022,SOC,3313,1,15995,Criminology,Nelson,Steven M,19,14,6,2,4,0,4,2.853
+Fall 2022,FINA,4330,3,15997,Corporate Finance,Roshak,Kevin T,4,5,0,0,0,0,0,3.224
+Fall 2022,COMD,1333,4,15999,Intro to Comm Sci & Disorders,Ross,Byron L,11,13,7,2,1,0,1,2.873
+Fall 2022,INDE,8398,5,16000,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,2,0,
+Fall 2022,PHIL,1361,4,16001,Philosophy and the Arts,Drapela,Nick Gerard,21,12,9,1,6,0,2,2.81
+Fall 2022,PSYC,3347,1,16012,Problems of Normal Life,Agan,Herb W,42,3,0,0,0,0,0,3.933
+Fall 2022,MUSA,8320,11,16013,Doctoral Applied Music,Yon,Kirsten A,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6304,1,16018,Conducting,Krager,Franz A,4,0,0,0,0,0,0,4.0
+Fall 2022,HON,3399,10,16019,Senior Honors Thesis,Rhoden,Brenda,4,0,0,0,0,0,0,4.0
+Fall 2022,MARK,8396,1,16021,Research Practicum,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1340,2,16022,Applied Trumpet,Vassallo,Jim Cates,4,0,0,0,0,0,0,4.0
+Fall 2022,MECE,6377,1,16023,Continuum Mechs I,Joshi,Shailendra Pramod,5,16,7,0,0,0,4,2.952
+Fall 2022,ECE,6337,1,16024,Stochastic Processes,Prasad,Saurabh,7,28,0,0,0,0,1,3.247
+Fall 2022,ARTS,2356,5,16026,Fundamentals of Photo/DM,Ranjbarcheshmehsorkhi,Mandana,16,0,0,0,2,0,0,3.501
+Fall 2022,DRAM,1310,8,16027,Introduction to Theatre,Young,Courtney Leigh,40,6,1,2,1,0,0,3.6
+Fall 2022,MECT,1365,1,16031,Elements Materials & Processes,Wari,Ezra Tsegaye,12,22,14,9,13,0,2,2.124
+Fall 2022,DIGM,4371,30,16038,3D Modeling and Animation,Pittman,Natalie,22,6,6,1,1,0,3,3.315
+Fall 2022,PSYC,8399,22,16042,Doctoral Dissertation,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6340,1,16043,Applied Trumpet,Hughes,Mark Alan,3,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,21,16049,Doctoral Research,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Fall 2022,PHCA,8298,2,16051,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Fall 2022,HRD,6301,30,16053,Leadership Development in HRD,Hausmann,Robert Carl,6,1,0,0,0,0,0,3.669
+Fall 2022,MANA,4331,1,16054,Current Issues Human Res Mgmt,Walker,William A,13,2,2,0,0,0,1,3.608
+Fall 2022,WGSS,2350,10,16055,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,3,0,0,1,0,0,3.745
+Fall 2022,PCOL,6398,3,16057,Special Problems,Zhang,Ruiwen,0,0,0,0,0,1,0,
+Fall 2022,COSC,3337,1,16058,Data Science I,Eick,Christoph F,16,39,22,5,0,0,9,2.777
+Fall 2022,PCOL,6398,4,16059,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6598,7,16062,Special Problems,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2022,NUTR,6308,1,16063,Clinical Nutrition Practice I,Haubrick,Kevin,0,0,0,0,0,3,0,
+Fall 2022,PSYC,6398,14,16066,Independent Studies,Neighbors,Clayton T,2,0,0,0,0,0,0,4.0
+Fall 2022,SCM,4330,3,16069,Bus Modeling and Dec Analysis,Cossick,Kathy L,25,14,9,5,1,0,3,3.056
+Fall 2022,MARK,4363,1,16070,International Marketing,Beveridge,Ivana,37,0,0,0,0,0,0,3.902
+Fall 2022,ECON,8399,5,16076,Doctoral Dissertation,Liu,Elaine Meichen,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6398,15,16079,Independent Studies,Kosten,Therese A,2,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8299,4,16086,Doctoral Dissertation,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,1397,1,16098,Sel Topic Fund Studio Art,Patzke,Katie,8,1,1,0,0,0,2,3.634
+Fall 2022,SPAN,1501,21,16100,Elementary Spanish I,Cicerchia,Jose,14,5,6,0,0,0,3,3.241
+Fall 2022,SPAN,1502,9,16102,Elementary Spanish II,Ruffino,Gustavo,9,5,6,0,1,0,5,2.921
+Fall 2022,PCOL,6198,5,16104,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2022,ECON,8399,6,16107,Doctoral Dissertation,Cubas Norando,German,2,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,8698,2,16109,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2022,GOVT,2306,10,16112,US and Texas Const/Politics,McDonald,John Terrence George,57,85,61,28,15,0,3,2.562
+Fall 2022,PHCA,6398,2,16120,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6352,5,16121,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,4,0,
+Fall 2022,PCEU,6398,2,16125,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,3,0,
+Fall 2022,DRAM,1310,1,16126,Introduction to Theatre,Ostrow,Stuart,24,0,0,0,0,0,0,3.986
+Fall 2022,DRAM,1310,3,16127,Introduction to Theatre,Verheyen PhD,Claremarie H,17,12,7,3,3,0,5,2.873
+Fall 2022,PHYS,1101,20,16128,College Physics I (lab),Wood,Lowell T,0,18,3,0,0,0,2,2.763
+Fall 2022,PCEU,8998,1,16129,Doctoral Research,Tam,Vincent H,0,0,0,0,0,1,0,
+Fall 2022,PHYS,1101,21,16130,College Physics I (lab),Wood,Lowell T,2,13,4,0,2,0,1,2.525
+Fall 2022,PHCA,8698,3,16131,Doctoral Dissertation Research,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6257,4,16138,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6257,6,16139,Research Practicum B,Porter,Jason,2,0,0,0,0,0,0,3.835
+Fall 2022,PHOP,6257,9,16141,Research Practicum B,Rump,Rachel,1,0,0,0,0,0,0,3.67
+Fall 2022,PHLA,7299,3,16142,Masters Thesis,Garey,Kevin W,0,0,0,0,0,2,0,
+Fall 2022,SOCI,1301,8,16143,Introduction To Sociology,Adams,Jennifer Lauren,41,9,3,0,4,0,2,3.398
+Fall 2022,PEP,8699,12,16144,Doctoral Dissertation,Gorniak,Stacey,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8241,5,16150,Doctoral Recital II,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2300,5,16151,Applied Voice,Vasquez,Hector A,1,0,0,0,0,0,0,4.0
+Fall 2022,WGSS,2350,1,16154,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,3,0,1,0,0,1,3.748
+Fall 2022,ARCH,2500,21,16157,Arc/Int Arc Design Studio III,Olwi,Asmaa,7,5,3,0,1,0,1,3.083
+Fall 2022,PCEU,8998,2,16159,Doctoral Research,Hu,Ming,0,0,0,0,0,1,0,
+Fall 2022,WGSS,2350,11,16160,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,27,1,1,0,1,0,0,3.756
+Fall 2022,PHCA,6297,3,16161,Selected Topics,Thornton,James D,0,0,0,0,0,0,0,
+Fall 2022,PCEU,6398,3,16164,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2022,PCEU,6398,4,16165,Special Problems,Tam,Vincent H,0,0,0,0,0,1,0,
+Fall 2022,PCEU,6398,5,16166,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,3399,2,16167,Senior Honors Thesis,Cole,Blaine J,0,0,0,0,0,0,0,
+Fall 2022,DRAM,1310,5,16171,Introduction to Theatre,Verheyen PhD,Claremarie H,20,15,5,1,4,0,4,2.971
+Fall 2022,DRAM,1310,6,16172,Introduction to Theatre,Verheyen PhD,Claremarie H,18,14,5,2,6,0,3,2.727
+Fall 2022,PCOL,6498,2,16175,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6398,6,16176,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6598,8,16181,Special Problems,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,8698,4,16182,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,8298,3,16183,Doctoral Dissertation Research,Aparasu,Rajender R,2,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,3500,19,16184,Architecture Design Studio V,Story,Jon Kevin,1,13,0,0,1,0,0,2.999
+Fall 2022,POLS,4398,12,16187,Independent Study,Cross,Renee D,8,0,0,0,0,0,0,3.918
+Fall 2022,PSYC,6365,3,16191,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,3,0,
+Fall 2022,PHYS,8999,15,16207,Doctoral Dissertation,Hosur,Pavan R,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8999,17,16209,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2022,PCEU,8998,3,16229,Doctoral Research,Liu,Xinli,2,0,0,0,0,0,0,4.0
+Fall 2022,CIS,3368,2,16230,Adv Info Systems Development,Dobretsberger,Otto,16,10,3,1,1,0,3,3.205
+Fall 2022,PCEU,6398,1,16232,Special Problems,Hu,Ming,0,0,0,0,0,2,0,
+Fall 2022,ARCH,7600,7,16234,Architecture Design Studio V,Woodfill,Celeste Ponce,9,0,0,0,0,0,1,3.743
+Fall 2022,PSYC,6365,4,16236,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,3,0,
+Fall 2022,KIN,4398,3,16238,Independent Study,Ledoux,Tracey A,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6398,16,16240,Independent Studies,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Fall 2022,PSYC,6398,18,16241,Independent Studies,Tamber-Rosenau,Benjamin J,4,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6365,5,16242,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,3,0,
+Fall 2022,ENGI,2304,9,16244,Technical Communications,Anderson,Roshawnda M,17,4,1,0,4,0,0,3.052
+Fall 2022,PSYC,6365,6,16246,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,4,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,6298,3,16248,Special Problems,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,8399,12,16250,Dissertation,Rivera Garza,Cristina,3,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,8699,12,16251,Dissertation,Rivera Garza,Cristina,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3400,8,16253,Applied Voice,Vasquez,Hector A,1,0,0,0,0,0,0,4.0
+Fall 2022,POLS,4398,15,16256,Independent Study,Belco,Michelle Helene,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,2100,2,16266,Intro To Biomedical Engr,Akay,Yasemin M,45,3,1,1,3,0,5,3.585
+Fall 2022,TLIM,3363,30,16270,Technical Communications,Piercy,Penelope Junker,37,13,5,1,1,0,3,3.404
+Fall 2022,PHIL,1334,1,16271,Minds and Machines,Weisberg,Joshua,13,43,38,5,11,0,8,2.355
+Fall 2022,MATH,2318,2,16277,Linear Algebra,Mamonov,Alexander V,9,20,21,11,5,0,14,2.243
+Fall 2022,MATH,3339,5,16278,Statistics for the Sciences,Niu,Yabo,27,21,8,3,5,0,6,2.969
+Fall 2022,GEOL,1102,4,16279,Intro to Climate Change Lab,Choi,Yunsoo,15,5,0,1,0,0,1,3.54
+Fall 2022,GEOL,1147,2,16280,Introductory Meteorology Lab,Rappenglueck,Bernhard,12,3,1,1,0,0,0,3.452
+Fall 2022,HDCS,6331,20,16281,Adv Strat For Futures Planning,Hines,Andrew Lewis,22,0,0,0,0,0,0,3.925
+Fall 2022,WCL,2351,1,16282,World Cultures Thru Lit & Arts,Adkins,Alexander,19,4,0,0,1,0,5,3.639
+Fall 2022,ARCH,6302,1,16283,Visual Studies II,Martinez,Marcus E,9,1,0,0,0,0,0,3.834
+Fall 2022,ARCH,6301,3,16285,Visual Studies I,Martinez,Marcus E,19,0,0,0,0,0,0,3.722
+Fall 2022,ARCH,6304,3,16287,Visual Studies IV,Plauche',Roya,18,7,0,0,0,0,1,3.707
+Fall 2022,ARCH,6361,1,16289,Integrated Practice,Hager,Jesse,4,9,5,0,0,0,0,2.908
+Fall 2022,MAS,3343,1,16291,Latino Psychology,Pino,Diana,12,9,6,5,3,0,4,2.581
+Fall 2022,SPAN,4357,1,16293,Spanish Phonetics,Goodin-Mayeda,Carrie Elizabeth,2,1,2,0,1,0,0,2.555
+Fall 2022,AAS,3350,1,16295,Slavery and Race Relations,Raynor,Autumn Fawn,10,1,1,0,4,0,2,2.792
+Fall 2022,ARCH,6393,3,16296,Master's Project Preparation,Borden,Gail,8,1,0,0,0,0,0,3.816
+Fall 2022,HDCS,3376,2,16297,Resources in Technology Entrep,Palmer,Kristin B,13,9,2,9,3,0,6,2.473
+Fall 2022,BIOL,2301,2,16298,Anatomy & Physiology I (lect),Gill,Tejendra,66,202,89,15,18,0,23,2.674
+Fall 2022,INDS,1360,1,16300,Visual Thinking,Kimbrough,Mark S,7,9,5,1,1,0,4,2.812
+Fall 2022,CHEE,3321,2,16301,Analytical Methods Chem Engr,Grabow,Lars C,2,0,2,1,0,0,0,2.534
+Fall 2022,BIOL,6315,2,16302,Neuroscience,Ziburkus,Jokubas,5,2,0,0,0,0,0,3.62
+Fall 2022,INDS,6310,1,16303,Visual Thinking,Kimbrough,Mark S,2,1,0,0,0,0,0,3.557
+Fall 2022,ENGI,2304,7,16304,Technical Communications,Estrada,Carl,8,13,3,0,1,0,0,3.014
+Fall 2022,ENGI,2304,12,16305,Technical Communications,Wilson,Chad A,12,5,1,0,1,0,2,3.404
+Fall 2022,CHEM,4115,3,16306,Inorganic Chem Laboratory II,Zaitsev,Vladimir G,3,10,1,0,0,0,0,3.261
+Fall 2022,GOVT,2306,12,16307,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,65,85,70,20,3,0,5,2.747
+Fall 2022,MECE,3345,2,16308,Materials Science,Ardebili,Haleh,18,24,24,0,2,0,4,2.746
+Fall 2022,PETR,6372,1,16309,Petroleum Production Operation,Wong,George K,6,5,0,0,0,0,0,3.485
+Fall 2022,POLS,3311,3,16310,Intro Compar Politics,Konak Unal,Saadet,11,14,6,6,2,0,5,2.633
+Fall 2022,POLS,3313,3,16313,Intro Internatl Relatns,Zwald,Zachary J,12,19,3,0,1,0,2,3.124
+Fall 2022,WGSS,3360,1,16314,Sexuality and Queer Theory,Pegoda,Andrew Joseph,10,2,2,1,0,0,4,3.422
+Fall 2022,PSYC,6344,1,16315,Functional Neuroanatomy,Leasure,Jennifer Leigh,2,7,0,0,0,0,0,3.296
+Fall 2022,COMM,1302,1,16316,Intro To Comm Theory,Lee,Jaesub,10,12,20,1,1,0,7,2.599
+Fall 2022,BZAN,6310,1,16317,Quant Analysis for Busn Dec,Hou,Jinghui,52,7,1,0,0,0,0,3.828
+Fall 2022,COMM,3317,1,16319,Multimedia Journalism,Smith,Camilo Hannibal,13,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2305,8,16321,Intro to Methods in Psychology,Tamber-Rosenau,Benjamin J,3,12,8,2,1,0,4,2.551
+Fall 2022,PSYC,2305,11,16323,Intro to Methods in Psychology,Yoruk,Harun,17,18,0,0,3,0,2,3.228
+Fall 2022,INDS,3397,1,16325,Selected Topics,Kang,Chul Min,6,4,0,0,0,0,1,3.501
+Fall 2022,BIOL,4384,1,16326,Developmental Biology,Lekven,Arne,19,23,11,0,0,0,1,3.151
+Fall 2022,BIOL,4355,1,16327,Human Virology,Zhang,Shaun Xiaoliu,37,40,22,8,0,0,4,2.994
+Fall 2022,GOVT,2306,4,16329,US and Texas Const/Politics,Cole,Jeffrey Bryan,22,12,4,2,9,0,1,2.681
+Fall 2022,INDS,3500,3,16330,Industrial Design Studio V,Kang,Chul Min,4,4,0,0,0,0,0,3.624
+Fall 2022,SOCI,1301,6,16332,Introduction To Sociology,Menon-Chembottil,Sarath Kumar,22,20,7,4,2,0,4,3.006
+Fall 2022,SOCI,1301,7,16333,Introduction To Sociology,Menon-Chembottil,Sarath Kumar,32,18,3,1,4,0,1,3.236
+Fall 2022,SOC,3355,1,16334,Sociology of India,Majumder,Sarasij,6,10,2,0,0,0,1,3.167
+Fall 2022,COMM,3369,3,16336,Strategic Comm. Writing,Emery II,Philip M,19,2,0,0,0,0,0,3.873
+Fall 2022,COMM,3380,1,16337,Electronic Field Production,Crowe,Craig Warren,12,6,1,0,0,0,0,3.527
+Fall 2022,COMM,4303,4,16339,Communication Law and Ethics,Payne,Latosha Lewis Terrell,15,12,5,2,2,0,0,2.918
+Fall 2022,SOC,3382,1,16340,Sociology of Drug Use & Recove,Adams,Jennifer Lauren,30,13,4,2,2,0,2,3.223
+Fall 2022,PSYC,2317,5,16341,Intro to Psychology Statistics,Le,Giang Xuan,21,26,17,3,7,0,6,2.694
+Fall 2022,COMM,4371,1,16342,American Cinema: The Directors,Vaughan,Thomas Michael,16,8,2,0,0,0,1,3.437
+Fall 2022,PSYC,3339,2,16343,Intro To Clinical Psychology,Szafranski,Derek D,76,14,6,1,2,0,1,3.616
+Fall 2022,MANA,4347,2,16345,Ethics and Corp Soc Respon.,Salaiz,Ashley,25,9,4,1,2,0,1,3.301
+Fall 2022,MANA,4353,1,16346,Mgmt Training and Career Devel,Bozeman,Dennis,34,13,3,0,0,0,0,3.666
+Fall 2022,MANA,6310,1,16347,Fundamentals of Business,Celly,Nikhil,16,0,0,0,0,0,0,3.918
+Fall 2022,SOCW,7304,8,16351,Brief Targeted Interventions,Cheung,Monit,19,1,0,0,1,0,0,3.762
+Fall 2022,SOCW,7335,2,16353,SW Practice in Communities,Goss,Deshara,25,0,0,0,0,0,0,4.0
+Fall 2022,KIN,3306,5,16354,Physiology-Human Performance,Hamilton,Marc,6,15,28,26,26,0,20,1.426
+Fall 2022,PSYC,4344,8,16355,Cultural Psychology,Brooks,Jasmin R,26,26,13,4,8,0,3,2.813
+Fall 2022,KIN,4370,1,16356,Exercise Testing,Breslin,Whitney L,18,32,36,2,4,0,1,2.627
+Fall 2022,CIS,3365,3,16363,Database Management,Hu,Renjie,3,20,12,0,0,0,0,2.677
+Fall 2022,MATH,4310,1,16365,Biostatistics,Labate,Demetrio,12,0,3,2,0,0,1,3.236
+Fall 2022,PSYC,2317,10,16366,Intro to Psychology Statistics,Pierce,Jace D,12,9,4,0,3,0,4,2.964
+Fall 2022,PSYC,2317,11,16367,Intro to Psychology Statistics,Pierce,Jace D,18,12,7,0,0,0,1,3.288
+Fall 2022,PETR,8298,14,16372,Doctoral Research,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Fall 2022,PSYC,2317,12,16373,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,23,28,16,3,4,0,4,2.86
+Fall 2022,MATH,6350,1,16374,Stat. Learning and Data Mining,Azencott,Robert Guy,21,1,0,0,1,0,0,3.74
+Fall 2022,ENGL,3330,2,16377,Beg Creative Writing-Fiction,Kennedy,Daniel Peter,11,6,1,0,2,0,0,3.151
+Fall 2022,ENGL,3331,3,16378,Beg Creative Writing-Poetry,Williams,Adele E,9,2,1,0,0,0,0,3.639
+Fall 2022,PSYC,4344,10,16380,Cultural Psychology,Haddad,Sana,26,15,8,0,5,0,0,3.037
+Fall 2022,ENGL,2318,1,16381,Creation and Perform of Lit,Belieu,Erin Colleen,30,2,0,0,1,0,2,3.798
+Fall 2022,ENGL,3360,1,16382,Survey of African-American Lit,Harrell,Haylee C,21,6,2,0,1,0,0,3.478
+Fall 2022,ENGL,4303,1,16383,Teaching Engl as a Second Lang,Duran,Chatwara,11,5,0,4,0,0,1,3.15
+Fall 2022,ECE,6331,1,16384,Advanced Telecommunications,Han,Zhu,9,3,0,0,0,0,0,3.695
+Fall 2022,NUTR,6303,1,16385,Nutrition Mgmt & Leadership,Haubrick,Kevin,9,5,0,0,0,0,1,3.407
+Fall 2022,NUTR,6302,1,16386,Adv Medical Nutrition Therapy,Ferrell,Carla Denise,12,3,0,0,0,0,0,3.756
+Fall 2022,ECE,5388,1,16387,Renewable Energy Technology,Huang,Hao,11,2,6,0,0,0,1,3.194
+Fall 2022,ECE,6372,1,16390,Advanced Hardware Design,Chen,Yuhua,49,18,3,0,0,0,0,3.563
+Fall 2022,ECE,5451,1,16391,Principles of Internetworking,Wolfe,John C,34,1,1,0,0,0,0,3.898
+Fall 2022,ECE,6321,1,16392,Principles of Internetworking,Wolfe,John C,41,3,0,0,0,0,0,3.909
+Fall 2022,TEPM,6391,2,16393,Project Management Seminar,Carden,Lila L,3,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,3377,4,16394,Cost Accounting,Lin,Haijin,14,9,7,0,1,0,4,3.097
+Fall 2022,SCLT,4389,31,16395,Practicum in Supply Chain,Henson,Alfred Bernard,26,4,0,0,0,0,0,3.735
+Fall 2022,BIOL,4323,1,16397,Immunology,Sen,Mehmet,43,48,15,0,0,0,9,3.214
+Fall 2022,BIOL,6323,1,16398,Immunology,Peng,Weiyi,18,7,0,0,0,0,0,3.654
+Fall 2022,SOCW,7356,3,16399,Groups in Clinical Settings,Cheung,Poi Ten Ada,18,1,0,0,0,0,0,3.947
+Fall 2022,SOCW,7356,4,16400,Groups in Clinical Settings,Gracely,Jill Marie,14,1,0,0,0,0,0,3.933
+Fall 2022,FINA,7323,1,16401,Applied Equity Fund Management,George,Thomas J,15,2,0,0,0,0,0,3.863
+Fall 2022,COSC,3320,1,16403,Algorithms and Data Structures,Leiss,Ernst L,65,54,19,2,4,0,15,3.176
+Fall 2022,NUTR,4201,1,16404,Dietetics as a Profession II,Ferrell,Carla Denise,22,10,3,3,1,0,1,3.223
+Fall 2022,KIN,4300,1,16406,Phys Activity Older Adults,Alastuey,Lisa L,35,51,23,7,3,0,4,2.83
+Fall 2022,GHL,1320,1,16407,Foodservice Management,Sirsat,Sujata Ashok,21,16,12,2,2,0,2,2.844
+Fall 2022,GHL,2356,1,16408,Comm Strategies for Hospitalty,Haskell,Rebecca Erin,21,9,5,1,1,0,1,3.208
+Fall 2022,ARCH,2331,1,16409,Digital Vocabularies,Jackson,Megan H,8,5,1,1,1,0,2,3.125
+Fall 2022,ARCH,1358,1,16410,Introduction to Design Culture,Kubo,Michael,96,31,7,3,1,0,6,3.544
+Fall 2022,CIVE,4332,2,16411,Hydrology,Li,Hongyi,43,32,5,1,0,0,0,3.416
+Fall 2022,CIVE,4333,2,16412,Water & Wastewater Treatment,Rixey,William G,28,23,25,2,2,0,0,2.867
+Fall 2022,CIVE,7342,1,16413,Engineer Geographic Info. Syst,Ekhtari,Nima,8,0,0,0,0,0,0,3.753
+Fall 2022,CIVE,5362,1,16414,Water Quality Engineering,Pena Bahamonde,Janire,6,8,1,0,0,0,1,3.377
+Fall 2022,CIVE,3332,1,16415,Engineering Materials,Krakowiak,Konrad,10,15,6,0,0,0,0,3.108
+Fall 2022,CIVE,3380,1,16417,Plane Surveying Fundamentals,Glennie,Craig Len,18,25,28,1,2,0,0,2.69
+Fall 2022,HON,3331,1,16419,Intro to Civic Engagement,Williamson,Jonathan Lyle,13,5,1,0,1,0,0,3.483
+Fall 2022,CNST,6307,1,16420,Stati and Optimiz Method in CM,Senouci,Ahmed,14,18,4,0,1,0,0,3.189
+Fall 2022,CNST,6308,1,16421,Data Analysis in Construc Mgmt,Gao,Lu,38,7,0,0,0,0,0,3.83
+Fall 2022,CNST,6350,1,16422,Decision Making and Risk Mgmt,Gao,Lu,25,0,1,0,1,0,0,3.766
+Fall 2022,GHL,3346,1,16424,Beer Appreciation,Corsi,Aaron James,7,5,1,0,0,0,0,3.614
+Fall 2022,GHL,3349,1,16425,Hosp Procurement & Purchasing,Ginapp,Kathrine,13,10,8,0,1,0,0,3.083
+Fall 2022,PHYS,6315,2,16426,Quantum Mechanics I,Ratti,Claudia,14,17,1,0,0,0,1,3.396
+Fall 2022,HON,3306,1,16427,Health and Human Rights,Lunstroth,John,20,0,0,0,0,0,1,3.934
+Fall 2022,BCHS,3307,1,16428,Biochem for Nutrition Majors,Briggs,James M,7,6,5,4,1,0,0,2.609
+Fall 2022,BUSI,1301,4,16430,Business Principles,Carvalho,Diogo,133,69,22,5,8,0,12,3.305
+Fall 2022,GEOL,4330,1,16431,Intro To Geophysics,Wang,Guoquan,14,4,0,0,1,0,0,3.527
+Fall 2022,GEOL,4381,1,16432,Geophysical Signals,Zheng,Yingcai,1,2,2,0,0,0,0,2.602
+Fall 2022,GEOL,3350,1,16434,Stratigraphy,Carlson,Brandee Nicole,12,12,4,4,0,0,0,2.959
+Fall 2022,ENGL,6323,1,16439,Fiction Workshop,Peynado,Brenda,7,0,0,0,0,0,0,4.0
+Fall 2022,ECE,5115,1,16440,Control Systems Lab II,Provence,Robert S,9,0,0,0,0,0,0,3.89
+Fall 2022,ECE,6111,5,16443,Graduate Research Seminar,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2022,ENRG,4320,1,16444,Case Studies-Enrgy & Sustainbl,Hallmark,Terrell L,9,9,1,0,0,0,1,3.404
+Fall 2022,COMM,1303,1,16445,Writing for Communicators,Lyn,Robyn,74,4,5,0,8,0,4,3.455
+Fall 2022,COMM,2326,1,16446,Intro to Sports Broadcasting,Trupiano,Jerome,19,0,0,0,0,0,1,4.0
+Fall 2022,COMM,2356,1,16447,Business & Professional Comm,Salisbury,Shelby,112,97,28,12,30,0,14,2.863
+Fall 2022,INDE,2333,3,16448,Engineering Statistics I,Kamrani,Ali K,20,11,6,0,1,0,4,3.229
+Fall 2022,ARCH,5500,11,16449,Architecture Design Studio IX,Kacmar,Donna,3,8,2,0,2,0,0,2.667
+Fall 2022,TEPM,6303,20,16451,Risk Assessment in Project Mgm,Carden,Lila L,11,2,0,1,0,0,0,3.596
+Fall 2022,BIOE,4350,1,16452,Genomic & Proteomic Engr,Wu,Tianfu,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,4311,1,16453,Advances in Vision Research,Naash,Muna,3,0,1,0,0,0,1,3.5
+Fall 2022,TEPM,6305,2,16459,Project Manager Tools,Sherman,Dennis Louis,5,0,0,0,0,0,0,4.0
+Fall 2022,TEPM,6306,2,16460,Project Management Office,Sherman,Dennis Louis,6,1,0,0,1,0,0,3.375
+Fall 2022,TEPM,6308,1,16461,Project Procurement Practices,Conover,Sharon Cecilia,7,2,0,0,0,0,0,3.851
+Fall 2022,TEPM,6391,20,16462,Project Management Seminar,Carden,Lila L,5,0,0,0,1,0,0,3.278
+Fall 2022,TEPM,6395,2,16463,Integration Project,Carden,Lila L,2,1,0,0,0,0,0,3.557
+Fall 2022,LAW,5409,10,16479,Contracts,Trujillo,Elizabeth I.,12,22,1,0,0,0,1,3.295
+Fall 2022,ARTS,1383,1,16480,Introduction to New Media,Reed,John G,8,4,0,1,5,0,6,2.482
+Fall 2022,LAW,6370,2,16481,Advanced Legal Research,Watson,Amanda,6,4,1,0,0,1,0,3.455
+Fall 2022,LAW,5323,1,16482,Conflict of Laws,Ungureanu,Razvan C,7,23,0,0,0,0,0,3.2
+Fall 2022,LAW,5368,1,16483,Estate Planning,Buckles,Johnny R,4,3,0,0,0,3,1,3.619
+Fall 2022,LAW,6347,1,16485,Secured Financing,Dole,Richard F,10,3,0,0,0,6,0,3.693
+Fall 2022,LAW,5241,1,16486,Adv Drafting Corporate Trnsact,Ginsburg,Richard Allen,5,5,0,0,0,0,1,3.401
+Fall 2022,LAW,6302,1,16487,Foreign Relations Law,Berman,Emily,9,20,0,0,0,0,0,3.322
+Fall 2022,HIST,2374,1,16493,Popular Culture in Latin Amer,Milanesio,Natalia,3,9,11,4,5,0,2,1.969
+Fall 2022,HIST,2321,1,16494,Study of Early Civilizations,Holt,Frank L,22,5,5,0,2,0,0,3.294
+Fall 2022,HIST,3319,1,16495,Plagues and Pestilence,Schafer Jr,James A,20,9,0,0,1,0,2,3.567
+Fall 2022,HIST,6381,1,16496,Readings in Public Hist,Perales,Monica,4,0,0,0,0,0,0,3.835
+Fall 2022,ELET,4352,1,16498,Computational Tools for Tech,Zouridakis,George,17,25,6,1,0,0,0,3.197
+Fall 2022,ELET,2105,2,16499,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,12,2,4,0,0,0,0,3.426
+Fall 2022,DANC,4330,1,16500,Career Skills for Dancers,Valle,Toni Leago,2,1,3,0,1,0,0,2.334
+Fall 2022,MUSI,6100,1,16501,Chamber Music,Hester,Timothy E,9,0,0,0,0,0,0,4.0
+Fall 2022,PHYS,1101,22,16502,College Physics I (lab),Wood,Lowell T,3,6,9,0,0,0,3,2.703
+Fall 2022,TEPM,6308,20,16503,Project Procurement Practices,Conover,Sharon Cecilia,7,0,0,0,0,0,0,3.953
+Fall 2022,PHYS,1102,15,16504,College Physics II (lab),Wood,Lowell T,2,10,10,0,0,0,1,2.711
+Fall 2022,PHYS,1102,16,16505,College Physics II (lab),Wood,Lowell T,2,7,7,0,0,0,0,2.646
+Fall 2022,PHYS,1102,17,16506,College Physics II (lab),Wood,Lowell T,0,12,9,0,0,0,1,2.681
+Fall 2022,PHYS,1102,18,16507,College Physics II (lab),Wood,Lowell T,0,11,2,0,0,0,1,2.694
+Fall 2022,PHYS,1102,19,16508,College Physics II (lab),Wood,Lowell T,1,14,7,0,0,0,1,2.727
+Fall 2022,ENGL,7324,1,16510,Writers On Literature,Serpas,Martha R,10,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4198,31,16511,SP-Opera Production,Edelson,Lawrence Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,THEA,3379,1,16513,Stage Design for Educators,Minor,Blake,6,0,0,0,0,0,0,3.89
+Fall 2022,THEA,6185,1,16514,Scenic Methods & Materials,Vlahos,Kalliope,2,0,0,0,0,0,0,4.0
+Fall 2022,THEA,6294,1,16515,Design and Production Studio,Vlahos,Kalliope,2,0,0,0,0,0,0,4.0
+Fall 2022,COSC,2436,3,16517,Programming and Data Structure,Ramamurthy,Uma,5,10,10,10,22,0,10,1.375
+Fall 2022,COSC,2436,5,16519,Programming and Data Structure,Rizk,Nouhad J,35,36,22,3,4,0,18,2.907
+Fall 2022,COSC,2436,7,16521,Programming and Data Structure,Rizk,Nouhad J,41,27,20,3,8,0,17,2.886
+Fall 2022,ARTH,3301,1,16522,Critical Theory,Meza,Abinadi,11,1,2,0,0,0,0,3.643
+Fall 2022,ARTH,6301,1,16523,Critical Theory,Meza,Abinadi,4,0,1,0,0,0,0,3.6
+Fall 2022,CIVE,3331,1,16524,Environmental Engineering,Louie,Stacey M,16,23,6,0,0,0,0,3.208
+Fall 2022,BIOE,4347,1,16525,Cell Biology for BME,Al-Ubaidi,Muayyad,0,3,1,0,0,0,0,2.915
+Fall 2022,PSYC,6308,1,16528,Foundations of Neuropsychology,Medina PhD,Luis Daniel,4,0,0,0,0,0,0,3.753
+Fall 2022,BIOL,6350,1,16529,Biomedical Sciences Practicum,Lin,Chin-Yo,25,0,0,0,0,0,0,3.987
+Fall 2022,BIOL,6351,1,16530,Integrative Anatomy & Physiol,Ogletree-Hughes,Monique L,20,6,1,0,0,0,0,3.728
+Fall 2022,MUSA,4430,1,16531,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Fall 2022,TLIM,3300,30,16532,Leadership & Innovation Fund,Evans,Gerald S,31,3,4,1,4,0,0,3.264
+Fall 2022,TLIM,3330,1,16533,Innovation Principles,Crawley,David L,7,4,11,2,3,0,1,2.297
+Fall 2022,MATH,6357,1,16534,Lin. Models & Des. Experiments,Wang,Wenshuang,19,0,0,0,1,0,0,3.767
+Fall 2022,MATH,4339,2,16536,Multivariate Statistics,Poliak,Cathy Dawn,20,4,3,0,0,0,0,3.593
+Fall 2022,PSYC,2330,6,16538,Biological Psychology,Leonard,Samuel J,26,13,1,0,0,0,0,3.691
+Fall 2022,MUSA,1324,2,16540,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2022,NUTR,6312,1,16544,Capstone II,Haubrick,Kevin,4,0,0,0,0,0,1,4.0
+Fall 2022,NUTR,6311,1,16545,Capstone I,Haubrick,Kevin,4,1,0,0,0,0,0,3.866
+Fall 2022,MIS,7374,1,16546,Bus Appls Database Mgt Sys II,Scamell,Richard W,2,0,0,0,0,0,0,4.0
+Fall 2022,ECON,3332,5,16548,Intermediate Microeconomics,Friedman,Willa H,20,12,18,0,1,0,0,2.922
+Fall 2022,CHEM,8999,21,16549,Doctoral Dissertation,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2022,PHAR,5325,1,16551,Literature Evaluation,Hatfield,Catherine L,27,48,33,0,0,0,0,2.944
+Fall 2022,PHAR,5224,1,16552,Integrated Renal Module,Marwaha,Aditi,30,57,23,3,0,0,0,3.009
+Fall 2022,PHAR,5225,1,16553,Integrated GI Module,Udugamasooriya,Damith Gomika,29,55,23,2,0,0,0,3.018
+Fall 2022,PHAR,5226,1,16554,Integrated Respiratory Module,Eriksen,Jason,24,53,32,2,0,0,0,2.892
+Fall 2022,PHAR,5111,1,16555,Leadership and IPE,Varkey,Divya A,102,4,2,0,0,0,0,3.926
+Fall 2022,PHAR,5195,1,16556,Pharmacy Skills Program III,Davis,Shantera Rayford,63,1,0,0,0,0,0,3.984
+Fall 2022,PHAR,5158,1,16557,Module Related Skills Lab I,Davis,Shantera Rayford,57,7,0,0,0,0,0,3.891
+Fall 2022,ECE,6382,1,16560,Engineering Analysis I,Jackson,David R,5,6,1,0,0,0,0,3.361
+Fall 2022,ECE,6377,1,16561,Power Systems Analysis,Phillips,Desiree Lyn,20,4,1,0,0,0,0,3.707
+Fall 2022,ECE,5377,1,16562,Power Systems Analysis,Phillips,Desiree Lyn,9,9,2,1,0,0,0,3.191
+Fall 2022,GHL,1367,1,16563,Lodging Management,Cheatham,Cathy A,34,20,5,1,5,0,0,3.22
+Fall 2022,GHL,1367,2,16564,Lodging Management,Popa,Iuliana,4,10,4,3,2,0,1,2.478
+Fall 2022,ECE,6342,1,16565,Digital Signal Process,Hebert,Thomas James,8,14,3,4,0,0,2,2.988
+Fall 2022,DRAM,1310,10,16567,Introduction to Theatre,Hinkel,Heidi Anne,385,98,30,12,15,0,4,3.489
+Fall 2022,THEA,6310,1,16568,CAD II for Theatre Design,Vlahos,Kalliope,0,1,1,0,0,0,0,2.83
+Fall 2022,THEA,6353,1,16569,"Scenic, Cost,& Light Design I",Vintu,Tatiana,3,0,0,0,0,0,0,3.89
+Fall 2022,MUSI,4298,2,16570,Special Problems in Pedagogy,Van Kekerix,Todd Evan,4,0,0,0,0,0,0,3.918
+Fall 2022,PHAR,5158,2,16571,Module Related Skills Lab I,Davis,Shantera Rayford,33,11,0,0,0,0,0,3.75
+Fall 2022,PHAR,5195,2,16572,Pharmacy Skills Program III,Davis,Shantera Rayford,39,5,0,0,0,0,0,3.886
+Fall 2022,MUSA,2342,1,16573,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2340,3,16574,Applied Trumpet,Vassallo,Jim Cates,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3446,1,16575,Applied Tuba,Barton,Mark,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8699,1,16576,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8399,1,16577,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,3,0,
+Fall 2022,MECE,6345,1,16579,Fluid Dynamics 1,Yang,Di,7,12,7,0,0,0,6,2.975
+Fall 2022,MUSI,8399,1,16580,Doctoral Document,Maroney,Marcus K,0,0,0,0,0,1,0,
+Fall 2022,ENGL,7399,1,16581,Essay,Voskuil,Lynn M,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6291,1,16582,Project Implementation,Ramirez,Arlene D,0,0,0,0,0,8,0,
+Fall 2022,MUSA,4440,4,16583,Applied Trumpet,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7398,1,16586,Special Problems,Tejada,Roberto Jose,2,0,0,0,0,0,0,4.0
+Fall 2022,ECE,3331,2,16587,Program Appl in Elec Comp Engr,Hebert,Thomas James,15,12,20,7,1,0,13,2.654
+Fall 2022,ARTS,4398,4,16590,Independent Study,Williams,Celeste,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6204,1,16592,Conducting,Krager,Franz A,5,0,0,0,0,0,1,4.0
+Fall 2022,ILAS,2350,1,16595,Knowledge and Methods,Oliva,Luca,34,18,17,4,15,0,7,2.572
+Fall 2022,ENGL,6698,2,16599,Research,Prufer,Kevin D,0,0,0,0,0,1,0,
+Fall 2022,ARTH,7393,1,16601,Art History Internship,Koontz,Rex A,2,0,0,0,0,0,0,4.0
+Fall 2022,COMM,3374,1,16602,Strategic Social Media,Uhrick,Jan,20,8,0,1,0,0,0,3.518
+Fall 2022,ENGL,4399,1,16603,Senior Honors Thesis,Backus,Margot Gayle,0,0,0,0,0,0,0,
+Fall 2022,BIOE,6311,1,16604,Advances in Vision Research,Naash,Muna,3,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8698,1,16606,Graduate Research,Berger,Jason,0,0,0,0,0,1,0,
+Fall 2022,SCLT,2362,32,16608,Intro To Logistics Technology,Cassler,Daniel,53,4,0,3,1,0,1,3.721
+Fall 2022,POLS,3312,4,16609,"Arguments, Data, Politics",Marinov,Nikolay,7,9,8,7,3,0,4,2.216
+Fall 2022,MUSI,6106,2,16610,Grad Large Ensemble,Marmolejo,Noe J,2,0,0,0,0,0,0,4.0
+Fall 2022,HRD,4352,1,16614,Facilitation Strategies,Hampton,Elaine Denae,14,4,0,0,0,0,1,3.741
+Fall 2022,ENGL,3399,1,16617,Senior Honors Thesis,Lecourt,Sebastian Joseph,1,0,0,0,0,0,0,4.0
+Fall 2022,MIS,7375,1,16618,Transaction Processing Systems,Messinger,Jacob Nelson,13,2,0,0,0,0,0,3.845
+Fall 2022,ARTS,3374,2,16619,Computer Imaging,Butler,Rontaye Micquan,12,3,0,0,0,0,1,3.624
+Fall 2022,MUSA,4400,7,16620,Applied Voice,Vasquez,Hector A,4,0,0,0,0,0,0,3.835
+Fall 2022,MANA,3335,6,16621,Intro Org Behavior and Mgmt,Essman,Spenser,25,30,10,1,0,0,0,3.257
+Fall 2022,MANA,3335,10,16622,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,179,97,16,0,7,0,1,3.448
+Fall 2022,CHIN,2311,2,16625,Intermediate Chinese I,Zhang,Xincui,7,2,0,0,0,0,2,3.704
+Fall 2022,MATH,6398,5,16630,Special Problems,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Fall 2022,PHOP,7275,1,16631,Intro Comp Thinking w/Python,Coates,Daniel R,5,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6377,1,16632,Intro Opt Sense &Biophotonics,Larin,Kirill,2,0,0,0,0,0,0,3.835
+Fall 2022,PHAR,5683,1,16633,Cardiology,Sulaica,Elisabeth,2,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6257,12,16636,Research Practicum B,Cheng,Han,2,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6467,2,16640,Research Practicuum A,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,3339,1,16653,Ancient Greece,Holt,Frank L,14,11,7,1,1,0,0,3.107
+Fall 2022,MUSA,6304,2,16654,Conducting,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,8399,14,16655,Dissertation,Kanellos,Nicolas,1,0,0,0,0,1,0,4.0
+Fall 2022,NURS,3310,1,16656,Prof Role Dev & Practice Issue,Phan,Huong Thi,42,4,0,1,0,0,0,3.851
+Fall 2022,PSYC,6359,3,16657,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,2,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,8399,2,16661,Dissertation,Sampson,McClain,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,2326,1,16666,Fundamentals of Sculpture,De Leon,Laura,11,1,0,0,0,0,1,3.807
+Fall 2022,CIS,3347,1,16667,IS Infrastructure and Networks,Martinez,Jose C,28,7,7,3,3,0,3,3.125
+Fall 2022,MATH,6380,1,16670,Programming for Data Analytics,Shastri,Dvijesh J,6,12,3,0,1,0,0,2.955
+Fall 2022,SOCW,8399,3,16673,Dissertation,Narendorf,Sarah C.,0,0,0,0,0,1,0,
+Fall 2022,MIS,4374,4,16676,Info Technology Project Mgmt,Campbell,Phillip James,2,6,3,0,0,0,0,2.849
+Fall 2022,PCOL,8998,3,16681,Doctoral Research,Hussain,Tahir,0,0,0,0,0,1,0,
+Fall 2022,PHCA,8698,5,16682,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,8298,4,16683,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,2101,21,16693,Anatomy & Physiology Lab I,Gill,Tejendra,4,13,5,1,0,0,1,2.898
+Fall 2022,BIOE,8598,3,16699,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Fall 2022,MUSA,1322,1,16705,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,3.835
+Fall 2022,CHEE,6399,1,16706,Masters Thesis,Karim,Alamgir,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,7399,1,16707,Masters Thesis,Karim,Alamgir,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,1303,2,16709,Writing for Communicators,Lyn,Robyn,61,12,3,5,2,0,8,3.486
+Fall 2022,MIS,7378,1,16710,Info.Tech Management & Control,Skinner,Richard James,20,6,0,0,0,0,0,3.769
+Fall 2022,MUSA,6142,2,16711,Graduate Recital III,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6400,3,16712,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2305,13,16713,Intro to Methods in Psychology,Wilson,Danielle,21,28,22,2,3,0,4,2.807
+Fall 2022,PHCA,8298,5,16718,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2022,MIS,4374,3,16719,Info Technology Project Mgmt,Campbell,Phillip James,25,13,1,0,2,0,0,3.439
+Fall 2022,PCEU,6698,4,16720,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2022,MECT,4331,2,16721,Heat Transfer Applications,Alba,Kamran,7,10,5,0,0,0,1,3.076
+Fall 2022,PETR,2311,1,16723,Reservoir Petrophysics,Myers,Michael Tolbert,0,3,0,0,0,0,0,2.78
+Fall 2022,PHCA,6298,6,16725,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,6398,1,16726,SP- Outcomes Research,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Fall 2022,OPTO,5133,1,16728,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,17,5,2,0,0,0,0,3.625
+Fall 2022,OPTO,5133,2,16729,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,20,5,1,0,0,0,0,3.731
+Fall 2022,MUSA,6342,1,16730,Applied French Horn,Johnson,Robert,0,0,0,0,0,0,1,
+Fall 2022,POLS,8699,12,16734,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,1,0,
+Fall 2022,ENGL,4300,1,16736,Intro-Study of Language,Lee,Eunjeong,23,5,2,0,0,0,0,3.744
+Fall 2022,PCOL,6498,5,16738,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4434,1,16739,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,5330,1,16756,Advanced Accounting,Ramaswamy,Vinita,0,1,1,0,0,0,0,2.83
+Fall 2022,ACCT,5330,2,16757,Advanced Accounting,Ramaswamy,Vinita,2,2,4,0,0,0,0,2.833
+Fall 2022,PEP,8699,11,16760,Doctoral Dissertation,Ledoux,Tracey A,0,0,0,0,0,2,0,
+Fall 2022,SOCI,1301,4,16761,Introduction To Sociology,Dorsey,Patricia Lynne,15,26,13,1,2,0,2,2.854
+Fall 2022,PEP,8699,3,16763,Doctoral Dissertation,LaVoy,Emily Claire-Pyle,1,0,0,0,0,0,0,4.0
+Fall 2022,POLS,8699,14,16764,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,2,0,
+Fall 2022,BCHS,3396,2,16765,Senior Research Project,Frankino,William A,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,4396,3,16766,Senior Research Project,Lin,Chin-Yo,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6322,1,16767,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,2326,4,16768,Fundamentals of Sculpture,Patzke,Katie,10,1,1,0,0,0,0,3.723
+Fall 2022,PCOL,8998,7,16770,Doctoral Research,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2022,CNST,3185,2,16772,Construction Experience,Eldin,Neil N,12,16,5,1,1,0,4,3.057
+Fall 2022,ENGL,1301,43,16782,First Year Writing I,Eliades,Addie C,12,6,0,0,0,0,1,3.667
+Fall 2022,ENGL,1301,44,16783,First Year Writing I,Eliades,Addie C,13,6,0,0,0,0,0,3.58
+Fall 2022,MUSI,6114,1,16787,Chamber Music - Brass,Derges,Julie D,7,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,1501,19,16788,Elementary Spanish I,Gonzalez,Viviannette,8,8,2,1,2,0,2,2.779
+Fall 2022,SPAN,2311,1,16789,Intermediate Spanish I,Morales Utria,Yordanis,7,13,3,2,1,0,1,2.948
+Fall 2022,PHCA,6298,2,16792,Special Problems,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2022,DIGM,4396,30,16793,Internship in Digital Media,Waite,Jerry J,3,1,0,0,0,0,0,3.833
+Fall 2022,PHLA,7299,2,16794,Masters Thesis,Tolleson,Shane Russell,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8320,30,16797,Doctoral Applied Music,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2022,DRAM,1310,11,16800,Introduction to Theatre,Hinkel,Heidi Anne,32,6,7,2,2,0,0,3.272
+Fall 2022,POLS,6399,2,16803,Masters Thesis,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,0,0,
+Fall 2022,ACCT,5337,1,16805,Management Accounting,Lin,Haijin,4,4,1,0,0,0,0,3.223
+Fall 2022,PHYS,1101,23,16806,College Physics I (lab),Wood,Lowell T,1,11,9,0,0,0,2,2.745
+Fall 2022,COMM,6390,1,16807,Applied Project,Harlow,Summer D,0,0,0,0,0,1,0,
+Fall 2022,COMM,6399,4,16812,Masters Thesis,Olson,Beth M,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8399,26,16814,Doctoral Dissertation,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Fall 2022,COMD,7392,5,16815,Adv Pract Sp & Lang Dis,Figueroa,Brenda Cristina,3,0,0,0,0,0,0,4.0
+Fall 2022,COMD,7391,10,16822,Clinic in Speech Lang Disorder,Cizek,Laura S,2,1,0,0,0,0,0,3.557
+Fall 2022,COMD,7391,1,16823,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,3,1,0,0,0,0,0,3.585
+Fall 2022,ACCT,2301,9,16826,Prin of Financial Accounting,Sykes,Mary Reeves,27,20,6,8,2,0,5,3.047
+Fall 2022,POLS,8699,15,16827,Doctoral Dissertation,Marinov,Nikolay,1,0,0,0,0,0,0,4.0
+Fall 2022,RELS,2340,1,16833,Introduction to Hinduism,Ullrey,Aaron Michael,18,11,1,0,3,0,9,3.212
+Fall 2022,PHCA,6198,1,16838,SP- Outcomes Research,Varkey,Divya A,0,0,0,0,0,0,0,
+Fall 2022,HON,3399,14,16842,Senior Honors Thesis,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,
+Fall 2022,PSYC,6365,7,16850,Dir Rsch in Dev Cog Beh Neuro,Kosten,Therese A,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8398,1,16851,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Fall 2022,BIOE,8598,5,16852,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,2,0,
+Fall 2022,HIST,8999,3,16857,Doctoral Dissertation,Perales,Monica,0,0,0,0,0,1,0,
+Fall 2022,MUSA,2334,2,16859,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Fall 2022,ECON,3357,1,16865,Data Mgmt with Econ Appl,Peru Durayalage,Dhanushka Arunasiri,16,9,9,3,7,0,2,2.538
+Fall 2022,ITAL,3307,1,16867,Italian Renaissance,Behr,Francesca D.,8,3,3,0,2,0,2,2.938
+Fall 2022,CLAS,3308,2,16869,Myths & Cult of the Greek Gods,Houlihan,James W,12,12,1,1,0,0,3,3.295
+Fall 2022,WCL,2351,2,16871,World Cultures Thru Lit & Arts,Ambikaipaker,Mohan,12,6,2,3,4,0,2,2.679
+Fall 2022,WCL,2352,1,16872,World Cinema,Centeno,Daniel,15,11,2,0,1,0,0,3.231
+Fall 2022,WCL,3366,2,16875,Latin American and Latino Film,Centeno,Daniel,9,17,2,0,0,0,2,3.191
+Fall 2022,MATH,1351,5,16878,Intro to Geometric Reasoning,Chang,James A,104,56,30,24,38,0,26,2.622
+Fall 2022,MATH,1342,3,16882,Elementary Statistical Methods,Caputo,Matthew G,130,156,106,48,98,0,50,2.28
+Fall 2022,MATH,3336,5,16884,Discrete Mathematics,Douglas,Casey,44,40,36,7,6,0,5,2.8
+Fall 2022,MATH,3338,1,16885,Probability,Timofeyev,Ilya,14,5,6,5,5,0,6,2.42
+Fall 2022,MATH,3339,1,16886,Statistics for the Sciences,Ryan,John M,97,49,47,16,25,0,18,2.759
+Fall 2022,MATH,4364,2,16887,Intro to Numerical Analysis,Morgan,Jeffrey,20,24,18,4,1,0,7,2.807
+Fall 2022,MATH,1100,1,16888,Developmental Math,Caputo,Matthew G,0,0,0,0,0,119,37,
+Fall 2022,CHIN,3342,1,16889,Tales of East Asian Cities,Li,Melody Yunzi,8,2,0,0,0,0,2,3.8
+Fall 2022,BIOL,4315,1,16890,Neuroscience,Ziburkus,Jokubas,57,35,23,0,0,0,13,3.267
+Fall 2022,BIOL,4315,2,16891,Neuroscience,Ziburkus,Jokubas,43,18,20,0,0,0,17,3.264
+Fall 2022,COMD,2376,3,16892,Anatomy for Communication,Daniels,Stephanie K,12,9,7,4,3,0,3,2.685
+Fall 2022,COMD,4333,1,16894,Neuroscience for COMD,Dial,Heather Raye,8,9,1,1,0,0,1,3.211
+Fall 2022,ILAS,4350,1,16895,Interdisciplinary Problem Solv,Oliva,Luca,12,7,4,0,1,0,2,3.277
+Fall 2022,ENGI,1100,25,16896,Introduction To Engineering,Kota,Venkata Krishna Tulasi,9,11,4,1,1,0,0,2.975
+Fall 2022,NUTR,4351,1,16897,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,83,62,35,6,8,0,4,3.016
+Fall 2022,CHEM,6312,1,16898,Bonding,Wu,Judy,12,5,0,0,0,0,0,3.706
+Fall 2022,BIOL,6315,1,16899,Neuroscience,Ziburkus,Jokubas,5,2,0,0,0,0,0,3.62
+Fall 2022,PHYS,4360,1,16901,Space and Atmospheric Physics,Bering,Edgar A,6,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,3150,1,16902,Prin-Stratigraphy Lab,Carlson,Brandee Nicole,9,6,0,2,0,0,0,3.216
+Fall 2022,NSS,2342,1,16903,Intro to Nat. Sec. Studies,Vardy,Ronald V,7,6,3,1,5,0,1,2.334
+Fall 2022,GOVT,2306,7,16904,US and Texas Const/Politics,Jefferies,Kevin E,106,84,22,13,18,0,5,2.987
+Fall 2022,GOVT,2306,8,16905,US and Texas Const/Politics,Cortina,Jeronimo,38,84,45,26,38,0,14,2.244
+Fall 2022,GOVT,2306,13,16906,US and Texas Const/Politics,McDonald,John Terrence George,35,31,26,4,2,0,2,2.922
+Fall 2022,GOVT,2306,16,16907,US and Texas Const/Politics,Marcinek,Elizabeth Nicole Simas,71,82,21,8,7,0,5,3.039
+Fall 2022,IDNS,1130,1,16909,Precalculus SEP Workshop,Pattison,Donna,15,5,1,2,0,0,5,3.349
+Fall 2022,IDNS,1130,2,16910,Precalculus SEP Workshop,Pattison,Donna,19,3,3,6,0,0,2,3.129
+Fall 2022,BIOL,6354,1,16911,Endocrinology,Warner,Margaret,11,1,0,0,0,0,0,3.917
+Fall 2022,BZAN,6354,1,16914,DB Mgt Tools Bus Analytics,Grimes,George M,27,5,1,0,0,0,1,3.788
+Fall 2022,BZAN,6356,1,16916,Adv DB Mgt Tools Bus Analytics,Grimes,George M,14,0,0,0,0,0,0,4.0
+Fall 2022,MIS,3360,4,16917,Systems Analysis and Design,Knighton,William B,36,20,4,2,0,0,1,3.452
+Fall 2022,MIS,3376,4,16918,Busn Appls Database Mgmt I,Jiang,Lianlian,36,18,2,1,0,0,2,3.602
+Fall 2022,IDNS,1131,1,16919,Calculus I SEP Workshop,Pattison,Donna,17,2,2,4,0,0,2,3.372
+Fall 2022,IDNS,1131,2,16920,Calculus I SEP Workshop,Pattison,Donna,12,3,5,3,4,0,3,2.593
+Fall 2022,IDNS,1131,3,16921,Calculus I SEP Workshop,Pattison,Donna,16,5,1,3,2,0,2,3.099
+Fall 2022,IDNS,1131,4,16922,Calculus I SEP Workshop,Pattison,Donna,13,3,3,5,1,0,1,2.933
+Fall 2022,IDNS,1132,1,16923,Calculus II SEP Workshop,Pattison,Donna,12,10,2,4,0,0,3,3.095
+Fall 2022,IDNS,1132,2,16924,Calculus II SEP Workshop,Pattison,Donna,14,4,5,4,1,0,2,2.834
+Fall 2022,IDNS,2133,1,16925,Calculus III SEP Workshop,Pattison,Donna,11,0,2,0,1,0,2,3.429
+Fall 2022,IDNS,3121,1,16926,Engineering Math SEP Workshop,Pattison,Donna,7,1,2,2,1,0,1,2.872
+Fall 2022,IDNS,1141,1,16927,Chemistry I SEP Workshop,Pattison,Donna,13,3,2,0,0,0,1,3.538
+Fall 2022,IDNS,1141,2,16928,Chemistry I SEP Workshop,Pattison,Donna,11,4,3,4,1,0,4,2.927
+Fall 2022,IDNS,1141,3,16929,Chemistry I SEP Workshop,Pattison,Donna,8,5,7,4,0,0,3,2.708
+Fall 2022,IDNS,1141,4,16931,Chemistry I SEP Workshop,Pattison,Donna,13,7,4,2,0,0,3,3.192
+Fall 2022,GOVT,2305,6,16932,"US Govt: Congress,Pres & Crts",Cortina,Jeronimo,64,82,56,14,14,0,15,2.716
+Fall 2022,IDNS,1141,5,16933,Chemistry I SEP Workshop,Pattison,Donna,13,6,4,6,0,0,0,2.885
+Fall 2022,IDNS,1141,6,16934,Chemistry I SEP Workshop,Pattison,Donna,12,8,6,2,0,0,2,3.083
+Fall 2022,IDNS,1142,1,16935,Chemistry II SEP Workshop,Pattison,Donna,5,5,3,2,1,0,0,2.605
+Fall 2022,IDNS,1142,2,16936,Chemistry II SEP Workshop,Pattison,Donna,7,9,4,1,0,0,1,2.953
+Fall 2022,IDNS,1142,3,16937,Chemistry II SEP Workshop,Pattison,Donna,7,1,1,2,0,0,2,3.182
+Fall 2022,IDNS,1142,4,16938,Chemistry II SEP Workshop,Pattison,Donna,15,2,2,8,1,0,1,2.868
+Fall 2022,IDNS,3131,1,16939,Organic Chem I SEP Workshop,Pattison,Donna,18,8,2,4,1,0,3,3.132
+Fall 2022,IDNS,3131,2,16940,Organic Chem I SEP Workshop,Pattison,Donna,26,4,4,1,0,0,1,3.609
+Fall 2022,IDNS,3131,3,16941,Organic Chem I SEP Workshop,Pattison,Donna,20,7,4,0,0,0,4,3.527
+Fall 2022,IDNS,3131,4,16942,Organic Chem I SEP Workshop,Pattison,Donna,21,8,0,2,1,0,2,3.458
+Fall 2022,PSYC,6370,1,16943,Fndtns-Indstrl Org Psyc,Reyes,Denise Lucia,6,0,0,0,0,0,0,4.0
+Fall 2022,IDNS,3131,5,16944,Organic Chem I SEP Workshop,Pattison,Donna,24,9,3,1,0,0,0,3.54
+Fall 2022,IDNS,3131,6,16946,Organic Chem I SEP Workshop,Pattison,Donna,27,4,0,2,0,0,1,3.687
+Fall 2022,IDNS,3131,7,16947,Organic Chem I SEP Workshop,Pattison,Donna,16,7,4,2,1,0,3,3.189
+Fall 2022,IDNS,3131,8,16948,Organic Chem I SEP Workshop,Pattison,Donna,8,5,0,2,1,0,2,3.083
+Fall 2022,IDNS,3131,9,16949,Organic Chem I SEP Workshop,Pattison,Donna,14,8,6,6,1,0,0,2.8
+Fall 2022,IDNS,3132,1,16950,Organic Chem II SEP Workshop,Pattison,Donna,7,3,9,0,0,0,8,2.895
+Fall 2022,IDNS,3132,2,16951,Organic Chem II SEP Workshop,Pattison,Donna,7,9,7,2,1,0,4,2.718
+Fall 2022,MATH,5382,1,16953,Probability,Torok,Andrei S,8,3,1,0,0,0,1,3.556
+Fall 2022,GOVT,2305,13,16954,"US Govt: Congress,Pres & Crts",Kistner,Michael,84,71,39,20,24,0,10,2.727
+Fall 2022,GOVT,2305,18,16955,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,26,53,26,4,10,0,31,2.625
+Fall 2022,POLS,3366,1,16958,Political Parties,Cole,Jeffrey Bryan,13,11,5,2,8,0,4,2.428
+Fall 2022,POLS,3372,1,16959,Latino Politics,Casellas,Jason,14,4,0,0,1,0,0,3.475
+Fall 2022,SOC,3301,1,16961,Intro to Sociological Research,Tuthill,Zelma,31,7,1,0,2,0,0,3.577
+Fall 2022,BIOE,6319,1,16962,Mass Transport Bio Systems,Majd,Sheereen,0,0,1,0,0,0,0,2.0
+Fall 2022,CIS,6396,1,16964,Internship in Infor. Security,Conklin,William A,19,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7334,1,16965,Learning Sys &Mgmt Development,Bozeman,Dennis,12,0,3,0,0,0,0,3.622
+Fall 2022,MANA,7339,1,16966,Leadership Development,Witt,Lawrence A,33,0,0,0,0,0,1,4.0
+Fall 2022,MANA,7355,1,16967,Staffing & Talent Management,Bozeman,Dennis,14,6,4,0,0,0,0,3.513
+Fall 2022,GHL,1320,2,16969,Foodservice Management,Ding,Anni,36,7,2,1,2,0,1,3.5
+Fall 2022,MANA,4355,1,16971,Selection and Staffing,Phillips,James S,27,11,7,0,1,0,3,3.42
+Fall 2022,MANA,4341,1,16972,Leading Organizational Change,Maneethai,Dustin,34,6,3,1,3,0,2,3.397
+Fall 2022,PSYC,2305,15,16973,Intro to Methods in Psychology,Jewell,Rebecca D,6,12,9,4,4,0,5,2.258
+Fall 2022,PSYC,2305,17,16975,Intro to Methods in Psychology,Jewell,Rebecca D,7,7,11,3,4,0,8,2.24
+Fall 2022,COMM,1307,4,16977,Media and Society,Washington,Germaine Monteil,17,6,0,2,1,0,1,3.334
+Fall 2022,COMM,2311,1,16980,Writing for Print and Digital,Crixell,Charles A,16,8,5,4,2,0,1,2.905
+Fall 2022,INDE,6377,1,16981,Ind Eng Application,Irani,Shahrukh A,32,5,0,0,0,0,0,3.856
+Fall 2022,GHL,3364,1,16983,Hotel Sales,Kenyan,Erin Oeser,28,8,6,0,4,0,4,3.138
+Fall 2022,BUSI,4350,1,16984,Business Law and Ethics,Krylova,Ksenia O,13,11,2,0,0,0,0,3.461
+Fall 2022,GHL,3420,1,16985,Foodservice Operations,Ginapp,Kathrine,12,5,4,2,0,0,0,3.231
+Fall 2022,SCM,4390,3,16987,Supply Chain Strategy,Smith,Gordon D,9,24,16,1,0,0,0,2.853
+Fall 2022,SCM,7325,1,16988,Process Analysis and Design,Robinson Jr,Powell Ersell,19,8,6,0,0,0,0,3.354
+Fall 2022,BUSI,4350,2,16989,Business Law and Ethics,Currie,Daniel David,195,55,12,10,0,0,2,3.57
+Fall 2022,BUSI,4350,4,16992,Business Law and Ethics,Currie,Daniel David,164,75,23,5,5,0,3,3.405
+Fall 2022,BUSI,4350,6,16994,Business Law and Ethics,Williams,John M,132,85,23,0,3,0,7,3.315
+Fall 2022,BUSI,4350,8,16996,Business Law and Ethics,Williams,John M,62,26,6,2,2,0,1,3.382
+Fall 2022,BUSI,4350,10,16998,Business Law and Ethics,Williams,John M,26,46,8,2,1,0,1,3.093
+Fall 2022,PSYC,2305,19,17000,Intro to Methods in Psychology,Shen,Shutian,29,28,7,0,8,0,7,2.945
+Fall 2022,PSYC,2305,21,17002,Intro to Methods in Psychology,Vahedi,Meisam,57,11,3,0,6,0,3,3.455
+Fall 2022,CNST,4220,1,17004,Comp CM & Emerging Practices,Coble,Lana Kay,25,15,1,0,0,0,2,3.561
+Fall 2022,ECE,3317,1,17005,Applied Electromagnetic Waves,Jackson,David R,12,13,13,1,0,0,0,2.915
+Fall 2022,PSYC,2305,23,17006,Intro to Methods in Psychology,Babalola,Olusegun Maria,18,25,8,1,4,0,4,2.905
+Fall 2022,ECE,4117,1,17010,Telecommunications Laboratory,Han,Zhu,8,0,0,0,0,0,0,4.0
+Fall 2022,MECE,4364,1,17011,Heat Transfer,Liu,Dong,21,32,53,15,0,0,7,2.409
+Fall 2022,GHL,4350,1,17012,Strategy&Innovation Hosp Ind,Johnson,Tucker A,32,3,6,1,2,0,0,3.342
+Fall 2022,GHL,4352,1,17013,Hosp Organizational Behavior,Doudna,Simone P,15,15,3,1,1,0,2,3.172
+Fall 2022,GHL,4360,1,17014,Hospitality Internship,Shepherd,Ashley,61,7,2,0,2,0,2,3.677
+Fall 2022,ECE,5127,1,17015,Power Transm & Distribut Lab,Phillips,Desiree Lyn,15,3,0,0,1,0,0,3.649
+Fall 2022,GHL,4352,2,17017,Hosp Organizational Behavior,Jarvis,Nathan Alexander,24,7,7,7,4,0,2,2.776
+Fall 2022,ECE,6319,1,17018,Dynamics of Electric Machines,Gokdere,Levent U,21,2,0,0,0,0,2,3.841
+Fall 2022,PSYC,2320,3,17019,Abnormal Psychology,Kim,Jinu,26,25,6,9,9,0,3,2.636
+Fall 2022,COMM,2311,2,17021,Writing for Print and Digital,Crixell,Charles A,8,9,1,1,1,0,1,3.051
+Fall 2022,PSYC,2320,4,17023,Abnormal Psychology,Busch,Haley Conroy,36,1,5,0,0,0,1,3.738
+Fall 2022,PSYC,2320,5,17025,Abnormal Psychology,Busch,Haley Conroy,38,3,1,0,1,0,1,3.791
+Fall 2022,PSYC,2320,6,17026,Abnormal Psychology,Lebeaut,Antoine M,41,1,4,3,1,0,1,3.54
+Fall 2022,ENGL,3348,1,17027,Thoreau,Snediker,Michael,18,5,2,0,0,0,0,3.587
+Fall 2022,ENGL,4340,1,17028,Feminist Criticism and Theory,Gregory,Elizabeth,5,2,0,0,0,0,0,3.667
+Fall 2022,PSYC,3331,1,17029,Psychology of Gender,Mayorga,Nubia Angelina,70,4,3,1,1,0,0,3.806
+Fall 2022,PSYC,2301,10,17032,Introduction to Psychology,Orr,Michael F,9,19,11,10,24,0,1,1.767
+Fall 2022,FINA,7382,1,17033,Developing Real Estate Project,Azuike,Acho Kelechi,12,1,0,0,0,0,0,3.847
+Fall 2022,INDE,6360,1,17034,Engineering Analytics,Lin PhD,Ying,29,17,0,0,0,0,1,3.58
+Fall 2022,IEEM,6360,1,17035,Data Analytics for Engr. Mgt,Chang,Feng-Chang Roger,40,40,1,0,0,0,0,3.388
+Fall 2022,PSYC,2330,8,17037,Biological Psychology,Jackson,Lillian Reed,33,40,2,1,2,0,0,3.244
+Fall 2022,PSYC,2320,7,17040,Abnormal Psychology,Ridgely,Natalie,24,27,15,1,4,0,5,2.865
+Fall 2022,ACCT,2301,20,17041,Prin of Financial Accounting,Newman,Michael Ray,19,4,1,0,0,0,0,3.695
+Fall 2022,ACCT,3366,3,17042,Financial Reporting Frameworks,Harris,Kathleen L,15,2,4,0,1,0,6,3.379
+Fall 2022,PSYC,2307,3,17043,Psychology of Adolescence,Anderson,Jill Annette,19,19,3,1,5,0,3,2.958
+Fall 2022,ENGL,3316,1,17045,Lit of Victorian Age,Wood,Wendy Sue,23,3,1,0,0,0,2,3.766
+Fall 2022,POLS,3310,4,17051,Intro to Political Theory,Hawley,Michael C,14,12,6,1,8,0,3,2.448
+Fall 2022,INDE,6380,2,17052,Accounting for Engr Managers,Rypien,David V,63,8,0,0,0,0,0,3.925
+Fall 2022,IEEM,6331,1,17053,Quant Methods for Engr Mgmt,Kamrani,Ali K,26,7,1,0,0,0,3,3.648
+Fall 2022,PETR,6352,1,17054,Shale Reservoirs,Hathon,Lori A,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,3337,2,17055,Signals and Systems Analysis,Roysam,Badrinath,12,10,8,1,2,0,5,2.859
+Fall 2022,BUSI,2305,1,17058,Business Statistics,Patterson,Staci A,104,106,122,78,10,0,90,2.462
+Fall 2022,BUSI,2305,2,17059,Business Statistics,Patterson,Staci A,78,104,102,74,38,0,116,2.233
+Fall 2022,COSC,1437,1,17061,Introduction to Programming,Rincon Castro,Carlos Alberto,44,21,13,6,13,0,23,2.743
+Fall 2022,COSC,1437,3,17063,Introduction to Programming,Biediger,Daniel Edward,66,22,13,3,4,0,8,3.321
+Fall 2022,ARCH,1198,1,17065,Special Problems,Phan,Trang Anh Thuc,10,0,0,1,0,0,0,3.697
+Fall 2022,ENGL,8323,1,17068,Master Workshop: Narrative,Divakaruni,Chitra B,7,0,0,0,0,0,0,4.0
+Fall 2022,FINA,3332,6,17069,Prin of Financial Management,Suleymanov,Masim,67,72,57,14,3,0,9,2.893
+Fall 2022,ACCT,7378,1,17070,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,15,5,1,0,0,0,0,3.667
+Fall 2022,POLS,3315,1,17071,International Organization,Sisman,Ozlem,4,19,9,0,4,0,5,2.509
+Fall 2022,ELET,6352,1,17072,Matlab Engineering Technology,Zouridakis,George,7,0,0,0,0,0,0,3.953
+Fall 2022,ELET,6353,1,17073,Applied Stats for Technology,Montero Hernandez,Samuel Antonio,4,0,0,0,0,0,0,4.0
+Fall 2022,ELET,6350,1,17074,Overview Com Health Informatic,Montero Hernandez,Samuel Antonio,4,0,0,0,0,0,0,4.0
+Fall 2022,BUSI,1301,5,17076,Business Principles,Carvalho,Diogo,146,58,16,5,11,0,10,3.335
+Fall 2022,CIS,3343,5,17077,Info Systems Analysis & Design,Greenfield,Brandon Scott,2,11,14,2,0,0,1,2.539
+Fall 2022,CIS,3355,1,17078,Integrated Information Systems,Zhang,Yunpeng,6,14,10,2,3,0,0,2.561
+Fall 2022,CIS,4375,2,17079,Project Management & Practice,Detillier,Bret James,4,16,6,0,0,0,0,2.961
+Fall 2022,HRD,4344,30,17080,Designing E-Learning,Bennett,LaTasha,30,6,2,0,1,0,0,3.523
+Fall 2022,HRD,4352,30,17081,Facilitation Strategies,Polesello,Daiane,8,5,0,2,0,0,0,3.201
+Fall 2022,SOCW,6307,1,17082,Policy in the Soc Environment,Ochoa,Ashley Marissa,20,1,0,0,0,0,1,3.952
+Fall 2022,SOCW,6307,2,17083,Policy in the Soc Environment,Ortiz,Lillian Aguirre,22,0,0,0,0,0,1,4.0
+Fall 2022,SOCW,6307,3,17084,Policy in the Soc Environment,Vogel,Alicia Nicole,24,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,6308,1,17085,Human Diversity & Development,Scott Jr.,Edward Douglas,24,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,6308,2,17086,Human Diversity & Development,Scott Jr.,Edward Douglas,21,0,0,0,0,0,1,4.0
+Fall 2022,SOCW,6308,3,17087,Human Diversity & Development,Bagneris,Jessica Rene',20,2,0,0,0,0,0,3.909
+Fall 2022,FORE,6396,1,17088,Internship,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Fall 2022,HON,3341,1,17090,Pre-Modern Science & Medicine,Bland,Laura Elizabeth,23,0,0,0,0,0,0,4.0
+Fall 2022,HDCS,4374,1,17091,Entrepreneurial E-Tailing,Johnson,Olivia,7,22,5,3,5,0,1,2.548
+Fall 2022,ENGI,8111,1,17092,FFP,Sharma,Pradeep,0,0,0,0,0,19,0,
+Fall 2022,HRD,3310,20,17093,Talent Management,Edwards,Malaika,14,10,2,1,1,0,0,3.144
+Fall 2022,SCLT,3385,30,17094,Transport Economics and Policy,Henson,Alfred Bernard,27,14,6,1,4,0,4,3.154
+Fall 2022,ELET,4302,1,17095,Data Communication Systems,Moges,Mequanint A,2,13,7,0,1,0,1,2.623
+Fall 2022,ELET,4360,1,17096,Sustainable & Resilient Tech,Yuan,Xiaojing,6,4,0,0,0,0,0,3.534
+Fall 2022,HRD,3350,30,17097,Workforce Diversity and Global,Polesello,Daiane,19,0,2,1,5,0,0,2.976
+Fall 2022,SOCW,7310,1,17098,Program Planning & Evaluation,Guzman,Paola E,27,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7347,1,17099,SW Practice & Interv in School,Jennings,Sheara Williams,14,8,0,0,0,0,0,3.636
+Fall 2022,SOCW,6306,5,17102,Social Work Practice Skills,White,Tamika Alonzo,25,1,0,0,0,0,0,3.962
+Fall 2022,ELET,4350,1,17103,Computation Health Informatics,Montero Hernandez,Samuel Antonio,12,7,3,0,0,0,1,3.349
+Fall 2022,INTB,3355,4,17104,Global Environment of Business,Farah,Elena,38,7,4,2,1,0,1,3.488
+Fall 2022,TLIM,3360,31,17105,Law & Ethics-Tech & Innovation,Feriante,Chris,24,3,16,0,4,0,4,2.915
+Fall 2022,COMM,2327,1,17106,Introduction to Screen Writing,Vaughan,Thomas Michael,16,2,2,0,0,0,1,3.684
+Fall 2022,COMM,3300,1,17107,Health Communication,Yamasaki,Jill S,51,8,2,1,0,0,0,3.758
+Fall 2022,COMM,3315,1,17108,News and Social Media,Bhat,Nandikoor R Prashanth,14,3,0,1,1,0,0,3.369
+Fall 2022,COMM,3326,3,17109,Graphics Applications,Economou-Clarke,Ann M,12,4,1,2,0,0,1,3.368
+Fall 2022,COMM,3328,1,17111,Intro to Sports Production,Freedman,Michael,12,7,5,3,2,0,0,2.862
+Fall 2022,HRD,4350,30,17112,Org Dev & Consulting,Polesello,Daiane,14,1,2,0,1,0,1,3.482
+Fall 2022,ENGL,3328,1,17113,Masterpieces of British Lit II,Guajardo,Paul,9,14,2,0,0,0,3,3.399
+Fall 2022,ENGL,3332,1,17114,Beg Crea Writing: Nonfiction,Colombe,Audrey A,7,6,1,0,2,0,2,3.0
+Fall 2022,ILAS,3350,1,17115,Power Writing,Oliva,Luca,4,3,2,2,1,0,0,2.611
+Fall 2022,DIGM,1300,30,17117,Introduction to Digital Media,Liao,Pamara F.,88,27,9,3,5,0,4,3.397
+Fall 2022,MECT,2354,1,17118,Introduction to Mechanics,Basaran,Burak,4,6,14,12,8,0,11,1.667
+Fall 2022,LAW,5258,1,17128,Eminent Domain Property Rights,Hodge,Justin Allen,7,4,2,0,0,0,0,3.385
+Fall 2022,MUED,3106,1,17129,Percussion,Warren,Paul Alexander,5,6,1,0,1,0,1,3.153
+Fall 2022,PHAR,5371,1,17130,Ambulatory Practice Management,Thornton,James D,61,46,0,0,0,0,0,3.57
+Fall 2022,PHAR,5335,1,17131,Integrated Neurology Module,Tejada-Simon,Maria Victoria,48,51,8,0,0,0,0,3.374
+Fall 2022,PHAR,5236,1,17132,Integrated Immunology Module,Knoll,Brian J,25,52,30,0,0,0,0,2.953
+Fall 2022,PHAR,5337,1,17133,Integrated ID I Module,Williams,Louis,26,52,30,1,1,0,0,2.918
+Fall 2022,PHAR,5338,1,17134,Integrated ID II Module,Cuny,Gregory D,28,53,24,3,0,0,0,2.981
+Fall 2022,PHAR,5268,1,17135,Module Related Skills Lab III,El-Desoky,Rania Hany,89,15,3,0,0,0,0,3.804
+Fall 2022,HON,3350,1,17137,Principles of Data and Society,Kapral,Andrew J,6,1,0,0,0,0,1,3.81
+Fall 2022,MUSI,1121,2,17138,Concert Chorus,Mueller,Jebediah Lee,24,0,0,0,0,0,1,3.986
+Fall 2022,MUSI,1122,1,17139,Concert Chorale,Weber,Mary E,41,1,0,0,0,0,1,3.96
+Fall 2022,COMM,3376,1,17140,Media Effects,Archer,Allison Michelle Nam,10,14,3,2,1,0,0,2.923
+Fall 2022,BZAN,6357,1,17141,BZAN-Frameworks & Methods,Ma,Xiao,37,11,8,0,0,0,2,3.424
+Fall 2022,COMM,3380,3,17142,Electronic Field Production,Newlin,Julye G,14,4,1,0,0,0,0,3.736
+Fall 2022,COMM,4303,5,17143,Communication Law and Ethics,Lee,Jaesub,39,6,2,1,2,0,1,3.534
+Fall 2022,COMM,4365,2,17144,Digital PR and Advertising,Choi,Ho Joon,15,3,2,0,1,0,0,3.398
+Fall 2022,MATH,4323,1,17145,Data Science and Stats Learn,Wang,Wenshuang,57,13,4,1,2,0,1,3.619
+Fall 2022,COSC,6320,1,17146,Data Structures & Algorithms,Pandurangan,Gopal,4,10,1,0,1,0,1,3.062
+Fall 2022,COSC,3320,2,17147,Algorithms and Data Structures,Wu,Panruo,40,47,32,9,3,0,7,2.784
+Fall 2022,GEOL,1102,5,17148,Intro to Climate Change Lab,Choi,Yunsoo,13,3,4,2,0,0,1,3.182
+Fall 2022,GEOL,1102,6,17149,Intro to Climate Change Lab,Choi,Yunsoo,15,4,2,2,0,0,0,3.233
+Fall 2022,COMM,4381,1,17150,Digital Cinematography,Houk,Keith R,19,0,0,0,0,0,0,3.913
+Fall 2022,COMM,4383,1,17152,Documentary Filmmaking,Houk,Keith R,20,2,0,0,1,0,0,3.653
+Fall 2022,TLIM,3330,30,17153,Innovation Principles,Mehring,Brian George,3,7,9,2,2,0,5,2.347
+Fall 2022,TLIM,3350,30,17154,Emergency Management Principle,Freedkin,Aaron Samuel,23,20,0,2,2,0,0,3.263
+Fall 2022,HIST,3353,1,17159,England To 1689,Patterson,Catherine F,12,13,5,0,4,0,0,2.746
+Fall 2022,HIST,3326,1,17160,Afr Am Women in Slavery & Frdm,Reed,Linda,17,7,1,1,4,0,2,3.045
+Fall 2022,LAW,6233,1,17161,Internet Law,Raimer,Anna,9,18,1,0,0,0,0,3.298
+Fall 2022,LAW,5267,1,17162,Tax Accounting,Gupta,Ajay,3,6,1,0,0,1,0,3.167
+Fall 2022,LAW,6377,1,17163,Entertainment Law,Alonso,Yocel,12,10,1,0,0,0,0,3.45
+Fall 2022,LAW,7341,1,17164,WRS: Modern Corporation,Nelson,James D,4,8,0,0,0,0,0,3.471
+Fall 2022,LAW,6376,1,17166,Intellectual Property Survey,Michaels,Andrew Charles,15,24,0,0,0,3,0,3.41
+Fall 2022,LAW,6369,1,17167,Legal Analysis and Writing,Nieuwveld,Lisa Bench,0,0,0,0,0,8,0,
+Fall 2022,LAW,7324,1,17168,WRC: Advanced Legal Writing,Maselli,Jani,6,6,0,0,0,0,0,3.39
+Fall 2022,ARTS,3331,2,17169,Graphic Design Software,Phenneger,Mary Jo,10,8,2,0,1,0,1,3.175
+Fall 2022,LAW,5118,1,17170,EENR Research,Drake,Alyson,5,7,1,0,0,0,0,3.282
+Fall 2022,ARTH,3380,1,17173,17Th Century Dutch Art,Nevitt Jr,Hugh R,19,5,1,0,0,0,0,3.614
+Fall 2022,NURS,4215,1,17177,Maternal Newborn Women Hlth,Lee,Andria Brown,5,19,0,1,0,0,0,3.12
+Fall 2022,NURS,4217,1,17178,Maternal Newborn Women Clin,Lee,Andria Brown,23,2,0,0,0,0,0,3.92
+Fall 2022,NURS,4316,1,17179,Medical Surgical Concepts,Edwards-Maddox,Shermel Vinese,1,22,0,2,0,0,0,2.88
+Fall 2022,NURS,4417,1,17180,Medical Surgical Clinical,Edwards-Maddox,Shermel Vinese,12,13,0,0,0,0,0,3.48
+Fall 2022,POLS,6369,1,17182,Seminar on the Presidency,Rottinghaus,Brandon J,10,0,0,0,0,0,0,3.769
+Fall 2022,DIGM,2357,30,17183,Content Strategy & Development,Alters,Monika Joanna,50,39,10,1,0,0,0,3.344
+Fall 2022,POLS,6382,1,17184,Quantitative Methods III,Clark,Jennifer H,15,0,0,0,0,0,0,3.934
+Fall 2022,LAW,5351,1,17188,Juvenile Law,Marrus,Ellen,5,9,0,0,0,0,0,3.404
+Fall 2022,ARLD,6335,1,17189,Leading Change in the Arts,Taylor,Glenn E,9,1,0,0,0,0,0,3.9
+Fall 2022,ARLD,6370,1,17190,Intro to Museum & Gallery Mgmt,DeHoyos,Ashley Delara,6,0,0,0,0,0,1,4.0
+Fall 2022,ENGL,2340,1,17191,Cosmic Narratives,Wood,Barry Albert,8,3,0,0,2,0,2,3.128
+Fall 2022,MARK,7371,1,17194,Pricing Strategy,Hu,Ye,21,18,1,0,1,0,0,3.39
+Fall 2022,MUSA,3432,1,17196,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,4323,1,17198,Investment & Mutual Fund Mgt,Blanchfield,Craig,38,9,3,0,0,0,0,3.7
+Fall 2022,MATH,4322,2,17199,Data Science and Machine Learn,Poliak,Cathy Dawn,70,18,3,0,0,0,4,3.733
+Fall 2022,AAS,6300,1,17200,Africana Study Theory & Method,Edwards,Crystal Latanya,3,3,1,0,1,0,0,2.916
+Fall 2022,PHYS,4340,3,17201,Research Methods,Ekeoba,Jacqueline Njideka,6,0,0,0,0,0,0,4.0
+Fall 2022,MECT,1364,30,17203,Materials & Processes,Hussain,Muhammad Muzamil,4,6,4,4,2,0,2,2.3
+Fall 2022,MUSA,3402,1,17205,Applied Composition,Maroney,Marcus K,1,0,0,0,0,0,0,4.0
+Fall 2022,POLS,6302,1,17206,Research Design,Jenke,Elizabeth,9,3,0,0,0,0,0,3.695
+Fall 2022,MARK,4380,1,17207,Digital Selling,Herman,Carl,9,10,0,0,0,0,1,3.369
+Fall 2022,MARK,4380,2,17208,Digital Selling,Herman,Carl,11,12,1,0,0,0,0,3.348
+Fall 2022,MUSA,2340,1,17209,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,6342,1,17210,Machine Learning,Vilalta,Ricardo,27,37,11,0,0,0,0,3.222
+Fall 2022,COSC,6398,106,17217,Special Problems,Deng,Zhigang,0,0,0,0,0,2,0,
+Fall 2022,COSC,6398,109,17220,Special Problems,Gnawali,Omprakash D,0,0,0,0,0,2,0,
+Fall 2022,COSC,6398,112,17223,Special Problems,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Fall 2022,COSC,6398,114,17225,Special Problems,Kakadiaris,Ioannis A.,0,0,0,0,0,0,0,
+Fall 2022,COSC,6398,127,17238,Special Problems,Subhlok,Jaspal,0,0,0,0,0,0,0,
+Fall 2022,COSC,6398,128,17239,Special Problems,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Fall 2022,COSC,6398,130,17241,Special Problems,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,102,17244,Doctoral Research,Chen,Guoning,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,103,17245,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Fall 2022,COSC,8398,106,17248,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,
+Fall 2022,COSC,8398,114,17256,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,3,0,
+Fall 2022,COSC,8398,116,17258,Doctoral Research,Leiss,Ernst L,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,118,17260,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,119,17261,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,120,17262,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,0,0,
+Fall 2022,COSC,8398,124,17266,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,125,17267,Doctoral Research,Shi,Weidong,0,0,0,0,0,2,0,
+Fall 2022,COSC,8398,127,17269,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,2,0,
+Fall 2022,COSC,8398,129,17271,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2022,COSC,8399,101,17274,Doctoral Dissertation,Alipour,Mohammad Amin,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8399,107,17280,Doctoral Dissertation,Eick,Christoph F,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8399,119,17292,Doctoral Dissertation,Ordonez,Carlos,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8399,122,17295,Doctoral Dissertation,Pavlidis,Ioannis T,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8399,125,17298,Doctoral Dissertation,Shi,Weidong,0,0,0,0,0,1,0,
+Fall 2022,COSC,8399,126,17299,Doctoral Dissertation,Solorio Martinez,Thamar Ivette,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8399,127,17300,Doctoral Dissertation,Subhlok,Jaspal,1,0,0,0,0,2,0,4.0
+Fall 2022,COSC,8399,128,17301,Doctoral Dissertation,Tsekos,Nikolaos V,2,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8399,129,17302,Doctoral Dissertation,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2022,COSC,8399,131,17304,Doctoral Dissertation,Wu,Panruo,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8698,101,17305,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,2,0,
+Fall 2022,COSC,8698,102,17306,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Fall 2022,COSC,8698,103,17307,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2022,COSC,8698,109,17313,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,2,0,
+Fall 2022,COSC,8698,118,17322,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Fall 2022,COSC,8698,119,17323,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2022,COSC,8698,120,17324,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,2,0,
+Fall 2022,COSC,8698,122,17326,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2022,COSC,8698,125,17329,Doctoral Research,Shi,Weidong,0,0,0,0,0,2,0,
+Fall 2022,COSC,8698,130,17334,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Fall 2022,COSC,8698,131,17335,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Fall 2022,COSC,8998,101,17367,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2022,COSC,8998,102,17368,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Fall 2022,COSC,8998,106,17372,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Fall 2022,COSC,8998,107,17373,Doctoral Research,Eick,Christoph F,0,0,0,0,0,3,0,
+Fall 2022,COSC,8998,112,17378,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,3,0,
+Fall 2022,COSC,8998,113,17379,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Fall 2022,COSC,8998,117,17383,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,
+Fall 2022,COSC,8998,122,17388,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,4,0,
+Fall 2022,COSC,8998,124,17390,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Fall 2022,COSC,8998,126,17392,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,2,0,
+Fall 2022,COSC,8998,128,17394,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,3,0,
+Fall 2022,COSC,8998,129,17395,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,2,0,
+Fall 2022,COSC,8998,130,17396,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Fall 2022,COSC,8998,131,17397,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Fall 2022,FINA,4325,1,17398,Retirement and Estate Planning,Lopez,John C,4,8,7,0,0,0,1,3.016
+Fall 2022,COSC,6399,129,17427,Masters Thesis,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2022,IART,1300,1,17430,The Arts in Society,Noble,Melissa Lynn,19,5,0,0,0,0,0,3.737
+Fall 2022,IART,1300,2,17431,The Arts in Society,Gaona,Veronica,18,4,1,1,1,0,0,3.467
+Fall 2022,IART,1300,3,17432,The Arts in Society,Averyt,Zachary Benjamin,12,8,3,0,1,0,0,3.181
+Fall 2022,IART,1300,4,17433,The Arts in Society,Harris,Jeanette Joy,16,5,1,1,2,0,1,3.24
+Fall 2022,COSC,7399,114,17447,Masters Thesis,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,
+Fall 2022,COSC,7399,129,17462,Masters Thesis,Verma,Rakesh M,1,0,0,0,0,0,0,3.67
+Fall 2022,BIOE,4302,1,17465,Numerical Analysis for BME,Zhang,Yingchun,10,4,0,0,0,0,0,3.738
+Fall 2022,ENGL,3352,1,17466,19th Century American Fiction,Wood,Barry Albert,22,7,3,1,0,0,0,3.345
+Fall 2022,DIGM,1350,30,17468,Graphics for Digital Media,Beyl,Charles Eugene,11,8,8,1,2,0,3,2.789
+Fall 2022,DIGM,1350,32,17469,Graphics for Digital Media,De Vega,Jaime M,14,5,2,0,1,0,8,3.349
+Fall 2022,DIGM,1350,33,17470,Graphics for Digital Media,Johnson,Kelsey,22,8,2,0,0,0,3,3.563
+Fall 2022,MUSA,8320,2,17472,Doctoral Applied Music,Evans,Joseph,3,0,0,0,0,0,0,3.89
+Fall 2022,MUSA,1300,5,17474,Applied Voice,Vasquez,Hector A,5,0,0,0,0,0,0,3.934
+Fall 2022,MUSA,2324,2,17475,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3410,1,17476,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3424,2,17477,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3434,1,17478,Applied Clarinet,Griffin,Randall S,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3440,1,17479,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3440,2,17480,Applied Trumpet,Vassallo,Jim Cates,1,1,0,0,0,0,0,3.665
+Fall 2022,MUSA,3442,1,17481,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4432,2,17482,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2022,WGSS,4395,1,17483,Sel Tops in Women's Studies,Tuthill,Zelma,11,0,0,0,1,0,0,3.667
+Fall 2022,CHEM,8999,22,17487,Doctoral Dissertation,Do,Loi H,0,0,0,0,0,1,0,
+Fall 2022,ENGI,2304,14,17489,Technical Communications,Contos,Ashlie Meghan,16,7,0,1,1,0,0,3.453
+Fall 2022,ENGI,2304,15,17490,Technical Communications,Estrada,Carl,5,13,4,0,2,0,2,2.819
+Fall 2022,BIOE,8598,16,17492,Doctoral Research,Wu,Tianfu,0,0,0,0,0,3,0,
+Fall 2022,INDS,2355,2,17497,Design History I,Williams,Celeste,20,1,0,0,0,0,0,3.921
+Fall 2022,ARTS,1303,1,17501,Art Hist I(Prehistoric 14th C),Koontz,Rex A,86,60,22,13,17,0,9,2.919
+Fall 2022,ENGL,7699,1,17504,Thesis,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8399,2,17507,Doctoral Dissertation,Kastely,James L,0,0,0,0,0,1,0,
+Fall 2022,ARTH,6399,2,17508,Master's Thesis,Tejada,Roberto Jose,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6304,3,17513,Conducting,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,8999,24,17514,Doctoral Dissertation,Cai,Chengzhi,0,0,0,0,0,1,0,
+Fall 2022,HON,4398,4,17519,Independent Study,Rhoden,Brenda,5,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7399,2,17522,Essay,Divakaruni,Chitra B,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8399,3,17523,Doctoral Dissertation,Shepley,Nathan,1,0,0,0,0,1,0,4.0
+Fall 2022,LAW,5291,1,17526,Partnership Tax,Bergez,Craig,3,0,0,0,0,0,1,3.67
+Fall 2022,PSYC,3399,3,17528,Senior Honors Thesis,Reyes,Denise Lucia,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,2301,1,17529,Texas History to 1865,Ramos,Raul,21,6,2,1,1,0,3,3.388
+Fall 2022,ARTH,6399,3,17530,Master's Thesis,Zalman,Sandra,1,0,0,0,0,0,0,4.0
+Fall 2022,MANA,4333,1,17532,Current Issues in Mgmt,Walker,William A,35,8,4,0,0,0,2,3.709
+Fall 2022,ENGL,8399,4,17538,Doctoral Dissertation,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2022,GHL,4350,2,17541,Strategy&Innovation Hosp Ind,Morosan,Cristian,26,8,8,4,3,0,1,3.0
+Fall 2022,GHL,3336,2,17542,Beverage Management,Jarvis,Nathan Alexander,15,11,10,1,7,0,0,2.561
+Fall 2022,ENGL,8399,5,17544,Doctoral Dissertation,Mazella,David S,0,0,0,0,0,2,0,
+Fall 2022,ENGL,8699,3,17545,Doctoral Dissertation,Mazella,David S,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8399,6,17546,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,5,0,
+Fall 2022,ENGL,8699,4,17547,Doctoral Dissertation,Harris,Francine Julia,0,0,0,0,0,1,0,
+Fall 2022,INDE,8598,2,17552,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Fall 2022,INDE,8598,5,17555,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,1,0,
+Fall 2022,PETR,5352,1,17557,Shale Reservoirs,Hathon,Lori A,4,0,0,0,0,0,0,4.0
+Fall 2022,MARK,3365,3,17558,Intro to Digital Marketing,Tirunillai,Seshadri N,71,46,23,1,0,0,4,3.322
+Fall 2022,BZAN,6353,1,17561,Res Design-Probs Busi Anlytcs,Aron,Ravi,7,12,0,0,0,0,1,3.334
+Fall 2022,TLIM,3330,2,17562,Innovation Principles,Feriante,Chris,6,2,2,1,0,0,2,3.212
+Fall 2022,BIOE,8298,23,17563,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2022,DRAM,1310,13,17565,Introduction to Theatre,Egging,Jon Leo,30,10,3,3,3,0,1,3.171
+Fall 2022,MECE,4398,1,17566,Independent Study,Bering,Edgar A,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8296,3,17567,Doctoral Essay,Koozin,Timothy,1,0,0,0,0,1,0,4.0
+Fall 2022,CNST,6308,2,17569,Data Analysis in Construc Mgmt,Gao,Lu,41,2,0,0,1,0,0,3.856
+Fall 2022,CNST,6375,2,17570,BIM Applications for CM,Din,Zia Ud,55,2,1,0,0,0,0,3.897
+Fall 2022,ENGL,8399,7,17573,Doctoral Dissertation,Voskuil,Lynn M,0,0,0,0,0,1,0,
+Fall 2022,FINA,3332,5,17574,Prin of Financial Management,Lopez,John C,51,61,55,26,4,0,20,2.784
+Fall 2022,ENGL,8698,3,17575,Graduate Research,Lee,Eunjeong,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8698,4,17576,Graduate Research,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8698,5,17577,Graduate Research,Wingard,Jennifer L,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8698,6,17578,Graduate Research,Harris,Francine Julia,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8698,7,17579,Graduate Research,Christensen,Ann C,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8698,8,17580,Graduate Research,Stock,Lorraine K,0,0,0,0,0,1,0,
+Fall 2022,MANA,4358,1,17581,Compensation and Benefits,Zamanipour,Tina,24,14,3,1,1,0,1,3.372
+Fall 2022,ENGL,8698,9,17582,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,SPAN,1507,3,17584,Intns Elem Span Heritage Learn,Hernandez,Estela,9,8,2,0,2,0,0,3.048
+Fall 2022,SPAN,2308,1,17586,Span for Heritage Learners II,Martinez,Raquel,8,4,0,3,0,0,3,3.023
+Fall 2022,ARLD,6330,1,17587,Arts and Technology,Gresham,Zachary Evan,13,0,0,0,0,0,0,3.975
+Fall 2022,SOC,7399,1,17590,Masters Thesis,Lee,Shayne,0,0,0,0,0,0,0,
+Fall 2022,FINA,6335,1,17598,Managerial Finance,Berta,Dom,9,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,1102,7,17599,Intro to Climate Change Lab,Choi,Yunsoo,15,3,1,2,2,0,0,3.059
+Fall 2022,MATH,2413,51,17601,Calculus I,Constante,Beatrice,216,98,62,46,62,0,48,2.712
+Fall 2022,ENGL,8399,8,17607,Doctoral Dissertation,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8699,5,17608,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8399,9,17609,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8240,1,17611,Doctoral Recital I,Evans,Joseph,1,0,0,0,0,0,0,3.67
+Fall 2022,HIST,3371,1,17612,Russian Imperial History,Rainbow,David,20,2,2,0,1,0,0,3.534
+Fall 2022,ENGL,8699,7,17614,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Fall 2022,ENGI,1101,1,17617,Engineering Success,Kota,Venkata Krishna Tulasi,2,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8388,1,17619,Dissertation Proposal,Howard,Philip,0,0,0,0,0,1,0,
+Fall 2022,ECON,3385,1,17620,Economics of Energy,Hirs,Edward A,32,7,5,0,0,0,5,3.591
+Fall 2022,ENGL,8699,8,17623,Doctoral Dissertation,Tejada,Roberto Jose,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8242,2,17624,Doctoral Recital III,Evans,Joseph,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8106,1,17625,Doctoral Large Ensemble,Bertman,David Garry,2,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,3307,4,17626,Public Speaking in Spanish,Aguilar,Jacqueline,14,0,0,0,0,0,0,3.953
+Fall 2022,PHCA,7340,1,17632,Data Analytics for PHOP,Johnson,Michael L,6,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,7305,1,17633,Theory in PHOP,Sansgiry,Sujit Sharad,6,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8699,9,17637,Doctoral Dissertation,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2022,GENB,5303,4,17638,Prof Acct Communication,Newman,Michael Ray,5,1,0,1,0,0,0,3.381
+Fall 2022,GENB,7303,2,17639,Prof Accounting Communication,Newman,Michael Ray,33,2,1,0,0,0,0,3.88
+Fall 2022,MUSA,8320,6,17641,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,7,17642,Doctoral Applied Music,Hester,Timothy E,3,0,0,0,0,0,0,3.89
+Fall 2022,SOCW,8395,1,17644,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,0,0,
+Fall 2022,MUSA,6140,5,17647,Graduate Recital I,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,CNST,3265,2,17650,Construction Layout & Site Dvp,Lupher,Jacob John,19,19,3,0,0,0,0,3.294
+Fall 2022,MUSA,1300,11,17651,Applied Voice,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2022,GERM,6361,1,17652,History in German Cinema,Frieden,Sandra M Gross,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1338,1,17653,Saxophone,Witt,Woodrow W,2,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,1350,1,17654,Applied Percussion,Warren,Paul Alexander,6,0,0,0,0,0,0,3.725
+Fall 2022,HIST,2328,1,17655,Chicano History since 1910,San Miguel Jr,Guadalupe,18,8,3,1,2,0,1,3.126
+Fall 2022,CHEM,3336,1,17660,Org Chem Biol Molecules,Gilbertson,Scott R,12,4,7,2,3,0,2,2.691
+Fall 2022,MUSA,2310,3,17661,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2320,2,17662,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,2338,1,17663,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3444,1,17664,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,3450,2,17665,Applied Percussion,Wilkins,Blake M,4,0,0,0,0,0,0,3.835
+Fall 2022,MATH,3338,5,17666,Probability,Kao,Edward P,3,9,1,0,2,0,6,2.733
+Fall 2022,MUSA,4450,2,17669,Applied Percussion,Wilkins,Blake M,5,0,0,0,0,0,0,3.934
+Fall 2022,POLS,3313,5,17671,Intro Internatl Relatns,Zwald,Zachary J,11,16,5,3,3,0,7,2.711
+Fall 2022,MUSA,6422,2,17676,Applied Viola,Brooks,Wayne A,1,1,0,0,0,0,0,3.5
+Fall 2022,MUSA,8220,2,17678,Doctoral Applied Music,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2022,CIS,3365,4,17684,Database Management,Detillier,Bret James,3,17,14,3,0,0,1,2.585
+Fall 2022,CIS,3367,1,17685,Cloud Computing Architecture,Martinez,Jose C,8,27,22,4,1,0,3,2.597
+Fall 2022,TLIM,3330,3,17686,Innovation Principles,Nsoh,Jovita T,9,5,7,3,3,0,1,2.482
+Fall 2022,ARCH,3380,2,17687,Architecture Plus Film,Froehlich,Dietmar,15,6,0,0,0,0,0,3.683
+Fall 2022,EGRP,1140,2,17690,Engineering Applications III,Luna Singh,Jennifer Austin,0,0,0,0,0,9,0,
+Fall 2022,EGRP,1141,2,17691,Engineering Applications IV,Luna Singh,Jennifer Austin,0,0,0,0,0,16,1,
+Fall 2022,EGRP,1150,2,17692,Engineering Applications VI,Luna Singh,Jennifer Austin,0,0,0,0,0,25,0,
+Fall 2022,EGRP,1142,2,17696,Engineering Applications V,Luna Singh,Jennifer Austin,0,0,0,0,0,17,3,
+Fall 2022,EGRP,1170,2,17697,Engineering Applications IX,Luna Singh,Jennifer Austin,0,0,0,0,0,4,2,
+Fall 2022,HIST,1301,50,17698,The U.S. to 1877,Bettinger,Rikki,10,13,0,0,0,0,2,3.449
+Fall 2022,MUSI,1220,3,17699,Class Piano I,Van Kekerix,Todd Evan,10,5,0,0,0,0,1,3.755
+Fall 2022,MUSI,2181,3,17700,Group Piano III,Van Kekerix,Todd Evan,5,1,0,0,0,0,0,3.833
+Fall 2022,PSYC,2320,8,17701,Abnormal Psychology,Farrell,Abigail,28,34,5,3,5,0,4,3.005
+Fall 2022,ECE,5330,1,17703,Introduction to Robotics,Becker,Aaron T,10,8,2,0,0,0,0,3.285
+Fall 2022,PHYS,3214,1,17706,Advanced Laboratory II,Varghese,Oomman K,6,3,0,1,0,0,0,3.433
+Fall 2022,ARCH,6380,2,17708,Architecture Plus Film,Froehlich,Dietmar,1,0,0,0,0,0,1,3.67
+Fall 2022,ACCT,2301,10,17709,Prin of Financial Accounting,Newman,Michael Ray,20,6,0,0,0,0,0,3.782
+Fall 2022,ACCT,2301,14,17710,Prin of Financial Accounting,Newman,Michael Ray,19,6,0,0,0,0,1,3.734
+Fall 2022,MUSI,6112,1,17711,Chamber Music - Woodwind,Derges,Julie D,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6350,2,17712,Applied Music Pedagogy,Cho,Eunghee,6,0,1,0,0,0,0,3.714
+Fall 2022,MUED,3320,1,17718,Intro To Education in Music,McGinnis,Emily Jane,14,6,2,0,2,0,1,3.278
+Fall 2022,MARK,4377,1,17728,Sales for Social Impact,Suki,Yara D,9,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7332,1,17729,Effective Negotiating,Miller,Carl Chet,22,14,0,0,0,0,0,3.51
+Fall 2022,ENTR,4350,1,17731,Entrepreneurial Strategy,Boles,James Read,26,4,0,0,0,0,0,3.768
+Fall 2022,CHEE,6323,1,17733,Fund of Tissue Engineering,Horton,Renita Elillian,0,1,0,0,0,0,0,3.0
+Fall 2022,BIOE,8398,15,17734,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Fall 2022,PCEU,7180,1,17738,Pharmaceutics Seminar,McConnell,Bradley K,0,0,0,0,0,9,0,
+Fall 2022,PHCA,7180,1,17739,Seminar,Varisco,Tyler J,13,0,0,0,0,0,0,4.0
+Fall 2022,DRAM,1351,1,17740,Acting I,Ferrarone,Jessica,11,3,0,0,0,0,0,3.739
+Fall 2022,DRAM,1351,2,17741,Acting I,Ferrarone,Jessica,5,0,0,0,0,0,1,3.934
+Fall 2022,PHCA,7308,1,17742,Biostatistics,Abughosh,Susan M,26,12,0,0,0,0,0,3.684
+Fall 2022,GENB,5304,1,17743,Business Ethics for Accountant,Spartalis,Emmanuel Michael,3,8,0,0,0,0,0,3.213
+Fall 2022,GENB,7304,1,17744,Bus Ethics for Accountants,Spartalis,Emmanuel Michael,16,7,0,0,0,0,0,3.653
+Fall 2022,INDS,3360,2,17746,Human Factors,Vos,Gordon A,16,0,0,0,0,0,0,3.876
+Fall 2022,INAR,3360,2,17747,Human Factors in Interior Arch,Vos,Gordon A,17,0,1,0,0,0,0,3.852
+Fall 2022,INDS,6333,2,17748,Human Factors,Vos,Gordon A,3,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,6361,3,17749,Integrated Practice,Rivers,Paul Joseph,1,9,5,0,0,0,1,2.733
+Fall 2022,ARCH,1500,23,17755,Design Studio I,Logan,Jason,8,1,2,0,0,0,1,3.395
+Fall 2022,ARCH,4510,21,17757,Integrated Arch Solutions,Wienert,Ross George,6,8,4,0,0,0,0,3.001
+Fall 2022,ARCH,2500,35,17759,Arc/Int Arc Design Studio III,LaRose,Katherine Gail,3,8,3,1,1,0,1,2.667
+Fall 2022,AAS,2320,5,17763,Intro To African American Stdy,Thompson,Kevin Bernard,27,9,0,0,0,0,0,3.768
+Fall 2022,PSYC,2307,4,17765,Psychology of Adolescence,Anderson,Jill Annette,11,13,12,5,3,0,4,2.553
+Fall 2022,ARCH,3500,31,17767,Architecture Design Studio V,Beneytez-Duran,Rafael,5,7,3,0,1,0,0,3.02
+Fall 2022,ARCH,7600,11,17771,Architecture Design Studio V,Zweig,Peter J,3,1,0,0,0,0,0,3.75
+Fall 2022,BCHS,3201,12,17773,Biochemistry I Laboratory,Pattison,Donna,5,8,3,1,2,0,2,2.667
+Fall 2022,ARCH,6600,5,17774,Architecture Design Studio I,Logan,Jason,7,3,1,0,0,0,0,3.455
+Fall 2022,PHYS,4398,4,17776,Independent Study,Gunaratne,Gemunu,0,0,1,0,0,0,0,2.33
+Fall 2022,INDS,4500,5,17777,Industrial Design Studio VII,Morshedzadeh,Elham,5,4,1,0,0,0,0,3.4
+Fall 2022,MUSA,3402,2,17781,Applied Composition,Smith,Robert Thomas,2,0,0,0,0,0,0,4.0
+Fall 2022,PHLA,7320,1,17783,Capstone,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4330,1,17786,Adv Instrumental Conducting,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Fall 2022,MSCI,4310,3,17787,The Army Officer,Comiskey,Melissa C,1,0,0,0,0,0,0,4.0
+Fall 2022,INDS,2355,3,17788,Design History I,Williams,Celeste,12,2,0,0,0,0,2,3.881
+Fall 2022,RELS,1301,4,17789,Intro To Religious Studies,Mummert,Claire Elizabeth,21,15,8,2,1,0,2,3.191
+Fall 2022,THEA,6325,1,17792,Alley Thea Dramaturgy Prac I,Shimko,Robert B,4,0,0,0,0,0,0,3.918
+Fall 2022,MANA,4356,2,17793,Managing Diversity,Ruggs,Enrica N,9,7,2,0,1,0,3,3.211
+Fall 2022,MATH,8398,2,17794,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,2,0,
+Fall 2022,ENGL,7399,5,17795,Essay,Stock,Lorraine K,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8698,5,17796,Doctoral Research,Labate,Demetrio,0,0,0,0,0,5,0,
+Fall 2022,MATH,8698,1,17797,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,2,0,
+Fall 2022,PHOP,6198,2,17801,Spec Prob-Physio Optics,Frishman,Laura J,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1302,21,17805,First Year Writing II,Sicinski,Michael J,12,8,1,0,1,0,2,3.274
+Fall 2022,ENGL,1302,23,17806,First Year Writing II,Garcia,Serena Mari,10,6,3,2,2,0,2,2.855
+Fall 2022,ENGL,1302,24,17807,First Year Writing II,Cowan,Joshua Jared,9,6,2,2,3,0,3,2.667
+Fall 2022,ENGL,2305,7,17808,Intro To Fiction,Bose,Godhuly,20,2,1,1,1,0,0,3.507
+Fall 2022,ENGL,2306,2,17809,Intro To Poetry,Decarion,Andrew P,12,8,4,0,3,0,2,2.902
+Fall 2022,ENGL,2307,3,17810,Intro To Drama,Christopherson,Alissa N,20,2,1,1,1,0,0,3.494
+Fall 2022,ENGL,2330,2,17811,Writing Discipline English,Wolfe,Steven R.,5,7,2,1,3,0,2,2.501
+Fall 2022,ENGL,1301,148,17812,First Year Writing I,Seelen,William,16,3,0,0,0,0,0,3.825
+Fall 2022,PHOP,6198,6,17818,Spec Prob-Physio Optics,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8498,5,17827,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6198,9,17828,Spec Prob-Physio Optics,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,6356,1,17833,Medical Ethics,Sater,Amy,7,1,0,0,0,0,0,3.834
+Fall 2022,ENGL,4398,3,17835,Independent Study,Nelms,Jodi Lynn,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,6398,2,17836,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7398,1,17837,Statistics in PSYC Practicum,Francis,David J,0,0,0,0,0,6,0,
+Fall 2022,ENGL,1302,12,17840,First Year Writing II,Sicinski,Michael J,5,10,2,0,4,0,3,2.556
+Fall 2022,ENGL,2305,6,17841,Intro To Fiction,Kennedy,Daniel Peter,15,8,2,1,2,0,1,3.037
+Fall 2022,ENGL,2306,3,17842,Intro To Poetry,Julian,Jennifer La'Vonne,28,0,0,2,0,0,1,3.778
+Fall 2022,ENGL,1301,64,17843,First Year Writing I,Rolater,Sara C,10,3,2,1,1,0,2,3.099
+Fall 2022,ENGL,1301,65,17844,First Year Writing I,Valcin,Mariot,14,6,2,1,0,0,2,3.334
+Fall 2022,ENGL,1301,66,17845,First Year Writing I,Decarion,Andrew P,11,5,0,0,3,0,1,3.14
+Fall 2022,ENGL,1301,68,17846,First Year Writing I,O'Bryan,Ann Patricia,15,1,2,0,1,0,0,3.492
+Fall 2022,ENGL,1301,69,17847,First Year Writing I,Lagana,Karen E,16,1,0,0,0,0,1,3.961
+Fall 2022,PHOP,8598,6,17848,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6857,1,17849,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6198,8,17852,Spec Prob-Physio Optics,Porter,Jason,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6198,10,17854,Spec Prob-Physio Optics,Burns,Alan R,2,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,3201,13,17856,Biochemistry I Laboratory,Pattison,Donna,9,9,0,2,2,0,1,2.925
+Fall 2022,BCHS,3201,14,17857,Biochemistry I Laboratory,Pattison,Donna,3,4,1,0,0,0,1,3.209
+Fall 2022,BIOL,2101,22,17858,Anatomy & Physiology Lab I,Gill,Tejendra,7,9,3,0,1,0,2,2.968
+Fall 2022,BIOL,2101,23,17859,Anatomy & Physiology Lab I,Gill,Tejendra,5,7,5,2,3,0,1,2.289
+Fall 2022,BIOL,2101,24,17860,Anatomy & Physiology Lab I,Gill,Tejendra,11,10,2,0,0,0,1,3.291
+Fall 2022,CIVE,6399,1,17864,Master's Thesis,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,PHCA,8199,2,17867,Doctoral Dissertation Defense,Sansgiry,Sujit Sharad,0,0,0,0,0,0,0,
+Fall 2022,WGSS,2350,12,17868,Intro To Women's Studies,Jagannathan PhD,Meera,19,9,2,0,0,0,0,3.512
+Fall 2022,PHCA,6297,1,17870,Selected Topics,Varkey,Divya A,5,0,0,0,0,0,0,4.0
+Fall 2022,DRAM,1310,12,17874,Introduction to Theatre,Hinkel,Heidi Anne,40,5,3,0,1,0,0,3.667
+Fall 2022,PHYS,4298,2,17875,Independent Study,Cherdack,Daniel David,0,0,0,0,0,1,0,
+Fall 2022,ECON,8399,8,17881,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,5,0,
+Fall 2022,ENTR,3342,1,17883,Women in Entrepreneurship,McCormick,Kelly,16,7,1,1,3,0,1,3.166
+Fall 2022,ENTR,7342,1,17884,Women in Entrepreneurship,McCormick,Kelly,8,0,0,0,0,0,0,4.0
+Fall 2022,MANA,3335,13,17885,Intro Org Behavior and Mgmt,Rude,Dale,18,5,1,0,0,0,0,3.64
+Fall 2022,PCOL,8698,4,17886,Doctoral Research,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Fall 2022,RELS,1301,5,17889,Intro To Religious Studies,Mummert,Claire Elizabeth,25,11,2,2,7,0,2,2.936
+Fall 2022,HDCS,4303,3,17892,Merchandising Systems,Gatterson,Beverly,25,15,4,4,4,0,0,2.988
+Fall 2022,PCOL,6498,6,17893,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6198,1,17895,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6498,7,17896,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2022,KIN,3309,1,17899,Biomechanics,Arellano,Christopher,10,31,8,1,0,0,0,2.921
+Fall 2022,PHLA,7299,5,17900,Masters Thesis,Wallace,David A,0,0,0,0,0,1,0,
+Fall 2022,PHLA,7299,6,17901,Masters Thesis,Wanat,Matthew A,0,0,0,0,0,1,0,
+Fall 2022,ENGL,1301,71,17902,First Year Writing I,Krajniak,Matthew J,5,9,1,0,2,0,2,2.999
+Fall 2022,ENGL,1301,72,17903,First Year Writing I,Khalil,Rand Omar,14,4,0,0,0,0,1,3.778
+Fall 2022,ENGL,1301,74,17904,First Year Writing I,Stockwell,Patrick Edward,17,0,0,1,1,0,0,3.649
+Fall 2022,PCOL,6198,6,17905,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6498,8,17906,Special Problems,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6398,7,17909,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8399,27,17910,Doctoral Dissertation,Venta,Amanda Cristina,1,0,0,0,0,0,0,4.0
+Fall 2022,MIS,3360,3,17912,Systems Analysis and Design,Harkness,Carol Louise,11,23,23,4,0,0,3,2.672
+Fall 2022,NUTR,6307,1,17920,Community Nutrition Practice,Haubrick,Kevin,0,0,0,0,0,4,0,
+Fall 2022,ENGL,1301,75,17921,First Year Writing I,Valcin,Mariot,3,10,7,1,2,0,2,2.478
+Fall 2022,MATH,8398,23,17922,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6198,1,17923,Special Problems,Widger,William R,0,0,0,0,0,5,0,
+Fall 2022,SPAN,1502,1,17924,Elementary Spanish II,Mejia Lara,Airy Sindik,11,9,4,0,1,0,1,3.134
+Fall 2022,SPAN,1501,3,17926,Elementary Spanish I,Torres,Cristina,12,9,2,0,1,0,1,3.209
+Fall 2022,POLS,3373,1,17928,Inside Texas Politics,Rottinghaus,Brandon J,10,14,7,4,9,0,1,2.228
+Fall 2022,ENGL,1301,53,17930,First Year Writing I,Backus,Margot Gayle,12,3,0,1,2,0,1,3.167
+Fall 2022,ENGL,1301,55,17931,First Year Writing I,Alcorn III,Charles William,17,0,1,0,0,0,0,3.834
+Fall 2022,ENGL,1301,56,17932,First Year Writing I,Backus,Margot Gayle,4,7,5,0,3,0,0,2.404
+Fall 2022,ENGL,1302,17,17933,First Year Writing II,Cowan,Joshua Jared,6,8,5,1,3,0,2,2.522
+Fall 2022,ENGL,1302,18,17934,First Year Writing II,Campese,Kathleen Ann,10,2,4,0,3,0,4,2.721
+Fall 2022,PHCA,7310,1,17936,Teaching Practicum,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,6297,4,17937,Selected Topics,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6198,14,17941,Spec Prob-Physio Optics,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6214,1,17943,Applied Harpsichord,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,3340,2,17944,Intro. to Automata and Comp.,Singh,Raj Kumar,91,11,2,0,0,0,1,3.834
+Fall 2022,BCHS,3399,1,17949,Senior Honors Thesis,Sen,Mehmet,0,0,0,0,0,0,0,
+Fall 2022,IRW,1300,3,17950,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,51,2,
+Fall 2022,ENGL,8698,12,17952,Graduate Research,Divakaruni,Chitra B,0,0,0,0,0,1,0,
+Fall 2022,SOCI,1301,10,17958,Introduction To Sociology,Colbert,Sharla Stettnisch,50,2,1,1,1,0,4,3.764
+Fall 2022,PSYC,6365,8,17968,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Fall 2022,SOCI,1301,12,17970,Introduction To Sociology,Davis,Mary A,34,10,6,2,4,0,3,3.173
+Fall 2022,HDCS,4369,4,17972,Entrepreneurship,Hitchman Sr,Cal M,29,8,3,0,5,0,3,3.171
+Fall 2022,ENGL,3399,2,17975,Senior Honors Thesis,Backus,Margot Gayle,0,0,0,0,0,0,0,
+Fall 2022,ENGL,7398,2,17984,Special Problems,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6420,1,17985,Applied Violin,Yon,Kirsten A,3,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8377,1,17994,Reading for Comps Exams,Perales,Monica,0,0,0,0,0,1,0,
+Fall 2022,PHCA,8199,3,17997,Doctoral Dissertation Defense,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2022,INDS,3397,11,18004,Selected Topics,Wells,Adam C,7,1,0,0,0,0,0,3.586
+Fall 2022,MUSI,6198,3,18006,Research in Chamber Music,Yon,Kirsten A,2,0,0,0,0,0,1,4.0
+Fall 2022,SOCW,7335,1,18011,SW Practice in Communities,Mayer,Margaret,21,1,0,0,0,0,0,3.955
+Fall 2022,MATH,2312,8,18012,Precalculus,Almus,Melahat,42,36,30,12,40,0,20,2.187
+Fall 2022,MARK,6A61,3,18013,Marketing Administration,Krishnamurthy,Parthasarathy,50,6,2,0,0,0,0,3.771
+Fall 2022,FINA,6A35,1,18014,Managerial Finance,Povel,Paul,11,8,1,0,0,0,0,3.517
+Fall 2022,FINA,6A35,3,18015,Managerial Finance,Berger,Elizabeth,18,15,3,1,1,0,3,3.281
+Fall 2022,MARK,6A61,2,18016,Marketing Administration,Galvani,Paul,10,7,1,0,0,0,0,3.372
+Fall 2022,SCM,6A01,1,18017,SCM Concepts,Sahin,Funda,12,6,2,0,0,0,0,3.5
+Fall 2022,MARK,6A61,4,18018,Marketing Administration,Krishnamurthy,Parthasarathy,27,7,0,0,0,0,0,3.814
+Fall 2022,SCM,6A01,3,18020,SCM Concepts,Sahin,Funda,5,3,1,2,0,0,0,3.06
+Fall 2022,MANA,6A32,1,18021,Organizational Behavior & Mgt,Krylova,Ksenia O,16,7,1,0,1,0,0,3.44
+Fall 2022,FINA,7A20,1,18024,Capital Markets,Jacobs,Kris,12,5,0,0,0,0,1,3.609
+Fall 2022,MATH,1342,6,18026,Elementary Statistical Methods,Caputo,Matthew G,34,48,34,18,72,0,52,1.77
+Fall 2022,GENB,6A50,1,18027,Business Communications,Pineda,Dalia Rivera,21,4,1,0,0,0,1,3.718
+Fall 2022,GENB,6A50,2,18034,Business Communications,Pettiette,Michael R,27,1,0,0,0,0,1,3.811
+Fall 2022,MATH,1314,8,18035,College Algebra,Xhabli,Blerina,26,20,12,5,27,0,18,2.086
+Fall 2022,MATH,1324,7,18036,Finite Math with Applications,Sosa,Moses,56,50,24,18,54,0,66,2.175
+Fall 2022,MATH,1325,3,18037,Calc for Bus & Social Sciences,Constante,Beatrice,16,10,12,8,16,0,18,1.968
+Fall 2022,GHL,6317,1,18038,Innovative Hosp. Technologies,Lee,Minwoo,25,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6324,1,18039,Hosp. Busn Strategies in Amer,Kim,Jaewook,25,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6340,1,18040,Behavior and Hosp. Lead. Strat,Guchait,Priyanko,24,1,0,0,0,0,0,3.934
+Fall 2022,FINA,7A23,1,18041,Portfolio Theory and Practice,Jacobs,Kris,9,6,0,0,0,0,0,3.556
+Fall 2022,NURS,4314,2,18042,Nursing Research,Phan,Huong Thi,40,21,0,0,0,0,0,3.656
+Fall 2022,BCHS,6230,1,18043,Grad Biochem Lab Rotation I,Widger,William R,4,1,0,0,0,0,0,3.8
+Fall 2022,CHEM,6398,29,18046,Special Problems,Czader,Arkadiusz,0,0,0,0,0,0,0,
+Fall 2022,MANA,6A83,1,18050,Strategic Analysis,Celly,Nikhil,30,1,0,0,0,0,0,3.925
+Fall 2022,FINA,7A10,2,18051,Valuation,Yerramilli,Vijay,15,9,0,0,2,0,0,3.257
+Fall 2022,FINA,6A31,1,18052,Analyzing Financial Statements,Woods,James D,7,3,4,3,1,0,0,2.667
+Fall 2022,GHL,6317,2,18053,Innovative Hosp. Technologies,Morosan,Cristian,10,1,1,0,0,0,0,3.778
+Fall 2022,SOCW,7324,5,18054,Clinical Apps of DSM in SW,Taylor,Patricia G,19,2,0,0,0,0,1,3.905
+Fall 2022,GENB,6A50,3,18056,Business Communications,Pettiette,Michael R,15,1,0,0,0,0,1,3.752
+Fall 2022,SOCW,7334,1,18057,Social Work Leadership,Powell,Torey Ian,21,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7304,7,18059,Brief Targeted Interventions,Cheung,Monit,28,0,0,0,0,0,1,4.0
+Fall 2022,MANA,6A25,5,18061,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,10,7,1,0,1,0,0,3.281
+Fall 2022,MANA,6A32,2,18062,Organizational Behavior & Mgt,Witt,Lawrence A,12,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7A49,1,18063,Managerial Decision Making,Carlin,Barbara A,10,7,2,0,1,0,0,3.283
+Fall 2022,BIOL,6230,1,18064,Advanced Cell Biology I,Dryer,Stuart E,13,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,6231,1,18065,Advanced Cell Biology II,Khurana,Seema,10,3,0,0,0,0,0,3.668
+Fall 2022,FINA,7A20,2,18066,Capital Markets,Wu,Guojun,29,0,0,0,0,0,0,3.989
+Fall 2022,FINA,7A30,1,18067,Advanced Corporate Finance,Povel,Paul,16,9,1,0,0,0,0,3.45
+Fall 2022,SOCW,7356,2,18068,Groups in Clinical Settings,O'Neal,Vaughn,22,1,0,0,0,0,0,3.957
+Fall 2022,INDS,2260,1,18077,Materials and Fab Methods,Wells,Adam C,6,18,0,0,1,0,1,3.212
+Fall 2022,SOCW,7319,2,18078,SW Practice in Organizations,Arora,Anil,21,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7324,4,18079,Clinical Apps of DSM in SW,Taylor,Patricia G,24,0,0,0,0,0,0,4.0
+Fall 2022,INDS,2170,1,18080,Digital Sketch Techniques I,Kimbrough,Mark S,5,1,0,0,0,0,1,3.833
+Fall 2022,MARK,7A75,1,18091,Marketing Strategy,Lish,Alan D,10,10,1,0,0,0,0,3.444
+Fall 2022,GHL,7366,1,18092,Hosp. Management Strategies,Rockett,Gregory,4,6,0,0,0,0,0,3.334
+Fall 2022,SOCW,6306,6,18093,Social Work Practice Skills,Lucas,Virginia,22,1,0,0,0,0,1,3.957
+Fall 2022,SOCW,6308,4,18094,Human Diversity & Development,Fernandez,Jason,28,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,6308,5,18095,Human Diversity & Development,Lucas,Virginia,26,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,6308,7,18096,Human Diversity & Development,Lucas,Virginia,22,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7304,9,18097,Brief Targeted Interventions,Walton,Quenette,21,2,0,0,0,0,0,3.913
+Fall 2022,SOCW,7356,5,18098,Groups in Clinical Settings,Carter,Cynthia J.,19,2,1,0,0,0,0,3.818
+Fall 2022,NURS,6320,1,18099,Healthcare Informatics,Smith,Deborah Ann,3,0,0,0,0,0,0,4.0
+Fall 2022,NURS,6351,1,18102,Evidence-Based Practice Projt,Love,Mary Frances,9,5,0,0,0,0,0,3.643
+Fall 2022,FINA,7A50,1,18103,Derivatives I,Rabinovitch,Ramon,5,5,2,1,0,0,0,3.077
+Fall 2022,FINA,7A51,1,18104,Derivatives II,Rabinovitch,Ramon,7,2,0,0,0,0,0,3.704
+Fall 2022,FINA,7A40,1,18105,Fixed Income I,Doshi,Hitesh B,13,12,2,0,0,0,0,3.444
+Fall 2022,FINA,7A41,1,18106,Fixed Income II,Doshi,Hitesh B,7,3,0,0,0,0,0,3.568
+Fall 2022,FINA,7A37,1,18107,Corp Strategy-Equity Fund Mgt,Kumar,Praveen,15,2,0,0,0,0,0,3.766
+Fall 2022,INDS,3160,2,18108,Design Issues I,McEuen,Aaron Ross,16,3,0,0,0,0,0,3.79
+Fall 2022,CHEM,1305,3,18109,Foundations of Chemistry,St Hill,Lydia Ruth,14,17,15,10,7,0,14,2.307
+Fall 2022,NURS,6306,1,18110,"Policy, Role & Economics",Brohard,Cheryl L,3,0,0,0,0,0,0,4.0
+Fall 2022,FINA,6A31,2,18111,Analyzing Financial Statements,Woods,James D,8,2,0,0,0,0,1,3.734
+Fall 2022,FINA,7A10,3,18112,Valuation,Yerramilli,Vijay,23,9,2,0,0,0,1,3.569
+Fall 2022,PSYC,2301,11,18115,Introduction to Psychology,Saiyed,Amna Shabbir,61,10,6,0,2,0,1,3.578
+Fall 2022,PSYC,2308,6,18116,Child Development,Merrill,Livia Christine,25,35,9,4,7,0,1,2.825
+Fall 2022,ECON,4390,2,18117,Economics Internship,Thornton,Rebecca Achee,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,8999,2,18118,Doctoral Dissertation,O'Connor,Daniel Patrick,0,0,0,0,0,1,0,
+Fall 2022,ENGL,1301,102,18119,First Year Writing I,Braniger,Leslie,4,10,4,2,5,0,0,2.2
+Fall 2022,BIOE,8399,3,18120,Doctoral Dissertation,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2022,MATH,3325,2,18123,Transition to Advanced Math,Vershynina,Anna,6,5,3,1,2,0,4,2.589
+Fall 2022,MATH,3330,1,18124,Abstract Algebra,O'Malley,Matthew J,3,4,2,0,2,0,1,2.545
+Fall 2022,GEOL,1102,8,18125,Intro to Climate Change Lab,Choi,Yunsoo,14,2,3,1,0,0,0,3.302
+Fall 2022,BCHS,6237,1,18127,Pharmacology and Drug Design,Bawa-Khalfe,Tasneem,10,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,6238,1,18128,Gene Regulation,Schwartz,Robert J,6,0,0,0,0,0,0,4.0
+Fall 2022,COMM,1303,3,18129,Writing for Communicators,Lyn,Robyn,36,5,0,0,3,0,2,3.614
+Fall 2022,COMM,2327,2,18130,Introduction to Screen Writing,Vaughan,Thomas Michael,14,3,3,0,0,0,0,3.517
+Fall 2022,COMM,2328,3,18131,Broadcast Writing Basics,Trigg,Katishia Leonna,5,10,3,0,2,0,0,2.833
+Fall 2022,PHYS,1301,5,18133,College Physics I (lecture),Meier,Mark Albert,35,38,76,17,0,0,15,2.51
+Fall 2022,COMM,3367,1,18135,Student-Run Agency Experience,Vardeman,Jennifer E,7,0,0,0,0,0,0,4.0
+Fall 2022,PHYS,4356,1,18137,Intro To Particle Physics,Renshaw,Andrew,11,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,1303,2,18145,Physical Geology,Robinson,Alexander C,19,24,26,4,1,0,3,2.712
+Fall 2022,GEOL,1303,4,18147,Physical Geology,Beverly,Emily Jane,66,75,34,11,8,0,3,2.897
+Fall 2022,GEOL,1303,5,18148,Physical Geology,Sisson,Virginia B,75,61,15,5,3,0,5,3.221
+Fall 2022,GEOL,1303,6,18149,Physical Geology,Hauptvogel,Daniel William,187,190,93,28,17,0,5,2.957
+Fall 2022,GEOL,1303,9,18150,Physical Geology,Murphy,Michael,86,64,34,6,9,0,3,3.059
+Fall 2022,GEOL,1303,7,18151,Physical Geology,Lytwyn,Jennifer N,23,55,41,19,17,0,16,2.301
+Fall 2022,GEOL,1303,8,18152,Physical Geology,Lytwyn,Jennifer N,44,56,38,18,21,0,15,2.413
+Fall 2022,COMM,4322,1,18153,TV Producing & Directing I,Crowe,Craig Warren,16,0,0,0,0,0,0,4.0
+Fall 2022,COMM,4363,3,18154,Integrated Comm. Campaigns,Clark,Thomas R,12,1,4,0,0,0,0,3.471
+Fall 2022,COMM,4382,1,18156,Narrative Non-Linear Editing,Houk,Keith R,13,7,1,0,0,0,0,3.571
+Fall 2022,COMM,2322,3,18158,Television Production I,Newlin,Julye G,18,0,0,0,0,0,0,4.0
+Fall 2022,COMM,2311,3,18172,Writing for Print and Digital,Butler,Bryan C,5,13,2,0,1,0,0,3.063
+Fall 2022,COMM,2311,4,18174,Writing for Print and Digital,Radcliffe Andre,Jennifer,12,5,1,0,1,0,1,3.438
+Fall 2022,COMM,2311,5,18176,Writing for Print and Digital,Radcliffe Andre,Jennifer,4,9,3,1,3,0,0,2.434
+Fall 2022,BIOL,7124,2,18178,Cell Biology Seminar,Kelleher Meisel,Erin S,0,0,0,0,0,5,0,
+Fall 2022,GEOL,6390,1,18184,3-D Seismic Exploration I,Zhou,Hua-Wei,5,0,0,0,0,0,0,3.868
+Fall 2022,GEOL,7331,1,18186,Seismic Structural Geology,Suppe,John,10,2,0,0,0,0,0,3.613
+Fall 2022,ENRG,3311,1,18190,Fundamentals of Sustainability,Dieterich,Michael,7,1,1,0,1,0,1,3.267
+Fall 2022,POLS,3397,1,18191,Selected Topics in Public Law,Tiede,Lydia B,10,0,0,0,0,0,0,3.967
+Fall 2022,HON,3360,1,18192,Global Engagement,Myrick,Keri D,8,0,0,0,0,0,0,4.0
+Fall 2022,MATH,1314,3,18193,College Algebra,Chang,James A,77,60,46,20,54,0,74,2.335
+Fall 2022,MATH,1324,4,18194,Finite Math with Applications,Watkins,Katie Nicole,128,176,50,42,160,0,114,2.088
+Fall 2022,HON,4350,1,18197,Data and Society in Practice,Price,Daniel M,6,0,0,0,2,0,0,2.835
+Fall 2022,COMM,3317,2,18198,Multimedia Journalism,Baruch Blanco,Maria Felicitas,16,0,0,0,0,0,0,3.938
+Fall 2022,COMM,2331,1,18199,Relational Communication,Hudson-Gillan,Gail,11,8,5,1,0,0,0,3.094
+Fall 2022,COMM,4374,1,18200,Capstone Research Projects,Liu,Wenlin,17,5,0,0,0,0,0,3.698
+Fall 2022,ARAB,3340,1,18205,Modern & Rational in Islam,El-Badawi,Emran,3,8,6,0,0,0,4,2.824
+Fall 2022,ECON,7330,1,18207,Quantitative Economic Analysis,Sorensen,Bent E,9,3,0,0,0,0,0,3.778
+Fall 2022,ECON,7341,1,18208,Microeconomic Theory I,Wang,Fan,2,15,0,0,0,0,0,3.118
+Fall 2022,ECON,7343,1,18209,Macroeconomic Theory I,Nygaard,Vegard Mokleiv,6,3,0,0,0,0,0,3.63
+Fall 2022,ECON,8331,1,18210,Econometrics II,Sorensen,Bent E,10,0,0,0,0,0,1,3.868
+Fall 2022,ECON,2302,5,18214,Principles of Microeconomics,Kim,Jeonghyeok,24,20,20,11,9,0,10,2.413
+Fall 2022,ECON,2302,6,18215,Principles of Microeconomics,Zuluaga Gonzalez,Victor Hugo,17,28,31,10,2,0,3,2.519
+Fall 2022,ECON,3320,2,18217,Intro to Econ Data Analysis,Zhivan,Natalia A.,31,24,19,7,29,0,31,2.14
+Fall 2022,CLAS,3307,1,18220,Greek & Roman Myths of Heroes,Wright,David John,16,2,1,0,0,0,0,3.633
+Fall 2022,CLAS,4381,1,18223,Latin Classics in Translation,Houlihan,James W,11,5,3,0,0,0,0,3.404
+Fall 2022,CHIN,6382,1,18227,Tales of East Asian Cities,Li,Melody Yunzi,1,0,0,0,0,0,0,3.67
+Fall 2022,KIN,3301,2,18231,Design/Eval Phys Activity Prog,Graham,Marilynn Hadassah,41,6,6,1,1,0,5,3.509
+Fall 2022,KIN,3305,2,18232,Sport Sociology,Hawkins,Billy J,34,10,4,0,0,0,0,3.598
+Fall 2022,KIN,3305,3,18233,Sport Sociology,Ogunrinde,Joyce,16,7,8,2,5,0,6,2.737
+Fall 2022,KIN,4315,2,18238,Motor Learning and Control,Parikh,Pranav J,7,9,8,0,1,0,2,2.88
+Fall 2022,ENGL,3323,1,18244,Development of Lit Crit & Thry,Lecourt,Sebastian Joseph,10,13,3,0,0,0,2,3.269
+Fall 2022,BIOE,4348,1,18246,Tissue Engineering,Horton,Renita Elillian,0,1,0,0,0,0,0,3.0
+Fall 2022,ECON,3344,1,18248,History of Economic Doctrine,Gosselin,Richard John,2,2,18,3,5,0,0,1.668
+Fall 2022,ITAL,1501,3,18251,Elementary Italian I,Nicosia,Alda,6,4,1,1,0,0,1,3.25
+Fall 2022,HIST,1302,51,18255,The U.S. Since 1877,Modaff,Abigail,23,1,1,0,0,0,0,3.88
+Fall 2022,HIST,1302,52,18256,The U.S. Since 1877,Modaff,Abigail,20,3,0,0,1,0,0,3.695
+Fall 2022,WCL,4351,1,18258,Frames of Modernity I,Zaretsky,Robert D,6,2,3,0,1,0,2,2.945
+Fall 2022,WCL,3342,1,18260,Tales of East Asian Cities,Li,Melody Yunzi,6,2,0,0,1,0,0,3.26
+Fall 2022,COMD,6372,3,18261,Remediation of Child Lang Dis,Ivey,Michelle L,17,13,3,0,0,0,0,3.404
+Fall 2022,BIOE,8298,25,18264,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7339,1,18267,CDLNeuropsych: Assess/App III,Medina PhD,Luis Daniel,4,1,0,0,0,0,0,3.734
+Fall 2022,COMD,2339,5,18270,Language Development,Mills,Monique T,27,3,3,0,0,0,0,3.667
+Fall 2022,COMD,2339,6,18271,Language Development,Mills,Monique T,12,3,2,0,0,0,1,3.569
+Fall 2022,COMD,2339,7,18272,Language Development,Ivey,Michelle L,11,10,6,0,2,0,7,3.0
+Fall 2022,ENGI,2304,16,18273,Technical Communications,Salvo,Deborah C,18,6,0,0,0,0,2,3.654
+Fall 2022,KIN,4330,3,18275,Child and Adolescent Obesity,Breslin,Whitney L,11,10,10,1,3,0,1,2.677
+Fall 2022,KIN,4365,3,18276,Legal/Ethical Aspects of Sport,Cottingham,Michael,10,11,11,7,5,0,7,2.363
+Fall 2022,BIOL,1306,51,18279,Biology for Science Majors I,Hanke,Marc H,5,8,7,3,0,0,6,2.523
+Fall 2022,BIOL,1306,52,18280,Biology for Science Majors I,Hanke,Marc H,3,7,8,6,0,0,5,2.347
+Fall 2022,BIOL,1306,53,18281,Biology for Science Majors I,Sirrieh,Rita Evelyn,12,10,9,1,0,0,1,3.042
+Fall 2022,GHL,4343,2,18282,Financial Admin for Hosp.Ind.,Koh,Yoon,23,15,6,2,4,0,0,3.013
+Fall 2022,HIST,3324,1,18283,Oral History Methods,Harwell,Debbie Z,10,2,0,0,1,0,0,3.538
+Fall 2022,HON,3304,1,18284,Material Cultures of Medicine,Lunstroth,John,20,4,0,0,0,0,0,3.751
+Fall 2022,ARCH,6393,4,18285,Master's Project Preparation,Longoria,Rafael R,6,5,0,0,0,0,0,3.605
+Fall 2022,HON,3305,1,18286,Medicine in Performance,Lambeth,Laurie Regine Clements,16,3,0,0,0,0,0,3.807
+Fall 2022,PSYC,4305,1,18287,Persuasion & Behavior,Knee,Clifford R,12,0,0,2,0,0,0,3.501
+Fall 2022,GHL,3372,1,18291,Convention and Meeting Mgmt,Kenyan,Erin Oeser,15,8,0,3,3,0,1,3.046
+Fall 2022,GHL,3440,1,18292,Hotel Operations,Cheatham,Cathy A,17,9,7,1,0,0,1,3.294
+Fall 2022,GHL,4361,1,18294,Marketing Strategies,Taylor,David C,17,4,2,0,1,0,0,3.473
+Fall 2022,GHL,4370,1,18295,Project Dev & Mgmt in Hosp Ind,Park,Hyekyung,9,0,0,0,0,0,0,4.0
+Fall 2022,GHL,4374,1,18296,"Korean Food,Culture,Trism Mgt",Back,KiJoon,16,4,0,0,0,0,0,3.8
+Fall 2022,PEP,6355,3,18297,Promotional Strategies,Cottingham,Michael,7,2,0,0,0,0,0,3.814
+Fall 2022,PEP,8306,3,18298,Scientific Inquiry in Hlt Prof,Hawkins,Billy J,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,4150,1,18300,Genomic & Proteomic Lab,Akay PhD,Metin,6,0,0,0,0,0,0,3.835
+Fall 2022,SOCW,7324,6,18301,Clinical Apps of DSM in SW,Parks,Steven Lee,17,5,0,0,1,0,0,3.609
+Fall 2022,SOCW,7324,7,18302,Clinical Apps of DSM in SW,Parks,Steven Lee,18,2,0,0,0,0,1,3.9
+Fall 2022,SOCW,7301,1,18303,Confronting Oppression & Injus,Barthelemy,Juan,27,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7301,2,18304,Confronting Oppression & Injus,Shepherd,Donisha Shanice,24,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6319,1,18305,"Korean Food, Cult. and Tour.",Back,KiJoon,6,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7301,3,18306,Confronting Oppression & Injus,Barthelemy,Juan,24,1,0,0,0,0,0,3.96
+Fall 2022,SOCW,7301,4,18307,Confronting Oppression & Injus,Mendoza,Yvonne Anette,22,3,0,0,0,0,0,3.88
+Fall 2022,PHIL,1301,5,18309,Intro To Philosophy,Aiman,Edwin E,46,21,2,0,1,0,1,3.496
+Fall 2022,GHL,7337,1,18310,Human Resources in Hospitality,Madera,Juan Manuel,30,0,1,0,0,0,0,3.935
+Fall 2022,GHL,7341,1,18311,Food and Beverage Management,Legendre,Jungyoung Shin,15,0,0,0,0,0,0,3.978
+Fall 2022,KIN,4303,2,18314,The Obesity Epidemic,Alastuey,Lisa L,11,19,7,1,3,0,2,2.805
+Fall 2022,HIST,2312,1,18315,Western Civilization from 1450,Golubev,Alexey Valeryevich,12,9,10,0,1,0,3,2.948
+Fall 2022,CHEM,1312,3,18316,Fundamentals of Chemistry 2,Czernuszewicz,Roman S,6,9,15,18,22,0,18,1.367
+Fall 2022,HIST,3390,1,18320,Middle East: Pictures & Words,Al-Sowayel,Dina,12,2,0,0,6,0,1,2.7
+Fall 2022,PHIL,1321,3,18321,Logic I,Haaga,Curtis W,10,9,8,5,2,0,11,2.54
+Fall 2022,COSC,1437,5,18322,Introduction to Programming,Biediger,Daniel Edward,52,28,16,5,5,0,13,3.107
+Fall 2022,COSC,2306,1,18324,Data Programming,Shah,Shishir,8,8,5,2,1,0,20,2.806
+Fall 2022,COSC,4337,1,18325,Data Science II,Rizk,Nouhad J,16,18,26,1,4,0,2,2.687
+Fall 2022,COSC,6353,1,18327,Software Design,Alipour,Mohammad Amin,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,6376,1,18332,Cloud Computing,Shi,Weidong,40,35,0,0,0,0,0,3.555
+Fall 2022,GHL,6352,1,18334,Hospitality Market Analysis,McCaslin,Glynn Randle,25,0,0,0,0,0,0,4.0
+Fall 2022,COMD,2338,4,18338,Phonetics,Roxburgh Wilson,Zoe,6,6,9,2,3,0,3,2.334
+Fall 2022,COMD,4333,2,18339,Neuroscience for COMD,Dial,Heather Raye,19,13,2,0,0,0,0,3.451
+Fall 2022,MATH,6360,1,18340,Applicable Analysis,Onofrei,Daniel T,7,0,0,0,0,0,0,4.0
+Fall 2022,NUTR,4345,2,18350,The Obesity Epidemic,Alastuey,Lisa L,38,20,4,0,2,0,1,3.345
+Fall 2022,TEPM,6304,1,18351,Quality Improvemnt in Proj Mgt,Kovach,Jamison,12,1,0,0,1,0,0,3.643
+Fall 2022,FORE,6371,20,18352,World Futures,Sweeney,John Arthur,6,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,2307,2,18353,Span for Heritage Learners I,Ferrer,Tatiana Ines,7,2,4,0,0,0,1,3.256
+Fall 2022,ATP,6113,3,18355,Lower Extremity Evaluation Lab,Harrison,Layci,14,2,0,0,0,0,0,3.875
+Fall 2022,ATP,6112,3,18356,Therapeutic Intervention 1 Lab,Yellen,Joshua B,15,1,0,0,0,0,0,3.938
+Fall 2022,ATP,6313,3,18357,Lower Extremity Evaluation,Harrison,Layci,10,5,1,0,0,0,0,3.563
+Fall 2022,ATP,7112,1,18358,Therapeutic Intervention 2 Lab,Yellen,Joshua B,15,0,0,0,0,0,0,4.0
+Fall 2022,BUSI,3300,4,18361,Intro to Personal Finance,Munchbach,Jim,43,6,1,1,2,0,1,3.579
+Fall 2022,FINA,4320,6,18362,Investment Management,Suleymanov,Masim,12,12,6,1,0,0,1,3.118
+Fall 2022,FINA,4353,3,18363,Practicum Pers Finan Planning,Lopez,John C,7,5,0,0,0,0,1,3.693
+Fall 2022,BUSI,3300,5,18364,Intro to Personal Finance,Munchbach,Jim,39,5,1,1,2,0,3,3.577
+Fall 2022,BUSI,3300,6,18365,Intro to Personal Finance,Harvey,Danny,54,1,0,0,0,0,0,3.97
+Fall 2022,BUSI,3300,7,18366,Intro to Personal Finance,Harvey,Danny,48,0,3,0,3,0,1,3.667
+Fall 2022,INDS,2500,5,18375,Industrial Design Studio III,Chow,George K,7,6,0,0,0,0,0,3.386
+Fall 2022,INDS,2500,7,18377,Industrial Design Studio III,McEuen,Aaron Ross,4,7,0,0,0,0,2,3.274
+Fall 2022,DIGM,3350,30,18379,Graph Comm Prod Processes,Pegram,Norman,14,3,1,0,0,0,0,3.704
+Fall 2022,DIGM,4351,30,18380,Portfolio Development for DIGM,Hargrove,Mark Stephen,49,19,3,0,0,0,1,3.527
+Fall 2022,DIGM,4373,31,18383,Photo Tone and Color Repro,Waite,Jerry J,14,5,1,0,0,0,0,3.469
+Fall 2022,INDS,3340,1,18384,Computer Aided Indus Design II,Chow,George K,10,6,0,0,0,0,0,3.522
+Fall 2022,BIOE,3341,1,18387,Biothermodynamics,Larin,Kirill,13,6,1,0,0,0,0,3.617
+Fall 2022,INDS,6340,1,18390,Advanced Design Materials,Wells,Adam C,2,0,0,0,0,0,0,4.0
+Fall 2022,INDS,4260,1,18396,Design Issues II,McEuen,Aaron Ross,14,8,0,0,0,0,0,3.591
+Fall 2022,SPAN,1501,5,18401,Elementary Spanish I,Scalzo,Dillon S,15,9,0,0,1,0,2,3.401
+Fall 2022,SPAN,1502,7,18403,Elementary Spanish II,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,8,10,8,0,2,0,0,2.786
+Fall 2022,SPAN,2311,3,18405,Intermediate Spanish I,Abend Van Dalen,Raquel Andreina de la Trinidad,2,4,9,2,2,0,2,2.14
+Fall 2022,SPAN,1501,15,18407,Elementary Spanish I,Lumbierres,M Pilar,8,6,3,1,4,0,5,2.471
+Fall 2022,PSYC,2316,2,18412,Psychology of Personality,Damian,Rodica Ioana,41,32,1,1,3,0,2,3.342
+Fall 2022,PSYC,2316,3,18413,Psychology of Personality,Damian,Rodica Ioana,28,17,4,0,1,0,0,3.367
+Fall 2022,INDS,6360,3,18414,Industrial Design Studio,Feng,Jeff Feng,2,0,0,0,0,0,0,4.0
+Fall 2022,SCLT,2362,33,18422,Intro To Logistics Technology,Cassler,Daniel,56,1,0,2,1,0,1,3.817
+Fall 2022,SCLT,2380,30,18424,Distribution Channels,Hu,Minxiang,55,30,2,3,4,0,1,3.299
+Fall 2022,SCLT,3381,32,18426,Industrial and Consumer Sales,Cassler,Daniel,54,5,0,0,0,0,0,3.915
+Fall 2022,SCLT,6316,1,18428,Global Supply Chain Logistics,Wang,Kailai,19,0,0,0,0,0,0,3.948
+Fall 2022,PSYC,2319,6,18429,Intro to Social Psychology,Weinstein,Andrew Philip,30,7,1,0,0,0,1,3.737
+Fall 2022,SCLT,6318,2,18432,Supply Chain Strategies,Bian,Zheyong,30,5,0,0,0,0,0,3.904
+Fall 2022,POLS,3388,1,18433,Politics in Film/Television,Davis,Sharon M,27,7,4,2,3,0,3,3.217
+Fall 2022,PSYC,3339,3,18434,Intro To Clinical Psychology,Healy,Nathaniel Andrew,20,35,13,4,2,0,5,2.901
+Fall 2022,CNST,1330,2,18437,Graphics I,Clark,Peter J,27,11,2,0,5,0,2,3.178
+Fall 2022,ARCH,1500,41,18454,Design Studio I,Plauche',Roya,4,8,2,0,0,0,0,3.143
+Fall 2022,CNST,6396,6,18465,Master's Project,Gao,Lu,2,0,0,0,0,0,0,4.0
+Fall 2022,CNST,2351,2,18468,Construction Estimating I,Liggin,Gregory G,3,5,6,2,1,0,0,2.412
+Fall 2022,CNST,3331,2,18469,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,6,6,6,1,3,0,1,2.5
+Fall 2022,CNST,3351,2,18470,Construction Estimating II,Siddiqui,Muhammad Ali,6,5,1,2,0,0,0,3.024
+Fall 2022,CORE,1101,2,18472,College Success,McKissic,Veronica,9,7,0,1,2,0,1,3.053
+Fall 2022,CORE,1101,3,18473,College Success,Jones,Tashemia V.,14,1,1,1,2,0,1,3.263
+Fall 2022,CORE,1101,4,18474,College Success,Brower,Samuel Richard,13,1,0,2,1,0,0,3.334
+Fall 2022,CORE,1101,5,18475,College Success,Thomas,Dustine J,13,0,2,0,0,0,2,3.755
+Fall 2022,CORE,1101,7,18477,College Success,Mahoney,Margaret Elizabeth,13,0,0,0,0,0,1,4.0
+Fall 2022,CORE,1101,8,18478,College Success,Guidry,Vanessa Lynn,13,1,2,0,1,0,1,3.509
+Fall 2022,INTB,3361,1,18479,Global Engagement and Research,Miljanic,Andra Olivia,5,1,0,0,0,0,0,3.778
+Fall 2022,CORE,1101,10,18481,College Success,Thompson,Amber M,9,0,0,2,0,0,2,3.365
+Fall 2022,CORE,1101,12,18483,College Success,King,Kelly N.,16,0,0,0,2,0,1,3.556
+Fall 2022,CORE,1101,13,18484,College Success,Howard,Nina M,14,1,2,2,0,0,1,3.456
+Fall 2022,CORE,1101,14,18485,College Success,Floyd,Monica,14,2,3,0,0,0,0,3.596
+Fall 2022,CORE,1101,15,18486,College Success,Perry,Deidra,6,6,1,1,2,0,1,2.792
+Fall 2022,CORE,1101,16,18487,College Success,Simpson,James Keir,14,1,1,0,1,0,1,3.569
+Fall 2022,CORE,1101,18,18490,College Success,Moreno,Susan E,15,0,0,1,0,0,1,3.813
+Fall 2022,CORE,1101,23,18495,College Success,Johnson,Whitney Nicole,10,1,1,0,1,0,0,3.487
+Fall 2022,ARTS,2346,1,18496,Fundamentals of Ceramics,Oloshove,Angel,13,2,1,0,0,0,0,3.729
+Fall 2022,ARTS,2346,2,18497,Fundamentals of Ceramics,Oloshove,Angel,15,1,0,0,0,0,0,3.896
+Fall 2022,CORE,1101,24,18498,College Success,Vernon-Harrison,Miranda Angelena,14,2,0,0,1,0,1,3.628
+Fall 2022,CORE,1101,25,18499,College Success,Phan,Trang Anh Thuc,8,1,1,0,0,0,2,3.7
+Fall 2022,CORE,1101,27,18501,College Success,Price,Chelsea T,8,0,1,0,1,0,1,3.367
+Fall 2022,ARTS,7310,1,18505,Printmaking Studio,Masterson,Patrick D,2,0,0,0,0,0,0,4.0
+Fall 2022,MECE,6384,2,18507,Methods of Applied Math I,Kulkarni,Yashashree,2,3,6,2,0,0,10,2.334
+Fall 2022,MECE,6345,2,18508,Fluid Dynamics 1,Yang,Di,3,2,0,0,0,0,2,3.534
+Fall 2022,ARTS,7310,2,18512,Printmaking Studio,Masterson,Patrick D,2,0,0,0,0,0,0,4.0
+Fall 2022,ELET,4105,1,18516,Senior Design Lab in EPET,Shi,Jian,1,0,0,0,0,0,0,4.0
+Fall 2022,ELET,4305,1,18518,Senior Design in EPET,Shi,Jian,24,0,0,0,0,0,0,3.973
+Fall 2022,CORE,1101,35,18519,College Success,Jones,Amber R,9,0,0,0,0,0,1,4.0
+Fall 2022,CORE,1101,36,18520,College Success,Spraggins,Brent R,6,1,0,0,0,0,0,3.763
+Fall 2022,HRD,6305,3,18522,Organizational Learning,Doss,Tommy,6,1,0,0,0,0,1,3.763
+Fall 2022,CORE,1101,38,18524,College Success,Reed,Erin A,3,1,0,0,0,0,0,3.668
+Fall 2022,CORE,1101,42,18529,College Success,Thomas,Trever LeAnn,11,1,0,0,0,0,0,3.917
+Fall 2022,CORE,1101,44,18531,College Success,Simpson,James Keir,12,1,2,0,3,0,0,3.092
+Fall 2022,CORE,1101,46,18533,College Success,Williams,Kimberly,14,1,0,0,2,0,0,3.471
+Fall 2022,CHEE,8598,13,18539,Doctoral Research,Orman,Mehmet,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8598,14,18540,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,
+Fall 2022,CHEE,8598,15,18541,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,7,0,
+Fall 2022,CHEE,8598,16,18542,Doctoral Research,Robertson,Megan L,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8598,17,18543,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,3,0,
+Fall 2022,CHEE,8598,18,18544,Doctoral Research,Vekilov,Peter,0,0,0,0,0,2,0,
+Fall 2022,CHEE,8598,19,18545,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2022,GOVT,2305,12,18547,"US Govt: Congress,Pres & Crts",Casellas,Jason,79,131,29,0,4,0,5,3.12
+Fall 2022,HDCS,1300,6,18548,Human Ecosystems & Tech Change,Vercher,Michelle Taylor,17,20,12,6,1,0,3,2.804
+Fall 2022,HDCS,1300,7,18549,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,41,6,3,2,3,0,3,3.401
+Fall 2022,SPAN,3306,2,18551,Intro Study Span Language,Fairclough,Marta A,5,4,3,0,1,0,1,2.796
+Fall 2022,ECE,5321,1,18552,Intro Nano Design & Fab,Brankovic,Stanko R,2,1,0,0,0,0,0,3.667
+Fall 2022,ACCT,3368,3,18554,Intermediate Accounting II,Sun,Xue,6,14,23,0,1,0,6,2.605
+Fall 2022,CIVE,6377,1,18557,Environmental Chemistry,Rahimi,Mohammad,9,2,1,0,0,0,0,3.612
+Fall 2022,SPAN,4343,1,18561,Health & Society in Hisp World,Zubiate,Maria Laura,7,0,0,0,0,0,0,3.906
+Fall 2022,LAW,5389,1,18563,Immigration Law,Morales,Daniel I,14,25,0,0,0,2,0,3.317
+Fall 2022,LAW,6372,1,18573,Analytic Methods,Chandler,Seth J,6,3,1,0,0,0,1,3.335
+Fall 2022,LAW,5344,1,18574,Appellate Advocacy I,Flores,Chad,10,13,1,0,0,1,0,3.389
+Fall 2022,ARTS,3370,1,18575,Traditional Photography,Duron-Larson,Angela Marie,12,1,0,1,2,0,1,3.291
+Fall 2022,ENGL,3340,2,18576,Advanced Composition,Shepley,Nathan,11,6,0,1,1,0,0,3.264
+Fall 2022,MECT,3360,30,18577,Automated Manufacturing System,Risal,Sandesh,5,15,9,1,2,0,4,2.584
+Fall 2022,ENRG,4302,1,18584,Energy Supply Chain,Radhakrishnan,Suryanarayanan,7,8,1,0,0,0,1,3.293
+Fall 2022,ENGL,3317,1,18586,The British Novel Before 1832,Mazella,David S,17,7,0,0,0,0,4,3.681
+Fall 2022,ENGL,3343,1,18588,Advanced Composition: Style,Butler,Paul G,10,7,0,0,1,0,1,3.371
+Fall 2022,ENGL,4384,1,18593,SR Writing Proj CW: Poetry,Serpas,Martha R,7,2,0,0,0,0,0,3.704
+Fall 2022,ENGL,4385,1,18594,Fiction Forms,Taurino,Giuseppe,16,2,0,2,0,0,0,3.567
+Fall 2022,MANA,4341,2,18595,Leading Organizational Change,Barrett,Beverly,15,2,2,0,0,0,1,3.58
+Fall 2022,ENGL,6321,1,18597,Fictional Forms and Techniques,Peynado,Brenda,10,0,0,0,0,0,0,4.0
+Fall 2022,MANA,4347,1,18599,Ethics and Corp Soc Respon.,Salaiz,Ashley,29,12,4,2,2,0,0,3.272
+Fall 2022,ENGL,7323,1,18600,Advncd Fiction Workshop,Turchi,Peter D,9,0,0,0,0,0,0,4.0
+Fall 2022,MANA,4336,1,18603,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,9,25,11,3,2,0,0,2.72
+Fall 2022,MANA,4337,1,18604,Stress and Work,Sebastijanovic,Marina,31,18,1,0,0,0,0,3.554
+Fall 2022,ENGL,8364,1,18605,Women Writers,Chatterjee,Sreya,11,1,0,0,0,0,0,3.944
+Fall 2022,MANA,4355,2,18606,Selection and Staffing,Van Egdom,Drake Alexander,34,8,5,1,1,0,0,3.53
+Fall 2022,ENGL,8392,1,18610,Topics in Poetics,Davies,Daniel,13,0,0,0,0,0,0,4.0
+Fall 2022,MANA,4385,2,18611,Intro to Strategic Management,Tabesh,Pooya,20,16,3,1,0,0,0,3.359
+Fall 2022,ENGL,2330,3,18612,Writing Discipline English,Bass,Kasey Dawn,12,2,2,0,1,0,0,3.392
+Fall 2022,HRD,3346,1,18613,Performance Assessment & Eval,Del Grande,Lisa,39,8,3,0,0,0,0,3.667
+Fall 2022,HRD,4350,1,18614,Org Dev & Consulting,Clancy,James Patrick,17,11,5,2,0,0,0,3.181
+Fall 2022,ECE,3355,2,18615,Electronics,Ruchhoeft,Paul,5,2,3,0,0,0,0,3.167
+Fall 2022,ACCT,7337,1,18617,Oil & Gas Taxation,Wright,Denney L,8,6,0,0,0,0,0,3.477
+Fall 2022,SOCI,1301,14,18618,Introduction To Sociology,Adams,Jennifer Lauren,35,6,3,2,0,0,1,3.58
+Fall 2022,MANA,6A25,6,18622,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,12,6,3,0,1,0,1,3.228
+Fall 2022,GOVT,2306,17,18623,US and Texas Const/Politics,McDonald,John Terrence George,71,77,29,11,15,0,7,2.857
+Fall 2022,ARCH,6603,7,18625,Architecture Design Studio III,Johnson,Matthew W,4,5,1,0,0,0,0,3.267
+Fall 2022,ARCH,6603,9,18627,Architecture Design Studio III,Plauche',Roya,7,2,0,0,0,0,0,3.631
+Fall 2022,ARCH,6603,11,18629,Architecture Design Studio III,Schuster,Kristin,5,1,1,0,0,0,1,3.43
+Fall 2022,LAW,6347,2,18631,Secured Financing,Moll,Douglas Keith,7,4,1,0,0,28,0,3.39
+Fall 2022,LAW,6364,1,18634,Contract Drafting,Toedt III,Dell Charles,8,6,2,0,0,0,0,3.396
+Fall 2022,LAW,6364,2,18635,Contract Drafting,Toedt III,Dell Charles,6,5,1,0,0,2,0,3.417
+Fall 2022,LAW,5326,1,18636,Criminal Procedure,Braley,Timothy Shawn,18,36,0,0,0,15,0,3.217
+Fall 2022,LAW,5326,2,18637,Criminal Procedure,Bregant,Jessica Lynn,15,26,4,0,0,0,0,3.31
+Fall 2022,ARTS,4381,1,18638,Pursuing Utopia,Reed,John G,10,7,0,1,2,0,1,3.1
+Fall 2022,LAW,5383,2,18640,Family Law,Oldham,J Thomas,19,37,3,0,0,9,0,3.31
+Fall 2022,LAW,5307,1,18641,How to Reason,Crump,David L,15,14,0,0,0,0,1,3.403
+Fall 2022,HIST,4369,1,18642,Modern Mexico 1810 To Present,Cedillo,Adela Cedillo,3,4,0,0,3,0,0,2.301
+Fall 2022,SOC,3312,1,18645,Sociology of Deviance,Nelson,Steven M,26,9,10,4,5,0,5,2.852
+Fall 2022,MANA,8340,1,18646,Sem Human Resource Mgmt,Ruggs,Enrica N,3,2,0,0,0,0,0,3.6
+Fall 2022,SOC,3353,1,18653,Health Disparities in Society,Anderson,Kathryn,30,16,3,0,0,0,0,3.591
+Fall 2022,FINA,4330,5,18654,Corporate Finance,Berger,Elizabeth,20,9,3,3,0,0,2,3.201
+Fall 2022,FINA,4330,6,18655,Corporate Finance,De Angelis,David,13,15,6,1,0,0,2,3.096
+Fall 2022,FINA,4330,7,18656,Corporate Finance,De Angelis,David,8,5,1,0,0,0,1,3.5
+Fall 2022,GCEE,6310,1,18657,"Glob Climate-Enrgy, Env, &Econ",Mantri,Vishakh B,8,0,0,0,0,0,0,3.835
+Fall 2022,SOC,3352,1,18658,Social Demography,Monserud,Maria Aleksandrovna,26,11,5,2,1,0,3,3.326
+Fall 2022,MUSI,6120,1,18664,Percussion Ensemble,Wilkins,Blake M,4,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7336,1,18666,Strategic Human Resource Mgt,Fernandez,Alejandro,28,1,0,0,0,0,0,3.966
+Fall 2022,MANA,7356,1,18670,Inclusive Leadership,Walker,William A,12,2,2,0,0,0,1,3.646
+Fall 2022,SOC,3390,1,18672,Sociology of Gender,Adams,Jennifer Lauren,44,12,5,0,0,0,1,3.591
+Fall 2022,MUSI,4378,1,18684,History of Jazz I,Marmolejo,Noe J,16,0,0,0,0,0,0,4.0
+Fall 2022,MUED,3105,1,18685,Strings,Hansen,Erin Melissa,3,2,0,0,0,0,0,3.666
+Fall 2022,MUED,3103,1,18686,Brasses,Bell,Priscilla Garrett,17,2,0,0,0,0,1,3.86
+Fall 2022,ECE,6112,1,18688,Department Colloquium,Nguyen,Hien V,0,0,0,0,0,7,0,
+Fall 2022,ECE,6317,1,18693,Motor Drives,Rajashekara,Kaushik,9,4,0,0,0,0,1,3.591
+Fall 2022,ARCH,3500,33,18694,Architecture Design Studio V,Diehl,Tom,3,10,2,0,0,0,0,3.177
+Fall 2022,ARCH,3500,35,18696,Architecture Design Studio V,Truitt,William C,7,8,0,0,0,0,0,3.445
+Fall 2022,ARCH,3500,37,18698,Architecture Design Studio V,Self,Ronnie L,2,9,4,0,0,0,0,3.043
+Fall 2022,ARCH,3500,39,18700,Architecture Design Studio V,Davis,Curtis M,5,4,6,0,0,0,0,2.867
+Fall 2022,ARCH,3500,41,18702,Architecture Design Studio V,Burrow,Robert W,3,11,0,0,0,0,0,3.191
+Fall 2022,ARCH,3500,43,18704,Architecture Design Studio V,Roldan Caballero,Jose Manuel,3,4,3,0,2,0,1,2.445
+Fall 2022,ARTH,3314,1,18708,Latin American Art,Decker,Arden,4,0,0,1,0,0,0,3.268
+Fall 2022,OPTO,7230,1,18712,Glaucoma,Marrelli,Danica J,10,45,34,0,0,0,0,2.708
+Fall 2022,OPTO,7375,1,18713,Contact Lens II,Dempsey,Robert L.,25,54,10,0,0,0,0,3.169
+Fall 2022,OPTO,7336,1,18714,Ocular Pathology III,Harrison,Wendy W,17,48,25,0,0,0,0,2.889
+Fall 2022,OPTO,7131,1,18715,Clinical Medicine,Dempsey,Robert L.,71,19,1,0,0,0,0,3.773
+Fall 2022,NURS,6230,1,18716,Diagnostic Tests & Procedures,Ecby,Chanique,3,1,0,0,0,0,0,3.75
+Fall 2022,NURS,6301,1,18717,Adv Rsrch Intgrtd Evdnce Prctc,Love,Mary Frances,5,8,0,0,0,0,0,3.385
+Fall 2022,NURS,6314,1,18718,Development of Nur Curriculum,Dwyer,Carol Ann,3,0,0,0,0,0,0,4.0
+Fall 2022,NURS,6333,1,18720,Population Health,Anderson,Viia,8,1,0,0,0,0,0,3.889
+Fall 2022,OPTO,8696,1,18721,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,29,0,
+Fall 2022,OPTO,8338,1,18722,Recent Developments/Round,Wheat,Joe L,10,17,3,0,0,0,0,3.244
+Fall 2022,OPTO,8384,1,18723,Practice Management II,Davis,Mark K,27,3,0,0,0,0,0,3.779
+Fall 2022,LAW,6213,1,18725,Innocence Investigations,Dow,David R,1,5,0,0,0,0,0,3.387
+Fall 2022,LAW,6240,1,18727,Death Penalty Clinic,Dow,David R,1,3,0,0,0,1,0,3.25
+Fall 2022,NURS,3311,2,18728,Health Assess Across Life Span,Phan,Huong Thi,18,27,0,1,0,0,2,3.348
+Fall 2022,PUBL,6312,1,18729,Public Finance,Zhu,Ling,6,0,0,0,0,0,0,3.945
+Fall 2022,NURS,4314,1,18730,Nursing Research,Phan,Huong Thi,10,15,0,0,0,0,0,3.4
+Fall 2022,THEA,1340,3,18732,Fundamentals of Acting,Knight,Olivia,10,1,2,0,0,0,1,3.59
+Fall 2022,PUBL,6342,3,18733,Budgeting For Public Agencies,Hawes,David Wright,11,4,0,0,0,0,0,3.689
+Fall 2022,CIVE,4364,1,18735,Structural Steel Design,Mercan,Bulent,15,19,14,2,0,0,0,2.874
+Fall 2022,THEA,2342,1,18736,Dramatic Structures & Genres,Coen,Elizabeth Manya,7,14,4,2,0,0,0,2.963
+Fall 2022,EDRS,8380,3,18740,Rsch Mthds in Educ,Freelon,Rhoda,4,1,0,0,0,0,0,3.866
+Fall 2022,ELCS,8301,2,18741,Leadership Theory School Admin,Davis,Bradley,4,2,0,0,0,0,0,3.667
+Fall 2022,GENB,6350,1,18743,Business Communications,Vandaveer,Amy L,16,4,0,0,0,0,0,3.734
+Fall 2022,MIS,3376,3,18744,Busn Appls Database Mgmt I,Jiang,Lianlian,41,9,2,3,2,0,4,3.508
+Fall 2022,MARK,4332,2,18781,Social Media Marketing,Noriega,Jaime L,15,8,2,1,1,0,1,3.235
+Fall 2022,PSYC,6336,5,18784,Directed Rsch in Social Psyc,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Fall 2022,THEA,6327,1,18794,Digital Rendering Techniques,Willson,Paige A,5,0,0,0,0,0,0,3.868
+Fall 2022,THEA,6356,1,18797,Tailoring Techniques I,Niederer,Barbara,0,0,0,0,0,0,0,
+Fall 2022,DANC,1103,1,18804,Freshman Seminar in Somatics,Chapman,Teresa Lynn,4,3,0,0,0,0,0,3.666
+Fall 2022,MATH,1100,2,18805,Developmental Math,Caputo,Matthew G,0,0,0,0,0,69,10,
+Fall 2022,MATH,1100,3,18806,Developmental Math,Caputo,Matthew G,0,0,0,0,0,29,14,
+Fall 2022,MATH,1100,4,18807,Developmental Math,Caputo,Matthew G,0,0,0,0,0,0,2,
+Fall 2022,ARCH,7600,13,18809,Architecture Design Studio V,Munenzon Titelboim,Dalia,9,3,0,0,0,0,0,3.613
+Fall 2022,ARLD,6360,1,18810,Arts & Community Engagement,Richardo,Nicole D,3,1,0,0,0,0,0,3.668
+Fall 2022,HLT,2320,3,18814,Introduction to Public Health,Solari Williams,Kayce D.,46,32,3,4,2,0,0,3.311
+Fall 2022,HLT,4392,2,18815,Field Work in Community Health,Solari Williams,Kayce D.,31,15,2,0,0,0,2,3.597
+Fall 2022,CIS,3347,2,18826,IS Infrastructure and Networks,Peddoju,Suresh Kumar,25,12,5,1,5,0,0,3.063
+Fall 2022,CIS,3355,2,18827,Integrated Information Systems,Peddoju,Suresh Kumar,5,12,6,0,1,0,3,2.833
+Fall 2022,HON,4355,1,18830,Engaged Data,Konstantinidis,Ioannis,4,0,0,0,1,0,0,3.2
+Fall 2022,BUSI,2305,4,18833,Business Statistics,Patterson,Staci A,24,10,6,0,0,0,4,3.384
+Fall 2022,CIS,4375,3,18836,Project Management & Practice,Martinez,Jose C,10,18,2,0,0,0,0,3.267
+Fall 2022,HLT,3304,1,18839,Child and Adolescent Health,Farmer,Jennifer,51,13,3,0,2,0,1,3.585
+Fall 2022,CORE,1101,50,18843,College Success,Peterson,Christal Helena,15,2,1,0,3,0,0,3.254
+Fall 2022,CORE,1101,51,18844,College Success,Peterson,Christal Helena,12,0,1,0,0,0,0,3.872
+Fall 2022,LAW,5402,2,18845,Entrpr Community Dev Clinic I,Heard,Christopher D,2,6,0,0,0,0,0,3.374
+Fall 2022,CIVE,6335,2,18859,Advanced Concrete Design,Belarbi,Abdeldjelil,1,1,0,0,1,0,0,2.333
+Fall 2022,HRD,6303,2,18863,Assessment & Evaluation in Hrd,Shin,Daeun,14,2,1,0,0,0,0,3.726
+Fall 2022,WGSS,2350,13,18864,Intro To Women's Studies,Slatton,Brittany Chevon,12,6,7,0,3,0,1,2.857
+Fall 2022,WGSS,2350,14,18866,Intro To Women's Studies,Slatton,Brittany Chevon,13,5,3,3,1,0,4,3.08
+Fall 2022,WGSS,2350,16,18868,Intro To Women's Studies,Pegoda,Andrew Joseph,18,4,2,1,1,0,3,3.398
+Fall 2022,TLIM,3330,31,18869,Innovation Principles,Mehring,Brian George,6,4,7,3,4,0,2,2.098
+Fall 2022,WGSS,2360,7,18870,Introduction to LGBT Studies,Pegoda,Andrew Joseph,15,7,1,0,3,0,3,3.243
+Fall 2022,WGSS,2360,9,18872,Introduction to LGBT Studies,Stone,Lauren Michelle,23,4,1,0,1,0,1,3.678
+Fall 2022,BUSI,2305,5,18873,Business Statistics,Wiley,Briceon C,84,120,114,76,26,0,92,2.35
+Fall 2022,TLIM,3331,30,18874,Innovation Development,Crawley,David L,5,0,2,0,0,0,0,3.429
+Fall 2022,TLIM,4335,1,18876,Communicating Innovation,Crawley,David L,2,0,2,0,0,0,0,3.083
+Fall 2022,LAW,5342,1,18891,Prof Writing Strategies,Swift,Kenneth Richard,7,3,1,0,0,0,0,3.455
+Fall 2022,CIVE,6111,2,18892,Graduate Seminar,Li,Hongyi,0,0,0,0,0,13,0,
+Fall 2022,MARK,4333,2,18893,Search Engine Marketing,Zahn,William J,18,8,3,4,0,0,0,3.212
+Fall 2022,MUSI,4100,2,18894,Chamber Music,Derges,Julie D,26,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4100,3,18895,Chamber Music,Bertman,David Garry,11,0,0,0,0,0,0,4.0
+Fall 2022,TLIM,3371,30,18896,Budgeting and Financial Princ,Burns,Maria,38,5,0,0,0,0,1,3.876
+Fall 2022,AAMS,4300,1,18897,Asian Amer Culture/Community,Nguyen,An,5,2,0,0,0,0,0,3.761
+Fall 2022,MARK,4379,2,18899,Personal Branding,Muschalik,Monica Harper,21,3,0,0,0,0,0,3.875
+Fall 2022,RELS,2360,1,18900,Introduction to Buddhism,Huynh,Trung,17,8,3,3,1,0,3,3.187
+Fall 2022,RELS,3339,1,18903,Secularisms and Atheisms,Pegoda,Andrew Joseph,7,5,3,1,2,0,1,2.704
+Fall 2022,RELS,3380,1,18904,Intro to Asian Religions,Huynh,Trung,8,4,1,0,0,0,0,3.589
+Fall 2022,RELS,3381,1,18906,Global Hinduism,Jones,Naamleela Free,16,6,1,1,1,0,0,3.387
+Fall 2022,LAW,5321,1,18907,Law Office Management,Brown,Charles D,14,28,0,0,0,26,0,3.396
+Fall 2022,ARCH,2327,3,18908,Technology I,Diehl,Tom,20,67,39,11,8,0,10,2.506
+Fall 2022,CUIN,4325,1,18910,Teach Science in Grades 4-8 I,Varnado,Jakarda Wiltz,7,1,0,0,0,0,0,3.916
+Fall 2022,HLT,4303,2,18911,The Obesity Epidemic,Olvera,Norma E,18,26,9,4,2,0,0,2.893
+Fall 2022,ANTH,2301,1,18912,Intro to Physical Anthropology,McElvaney,Katherine Anne,43,16,2,6,2,0,1,3.29
+Fall 2022,ANTH,2302,1,18913,Introduction to Archeology,Brown,Kenneth L,27,25,14,0,3,0,4,3.053
+Fall 2022,ANTH,2346,1,18914,Introduction to Anthropology,Higgs,Elizabeth Wayne,76,27,5,1,3,0,5,3.536
+Fall 2022,ANTH,6310,1,18923,Anthropological Resrch Design,Hannaford,Dinah Rebecca,8,0,0,0,0,0,1,3.918
+Fall 2022,WGSS,2360,1,18927,Introduction to LGBT Studies,Boffone,Trevor James,28,1,1,0,0,0,0,3.9
+Fall 2022,ARCH,6393,5,18930,Master's Project Preparation,Froehlich,Dietmar,9,0,0,0,0,0,0,3.853
+Fall 2022,PHLS,8348,1,18931,Evidence-Based Practice,Smith,Bradley,2,1,0,0,0,0,0,3.667
+Fall 2022,INDE,8699,5,18933,Doctoral Dissertation,Lin PhD,Ying,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,7375,1,18935,Intro To Family Counsl,Smedley,Diane Renee,17,2,0,0,0,0,0,3.791
+Fall 2022,PHLS,7375,2,18936,Intro To Family Counsl,Smedley,Diane Renee,9,1,0,0,0,0,0,3.867
+Fall 2022,ARCH,6393,7,18937,Master's Project Preparation,Fonseca,Sofia Y,2,5,2,0,0,0,1,3.073
+Fall 2022,GENB,7305,1,18943,Commercial Law,Hopkins,Troy D,11,3,1,0,0,0,0,3.623
+Fall 2022,ACCT,5368,2,18944,Intermediate Accounting II,Muslu,Volkan,3,6,5,1,0,0,1,2.645
+Fall 2022,CIS,3355,3,18945,Integrated Information Systems,Peddoju,Suresh Kumar,10,16,3,1,2,0,0,2.814
+Fall 2022,GENB,5305,3,18947,Commercial Law,Hopkins,Troy D,1,1,1,0,0,0,0,2.89
+Fall 2022,MANA,4350,1,18949,International Management,Celly,Nikhil,42,6,0,2,0,0,0,3.767
+Fall 2022,FINA,4328,2,18950,Principles of Personal Finance,Coleman,Alfred G,21,15,7,5,3,0,0,2.876
+Fall 2022,FINA,6A35,5,18951,Managerial Finance,De Angelis,David,9,4,1,1,0,0,1,3.334
+Fall 2022,ACCT,4332,4,18952,Corporate Taxation,Fernandez,Ramon,2,10,1,0,0,0,0,3.153
+Fall 2022,ACCT,5332,3,18953,Corporate Taxation,Fernandez,Ramon,3,2,5,0,0,0,0,2.932
+Fall 2022,GENB,6350,2,18955,Business Communications,Vandaveer,Amy L,7,0,0,0,0,0,0,3.906
+Fall 2022,ARCH,4367,1,18957,Case Studies in Sustain Design,Taylor,Rives,1,0,0,0,0,0,0,4.0
+Fall 2022,SUBS,6320,2,18969,Riser Design,Sun,Li,2,1,0,0,1,0,1,2.833
+Fall 2022,SCM,6A01,4,18973,SCM Concepts,Sahin,Funda,17,12,3,0,0,0,2,3.438
+Fall 2022,SCM,7A01,1,18974,Project Management,Tibodeau,Dale,10,0,1,0,0,0,0,3.728
+Fall 2022,ACCT,7374,2,18975,Appl Data Analytics Acct II,Seijas,Nuria S,7,0,0,0,0,0,0,4.0
+Fall 2022,BUSI,4320,2,18976,Commercial Law,Hopkins,Troy D,1,4,0,0,0,0,0,3.332
+Fall 2022,MANA,7347,1,18977,Environm & Social Governance,Angelides,Christos O,4,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,6320,1,18984,Tissue Engineering,Horton,Renita Elillian,2,5,0,0,0,0,0,3.191
+Fall 2022,ARTS,3300,1,18987,Advanced Drawing,Safaitakhtehfooladi,Farima,21,1,0,0,0,0,0,3.94
+Fall 2022,ARTS,3300,2,18988,Advanced Drawing,Barrera,Debra,22,0,1,0,1,0,0,3.75
+Fall 2022,GHL,2356,2,19003,Comm Strategies for Hospitalty,Haskell,Rebecca Erin,32,7,4,3,4,0,2,3.207
+Fall 2022,NSS,4345,1,19006,Capstone - Nat. Sec. Studies,Manning,Matthew,6,1,1,0,0,0,0,3.501
+Fall 2022,FINA,7A10,4,19011,Valuation,Povel,Paul,5,5,0,0,0,0,2,3.401
+Fall 2022,FINA,4335,1,19019,Brainstorming to Bankrolling,Khumawala,Saleha B,15,9,6,0,0,0,0,3.256
+Fall 2022,HIST,2372,1,19020,Latin American Hist Since 1820,Milanesio,Natalia,7,12,5,3,4,0,4,2.558
+Fall 2022,FINA,4336,1,19021,Consulting-Small Business Need,Bailey-Rihawi,Esther Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2022,DIGM,4390,30,19023,Current Issues Digital Media,Snyder,Philip Charles,10,4,0,0,0,0,0,3.62
+Fall 2022,MUSA,8320,5,19029,Doctoral Applied Music,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8199,3,19031,Dissertation,Margulis,Milena A,0,0,0,0,0,1,0,
+Fall 2022,BUSI,4396,2,19035,Business Internship,Hopkins,Troy D,0,0,0,0,0,7,0,
+Fall 2022,WGSS,4395,2,19038,Sel Tops in Women's Studies,Miller,Audrey,6,2,1,0,0,0,0,3.519
+Fall 2022,GEOL,8998,1,19040,Doctoral Research,Khan,Shuhab D.,0,0,0,0,0,5,0,
+Fall 2022,GEOL,8399,1,19043,Doctoral Dissertation,Stewart,Robert R,0,0,0,0,0,3,0,
+Fall 2022,PHLS,8199,4,19047,Dissertation,de Dios,Marcel A,0,0,0,0,0,2,0,
+Fall 2022,MECE,8298,24,19050,Doctoral Research,Sharma,Pradeep,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8698,3,19051,Doctoral Research,Khan,Shuhab D.,0,0,0,0,0,1,0,
+Fall 2022,GEOL,7399,1,19054,Masters Thesis,Sager,William W,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,3,19055,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,3,0,
+Fall 2022,GEOL,8998,4,19056,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2022,ACCT,5335,3,19058,Financial Statement Auditing,Kuruvilla,Mohan,5,3,1,3,0,0,1,2.833
+Fall 2022,ACCT,4335,5,19059,Financial Statement Auditing,Kuruvilla,Mohan,1,2,3,1,0,0,0,2.617
+Fall 2022,ACCT,5377,1,19060,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,2,5,0,0,0,0,0,3.333
+Fall 2022,SPAN,2311,6,19061,Intermediate Spanish I,Morales Utria,Yordanis,5,9,9,0,2,0,2,2.613
+Fall 2022,SPAN,2311,8,19062,Intermediate Spanish I,Patron Rivera,Mauricio,9,7,6,1,1,0,2,2.834
+Fall 2022,SPAN,2312,6,19063,Intermediate Spanish II,Miranda Moreno,Sujaila Abigail,7,13,4,0,1,0,1,2.974
+Fall 2022,SPAN,2312,7,19064,Intermediate Spanish II,Martinez,Carlos David,4,6,5,1,0,0,1,2.73
+Fall 2022,COSC,6360,1,19065,Operating Systems,Cheng,Albert M K,7,13,0,0,0,0,2,3.268
+Fall 2022,PHLS,8699,4,19066,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,7,19078,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,
+Fall 2022,BIOE,4115,3,19079,Intro Bioinstrumentation Lab,Ince,Nuri Firat,3,0,0,1,0,0,0,3.25
+Fall 2022,BCHS,4355,1,19080,Eukaryotic Gene Regulation,Schwartz,Robert J,9,0,0,0,0,0,2,3.89
+Fall 2022,INDS,6330,1,19083,Comp Aided Industr Design II,Chow,George K,2,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5675,4,19087,Disease State Management,Rosario,Natalie,3,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,6399,1,19091,Masters Thesis,Wu,Jonathan En Lin,1,0,0,0,0,0,0,3.67
+Fall 2022,GEOL,8698,5,19095,Doctoral Research,Castagna,John P,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8399,2,19096,Doctoral Dissertation,Casey,John F,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,8396,1,19098,Research Practicum,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,4386,1,19100,Short Story Writing,Turchi,Peter D,12,6,2,0,0,0,0,3.467
+Fall 2022,SPAN,2311,9,19103,Intermediate Spanish I,Patron Rivera,Mauricio,4,13,9,0,0,0,2,2.706
+Fall 2022,SPAN,2312,3,19104,Intermediate Spanish II,Reyes Ferrufino,Diana Eufemia,3,11,10,0,4,0,0,2.333
+Fall 2022,BUSI,4396,3,19105,Business Internship,Newman,Michael Ray,0,0,0,0,0,3,0,
+Fall 2022,GEOL,8998,10,19107,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8398,3,19112,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,11,19113,Doctoral Research,Li,Aibing,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,12,19114,Doctoral Research,Han,De-Hua,0,0,0,0,0,1,0,
+Fall 2022,CHEM,3333,1,19115,Inorganic Chemistry I,Brgoch,Jakoah,5,12,5,2,2,0,3,2.565
+Fall 2022,BZAN,7320,1,19117,Bus Modeling For Comp Adv,Murray,Michael J,9,4,2,0,0,0,1,3.423
+Fall 2022,DRAM,1310,14,19118,Introduction to Theatre,Egging,Jon Leo,28,7,2,1,7,0,4,3.045
+Fall 2022,GEOL,7399,2,19119,Masters Thesis,Casey,John F,0,0,0,0,0,1,0,
+Fall 2022,ENGL,4303,2,19120,Teaching Engl as a Second Lang,Nelms,Jodi Lynn,16,4,0,0,2,0,0,3.44
+Fall 2022,PETR,6328,2,19121,Petro Fluid Prop & Phase Equil,Dindoruk,Birol,2,1,0,0,0,0,1,3.667
+Fall 2022,PETR,6350,2,19123,Natural Gas Engineering,Farouq-Ali,Syed,8,2,0,0,0,0,0,3.635
+Fall 2022,PETR,6352,2,19124,Shale Reservoirs,Hathon,Lori A,4,2,0,0,0,0,0,3.612
+Fall 2022,PETR,6362,2,19125,Reservoir Engineering I,Sakhaee Pour,Ahmad,3,1,0,0,0,0,0,3.75
+Fall 2022,PETR,6368,2,19126,Well Drilling and Completion I,Samuel,Robello,1,3,1,1,0,0,0,2.557
+Fall 2022,PETR,6372,2,19127,Petroleum Production Operation,Wong,George K,1,4,0,1,0,0,0,2.778
+Fall 2022,PETR,6332,2,19128,Deterministic Reserves Estimat,Zargar,Zeinab,9,0,0,0,0,0,0,3.743
+Fall 2022,ENGL,7398,3,19129,Special Problems,Wingard,Jennifer L,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7398,4,19130,Special Problems,Ehlers,Sarah E,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,3399,1,19132,Senior Honors Thesis,Hernandez,Jose A.,0,0,0,0,0,0,0,
+Fall 2022,GEOL,8998,13,19133,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8698,6,19135,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2022,GEOL,6399,3,19139,Masters Thesis,Robinson,Alexander C,0,0,0,0,0,0,0,
+Fall 2022,GEOL,7399,4,19140,Masters Thesis,Robinson,Alexander C,0,0,0,0,0,2,0,
+Fall 2022,BIOL,8399,2,19141,Doctoral Dissertation,Dauwalder,Brigitte,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7399,5,19143,Masters Thesis,Khan,Shuhab D.,0,0,0,0,0,0,0,
+Fall 2022,WGSS,2350,17,19144,Intro To Women's Studies,Priest,Joy M,27,1,0,0,2,0,0,3.678
+Fall 2022,BIOL,8199,1,19154,Doctoral Dissertation,Azevedo,Ricardo,1,0,0,0,0,0,0,3.67
+Fall 2022,PHCA,7316,1,19156,Pharmacoepidemiology,Chen,Hua,4,0,2,0,0,0,0,3.333
+Fall 2022,PHCA,7306,1,19157,Health Outcomes and Quality,Aparasu,Rajender R,2,1,3,0,0,0,0,2.833
+Fall 2022,MATH,6358,3,19160,Probability & Stat. Computing,Poliak,Cathy Dawn,1,0,0,0,0,0,0,3.67
+Fall 2022,GEOL,8698,7,19161,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,2,0,
+Fall 2022,MECE,8399,19,19162,Doctoral Dissertation,Ardebili,Haleh,2,0,0,0,0,0,0,4.0
+Fall 2022,FINA,6387,7,19165,Managerial Analysis,Basu,Swati,21,5,0,0,0,0,0,3.77
+Fall 2022,INDE,2331,2,19167,Computer Applications for IE,Wiggins,Nathanial David,7,0,0,0,0,0,0,3.764
+Fall 2022,INDE,2333,2,19168,Engineering Statistics I,Wiggins,Nathanial David,12,6,0,0,0,0,0,3.612
+Fall 2022,ENGR,2301,3,19169,Mechanics I,Safa,Mahdi,8,1,4,0,2,0,0,2.867
+Fall 2022,BCHS,8399,2,19172,Doctoral Dissertation,Sen,Mehmet,1,0,0,0,0,0,0,4.0
+Fall 2022,MIS,7373,3,19173,Bus Appls Database Mgt Sys I,Scamell,Richard W,4,2,0,0,0,0,0,3.667
+Fall 2022,GHL,6382,1,19177,Meth of Res in Hospitality Ind,Legendre,Jungyoung Shin,1,2,0,0,0,0,0,3.223
+Fall 2022,ARCH,4393,1,19180,Thesis Publication,Grimley,Chris,11,3,0,0,0,0,0,3.644
+Fall 2022,MANA,4398,1,19183,Independent Study,Rude,Dale,0,1,0,0,0,0,0,2.67
+Fall 2022,GEOL,8998,14,19185,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,3,0,
+Fall 2022,GEOL,8998,15,19188,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,5,0,
+Fall 2022,HIST,1302,53,19193,The U.S. Since 1877,Modaff,Abigail,21,0,2,0,0,0,1,3.697
+Fall 2022,TMTH,3360,11,19196,Applied Technical Statistics,Schroeder,Susan L,3,20,15,1,2,0,6,2.496
+Fall 2022,MARK,4398,1,19197,Independent Study,Pingel,John W,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8699,5,19199,Doctoral Dissertation,Margulis,Milena A,0,0,0,0,0,2,0,
+Fall 2022,MUSA,6326,1,19204,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTH,6399,4,19206,Master's Thesis,Harren,Natilee O,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8998,16,19207,Doctoral Research,Mann,Paul,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,17,19211,Doctoral Research,Stewart,Robert R,0,0,0,0,0,2,0,
+Fall 2022,HIST,2312,2,19214,Western Civilization from 1450,Ittmann,Karl,2,10,13,4,4,0,2,2.061
+Fall 2022,ENGL,6311,1,19215,Research Methods,Voskuil,Lynn M,8,1,0,0,0,0,1,3.706
+Fall 2022,PHLS,6398,1,19216,Special Problems,Whitaker,Rachael Gwin,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8398,5,19217,Doctoral Research,Mann,Paul,0,0,0,0,0,5,0,
+Fall 2022,MUSA,6344,1,19218,Applied Trombone,Kauk,Brian Keith,1,0,0,0,0,0,0,4.0
+Fall 2022,PUBL,6346,1,19219,Seminar Emergency Mgt,Sanchez,Francisco,8,0,1,0,0,0,0,3.741
+Fall 2022,ECE,6305,2,19220,Power Electronics,Krishnamoorthy,Harish Sarma,6,19,1,0,0,0,2,3.091
+Fall 2022,BZAN,6310,9,19221,Quant Analysis for Busn Dec,Hou,Jinghui,16,1,0,0,0,0,0,3.883
+Fall 2022,CIS,6324,1,19222,Cybersecurity Risk Management,Conklin,William A,12,3,0,0,0,0,1,3.8
+Fall 2022,COSC,4370,3,19223,Interactive Computer Graphics,Deng,Zhigang,35,30,4,2,1,0,1,3.31
+Fall 2022,MECE,8298,25,19224,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,5,0,
+Fall 2022,BZAN,6350,2,19225,Quant Found for Busi Analytics,Tan,Yinliang,15,16,0,0,0,0,1,3.367
+Fall 2022,SPAN,3307,2,19227,Public Speaking in Spanish,Ventura,Gabriela Baeza,14,3,0,0,0,0,0,3.765
+Fall 2022,ENGL,1301,29,19229,First Year Writing I,Horton,Lara,5,5,6,0,1,0,0,2.706
+Fall 2022,ENGL,1301,104,19230,First Year Writing I,Burns,William,7,6,2,0,3,0,0,2.723
+Fall 2022,ENGL,1301,107,19231,First Year Writing I,Burns,William,6,5,3,2,0,0,0,2.896
+Fall 2022,ENGL,1301,108,19232,First Year Writing I,Bass,Kasey Dawn,9,5,4,0,0,0,0,3.259
+Fall 2022,ENGL,1301,114,19233,First Year Writing I,Bass,Kasey Dawn,13,0,2,0,1,0,0,3.438
+Fall 2022,ENGL,1301,116,19234,First Year Writing I,McAlister,Susan Barbara,5,8,3,0,1,0,0,2.825
+Fall 2022,ENGL,1301,117,19235,First Year Writing I,Chatham,Donna Marie,6,9,1,0,1,0,0,3.059
+Fall 2022,ENGL,1301,118,19236,First Year Writing I,Chatham,Donna Marie,5,8,0,2,1,0,0,2.813
+Fall 2022,ENGL,1301,126,19237,First Year Writing I,Horton,Lara,3,8,5,0,1,0,0,2.57
+Fall 2022,KIN,4370,8,19238,Exercise Testing,Thomas,Shernice Avionne,4,17,9,2,2,0,0,2.539
+Fall 2022,GEOL,7399,6,19245,Masters Thesis,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2022,PHLA,6206,1,19246,Lean Six Sigma,Garey,Kevin W,7,0,0,0,0,0,0,4.0
+Fall 2022,TLIM,3330,32,19248,Innovation Principles,Feriante,Chris,4,5,12,0,2,0,5,2.549
+Fall 2022,ECE,6337,2,19252,Stochastic Processes,Prasad,Saurabh,3,15,0,0,0,0,0,3.24
+Fall 2022,MUSA,6350,1,19255,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2022,HRD,6353,30,19260,Methods of Adult Learning,Shirmohammadi,Melika,8,0,0,0,0,0,0,3.959
+Fall 2022,GEOL,7399,8,19264,Masters Thesis,Murphy,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,6A35,6,19268,Managerial Finance,De Angelis,David,6,7,2,0,0,0,0,3.267
+Fall 2022,FINA,6A35,7,19269,Managerial Finance,Berger,Elizabeth,22,19,4,1,0,0,1,3.405
+Fall 2022,PUBL,6314,1,19270,Administrative Law,Abbott Jr,Kenneth Wayne,9,0,0,0,0,0,0,3.853
+Fall 2022,MECE,7399,16,19271,Masters Thesis,Ghasemi,Hadi,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,8399,3,19273,Doctoral Dissertation,Udugamasooriya,Damith Gomika,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,26,19275,Doctoral Research,Chen,Zheng,0,0,0,0,0,2,0,
+Fall 2022,COSC,4377,1,19280,Intro To Computer Networks,Gnawali,Omprakash D,11,42,29,1,3,0,7,2.659
+Fall 2022,BIOL,6398,3,19282,Special Problems,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6398,4,19283,Special Problems,Nunez,Martin A.,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6398,5,19284,Special Problems,Frankino,William A,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6398,6,19285,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6398,8,19287,Special Problems,Chung,Sanghyuk,0,0,0,0,0,3,0,
+Fall 2022,COSC,6306,3,19307,Data Structures,Ramamurthy,Uma,0,2,1,0,1,0,0,2.0
+Fall 2022,GEOL,8698,8,19308,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,1,0,
+Fall 2022,MECE,8399,20,19309,Doctoral Dissertation,Ardebili,Haleh,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8398,1,19310,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6498,3,19314,Special Problems,Chung,Sanghyuk,0,0,0,0,0,2,0,
+Fall 2022,BIOL,6498,4,19315,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6498,5,19316,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6498,6,19317,Special Problems,Azevedo,Ricardo,0,0,0,0,0,2,0,
+Fall 2022,BIOL,6498,7,19318,Special Problems,Khan,Abdul Latif,0,0,0,0,0,1,0,
+Fall 2022,BZAN,6351,2,19342,Basic Prog for Busi Analytics,Wang,Cheng,50,4,0,0,0,0,0,3.901
+Fall 2022,ANTH,4310,1,19345,Theories of Culture,Sen,Debarati,22,9,4,1,0,0,2,3.444
+Fall 2022,BCHS,6398,2,19346,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6398,3,19347,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8598,2,19363,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2022,IRW,1300,5,19382,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,51,1,
+Fall 2022,ENGL,1301,14,19383,First Year Writing I,Stewart-Steele,Heather Marie,7,6,1,2,5,0,2,2.318
+Fall 2022,ENGL,1301,38,19384,First Year Writing I,Alcorn III,Charles William,16,3,0,0,2,0,3,3.35
+Fall 2022,PHYS,2325,5,19386,University Physics I (lecture),Portillo Vazquez,Israel,10,18,18,10,1,0,18,2.421
+Fall 2022,MECE,8399,22,19394,Doctoral Dissertation,Liu,Dong,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8699,20,19395,Doctoral Dissertation,Metcalfe,Ralph W,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,29,19397,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2022,MECE,8298,30,19399,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,3,0,
+Fall 2022,MECE,8399,23,19402,Doctoral Dissertation,Ryou,Jae-Hyun,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4198,20,19407,Reed Making,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8699,10,19408,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Fall 2022,SOCI,1301,22,19409,Introduction To Sociology,Colbert,Sharla Stettnisch,43,8,0,0,7,0,1,3.379
+Fall 2022,ENGL,2330,4,19410,Writing Discipline English,Coleman,Quintin,13,3,0,0,1,0,2,3.491
+Fall 2022,ENGL,2330,5,19411,Writing Discipline English,Coleman,Quintin,8,8,3,0,1,0,0,3.084
+Fall 2022,DANC,2202,1,19412,Sophomore Technique,Bobet,Jacqueline A,8,0,0,0,0,0,0,4.0
+Fall 2022,OPTO,5250,1,19413,Seminar Scientific Investigatn,Frishman,Laura J,4,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8699,6,19414,Doctoral Dissertation,Arbona,Consuelo,0,0,0,0,0,2,0,
+Fall 2022,OPTO,5198,3,19418,Spec Prob - Clerkship,Piccolo,Marcus G,0,0,0,0,0,12,0,
+Fall 2022,CIVE,6377,3,19419,Environmental Chemistry,Rahimi,Mohammad,5,1,0,0,0,0,1,3.833
+Fall 2022,MUSA,8420,1,19423,Doctoral Applied Music,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,6498,2,19425,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6498,4,19427,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6498,5,19428,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,2,0,
+Fall 2022,PHOP,6867,1,19449,Research Practicum A,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6867,2,19451,Research Practicum A,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8299,8,19452,Doctoral Dissertation,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8299,9,19453,Doctoral Dissertation,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,7342,3,19492,Engineer Geographic Info. Syst,Ekhtari,Nima,5,1,0,0,0,0,0,3.723
+Fall 2022,GEOL,8398,7,19495,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2022,GCEE,6310,2,19496,"Glob Climate-Enrgy, Env, &Econ",Mantri,Vishakh B,3,2,0,0,0,0,0,3.732
+Fall 2022,PHLS,8699,8,19497,Doctoral Dissertation,Master,Allison,0,0,0,0,0,1,0,
+Fall 2022,BIOE,6350,2,19498,Genomic and Proteomic Engr,Wu,Tianfu,18,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,6598,2,19499,Special Problems,Mohan,Chandra,0,0,0,0,0,2,0,
+Fall 2022,BIOL,6598,3,19501,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6598,4,19502,Special Problems,Chung,Sanghyuk,0,0,0,0,0,4,0,
+Fall 2022,BIOL,6598,6,19504,Special Problems,Cirino,Patrick C,0,0,0,0,0,1,0,
+Fall 2022,MECE,8399,25,19526,Doctoral Dissertation,Wang,Su Su,0,0,0,0,0,0,0,
+Fall 2022,BIOL,8598,2,19527,Doctoral Research,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8598,3,19528,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Fall 2022,CHEE,6331,2,19550,Math Mtds in Chem Engr,Mountziaris,Triantafillos John,0,1,0,0,0,0,1,3.0
+Fall 2022,CHEE,6333,2,19551,Transport Processes,Karim,Alamgir,0,1,0,0,0,0,0,3.0
+Fall 2022,CHEE,6335,2,19552,Classicl-Statist Thermo,Palmer,Jeremy,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,2201,3,19554,Circuit Analysis I,Shattuck,David P,17,16,22,6,5,0,6,2.52
+Fall 2022,BIOL,6298,2,19558,Special Problems,Graur,Dan,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6298,3,19559,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8398,8,19576,Doctoral Research,Castagna,John P,0,0,0,0,0,1,0,
+Fall 2022,OPTO,5198,1,19586,Spec Prob - Clerkship,Dempsey,Robert L.,0,0,0,0,0,10,0,
+Fall 2022,PHLS,8999,3,19589,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Fall 2022,ACCT,8333,1,19590,Capital Market Research,Lobo,Gerald,0,1,0,0,0,0,0,3.33
+Fall 2022,BZAN,4397,2,19592,Sel Topics in Bus Analytics,Wang,Cheng,1,1,0,0,0,0,0,3.665
+Fall 2022,PSYC,2305,31,19594,Intro to Methods in Psychology,Anderson,Jill Annette,33,23,5,2,5,0,0,3.064
+Fall 2022,MUSA,6434,1,19597,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2022,HDCS,1300,8,19598,Human Ecosystems & Tech Change,Mudd,Blake Stevens,34,10,5,3,5,0,2,3.14
+Fall 2022,MECE,8398,4,19599,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Fall 2022,PETR,8298,5,19601,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,4,0,
+Fall 2022,FINA,4398,1,19602,Independent Study,Bean,Gregory S.,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8338,2,19605,Sem in Financial Management I,Kumar,Praveen,1,1,0,0,0,0,0,3.5
+Fall 2022,DIGM,1376,30,19608,User Experience (UX)Principles,Rodwell,Elizabeth Ann,54,66,14,7,7,0,5,2.991
+Fall 2022,MECE,8298,31,19610,Doctoral Research,Yang,Di,0,0,0,0,0,2,0,
+Fall 2022,MECE,8399,26,19611,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Fall 2022,ECE,2201,5,19613,Circuit Analysis I,Ramachandran,Deepa,1,0,4,3,0,0,0,1.669
+Fall 2022,MECE,8699,22,19614,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Fall 2022,ACCT,4379,1,19618,Enterprise Risk Management,Neely,Gregory Wayne,3,2,0,0,0,0,0,3.732
+Fall 2022,ECE,3441,7,19622,Digital Logic Design,Ramachandran,Deepa,1,2,1,0,0,0,0,3.165
+Fall 2022,ECE,3441,9,19624,Digital Logic Design,Ramachandran,Deepa,11,5,3,0,0,0,1,3.543
+Fall 2022,PHYS,2126,1,19627,University Physics Lab II,Wood,Lowell T,2,58,8,3,1,0,2,2.718
+Fall 2022,BIOL,8698,2,19630,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8698,4,19632,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8698,5,19633,Doctoral Research,Sater,Amy,0,0,0,0,0,0,0,
+Fall 2022,BIOL,8698,6,19634,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Fall 2022,ENGI,1331,8,19646,Computing for Engineers,Kowal,Marsha Christine,13,15,12,3,2,0,14,2.704
+Fall 2022,ENGI,1100,26,19656,Introduction To Engineering,Kota,Venkata Krishna Tulasi,9,12,4,1,5,0,0,2.538
+Fall 2022,PSYC,2305,33,19688,Intro to Methods in Psychology,Anderson,Jill Annette,28,29,6,1,4,0,1,3.113
+Fall 2022,MECE,8699,23,19690,Doctoral Dissertation,Liu,Dong,0,0,0,0,0,0,0,
+Fall 2022,MECE,8399,27,19691,Doctoral Dissertation,Liu,Dong,0,0,0,0,0,0,0,
+Fall 2022,MECE,8398,5,19692,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,
+Fall 2022,MECE,8298,32,19693,Doctoral Research,Franchek,Matthew,0,0,0,0,0,5,0,
+Fall 2022,MECE,8399,28,19694,Doctoral Dissertation,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Fall 2022,ANTH,7399,4,19700,Masters Thesis,Gordon,Andrew J,0,0,0,0,0,1,0,
+Fall 2022,ACCT,2302,1,19702,Prin of Managerial Accounting,Weber,Catherine K,26,19,11,7,4,0,0,2.895
+Fall 2022,ACCT,2302,5,19704,Prin of Managerial Accounting,Seltz,Joe D,10,13,9,4,2,0,6,2.753
+Fall 2022,ACCT,2302,6,19705,Prin of Managerial Accounting,Seltz,Joe D,24,19,8,7,5,0,0,2.836
+Fall 2022,ACCT,2302,7,19706,Prin of Managerial Accounting,Weber,Catherine K,47,39,23,7,0,0,3,3.149
+Fall 2022,ACCT,3371,6,19707,Accounting Information Systems,Seijas,Nuria S,14,21,6,3,1,0,0,2.948
+Fall 2022,ACCT,5371,3,19708,Accounting Information Systems,Seijas,Nuria S,7,5,2,0,0,0,0,3.31
+Fall 2022,GEOL,8998,20,19717,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Fall 2022,MECE,8598,27,19721,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2022,MECE,8399,30,19722,Doctoral Dissertation,Ghasemi,Hadi,0,0,0,0,0,0,0,
+Fall 2022,MECE,8399,31,19726,Doctoral Dissertation,Baxevanis,Theocharis,0,0,0,0,0,1,0,
+Fall 2022,MECE,8699,24,19727,Doctoral Dissertation,Baxevanis,Theocharis,0,0,0,0,0,1,0,
+Fall 2022,MANA,6A32,3,19735,Organizational Behavior & Mgt,Krylova,Ksenia O,2,2,0,0,0,0,0,3.418
+Fall 2022,MECE,8198,16,19736,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,1,0,
+Fall 2022,MECE,8398,6,19738,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,2,0,
+Fall 2022,MECE,8598,28,19740,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,4,0,
+Fall 2022,MECE,8399,32,19741,Doctoral Dissertation,Selvamanickam,Venkat,4,0,0,0,0,2,0,4.0
+Fall 2022,HLT,1353,3,19750,Personal Health,Selzer,Lori Michele,68,35,10,2,1,0,3,3.36
+Fall 2022,GEOL,8998,21,19759,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,1,0,
+Fall 2022,HLT,3304,2,19780,Child and Adolescent Health,Farmer,Jennifer,69,12,3,5,0,0,1,3.57
+Fall 2022,MECE,8398,10,19785,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Fall 2022,MECE,8399,34,19786,Doctoral Dissertation,Chen,Zheng,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8377,2,19794,Reading for Comps Exams,Ramos,Raul,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8377,3,19795,Reading for Comps Exams,Reed,Linda,0,0,0,0,0,2,0,
+Fall 2022,RELS,2350,1,19796,Introduction to Islam,Said,Karem Irene,13,12,1,1,2,0,1,3.047
+Fall 2022,GEOL,3130,1,19797,Paleobiology Laboratory,Maddocks,Rosalie F,2,6,4,0,1,0,1,2.666
+Fall 2022,GEOL,3130,2,19798,Paleobiology Laboratory,Maddocks,Rosalie F,1,9,4,1,1,0,0,2.459
+Fall 2022,MECE,8598,29,19802,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,3,0,
+Fall 2022,MECE,8399,35,19804,Doctoral Dissertation,Joshi,Shailendra Pramod,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGI,1100,27,19812,Introduction To Engineering,Luna Singh,Jennifer Austin,9,4,4,0,0,0,0,3.216
+Fall 2022,ENGI,1101,2,19813,Engineering Success,Kota,Venkata Krishna Tulasi,0,1,1,0,0,0,0,2.335
+Fall 2022,FINA,3332,1,19814,Prin of Financial Management,Blanchfield,Craig,24,1,0,0,0,0,0,3.881
+Fall 2022,SCM,7A01,3,19817,Project Management,Tibodeau,Dale,21,6,0,0,0,0,0,3.704
+Fall 2022,ENTR,7335,1,19818,Entreprnl Profit & Cash Mgt,Becker,Charles D,14,13,0,0,0,0,0,3.482
+Fall 2022,MECE,8399,36,19821,Doctoral Dissertation,Sun,Li,1,0,0,0,0,2,0,4.0
+Fall 2022,MECE,8699,27,19822,Doctoral Dissertation,Sun,Li,0,0,0,0,0,1,0,
+Fall 2022,MANA,3335,14,19826,Intro Org Behavior and Mgmt,Tabesh,Pooya,31,15,2,2,0,0,0,3.5
+Fall 2022,SCM,7325,2,19828,Process Analysis and Design,Robinson Jr,Powell Ersell,7,3,3,0,0,0,0,3.257
+Fall 2022,MECE,7399,20,19836,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,6399,18,19837,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,23,19844,Doctoral Research,Castagna,John P,0,0,0,0,0,1,0,
+Fall 2022,MECE,8598,33,19847,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,
+Fall 2022,MECE,8398,12,19848,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,0,1,
+Fall 2022,GEOL,8998,24,19849,Doctoral Research,Zhou,Hua-Wei,0,0,0,0,0,3,0,
+Fall 2022,MECE,8298,34,19857,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Fall 2022,MECE,8598,34,19858,Doctoral Research,Sun,Li,0,0,0,0,0,2,0,
+Fall 2022,MECE,8398,13,19859,Doctoral Research,Sun,Li,0,0,0,0,0,3,0,
+Fall 2022,GEOL,8398,11,19861,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,3,0,
+Fall 2022,WGSS,2350,18,19870,Intro To Women's Studies,Martinez,Itzel Areli,17,6,2,2,0,0,1,3.359
+Fall 2022,GEOL,8698,12,19871,Doctoral Research,Mann,Paul,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8398,13,19895,Doctoral Research,Capuano,Regina M,0,0,0,0,0,1,0,
+Fall 2022,MIS,8999,1,19896,Doctoral Dissertation in MIS,Silva,Leiser O,0,0,0,0,0,1,0,
+Fall 2022,MARK,8999,3,19899,Doctoral Dissertation,Tirunillai,Seshadri N,0,0,0,0,0,1,0,
+Fall 2022,MIS,7373,4,19900,Bus Appls Database Mgt Sys I,Grimes,George M,5,21,3,2,0,0,0,2.935
+Fall 2022,COMM,1303,4,19901,Writing for Communicators,Lyn,Robyn,41,3,1,0,1,0,2,3.776
+Fall 2022,PHYS,2326,7,19911,University Physics II(lecture),Chen,Shuo,73,95,18,0,6,0,1,3.189
+Fall 2022,INAR,4398,1,19913,Independent Study,Wienert,Ross George,3,4,0,0,0,0,0,3.334
+Fall 2022,FINA,8999,2,19914,Doctoral Dissertation,Jacobs,Kris,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8688,2,19919,Dissertation Proposal,McNally,David Joseph,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,25,19923,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2022,HIST,8377,4,19924,Reading for Comps Exams,Neumann,Kristina Marie,0,0,0,0,0,0,0,
+Fall 2022,CUIN,6301,3,19927,The Teaching Profession,Ronduen,Lionnel Ganir,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,8999,2,19934,Doctoral Dissertation,Larson,Chad R,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8698,13,19936,Doctoral Research,Sager,William W,0,0,0,0,0,1,0,
+Fall 2022,PSYC,2319,9,19939,Intro to Social Psychology,Anderson,Jill Annette,7,30,19,6,7,0,3,2.348
+Fall 2022,FINA,8398,2,19944,Special Problems,Doshi,Hitesh B,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8699,10,19948,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2022,INDS,3397,14,19950,Selected Topics,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8398,3,19956,Special Problems,Yerramilli,Vijay,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8368,2,19957,Seminar in Investments,Jacobs,Kris,2,2,0,0,0,0,0,3.418
+Fall 2022,ECE,6314,1,19958,Nanoscale Design & Fabrication,Brankovic,Stanko R,6,9,3,0,0,0,0,3.13
+Fall 2022,HIST,6380,2,19960,Public History Internship,Young,Nancy Beck,2,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6267,4,19962,Research Practicum A,Rump,Rachel,1,0,0,0,0,0,0,3.67
+Fall 2022,GEOL,8998,26,19971,Doctoral Research,Suppe,John,0,0,0,0,0,1,0,
+Fall 2022,MECE,8399,39,19974,Doctoral Dissertation,Ostilla Monico,Rodolfo,1,0,0,0,0,0,0,4.0
+Fall 2022,CIS,6398,1,19976,Special Problems,Bronk,Robert C.,1,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,3198,2,19978,Independent Study,Phan,Trang Anh Thuc,7,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,37,19990,Doctoral Research,Liu,Dong,0,0,0,0,0,2,0,
+Fall 2022,PHLS,8199,7,19993,Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,
+Fall 2022,GEOL,6399,8,19995,Masters Thesis,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2022,INDS,3398,1,19999,Independent Study,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Fall 2022,IDNS,1131,11,20017,Calculus I SEP Workshop,Pattison,Donna,3,2,2,1,0,0,3,2.916
+Fall 2022,IDNS,1131,12,20018,Calculus I SEP Workshop,Pattison,Donna,1,0,2,0,1,0,0,2.083
+Fall 2022,MUSI,4198,4,20026,Research in Chamber Music,Suits,Brian J,4,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,38,20029,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6298,8,20031,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6398,8,20032,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8998,29,20049,Doctoral Research,Sager,William W,0,0,0,0,0,1,0,
+Fall 2022,PHYS,4398,5,20053,Independent Study,Bering,Edgar A,0,0,0,0,0,0,0,
+Fall 2022,HON,4398,9,20063,Independent Study,Rhoden,Brenda,2,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6298,2,20074,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2022,PEP,7193,1,20078,Internship & Practicum,Knoblauch,Mark Alan,13,2,0,0,0,0,0,3.867
+Fall 2022,ECON,4389,1,20081,Tops-Contemporary Economics II,Saboury,Piruz,6,5,2,1,0,0,0,3.119
+Fall 2022,ECON,4395,1,20082,Topics - Applied Econometrics,Szabo,Andrea,4,4,5,1,0,0,3,2.786
+Fall 2022,ECON,4363,1,20083,Political Economy,Ujhelyi,Gergely,2,5,3,1,5,0,4,1.834
+Fall 2022,ECON,3363,1,20084,Environmental Economics,Kohlhase,Janet E,10,13,8,1,1,0,7,2.889
+Fall 2022,ECON,3351,1,20085,The Economics of Development,Liu,Elaine Meichen,13,20,6,2,0,0,1,3.033
+Fall 2022,ECON,4345,1,20086,Social Economics,Maheshri,Vikram,13,26,1,0,0,0,2,3.292
+Fall 2022,ECON,4377,1,20088,Urban Economics,Kohlhase,Janet E,5,8,5,2,0,0,4,2.817
+Fall 2022,ECON,7382,1,20089,Intranational Macroeconomics,Craig,Steven G,5,0,0,0,0,0,0,4.0
+Fall 2022,ECON,7380,1,20090,Macro Modeling & Forecasting,Papell,David H,11,0,0,0,0,0,0,4.0
+Fall 2022,ECON,7384,1,20091,Political Economy,Ujhelyi,Gergely,3,0,0,0,0,0,0,4.0
+Fall 2022,ECON,7395,1,20092,Selected Topics,Juhn,Chinhui,8,0,0,0,0,0,0,3.876
+Fall 2022,ECON,7395,2,20093,Selected Topics,Wang,Fan,10,0,0,0,0,0,0,4.0
+Fall 2022,ECON,4335,1,20094,Economic Growth Theory,Vollrath,Dietrich E,15,9,8,5,2,0,0,2.769
+Fall 2022,BIOL,3311,1,20095,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,58,30,15,3,10,0,1,3.026
+Fall 2022,SPAN,2311,2,20097,Intermediate Spanish I,Benalcazar Astudillo,Diana Salome,6,7,5,0,1,0,0,2.947
+Fall 2022,ARCH,3397,2,20099,Selected Topics,Louie,Jonathan Bung Chan,5,0,0,0,0,0,1,4.0
+Fall 2022,ARCH,3397,11,20108,Selected Topics,Jacobs,Daniel,7,4,2,0,0,0,0,3.308
+Fall 2022,ARCH,3397,12,20109,Selected Topics,Bell,Larry S,9,5,0,0,0,0,0,3.643
+Fall 2022,ARCH,6397,5,20166,Sel Tpcs-Arc/Urbn Desgn,Smith,Joshua S,2,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,6397,13,20174,Sel Tpcs-Arc/Urbn Desgn,Adams,Vera A,2,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,6397,15,20176,Sel Tpcs-Arc/Urbn Desgn,Race,Bruce Alan,2,0,0,0,0,0,0,3.835
+Fall 2022,LAW,5116,1,20353,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,16,0,
+Fall 2022,LAW,5117,1,20356,Advocacy Board TWO,Lawrence,Jim E,0,0,0,0,0,6,0,
+Fall 2022,CLAS,3341,1,20436,The Roman Republic,Armstrong,Richard H,20,3,1,0,1,0,2,3.627
+Fall 2022,CLAS,3345,1,20437,Myth&Performance in Greek Trag,Kidder,Kathleen,20,7,2,0,0,0,0,3.598
+Fall 2022,CLAS,3381,1,20438,From Homer To Hollywood,Kidder,Kathleen,15,11,1,0,1,0,2,3.381
+Fall 2022,GREK,2301,1,20439,Intermediate Greek I,Kidder,Kathleen,4,0,0,0,0,0,3,3.835
+Fall 2022,LAW,5125,1,20440,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,6,0,
+Fall 2022,LAW,5128,1,20441,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,60,0,
+Fall 2022,LAW,5129,1,20442,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,9,0,
+Fall 2022,CUIN,6307,1,20593,Change and Diffusion,Hausmann,Robert Carl,14,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,7318,1,20595,Curr Issues Learning & Design,Dogan,Bulent,6,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,7368,1,20596,Digital Imaging in Education,McNeil,Sara G,17,2,1,0,0,0,0,3.767
+Fall 2022,CUIN,7381,1,20597,Instructional Evaluation,Gronseth,Susie L B,14,0,1,0,1,0,1,3.646
+Fall 2022,CUIN,8397,1,20598,Selected Topics in C&I,Hausmann,Robert Carl,4,0,0,0,0,0,0,4.0
+Fall 2022,GERM,3385,1,20617,East German Cinema,Frieden,Sandra M Gross,14,7,0,3,0,0,1,3.21
+Fall 2022,GERM,3350,1,20618,20Th C Thru German Culture,Luke-Dorn,Martina,21,0,1,0,0,0,2,3.864
+Fall 2022,GERM,4398,1,20619,Independent Study,Kleinheider,Julia D,1,0,0,0,0,0,0,4.0
+Fall 2022,GERM,6392,1,20620,Reading German/Non-Majors I,Luke-Dorn,Martina,4,0,0,0,0,0,0,4.0
+Fall 2022,ITAL,3305,1,20621,Italian Culture Through Films,Carrera,Alessandro,5,4,0,0,0,0,0,3.519
+Fall 2022,ITAL,3306,1,20622,Italian Cinema,Carrera,Alessandro,5,2,0,0,1,0,1,3.291
+Fall 2022,ITAL,6306,1,20623,Advanced Italian Cinema,Carrera,Alessandro,1,0,0,0,0,0,0,4.0
+Fall 2022,FREN,3320,1,20624,Intro to French Literature,Gnanwo Hounfodji,Raymond,3,4,1,0,1,0,1,2.706
+Fall 2022,FREN,3340,1,20625,Contemporary French Society,Giacchetti,Claudine A,3,5,1,2,0,0,1,2.848
+Fall 2022,FREN,4343,1,20626,Short Fiction,Giacchetti,Claudine A,2,2,2,0,0,0,1,3.0
+Fall 2022,FREN,6397,1,20628,Topics-Fre Lit Lang Cul,Giacchetti,Claudine A,3,0,0,0,0,0,0,3.89
+Fall 2022,CUIN,4361,5,20661,Second Language Methodology,Latiolais,Cheryl S,5,0,0,0,0,0,1,3.934
+Fall 2022,CUIN,8361,1,20662,State of the Curriculum Field,Alarcon,Jeannette Driscoll,13,1,1,0,0,0,0,3.822
+Fall 2022,GEOL,1147,4,20663,Introductory Meteorology Lab,Rappenglueck,Bernhard,1,3,2,0,1,0,2,2.429
+Fall 2022,CLAS,4375,1,20665,Gender and Race in Greek Myths,Wright,David John,13,3,1,0,0,0,0,3.667
+Fall 2022,CUIN,7383,1,20666,Early Chld Curr,Siller Escudero,Patricia,8,1,0,0,1,0,0,3.434
+Fall 2022,CHIN,3346,1,20667,Chinese Sociolinguistics,Wang,Wei,7,9,1,0,4,0,2,2.699
+Fall 2022,INDI,3397,1,20668,Topics in India Studies,Majumder,Sarasij,1,7,0,0,1,0,0,2.668
+Fall 2022,INDI,3397,2,20669,Topics in India Studies,Majumder,Sarasij,1,0,0,0,0,0,0,3.67
+Fall 2022,CUIN,7334,1,20672,Develop Proportional Reasoning,Chauvot,Jennifer B,20,1,0,0,1,0,0,3.788
+Fall 2022,ARED,7305,1,20674,History of Art Education,Chung,Sheng Kuan,6,0,0,0,0,0,0,3.945
+Fall 2022,ARED,2310,2,20675,Intro Critical Visual Culture,Lee,Jhih-yin Diane,21,5,1,0,0,0,0,3.716
+Fall 2022,WCL,3385,1,20676,Cultures and Capitalisms,Majumder,Sarasij,1,4,1,0,0,0,4,2.89
+Fall 2022,WCL,3397,1,20678,Selected Topics in WCL,Zaretsky,Robert D,1,0,0,0,0,0,0,4.0
+Fall 2022,WCL,4354,1,20679,Global South Before WWII,Ramirez,Marie Theresa,4,1,0,0,0,0,0,3.668
+Fall 2022,WCL,6397,1,20680,Selected Topics in WCL,Ramirez,Marie Theresa,2,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,7354,1,20682,Perspectives in Science & Math,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Fall 2022,MATH,3336,2,20690,Discrete Mathematics,Xhabli,Blerina,37,19,13,8,19,0,18,2.479
+Fall 2022,JWST,3371,1,20692,Women in the Bible,Tamber-Rosenau,Caryn M,4,8,4,2,2,0,0,2.401
+Fall 2022,JWST,2380,1,20693,Introduction to Jewish Studies,Tamber-Rosenau,Caryn M,10,2,1,0,1,0,0,3.381
+Fall 2022,JWST,3380,1,20694,American Jewish Culture,Weiss,Kenneth Scott,2,6,2,0,5,0,0,2.044
+Fall 2022,WCL,2380,1,20695,Introduction to Jewish Studies,Tamber-Rosenau,Caryn M,4,2,3,1,1,0,2,2.726
+Fall 2022,WCL,3380,1,20696,American Jewish Culture,Weiss,Kenneth Scott,8,4,4,1,1,0,0,2.816
+Fall 2022,CHIN,6397,1,20697,Selected Topics,Wang,Wei,2,0,0,0,0,0,0,3.67
+Fall 2022,CUIN,7393,1,20698,Practicum for Rdg Specialist,Hale,Margaret Ann,0,0,0,0,0,5,0,
+Fall 2022,CUIN,7331,1,20699,Supporting Striving Readers,Reis,Nancy,21,0,0,0,1,0,0,3.818
+Fall 2022,CUIN,8383,1,20701,Action Research,Pauloski,Gwendolyn Jordan,20,1,0,0,0,0,0,3.921
+Fall 2022,CUIN,8374,1,20702,Policy/Politics-Edu Governance,Hutchison,Laveria F,21,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8397,2,20703,Selected Topics in C&I,Alba,Celeste,5,0,0,0,0,0,0,4.0
+Fall 2022,FINA,3332,2,20704,Prin of Financial Management,Suleymanov,Masim,64,80,45,18,3,0,5,2.884
+Fall 2022,CUIN,8301,1,20705,Erly Chld Ed-Tchng Prcs,Siller Escudero,Patricia,1,0,0,0,0,0,0,4.0
+Fall 2022,JAPN,1501,1,20706,Elementary Japanese I,LIU,JING,23,5,3,0,1,0,2,3.542
+Fall 2022,JAPN,1501,3,20708,Elementary Japanese I,LIU,JING,24,7,0,0,0,0,1,3.732
+Fall 2022,FINA,4397,1,20710,Selected Topics in Finance,Pena,Juan F,32,8,1,0,0,0,1,3.716
+Fall 2022,FINA,4397,3,20712,Selected Topics in Finance,Susmel,Raul,0,1,0,0,0,0,1,3.33
+Fall 2022,FINA,4397,4,20713,Selected Topics in Finance,Hughes,James F,14,19,6,0,0,0,1,3.188
+Fall 2022,FINA,7397,1,20714,Selected Topics in Finance,Bailey-Rihawi,Esther Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7397,2,20715,Selected Topics in Finance,Smith III,Edwin A,2,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7397,3,20716,Selected Topics in Finance,George,Thomas J,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7397,4,20717,Selected Topics in Finance,Bean,Gregory S.,11,0,0,0,0,0,0,4.0
+Fall 2022,HISP,2374,3,20728,Spanish American Culture & Civ,Ruisanchez Serra,Jose Ramon,11,5,0,0,3,0,6,3.053
+Fall 2022,HISP,2375,1,20729,US Hispanic Culture & Civ,Sisk,Christina L,9,8,6,1,0,0,0,2.945
+Fall 2022,SPAN,1501,23,20730,Elementary Spanish I,Pueyo Castan,Josefa,3,2,6,2,2,0,0,2.155
+Fall 2022,PHYS,4350,1,20734,Computational Physics,Cardoso Barato,Andre,4,3,2,0,0,0,0,3.296
+Fall 2022,PHYS,1301,6,20735,College Physics I (lecture),McElhenny,Brian Patrick,43,40,52,18,10,0,30,2.548
+Fall 2022,PHYS,6366,1,20738,Quantum Field Theory,Ordonez,Carlos,6,5,0,0,0,0,0,3.515
+Fall 2022,WCL,3397,2,20740,Selected Topics in WCL,LIU,JING,16,2,1,0,1,0,0,3.633
+Fall 2022,SPAN,3301,1,20743,Span Oral Comm for Crit Think,Sisk,Christina L,2,6,1,0,0,0,0,3.074
+Fall 2022,SPAN,3331,1,20744,Mexican American Literature,Ventura,Gabriela Baeza,12,6,0,1,4,0,1,2.856
+Fall 2022,SPAN,4374,1,20745,Teach Span Heritage Learner,Fairclough,Marta A,9,3,2,2,2,0,0,2.852
+Fall 2022,CUIN,6313,1,20768,Foundations of Bilingual Ed,Cole,Mikel Walker,10,4,0,0,0,0,0,3.667
+Fall 2022,CUIN,7311,1,20769,Lang&Lit to Bilingual Learners,Li,Miao,13,2,0,0,0,0,0,3.801
+Fall 2022,PHYS,6387,1,20772,Solid State Physics I,Ting,Chin Sen,12,7,0,0,0,0,0,3.545
+Fall 2022,PHYS,7397,1,20773,Selected Topics in Phy,Hosur,Pavan R,8,0,0,0,0,0,0,3.959
+Fall 2022,POLC,1311,1,20774,Public Policy Laboratory,Luttrell,Johanna,15,3,1,0,0,0,2,3.667
+Fall 2022,PUBL,6398,1,20775,Special Probs Publ Adm/Policy,Koelling,Peter,6,0,0,0,0,0,0,3.89
+Fall 2022,CUIN,4361,4,20779,Second Language Methodology,Li,Miao,26,3,2,0,0,0,0,3.742
+Fall 2022,POLC,2312,1,20781,Intro to Econ Policy Analysis,Wong,Man Chiu,3,6,3,1,2,0,1,2.555
+Fall 2022,POLC,3313,1,20782,Contemporary Poli Phil Policy,Luttrell,Johanna,7,3,2,2,1,0,0,2.779
+Fall 2022,POLC,3314,1,20783,Leadership and Public Policy,Witt,Lawrence A,18,3,1,0,0,0,0,3.758
+Fall 2022,POLC,3315,1,20784,Policy Res Methods Stat & Reg,Buttorff,Gail J.,1,0,2,2,0,0,2,2.132
+Fall 2022,POLC,3322,1,20785,Public Policy Analysis,Heller,Blake Harrison,3,2,0,0,0,0,2,3.534
+Fall 2022,POLC,3341,1,20787,State Authority and Freedom,Bronk,Robert C.,4,0,0,0,1,0,0,3.2
+Fall 2022,POLC,4349,1,20788,EDR Ethics Leadership Seminar,Engster,Daniel A,1,0,0,0,0,0,0,4.0
+Fall 2022,MARK,3338,1,20792,Intro to Marketing Analytics,Hu,Ye,42,58,13,5,2,0,8,3.064
+Fall 2022,MARK,3338,2,20793,Intro to Marketing Analytics,Hu,Ye,28,65,10,13,4,0,9,2.864
+Fall 2022,MECE,6333,1,20795,Conduction and Radiation,Ghasemi,Hadi,5,3,1,0,0,0,2,3.188
+Fall 2022,MECE,6361,2,20796,Mechanical Behavior/Materials,Ryou,Jae-Hyun,10,2,0,0,0,0,3,3.751
+Fall 2022,MECE,7362,1,20797,Robust Multivariable Control,Franchek,Matthew,7,7,1,0,0,0,1,3.488
+Fall 2022,MECE,6397,1,20798,Selected Topics,Sun,Li,5,0,0,0,0,0,0,3.934
+Fall 2022,MECE,6397,2,20799,Selected Topics,Agrawal,Ashutosh,7,1,0,0,0,0,0,3.751
+Fall 2022,MECE,6397,3,20800,Selected Topics,Song,Gangbing,3,4,1,0,0,0,2,3.168
+Fall 2022,MECE,5397,3,20804,Selected Topics,Agrawal,Ashutosh,18,9,0,0,0,0,0,3.581
+Fall 2022,MECE,5397,4,20806,Selected Topics,Song,Gangbing,10,24,3,0,0,0,0,3.154
+Fall 2022,MECE,5397,6,20808,Selected Topics,Chen,Zheng,0,2,2,0,0,0,1,2.5
+Fall 2022,SPAN,6352,1,20832,Sociolinguistic Aspect US Span,Gutierrez,Manuel J,8,3,0,0,0,0,0,3.787
+Fall 2022,SPAN,6354,1,20833,Span Phonetics and Variation,Goodin-Mayeda,Carrie Elizabeth,4,2,1,0,0,0,0,3.381
+Fall 2022,SPAN,6395,1,20834,Topics-Lang&Linguistics,Lopez Otero,Julio Cesar,5,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,6396,1,20835,Topics in Spanish Lit,Gutierrez,Pedro Revuelta,7,1,0,0,0,0,0,3.834
+Fall 2022,SPAN,7391,1,20836,Sel Topics Spanish Amer Lit,Rivera Garza,Cristina,14,0,0,0,0,0,0,3.882
+Fall 2022,PSYC,4397,1,20872,Selected Topics in Psychology,Williams,Michael W,10,10,8,1,1,0,0,2.878
+Fall 2022,SPAN,6397,1,20881,Topics in Span-Amer Lit,Cuesta,Mabel,5,0,0,0,0,0,0,4.0
+Fall 2022,SPAN,7395,1,20882,Sel Topics in US Hispanic Lit,Kanellos,Nicolas,9,0,0,0,0,0,0,3.963
+Fall 2022,MARK,7399,1,20883,MS Marketing Prof Project,Koch,Steven F.,12,2,0,0,0,0,0,3.857
+Fall 2022,MANA,4338,2,20911,Performance Management Systems,Sullivan,David Walter,8,5,1,0,1,0,1,3.311
+Fall 2022,MANA,4346,3,20912,Leadership Development,Evans,Klavdia Markelova,36,11,1,1,0,0,0,3.64
+Fall 2022,MANA,7322,1,20914,Qual-Perf Mgmt in Healthcare,Kroger,Edward John,7,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7342,1,20916,Challenges in Healthcare Law,Kroger,Edward John,6,0,0,0,0,0,0,4.0
+Fall 2022,MANA,8330,1,20928,Sem in Mgt Research,Avery,Derek Reynold,4,1,0,0,0,0,0,3.668
+Fall 2022,MANA,8331,1,20929,Seminar in Organization Theory,Miller,Carl Chet,5,1,0,0,0,0,0,3.833
+Fall 2022,MANA,6A83,2,20930,Strategic Analysis,Carlin,Barbara A,9,3,1,0,0,0,1,3.615
+Fall 2022,MANA,6A83,3,20931,Strategic Analysis,Celly,Nikhil,14,2,0,0,0,0,0,3.834
+Fall 2022,ARLD,6395,1,23286,Sel Topics in Arts Leadership,Kulha,Shay Thornton,4,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,4397,1,23321,Selected Topics,Race,Bruce Alan,0,11,0,0,0,0,1,3.06
+Fall 2022,ECON,6394,1,23323,Tpcs-Eco of Socl Issue,Obrizan,Maksym,0,0,0,0,0,0,0,
+Fall 2022,ECON,6394,3,23325,Tpcs-Eco of Socl Issue,Prokopovych,Pavlo,2,5,0,0,0,0,0,3.239
+Fall 2022,PHIL,1321,4,23326,Logic I,Buckner,Cameron J,27,38,19,6,6,0,17,2.774
+Fall 2022,PHIL,1361,5,23327,Philosophy and the Arts,Drapela,Nick Gerard,13,19,8,4,2,0,4,2.812
+Fall 2022,ARCH,4376,1,23332,Community Design Workshop,Rogers,Susan,5,8,0,0,0,0,2,3.41
+Fall 2022,ARCH,6397,16,23333,Sel Tpcs-Arc/Urbn Desgn,Rogers,Susan,1,2,0,0,0,0,0,3.333
+Fall 2022,ARLD,6395,3,23353,Sel Topics in Arts Leadership,Castillo,James Phillip,9,0,0,0,0,0,0,4.0
+Fall 2022,ARLD,6398,1,23355,Special Prob in Arts Leadrshp,Fernando,Fleurette S,4,0,0,0,0,0,0,4.0
+Fall 2022,MANA,7357,1,23358,Fund of Diversity Equity & Inc,Baldwin,Cheryl,18,5,1,1,0,0,1,3.56
+Fall 2022,CUIN,3317,11,23385,Kindergarten/Elem Curr & Instr,Gist,Conra D.,2,0,0,0,0,0,0,3.835
+Fall 2022,CUIN,4315,11,23386,Assessment of Children,Gist,Conra D.,1,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,3316,11,23389,Prekindergarten Curr & Instr,Gist,Conra D.,2,0,0,0,0,0,0,4.0
+Fall 2022,PHIL,3305,1,23420,Hist of 18Th Century Phil,Morrison,Iain P D,6,11,2,0,0,0,0,3.193
+Fall 2022,PHIL,3358,1,23433,Classics in Hist of Ethics,Phillips,David K,16,12,3,1,0,0,2,3.354
+Fall 2022,PHIL,3350,1,23581,Ethics,Coates,Daniel J,15,11,1,1,1,0,0,3.356
+Fall 2022,HIST,6397,1,23584,Selected Topics in History,Boyd,Sarah Fishman,9,0,0,0,0,0,0,3.817
+Fall 2022,HIST,6393,1,23587,Rdgs Seminar in US History,Reed,Linda,4,0,0,0,0,0,0,3.753
+Fall 2022,HIST,6370,1,23589,Adv Research & Writ Sem,Yuksel,Emire Cihan,6,0,0,0,0,0,0,3.78
+Fall 2022,HIST,6356,1,23590,U.S Historiography to 1877,Hopkins,Kelly Y,9,0,0,0,0,0,0,3.963
+Fall 2022,BUSI,2305,6,23592,Business Statistics,Patterson,Staci A,8,6,10,4,0,0,24,2.572
+Fall 2022,CUIN,7341,1,23593,Math Education Capstone,Gallagher,Melissa Ann,12,2,0,0,1,0,1,3.6
+Fall 2022,ENGI,1100,28,23661,Introduction To Engineering,Claydon,Frank J,16,7,2,0,0,0,0,3.547
+Fall 2022,PHLS,8349,1,23679,Advanced Psyc Assessment II,Stinson,Jennifer Megan,4,0,0,0,0,0,0,3.835
+Fall 2022,RELS,3371,1,23682,Women in the Bible,Tamber-Rosenau,Caryn M,10,6,4,0,0,0,0,3.267
+Fall 2022,BIOL,4342,50,23684,Introduction to Marine Biology,Hanke,Marc H,2,11,5,0,2,0,0,2.534
+Fall 2022,BIOL,3397,50,23685,Selected Topics in Biology,Sirrieh,Rita Evelyn,25,0,0,0,0,0,0,3.934
+Fall 2022,BCHS,4322,1,23686,Biochemistry of Organelles,Widger,William R,16,14,1,0,1,0,1,3.354
+Fall 2022,POLS,3349,50,23687,American Political Thought,Gish,Dustin,11,10,1,0,1,0,2,3.276
+Fall 2022,ANTH,3396,1,23689,Selected Tops in Cultural Anth,Ramirez,Marie Theresa,9,5,0,0,1,0,0,3.378
+Fall 2022,WCL,3397,3,23690,Selected Topics in WCL,Back,Eunkyung Lee,4,1,2,1,0,0,0,2.959
+Fall 2022,BIOL,7124,3,23691,Cell Biology Seminar,Lekven,Arne,0,0,0,0,0,8,0,
+Fall 2022,BIOL,6204,1,23692,Advanced Ecology & Evolution I,Crawford,Kerri M,10,1,0,0,0,0,0,3.909
+Fall 2022,CHEM,1321,1,23693,Honors Fund. of Chem 1,Halasyamani,P Shiv,8,11,8,6,1,0,8,2.607
+Fall 2022,BIOL,6205,1,23694,Adv Ecology & Evolution II,Graur,Dan,9,1,0,0,0,0,0,3.834
+Fall 2022,BIOL,6312,1,23695,Scientific Communication,Frankino,William A,12,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6343,1,23709,Psychopharmacology,Kosten,Therese A,3,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6397,1,23710,Sel Top in Psychology,Derrick,Jaye L,7,0,0,0,0,0,0,3.859
+Fall 2022,PSYC,6397,2,23711,Sel Top in Psychology,Alward,Beau Andrew,10,0,0,0,0,0,0,4.0
+Fall 2022,STAT,3331,2,23712,Statistical Anal Bus Appl I,Wiley,Briceon C,2,4,4,3,2,0,4,2.111
+Fall 2022,PSYC,6397,3,23713,Sel Top in Psychology,Yoshida,Hanako,8,2,0,0,0,0,0,3.8
+Fall 2022,HIST,4392,1,23714,Sel Topics in Asian History,Bhattacharya,Nandini Saradindu,2,2,3,2,0,0,1,2.481
+Fall 2022,PSYC,4397,2,23715,Selected Topics in Psychology,Alfano,Candice A,5,11,7,2,0,0,3,2.694
+Fall 2022,DIGM,3152,30,23716,Graphic Comm Output Lab,Dawson,Michael John,2,1,0,0,0,0,0,3.667
+Fall 2022,DIGM,3353,33,23718,Visual Communications Tech,Bravo,Gina C,46,5,0,0,1,0,1,3.77
+Fall 2022,HIST,4375,1,23720,The Atlantic World Since 1450,McNally,David Joseph,5,6,1,0,0,0,1,3.416
+Fall 2022,HIST,4373,1,23721,US-Mexico Borderlands,Ramos,Raul,13,2,0,0,0,0,0,3.691
+Fall 2022,DIGM,4397,30,23722,Selected Tops in Digital Media,Liao,Tony Chung-Li,11,1,1,0,0,0,0,3.668
+Fall 2022,DIGM,4397,31,23723,Selected Tops in Digital Media,Alters,Monika Joanna,10,3,2,1,0,0,0,3.334
+Fall 2022,ARCH,6376,1,23724,Urban Determinants,Rogers,Susan,23,6,0,0,0,0,1,3.77
+Fall 2022,HIST,4343,1,23728,Russian Revolutions Stalinism,Golubev,Alexey Valeryevich,13,9,6,0,1,0,1,3.127
+Fall 2022,HIST,4340,1,23729,Philosophies of History,Howard,Philip,4,4,5,0,0,0,1,2.822
+Fall 2022,HIST,4340,2,23730,Philosophies of History,Sbardellati,John,2,7,3,0,0,0,3,2.862
+Fall 2022,HIST,4318,1,23734,Africa and The Oil Industry,Klieman,Kairn,12,1,9,0,1,0,1,2.857
+Fall 2022,HIST,4314,1,23735,Am Hist Through Film,Sbardellati,John,6,8,7,1,5,0,2,2.394
+Fall 2022,HIST,4301,1,23738,Issues in Feminist Research,Young,Nancy Beck,6,0,1,0,0,0,0,3.667
+Fall 2022,HIST,3397,1,23742,Sel Tops-African History,Chakrabarti,Pratik,10,2,0,0,0,0,0,3.723
+Fall 2022,HIST,3396,1,23745,Sel Top-Latin Amer Hist,Cedillo,Adela Cedillo,7,2,1,0,2,0,1,2.918
+Fall 2022,BIOL,3301,1,23748,Mendelian and Pop Genetics,Dauwalder,Brigitte,95,65,45,15,5,0,8,3.002
+Fall 2022,HIST,3394,1,23749,Sel Tops-Us History,Clavin,Matthew J,4,9,6,0,1,0,0,2.75
+Fall 2022,HIST,3391,1,23755,"Africa, Islam, Indian Ocean",Klieman,Kairn,4,6,0,0,0,0,1,3.301
+Fall 2022,HIST,3385,1,23757,Ottoman Empire I,Yuksel,Emire Cihan,19,9,0,0,3,0,1,3.312
+Fall 2022,BIOL,3301,2,23759,Mendelian and Pop Genetics,Dauwalder,Brigitte,42,54,36,15,7,0,8,2.684
+Fall 2022,BIOL,3301,3,23760,Mendelian and Pop Genetics,Farmer,Lisa M,64,65,34,25,8,0,14,2.769
+Fall 2022,HIST,3376,1,23763,Caribbean History,Howard,Philip,5,9,3,1,10,0,3,1.929
+Fall 2022,HIST,3355,1,23769,British Empire Since 1500,Ittmann,Karl,3,9,11,1,1,0,4,2.44
+Fall 2022,HIST,3336,1,23772,History of U.S. Latinx Music,Goldberg,Mark A.,19,6,0,0,1,0,1,3.527
+Fall 2022,PSYC,4363,1,23773,Abnormal Child Psych,Viana,Andres G,18,18,7,1,0,0,6,3.167
+Fall 2022,HIST,3310,1,23778,"Jacksonian America, 1820-1850",Deyle,Steven H,11,13,2,0,3,0,2,2.909
+Fall 2022,HIST,2397,1,23779,Selected Topics in History,Bhattacharya,Nandini Saradindu,9,8,1,1,7,0,0,2.398
+Fall 2022,HIST,2348,1,23785,U.S. Latino/a Histories,Goldberg,Mark A.,17,10,4,2,0,0,2,3.223
+Fall 2022,BIOL,4397,1,23789,Selected Topics in Biology,McKeon,Frank D,20,0,0,0,0,0,0,4.0
+Fall 2022,HIST,2346,1,23792,Intro to Food History,Perales,Monica,19,8,3,1,3,0,1,2.992
+Fall 2022,BIOL,4354,2,23796,Endocrinology,Gill,Tejendra,15,48,8,3,4,0,10,2.812
+Fall 2022,CHEM,2325,2,23815,Organic Chemistry II,Cai,Chengzhi,2,8,12,11,9,0,13,1.548
+Fall 2022,CHEM,4373,2,23827,Survey of Physical Chemistry,Baldelli,Steve,3,10,3,1,1,0,1,2.777
+Fall 2022,CHEM,6115,2,23835,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,1,0,
+Fall 2022,ECON,3371,2,23841,Economics of Money & Banking,Dasari,Babu,23,9,8,1,2,0,2,3.186
+Fall 2022,HON,3311,1,23850,Creative Cities,Cremins,Robert Paul,17,1,0,0,2,0,0,3.501
+Fall 2022,POLS,3340,1,23853,Ancient/Medieval Pol Thought,Cooper,Carol B,16,5,0,0,0,0,1,3.699
+Fall 2022,GEOL,1103,13,23855,Physical Geology Lab,Hauptvogel,Daniel William,13,1,0,0,0,0,1,3.929
+Fall 2022,GEOL,1103,14,23856,Physical Geology Lab,Hauptvogel,Daniel William,17,2,0,2,1,0,1,3.47
+Fall 2022,HON,3350,2,23857,Principles of Data and Society,Price,Daniel M,11,2,0,0,0,0,0,3.821
+Fall 2022,HON,3397,1,23859,Honors Selected Topics,Trninic,Marina,5,1,1,0,0,0,1,3.571
+Fall 2022,SCM,7390,1,23864,Global Supply Chain Strategy,Smith,Gordon D,2,2,2,0,0,0,0,3.11
+Fall 2022,GEOL,1302,2,23866,Intro To Global Climate Change,Choi,Yunsoo,772,139,41,19,18,0,4,3.597
+Fall 2022,HON,3376,1,23869,Constitutional Cases & Controv,Erwing,Douglas A,15,1,0,0,0,0,4,3.938
+Fall 2022,GEOL,1303,1,23870,Physical Geology,Capuano,Regina M,18,24,10,0,0,0,3,3.179
+Fall 2022,POLS,3352,1,23871,Immigration: Politics/Policy,Belco,Michelle Helene,15,5,1,1,2,0,0,3.236
+Fall 2022,GEOL,1303,10,23872,Physical Geology,Wu,Jonathan En Lin,27,41,26,8,8,0,4,2.66
+Fall 2022,HON,3397,4,23873,Honors Selected Topics,Leland,Alison W,8,8,0,0,0,0,1,3.521
+Fall 2022,HON,4330,1,23874,Narratives in the Professions,Reynolds,Aaron E,24,1,0,0,0,0,0,3.934
+Fall 2022,HON,4397,1,23876,Honors Selected Topics,Garner,Richard A,16,0,0,0,0,0,4,3.979
+Fall 2022,MIS,7397,1,23877,Selected Topics in MIS,Cooper,Randolph B,13,6,6,1,1,0,3,3.074
+Fall 2022,MIS,7397,2,23878,Selected Topics in MIS,Pena,Juan F,27,0,2,0,0,0,0,3.851
+Fall 2022,MIS,7397,3,23879,Selected Topics in MIS,Zhao,Keran,20,2,0,0,0,0,0,3.894
+Fall 2022,MIS,3370,4,23882,Info Systems Development Tools,Lewis,Michael Joseph,15,15,17,5,2,0,11,2.667
+Fall 2022,MIS,3371,2,23883,Transaction Processing Sys I,Messinger,Jacob Nelson,72,38,3,0,0,0,0,3.596
+Fall 2022,GEOL,4365,1,23957,Environmental Geochemistry,Capuano,Regina M,9,14,7,3,2,0,0,2.677
+Fall 2022,MIS,4397,1,24000,Selected Topics in MIS,Zhao,Keran,7,1,0,0,0,0,0,3.916
+Fall 2022,MIS,4397,2,24003,Selected Topics in MIS,Scott,Carl P,12,8,0,0,1,0,1,3.334
+Fall 2022,MIS,4397,3,24006,Selected Topics in MIS,Hernandez,Jesus S,16,1,0,0,0,0,1,3.864
+Fall 2022,MIS,4397,5,24012,Selected Topics in MIS,Wang,Cheng,39,6,2,0,0,0,0,3.787
+Fall 2022,SOCI,1301,9,24021,Introduction To Sociology,Dorsey,Patricia Lynne,19,30,4,1,6,0,0,2.878
+Fall 2022,SOCI,1301,16,24024,Introduction To Sociology,Dorsey,Patricia Lynne,16,29,11,2,1,0,1,2.988
+Fall 2022,SGNL,1301,9,24032,Elementary Sign Language I,Brittain,Terrell,5,8,4,3,2,0,0,2.395
+Fall 2022,SOC,6390,1,24033,Seminar in Sociology of Gender,Katz,Sheila,9,0,0,0,0,0,0,4.0
+Fall 2022,SOC,6330,1,24034,Sem Social Psychology,Savage,Scott Vandenburgh,10,1,0,0,0,0,0,3.879
+Fall 2022,GEOL,4397,1,24036,Selected Topics-Geology,Stewart,Robert R,4,4,1,0,0,0,3,3.333
+Fall 2022,SOC,3300,2,24037,Intro to Sociological Theory,Grigorian,Stella,17,5,6,2,5,0,4,2.762
+Fall 2022,SOC,3340,1,24040,Sociology of Film,Lee,Shayne,31,8,2,1,6,0,0,3.126
+Fall 2022,SOC,3341,1,24041,Organizations,Savage,Scott Vandenburgh,12,13,11,2,4,0,4,2.549
+Fall 2022,GEOL,6338,1,24042,Paleoclimate,Voarintsoa,Ny Riavo Gilbertinie,7,2,1,0,0,0,2,3.6
+Fall 2022,GEOL,4338,1,24043,Advanced Climate Change,Voarintsoa,Ny Riavo Gilbertinie,1,0,0,1,2,0,1,1.085
+Fall 2022,GEOL,4379,1,24044,Groundwater/Eng Geophys,Wiley,Robert W,3,0,1,0,0,0,0,3.5
+Fall 2022,GEOL,4398,1,24047,Independent Study,Bering,Edgar A,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,6375,1,24053,Tecton Himalayan-Tibet Orogen,Robinson,Alexander C,3,0,0,0,0,0,0,3.67
+Fall 2022,ACCT,2301,23,24074,Prin of Financial Accounting,Parthasarathy,Kiran M,112,110,42,19,8,0,25,3.097
+Fall 2022,ACCT,2301,24,24075,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,14,17,8,3,8,0,7,2.573
+Fall 2022,ACCT,2301,25,24076,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,20,14,5,2,1,0,2,3.261
+Fall 2022,BUSI,4305,1,24077,Business Ethics for Accountant,Spartalis,Emmanuel Michael,9,8,0,0,0,0,0,3.568
+Fall 2022,ACCT,2302,10,24078,Prin of Managerial Accounting,Seltz,Joe D,22,8,4,3,1,0,4,3.263
+Fall 2022,ACCT,2302,11,24079,Prin of Managerial Accounting,Seltz,Joe D,23,13,9,5,4,0,6,2.925
+Fall 2022,ACCT,2302,12,24080,Prin of Managerial Accounting,Seltz,Joe D,34,32,16,10,2,0,7,2.985
+Fall 2022,SOC,3360,1,24081,Sociology of Food,Grigorian,Stella,28,9,4,0,5,0,2,3.138
+Fall 2022,SOC,3397,1,24083,Sel-Topics in Sociology,Hwang,Hyunseok,8,3,1,0,2,0,0,3.048
+Fall 2022,HISP,2374,4,24084,Spanish American Culture & Civ,Ruisanchez Serra,Jose Ramon,7,9,3,2,0,0,1,2.969
+Fall 2022,GEOL,6397,2,24086,Selected Topics in Geology,Castagna,John P,21,1,0,0,0,0,0,3.94
+Fall 2022,GEOL,6397,1,24087,Selected Topics in Geology,Beverly,Emily Jane,4,2,0,0,0,0,0,3.722
+Fall 2022,ACCT,3366,5,24108,Financial Reporting Frameworks,Parthasarathy,Kiran M,24,10,11,8,4,0,12,2.777
+Fall 2022,GEOL,6380,1,24111,Sequence Stratigraphy,Wellner,Julia S,5,5,0,0,1,0,1,3.062
+Fall 2022,GEOL,3380,1,24112,Physical Meteorology,Jiang,Xun,15,8,0,0,0,0,0,3.623
+Fall 2022,GEOL,6337,1,24113,Atmospheric Physics,Jiang,Xun,20,0,0,0,0,0,0,3.951
+Fall 2022,GEOL,4347,1,24114,Atmospheric Biogeochemistry,Wang,Yuxuan,9,6,1,0,0,0,0,3.397
+Fall 2022,GEOL,6370,1,24115,Atmospheric Biogeochemistry,Wang,Yuxuan,19,1,0,0,0,0,0,3.835
+Fall 2022,IART,3395,1,24129,Sel Topics in Interdis Arts,Meza,Abinadi,1,0,0,0,1,0,0,2.0
+Fall 2022,BIOE,4308,1,24139,Neural Eng. Methods & Apps,Romero Ortega,Mario Ignacio,6,4,2,0,1,0,0,3.077
+Fall 2022,BIOE,6308,1,24140,Neural Eng. Methods & Apps,Romero Ortega,Mario Ignacio,7,2,1,0,0,0,0,3.468
+Fall 2022,ARTH,6394,1,24141,Sel Top in Art History,Decker,Arden,8,1,0,0,0,0,0,3.852
+Fall 2022,ACCT,3367,4,24146,Intermediate Accounting I,Noland,Thomas R,19,19,15,11,0,0,4,2.755
+Fall 2022,ACCT,3367,5,24147,Intermediate Accounting I,Kilic,Emre,5,13,30,4,0,0,12,2.505
+Fall 2022,ACCT,3368,4,24151,Intermediate Accounting II,Muslu,Volkan,7,24,19,0,1,0,3,2.654
+Fall 2022,ACCT,7379,1,24152,Current Issues in Taxation,Evetts,Nancy Zalmanek,27,3,0,0,0,0,0,3.9
+Fall 2022,ACCT,7382,1,24153,"Governance, Risk & Compliance",Brant Jr.,Robert Edward,10,4,0,0,0,0,0,3.761
+Fall 2022,ACCT,7384,1,24155,Enterprise Risk Management,Neely,Gregory Wayne,13,1,0,0,0,0,0,3.952
+Fall 2022,ACCT,7320,1,24170,Intro to Data Analytics-Acct,Erdem,Ozer,41,3,1,0,0,0,0,3.852
+Fall 2022,ACCT,4335,6,24173,Financial Statement Auditing,Zhao,Yuping,16,23,6,0,0,0,0,3.2
+Fall 2022,ACCT,5301,1,24174,Financial and Managerial Acct,Kuruvilla,Mohan,1,6,2,0,0,0,5,2.999
+Fall 2022,INDS,6397,1,24178,Selected Topics,Kang,Chul Min,2,0,0,0,0,0,0,3.835
+Fall 2022,INDS,6397,2,24179,Selected Topics,Chow,George K,0,2,0,0,0,0,0,3.33
+Fall 2022,BIOL,3340,1,24190,Invertebrate Zoology,Pennings,Steven C,8,6,9,3,6,0,2,2.198
+Fall 2022,PHIL,3395,1,24192,Selected Topics in Phil,Zaretsky,Robert D,6,0,3,0,1,0,2,2.901
+Fall 2022,BCHS,6226,1,24233,Enzyme Catalysis and Kinetics,Wang,Yuhong,16,0,0,0,0,0,0,4.0
+Fall 2022,BZAN,7397,1,24267,Sel Topics in Busn Analytics,Aron,Ravi,34,0,0,0,0,0,0,3.99
+Fall 2022,BZAN,7397,2,24269,Sel Topics in Busn Analytics,Aron,Ravi,6,1,0,0,0,0,0,3.763
+Fall 2022,ELED,4311,1,24272,Science in Elementary School I,Thompson,Amber M,23,1,1,0,0,0,1,3.88
+Fall 2022,ELED,4311,5,24273,Science in Elementary School I,Wong,Sissy S,13,8,1,0,0,0,0,3.515
+Fall 2022,ELED,4311,2,24274,Science in Elementary School I,Khalidi,Rana,22,3,0,0,0,0,0,3.827
+Fall 2022,ELED,4311,3,24275,Science in Elementary School I,Bailer,Jill,25,1,0,0,0,0,0,3.923
+Fall 2022,ELED,4311,4,24276,Science in Elementary School I,Khalidi,Rana,19,5,0,0,0,0,0,3.75
+Fall 2022,BIOL,1197,1,24283,Selected Topics in Biology,Ogletree-Hughes,Monique L,27,4,4,6,6,0,1,2.83
+Fall 2022,BIOL,1197,2,24284,Selected Topics in Biology,Ogletree-Hughes,Monique L,13,3,2,2,3,0,1,2.884
+Fall 2022,PHIL,3333,1,24291,Metaphysics,Loewenstein,Yael R,13,7,8,3,2,0,0,2.758
+Fall 2022,PHIL,6395,1,24292,Seminar Philos Problems,Oliveira,Luis RG,13,0,0,0,0,0,0,3.67
+Fall 2022,PHIL,6395,2,24293,Seminar Philos Problems,Weisberg,Joshua,8,0,0,0,0,0,0,3.959
+Fall 2022,MATH,5333,1,24321,Analysis,Etgen,Garret J,11,4,2,0,0,0,2,3.413
+Fall 2022,MATH,6322,1,24322,Func Complex Variable,Ji,Shanyu,12,5,1,2,0,0,0,3.334
+Fall 2022,MATH,6324,1,24323,Differential Equations,Nicol,Matthew J.,6,4,0,0,3,0,0,2.744
+Fall 2022,MATH,6397,1,24324,Selected Topics in Math,Jun,Mikyoung,1,1,0,0,0,0,0,3.5
+Fall 2022,MATH,6397,2,24325,Selected Topics in Math,Jun,Mikyoung,3,0,0,0,0,0,0,3.89
+Fall 2022,MATH,7320,1,24328,Functional Analysis,Bodmann,Bernhard G,12,3,0,0,0,0,0,3.778
+Fall 2022,MATH,5344,1,24330,Intro to Scientific Computing,Morgan,Jeffrey,3,2,0,0,1,0,0,3.0
+Fall 2022,MATH,5310,1,24331,History of Mathematics,Ji,Shanyu,11,2,0,0,2,0,0,3.289
+Fall 2022,MATH,4397,1,24332,Selected Topics in Math,Gao,Li,1,0,0,0,1,0,0,2.0
+Fall 2022,MATH,6397,5,24333,Selected Topics in Math,Gao,Li,9,0,0,0,0,0,0,3.963
+Fall 2022,ARTS,3304,3,24335,Intermediate Painting,Huynh,Loc,10,9,0,1,0,0,0,3.318
+Fall 2022,PHYS,7350,1,24336,Advanced Computational Physics,Bassler,Kevin E,8,1,0,0,0,0,0,3.889
+Fall 2022,COMD,3321,1,24355,Multicultural Consid -- COMD,Townsend,Alayna,20,2,0,0,0,0,0,3.909
+Fall 2022,COMD,3371,1,24356,Speech Devel & Dis in Children,Schaff,Carrie Allyson,10,5,2,0,1,0,0,3.259
+Fall 2022,COMD,3385,1,24357,Speech Science,Bunta,Ferenc,3,6,3,1,3,0,0,2.333
+Fall 2022,ARTS,4397,1,24361,Sel Topics in Fine Arts,Huynh,Loc,10,4,0,0,0,0,0,3.644
+Fall 2022,ARTS,6397,1,24362,Sel Topics/Studio Arts,Huynh,Loc,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,3304,50,24368,General Biochemistry I,Yeo,Hye-Jeong,5,12,5,0,1,0,0,2.798
+Fall 2022,IDNS,2197,1,24369,Top-Natrl Sci & Mth,Pattison,Donna,26,5,0,0,0,0,0,3.817
+Fall 2022,ENTR,3310,6,24370,Entrepreneurship,Boles,James Read,15,7,0,0,0,0,1,3.577
+Fall 2022,IDNS,2197,2,24371,Top-Natrl Sci & Mth,Pattison,Donna,17,5,2,3,0,0,1,3.309
+Fall 2022,BIOL,3311,2,24372,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,68,34,15,5,7,0,2,3.163
+Fall 2022,ENTR,4330,1,24377,Entrepreneurial Costs/Budgets,Becker,Charles D,13,9,3,2,1,0,0,3.06
+Fall 2022,MARK,7397,2,24390,Selected Topics in Marketing,Franco,Rodi L,5,5,4,0,0,0,0,3.119
+Fall 2022,ARTS,2311,3,24394,"Color, Materials and Methods",Williams,Ian Harrison,18,3,0,0,0,0,1,3.857
+Fall 2022,ARTS,3330,3,24396,Intermediate Graphic Design,Jamaluddin,Mohd Ikhram,9,6,3,0,1,0,4,3.019
+Fall 2022,GEOL,1103,15,24401,Physical Geology Lab,Hauptvogel,Daniel William,16,3,1,0,0,0,0,3.701
+Fall 2022,GEOL,1103,16,24402,Physical Geology Lab,Hauptvogel,Daniel William,15,1,3,0,0,0,1,3.632
+Fall 2022,IDNS,2197,3,24404,Top-Natrl Sci & Mth,Stokes,Donna,4,2,1,0,0,0,1,3.334
+Fall 2022,ARCH,3311,1,24405,Topics in Design History,Kacmar,Donna,9,5,2,0,0,0,0,3.376
+Fall 2022,AAS,2320,6,24409,Intro To African American Stdy,Raynor,Autumn Fawn,26,3,1,1,2,0,2,3.495
+Fall 2022,COMM,6345,1,24410,Health Campaigns,Xiao,Zhiwen,6,0,0,0,0,0,0,4.0
+Fall 2022,COMM,7397,1,24411,Selected Topics - Comm,Olson,Beth M,24,0,0,0,0,0,0,3.931
+Fall 2022,COMM,7397,2,24413,Selected Topics - Comm,Choi,Ho Joon,18,0,0,0,0,0,0,3.982
+Fall 2022,AAS,2330,1,24414,Black Liberation Theology,Mitchell,Joshua,16,5,3,1,3,0,1,3.036
+Fall 2022,ACCT,5372,1,24416,Intro-Data Analytics in ACCT,Erdem,Ozer,0,1,2,0,0,0,0,2.553
+Fall 2022,IART,3395,2,24417,Sel Topics in Interdis Arts,Reed,John G,2,0,0,0,1,0,0,2.557
+Fall 2022,ARCH,4510,9,24418,Integrated Arch Solutions,Hager,Jesse,14,3,0,0,0,0,0,3.785
+Fall 2022,MATH,4350,1,24420,Differential Geometry I,Ru,Min,7,3,3,2,3,0,2,2.5
+Fall 2022,ARTS,6397,4,24424,Sel Topics/Studio Arts,Meza,Abinadi,2,0,0,0,0,0,0,4.0
+Fall 2022,IART,3395,3,24425,Sel Topics in Interdis Arts,Meza,Abinadi,4,0,0,0,0,0,1,4.0
+Fall 2022,ARCH,5500,13,24426,Architecture Design Studio IX,Woodfill,Celeste Ponce,6,0,0,0,0,0,0,3.89
+Fall 2022,ARTS,6394,1,24432,Sel Tops in Contemporary Art,Reed,John G,1,1,0,1,0,0,0,2.557
+Fall 2022,ARTS,4397,2,24437,Sel Topics in Fine Arts,Lowe,Rick,7,0,0,0,0,0,0,3.953
+Fall 2022,ARTS,6397,5,24438,Sel Topics/Studio Arts,Lowe,Rick,1,1,0,0,0,0,0,3.5
+Fall 2022,IART,3395,4,24439,Sel Topics in Interdis Arts,Lowe,Rick,2,1,0,0,0,0,0,3.667
+Fall 2022,PHIL,6396,1,24446,Seminar in Hist of Phil,Hattab,Helen,10,2,0,0,0,0,0,3.641
+Fall 2022,LAW,5390,2,24448,Environmental Law,Hester,Tracy,17,17,3,0,0,3,0,3.387
+Fall 2022,ARTS,6396,1,24449,Sel Topics in Fine Arts Media,Giampietro,Francis A,4,0,0,0,0,0,0,4.0
+Fall 2022,PHIL,3334,1,24450,Philosophy of Mind,Garson,James W,5,4,6,4,0,0,4,2.509
+Fall 2022,PHIL,3332,1,24451,Philosophy of Language,Buckner,Cameron J,11,11,6,2,1,0,6,2.893
+Fall 2022,LAW,6326,1,24452,Diplomacy for Oil and Gas,Cardenas Garcia,Julian Jose,7,11,0,0,0,0,0,3.462
+Fall 2022,LAW,7305,1,24453,WRS: Hot Topic Crim Law & Proc,Thompson,Sandra Guerra,3,3,0,0,0,0,0,3.39
+Fall 2022,LAW,6357,1,24454,Children's Rights,Marrus,Ellen,3,12,0,0,0,0,1,3.398
+Fall 2022,LAW,6396,1,24455,Genetics and the Law,Roberts,Jessica,16,15,1,0,0,8,0,3.376
+Fall 2022,LAW,7304,1,24456,WRS: Bioethics,Koch,Valerie Gutmann,6,5,1,0,0,0,0,3.389
+Fall 2022,LAW,5297,2,24457,Selected Topics,LaPar,Kelly,4,10,1,0,0,0,1,3.2
+Fall 2022,LAW,5397,2,24458,Selected Topics,Alonso,Yocel,0,2,0,0,0,0,0,3.33
+Fall 2022,LAW,5497,1,24459,Selected Topics,Marquez,Jason R,0,2,0,0,0,0,0,3.33
+Fall 2022,LAW,5497,2,24460,Selected Topics,Marquez,Jason R,1,0,0,0,0,0,0,3.67
+Fall 2022,LAW,5397,1,24461,Selected Topics,Marquez,Jason R,0,2,0,0,0,0,0,3.33
+Fall 2022,LAW,5397,3,24462,Selected Topics,Marquez,Jason R,0,1,0,0,0,0,0,3.33
+Fall 2022,KIN,4370,11,24464,Exercise Testing,Markofski,Melissa,7,8,22,0,0,0,0,2.532
+Fall 2022,LAW,5397,4,24466,Selected Topics,Siegel,Martin Jonathan,2,1,0,0,0,0,0,3.447
+Fall 2022,LAW,5391,1,24468,Immigration and Family Law,Heppard,Janet M,6,9,1,0,0,0,1,3.333
+Fall 2022,BIOL,4397,2,24469,Selected Topics in Biology,Frankino,William A,1,0,0,0,0,0,0,4.0
+Fall 2022,AAS,3394,1,24470,Selected Topics Afr Am Stdy,Shinault,Carley Michelle,3,6,0,0,0,0,0,3.15
+Fall 2022,COMM,3369,5,24471,Strategic Comm. Writing,Belton,Stephanie,16,1,1,0,1,0,0,3.597
+Fall 2022,COMM,3374,2,24472,Strategic Social Media,Williams,Alexandria Simone,16,9,1,1,1,0,1,3.345
+Fall 2022,COMM,4355,1,24473,Organizational Comm,Liu,Wenlin,19,8,1,0,2,0,0,3.345
+Fall 2022,IDNS,1132,3,24474,Calculus II SEP Workshop,Pattison,Donna,6,3,1,2,0,0,3,3.193
+Fall 2022,COMM,4357,1,24475,Intercultural Communication,Vaughn,Ginger Koto,12,4,0,0,0,0,1,3.709
+Fall 2022,ARTS,3350,1,24479,Intermediate Ceramics,Mayer,Anna W,15,0,0,0,0,0,1,3.89
+Fall 2022,SPEC,8395,2,24481,Doctoral Thesis,Hawkins,Jacqueline McLean,5,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,8695,1,24482,Doctoral Thesis,Santi,Kristi L,5,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,8695,2,24483,Doctoral Thesis,Hawkins,Jacqueline McLean,6,0,0,0,0,1,0,4.0
+Fall 2022,ARTS,3396,1,24485,Selected Tops Studio Practice,Giampietro,Francis A,8,1,0,0,0,0,0,3.816
+Fall 2022,ARTS,6396,2,24486,Sel Topics in Fine Arts Media,Giampietro,Francis A,4,0,0,0,0,0,0,4.0
+Fall 2022,SCLT,4386,30,24487,Project Logistics,Poisler,Marco A,13,0,0,0,2,0,2,3.467
+Fall 2022,COMM,3315,2,24490,News and Social Media,Trigg,Katishia Leonna,11,8,0,1,0,0,0,3.467
+Fall 2022,COMM,4302,1,24491,Latinx Media Studies,Baruch Blanco,Maria Felicitas,9,1,1,0,1,0,0,3.389
+Fall 2022,COMM,4372,1,24492,"Media, Power, and Society",Harlow,Summer D,8,5,4,1,0,0,0,3.074
+Fall 2022,COMM,4397,2,24494,Selected Topics Communication,Trupiano,Jerome,19,0,0,0,0,0,1,4.0
+Fall 2022,GOVT,2306,5,24495,US and Texas Const/Politics,Davis,Sharon M,49,67,56,28,29,0,18,2.316
+Fall 2022,ACCT,4105,2,24499,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,49,3,
+Fall 2022,GOVT,2305,16,24500,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,21,78,62,21,35,0,24,2.14
+Fall 2022,POLS,3354,1,24501,Law and Society,Tiede,Lydia B,7,22,7,3,0,0,3,2.855
+Fall 2022,ACCT,4106,2,24502,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,40,0,
+Fall 2022,SCLT,6316,2,24503,Global Supply Chain Logistics,Wang,Kailai,18,0,0,0,0,0,0,3.927
+Fall 2022,CHEE,5397,1,24505,Selected Topics,Rojas,Mario Roberto,7,2,1,0,0,0,0,3.633
+Fall 2022,CHEE,6397,1,24506,Selected Topics,Rojas,Mario Roberto,4,0,0,0,0,0,0,4.0
+Fall 2022,HON,3397,6,24509,Honors Selected Topics,Rayder,Benjamin Taylor,4,1,0,0,0,0,0,3.8
+Fall 2022,BIOL,3301,50,24510,Mendelian and Pop Genetics,Newman,Anna P,15,9,2,0,0,0,0,3.475
+Fall 2022,BIOL,3301,51,24511,Mendelian and Pop Genetics,Newman,Anna P,12,6,4,0,0,0,2,3.319
+Fall 2022,GEOL,6397,4,24513,Selected Topics in Geology,Stewart,Robert R,5,3,0,0,0,0,1,3.543
+Fall 2022,MANA,7339,2,24523,Leadership Development,Atwater,Leanne E,26,3,1,0,0,0,0,3.833
+Fall 2022,MUSI,1116,2,24524,Aural Skills I,Lee,Ji Yeon,7,8,2,0,0,0,0,3.333
+Fall 2022,NUTR,3330,2,24525,Mgmt in Food & Nutr Systems,Haubrick,Kevin,5,13,7,0,0,0,1,2.828
+Fall 2022,NUTR,4352,1,24526,Child and Adolescent Nutrition,Vollrath,Kirstin,22,23,17,6,1,0,1,2.807
+Fall 2022,ARCH,3311,2,24527,Topics in Design History,Binboga,Secil,14,0,0,0,0,0,0,3.976
+Fall 2022,HIST,1301,15,24540,The U.S. to 1877,Johnson,Michele R,160,78,46,20,38,0,13,2.894
+Fall 2022,HIST,1301,28,24553,The U.S. to 1877,Johnson,Michele R,152,97,44,21,31,0,11,2.915
+Fall 2022,HIST,1301,41,24567,The U.S. to 1877,McDonald,Eric John,133,102,9,8,9,0,5,3.256
+Fall 2022,HIST,1301,42,24568,The U.S. to 1877,McDonald,Eric John,106,90,33,8,28,0,5,2.838
+Fall 2022,ELCS,6338,1,24569,American Higher Education,McKinney,Lonnie Lyle,18,2,0,0,0,0,0,3.9
+Fall 2022,ELCS,6338,2,24570,American Higher Education,Carales,Vincent D,18,1,1,0,0,0,0,3.735
+Fall 2022,ELCS,6370,1,24572,Research for Educatnal Leaders,Davis,Tiffany J,16,1,0,0,0,0,0,3.941
+Fall 2022,ELCS,6370,2,24573,Research for Educatnal Leaders,Templeton,Toni,18,0,0,0,0,0,0,3.945
+Fall 2022,ELCS,7330,1,24574,Admin of Higher Educ I,Turnquest,Krysti Nicole,15,4,0,0,0,0,0,3.789
+Fall 2022,MUSI,1181,4,24575,Group Piano I,Van Kekerix,Todd Evan,5,7,1,0,1,0,0,3.024
+Fall 2022,ELCS,7371,1,24576,Higher Educ Law,Longacre,Teri,19,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,1181,5,24577,Group Piano I,Van Kekerix,Todd Evan,2,2,1,0,1,0,0,2.667
+Fall 2022,HIST,1302,1,24578,The U.S. Since 1877,Buzzanco,Robert,247,13,3,1,1,0,1,3.893
+Fall 2022,HIST,1302,2,24579,The U.S. Since 1877,Buzzanco,Robert,229,18,2,4,6,0,6,3.751
+Fall 2022,HIST,1302,3,24580,The U.S. Since 1877,Deyle,Steven H,45,36,21,9,13,0,7,2.678
+Fall 2022,ELCS,8397,1,24581,Sem Top Ed Ldshp&Cul St,Messa,Emily Alice,15,0,0,0,0,0,0,4.0
+Fall 2022,HIST,1302,4,24582,The U.S. Since 1877,Amaral,Lindsay,102,74,36,15,28,0,10,2.776
+Fall 2022,HIST,1302,5,24583,The U.S. Since 1877,Wilson,Ezell Lamont,187,42,13,3,9,0,4,3.517
+Fall 2022,HIST,1302,6,24584,The U.S. Since 1877,Contreras,Ramiro,185,33,15,9,21,0,5,3.307
+Fall 2022,SAER,8320,1,24585,Ethnog Mthds Educ,Louis,Dave A,13,0,0,0,0,0,0,4.0
+Fall 2022,HIST,2303,1,24586,Historians Craft,Hernandez,Jose A.,26,7,0,0,0,0,1,3.728
+Fall 2022,LAW,5397,5,24588,Selected Topics,Brown,Charles D,11,17,0,0,0,10,0,3.428
+Fall 2022,POLS,3313,4,24590,Intro Internatl Relatns,Kharmats,Polina G,26,0,0,0,1,0,3,3.852
+Fall 2022,LAW,5497,3,24591,Selected Topics,Krasny,Frederick A,2,11,0,0,0,0,0,3.382
+Fall 2022,LAW,5297,3,24592,Selected Topics,Marquez,Ryan Michael,1,0,0,0,0,0,0,3.67
+Fall 2022,LAW,5497,4,24593,Selected Topics,Marquez,Ryan Michael,1,0,0,0,0,0,0,3.67
+Fall 2022,MUSI,1311,2,24594,Music Theory I,Lee,Ji Yeon,10,7,0,0,0,0,0,3.569
+Fall 2022,POLS,3319,1,24596,Politics of Social Policy,Shor,Boris,4,15,3,3,0,0,4,2.8
+Fall 2022,POLS,3360,1,24597,Politics & Mass Media,Archer,Allison Michelle Nam,19,15,3,0,1,0,0,3.255
+Fall 2022,LAW,7397,1,24598,Selected Topics,Morales,Daniel I,5,7,0,0,0,0,0,3.362
+Fall 2022,POLS,3393,1,24599,Model United Nations,Kennedy,Ryan P,9,4,1,0,0,0,1,3.501
+Fall 2022,POLS,3344,1,24600,Inter'l Law & Law of War,Jackson,Jerald W,20,15,6,1,0,0,3,3.199
+Fall 2022,POLS,3367,1,24601,Campaings and Elections,Marcinek,Elizabeth Nicole Simas,29,10,2,1,2,0,1,3.357
+Fall 2022,POLS,3387,1,24602,Politics of the Qur'an,Contractor,Cyrus Ali,16,14,0,1,0,0,0,3.473
+Fall 2022,POLS,3389,1,24603,European Union Politics,Littlepage,Kelley G,1,12,4,0,0,0,0,2.882
+Fall 2022,POLS,3356,1,24604,Intro-Constitutionl Law,Abbott Jr,Kenneth Wayne,28,7,3,0,0,0,0,3.554
+Fall 2022,POLS,3392,1,24605,Nuclear Weapons and Security,Zwald,Zachary J,10,8,4,2,0,0,0,3.042
+Fall 2022,ARCH,5508,1,24606,Design Studio Hist Struc/Sites,Zweig,Peter J,2,1,1,0,0,0,1,3.25
+Fall 2022,ARCH,5508,3,24608,Design Studio Hist Struc/Sites,Brune,Geoffrey,6,8,0,0,0,0,0,3.405
+Fall 2022,ARCH,5508,5,24610,Design Studio Hist Struc/Sites,Race,Bruce Alan,6,10,1,0,0,0,0,3.314
+Fall 2022,POLS,3336,1,24612,Globalization,Vardy,Ronald V,32,6,3,1,0,0,4,3.572
+Fall 2022,POLS,6363,1,24617,Race and Ethnic Politics,Raychaudhuri,Tanika,11,1,0,0,0,0,0,3.834
+Fall 2022,POLS,6396,1,24618,Selected Topics in Compar IR,Jung,Jae Hee,5,1,0,0,0,0,0,3.833
+Fall 2022,POLS,6332,1,24619,Formal Models in Int'l Rel,Chatagnier,John Tyson,3,3,0,0,0,0,0,3.61
+Fall 2022,POLS,6311,1,24620,Comp Pol Analysis,Aleman,Eduardo,12,3,0,0,0,0,0,3.69
+Fall 2022,POLS,6390,1,24621,Experimental Design,Clifford,Scott,9,2,0,0,0,0,0,3.818
+Fall 2022,POLS,6394,1,24622,Selected Topics in Methods,Church,Jeffrey,8,0,0,0,0,0,0,4.0
+Fall 2022,POLS,6368,1,24623,Political Psychology,Clifford,Scott,0,0,0,0,0,0,0,
+Fall 2022,GHL,2382,1,24626,Introductn To Club Management,Bendy Jr,Cecil J,5,1,4,0,1,0,1,2.818
+Fall 2022,GHL,3197,1,24627,Selected Topics in Hospitality,Legendre,Jungyoung Shin,6,0,0,0,0,0,0,4.0
+Fall 2022,GHL,3197,2,24628,Selected Topics in Hospitality,Haskell,Rebecca Erin,14,4,1,1,2,0,0,3.197
+Fall 2022,GHL,3197,3,24629,Selected Topics in Hospitality,Cheatham,Cathy A,7,2,1,0,2,0,0,2.918
+Fall 2022,GHL,3153,1,24630,Htl Mrktng New York Style,Boger Jr,Carl A,15,0,0,0,0,0,0,4.0
+Fall 2022,COMM,3313,1,24631,Data-Driven Storytelling,Camaj,Lindita,10,7,4,1,0,0,1,3.152
+Fall 2022,GHL,3349,2,24632,Hosp Procurement & Purchasing,Jarvis,Nathan Alexander,17,6,3,5,4,0,2,2.753
+Fall 2022,GHL,4197,1,24633,Sel Tops Hosptlty Mgmnt,Haskell,Rebecca Erin,15,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,6397,17,24634,Sel Tpcs-Arc/Urbn Desgn,Kacmar,Donna,0,1,0,0,0,0,0,3.33
+Fall 2022,GENB,7397,1,24635,Selected Topics,Webb,James R,14,0,0,0,0,0,0,3.953
+Fall 2022,GHL,4397,1,24637,Selected Topics Hosp Mgt,Boger Jr,Carl A,3,0,0,0,0,0,0,4.0
+Fall 2022,GHL,4397,2,24638,Selected Topics Hosp Mgt,Doudna,Simone P,5,9,1,0,1,0,1,3.042
+Fall 2022,GOVT,2306,18,24639,US and Texas Const/Politics,Sisman,Ozlem,74,81,20,12,12,0,8,2.937
+Fall 2022,GOVT,2306,19,24640,US and Texas Const/Politics,Sisman,Ozlem,46,83,30,19,21,0,8,2.563
+Fall 2022,MUSI,4197,1,24642,Selected Topics in Music,Suits,Brian J,5,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6197,1,24643,Selected Topics,Legendre,Jungyoung Shin,1,0,0,0,0,0,0,4.0
+Fall 2022,PHIL,3354,1,24644,Medical Ethics,Sater,Amy,3,1,0,0,1,0,1,3.0
+Fall 2022,GENB,7397,2,24645,Selected Topics,Wilbur,Stephen,9,0,0,0,0,0,0,3.78
+Fall 2022,HLT,4397,1,24646,Selected Topics in Health,Carmack,Chakema,18,0,0,0,1,0,0,3.789
+Fall 2022,LAW,6232,1,24647,HIPAA,Ewer,Michael S,12,14,0,0,0,0,0,3.411
+Fall 2022,ACCT,3366,7,24648,Financial Reporting Frameworks,Parthasarathy,Kiran M,36,15,25,14,10,0,8,2.566
+Fall 2022,CHEE,8298,20,24651,Doctoral Research,Zerze,Gul,0,0,0,0,0,3,0,
+Fall 2022,GHL,6381,1,24654,Strategic Decisions in Hosp.,DeFranco,Agnes L,13,0,0,0,0,0,0,3.924
+Fall 2022,GHL,6397,1,24655,Selected Topics,Doudna,Simone P,7,1,3,1,0,0,0,3.029
+Fall 2022,GHL,6397,2,24656,Selected Topics,Boger Jr,Carl A,13,0,0,0,0,0,0,4.0
+Fall 2022,GHL,7369,1,24657,Hospitality Financial Assets,Koh,Yoon,21,4,0,0,0,0,1,3.787
+Fall 2022,GHL,8188,1,24658,Ph.D. Colloquium,Back,KiJoon,0,0,0,0,0,3,0,
+Fall 2022,GHL,6197,4,24662,Selected Topics,Haskell,Rebecca Erin,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6197,5,24663,Selected Topics,Padilla,Magdalena Manzano,8,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,8398,20,24664,Doctoral Research,Zerze,Gul,0,0,0,0,0,1,0,
+Fall 2022,PSYC,2306,2,24670,Psychology of Human Sexuality,Browne,Lindsay J,13,10,4,1,2,0,2,3.132
+Fall 2022,CHEE,8399,20,24671,Doctoral Dissertation,Zerze,Gul,0,0,0,0,0,1,0,
+Fall 2022,PSYC,2306,3,24672,Psychology of Human Sexuality,Browne,Lindsay J,17,7,0,3,2,0,1,3.07
+Fall 2022,PHLS,8350,1,24675,Educational Psychology,Master,Allison,1,0,0,0,0,0,0,4.0
+Fall 2022,HDFS,4397,1,24676,Selected Topics in Hdfs,Master,Allison,4,0,1,0,0,0,0,3.6
+Fall 2022,ENGL,7322,1,24677,Advncd Poetry Workshop,Prufer,Kevin D,8,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7337,1,24678,Second Lang Acquisition,Duran,Chatwara,6,1,0,0,0,0,0,3.857
+Fall 2022,ENGL,7368,1,24679,CSA Theories and Methods,Berger,Jason,14,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7396,1,24681,Topics in Language & Literatre,Ellis,Amanda,7,2,0,0,0,0,0,3.814
+Fall 2022,ENGL,7396,2,24682,Topics in Language & Literatre,Stock,Lorraine K,5,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8318,1,24683,Research in Rhet & Comp,Butler,Paul G,7,0,0,0,0,0,0,3.953
+Fall 2022,ENGL,8354,1,24684,18th-C British Fiction,Womble,David Avari Patrick,11,1,0,0,0,0,0,3.917
+Fall 2022,ENGL,8394,1,24685,Sel Topics-Compar Lit,Singh,Kavita Ashana,4,0,0,0,0,0,1,4.0
+Fall 2022,PSYC,2308,4,24686,Child Development,Trent,Erika S,19,10,5,1,1,0,3,3.204
+Fall 2022,PSYC,2308,5,24687,Child Development,Trent,Erika S,25,12,4,0,0,0,0,3.512
+Fall 2022,ITEC,1301,2,24688,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,12,16,7,3,7,0,4,2.474
+Fall 2022,ITEC,1301,3,24689,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,2,5,7,5,7,0,6,1.577
+Fall 2022,PHLS,7302,1,24690,Internship I,Zatopek,Audrey,0,0,0,0,0,8,0,
+Fall 2022,PHLS,7302,2,24691,Internship I,Smedley,Diane Renee,0,0,0,0,0,7,0,
+Fall 2022,PHLS,7302,3,24692,Internship I,Smedley,Diane Renee,0,0,0,0,0,8,0,
+Fall 2022,PHLS,7302,4,24693,Internship I,Hurt,Kara Marie,0,0,0,0,0,8,0,
+Fall 2022,ELCS,8310,2,24695,The Superintendency,Klussmann,Duncan Foster,5,0,0,0,0,0,0,4.0
+Fall 2022,LAW,5306,1,24696,Criminal Litigation & Issues,Lowery,Jennifer,2,8,0,0,0,2,0,3.233
+Fall 2022,ELCS,7392,2,24697,Internship in Superintendent,Martinez,Roberto,8,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,6301,4,24699,Leadership for Equity,Johnson PhD,Detra DeVerne,14,0,0,0,0,0,1,4.0
+Fall 2022,ELCS,6302,4,24700,Decision Making School Ldrs,Cantu,Faviola,12,0,0,0,0,0,0,3.945
+Fall 2022,RELS,2350,2,24705,Introduction to Islam,Yavuz,Matthew Sean,34,0,0,0,0,0,0,3.961
+Fall 2022,RELS,1301,3,24706,Intro To Religious Studies,Langton,Karen J,39,4,2,0,0,0,3,3.822
+Fall 2022,RELS,2330,1,24707,Judaism,Weiss,Kenneth Scott,4,4,2,3,0,0,0,2.743
+Fall 2022,RELS,3325,1,24708,Paul of Tarsus,Eberhart,Christian,8,4,0,0,0,0,2,3.667
+Fall 2022,RELS,3330,1,24709,Christianity,Pegoda,Andrew Joseph,10,12,5,0,2,0,7,3.022
+Fall 2022,RELS,2380,1,24710,Religion and Film,Mummert,Claire Elizabeth,9,1,0,0,1,0,0,3.575
+Fall 2022,RELS,3355,1,24712,Yoga and Philosophy,Ullrey,Aaron Michael,5,3,0,0,0,0,2,3.46
+Fall 2022,RELS,3360,1,24713,Muslim-Christian Relations,Haq,Muhammad Nisarul,18,5,5,3,2,0,1,2.93
+Fall 2022,RELS,3396,1,24714,Sel Topics Religious Studies,Clark,Laura B,12,1,0,1,0,0,1,3.596
+Fall 2022,RELS,3396,2,24715,Sel Topics Religious Studies,Huynh,Trung,4,1,1,1,0,0,0,3.096
+Fall 2022,RELS,3396,3,24716,Sel Topics Religious Studies,Allen,Paul J,23,1,0,0,0,0,0,3.931
+Fall 2022,ANTH,3396,2,24717,Selected Tops in Cultural Anth,Majumder,Sarasij,7,8,0,0,0,0,0,3.357
+Fall 2022,ANTH,3396,3,24718,Selected Tops in Cultural Anth,Higgs,Elizabeth Wayne,12,4,0,0,2,0,0,3.223
+Fall 2022,ANTH,2304,1,24719,Intro To Language and Culture,Rasmussen,Susan J,13,20,4,1,0,0,1,3.106
+Fall 2022,ANTH,4394,1,24720,Selected Topics in Ant,De Genova,Nicholas Paul,7,0,0,0,0,0,0,3.906
+Fall 2022,ANTH,4394,2,24721,Selected Topics in Ant,Rasmussen,Susan J,3,2,2,0,0,0,2,3.001
+Fall 2022,ANTH,4373,1,24722,Aztec Archaeology,Brown,Kenneth L,12,22,8,0,2,0,2,2.947
+Fall 2022,ANTH,4351,1,24723,Human Osteology,Bytheway,Joan A,3,8,4,2,15,0,3,1.417
+Fall 2022,ANTH,6311,1,24724,Issues/Debates Cultural Theory,De Genova,Nicholas Paul,5,0,0,0,0,0,1,3.802
+Fall 2022,ANTH,6319,1,24725,"African Myth, Cosmlgy & Symbol",Rasmussen,Susan J,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2330,5,24727,Biological Psychology,Leonard,Samuel J,20,15,4,0,1,0,0,3.408
+Fall 2022,PSYC,3310,5,24728,Indstrl-Orgnztnl Psy,Van Egdom,Drake Alexander,42,10,3,2,1,0,1,3.58
+Fall 2022,PSYC,3331,2,24731,Psychology of Gender,Kehoe,Caitlin,27,25,20,3,4,0,1,2.936
+Fall 2022,ELCS,8371,1,24732,Legal Issues Sch District Levl,Goree,Tonya,8,0,0,0,0,0,0,3.918
+Fall 2022,ELCS,8350,1,24733,Resource Management,Stallworth,Lance,8,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,2301,6,24734,Introduction to Psychology,Thompson,Jennifer L,52,12,11,5,2,0,0,3.236
+Fall 2022,PSYC,2301,7,24735,Introduction to Psychology,Wu,Dongjie,52,15,7,3,5,0,3,3.256
+Fall 2022,NUTR,6314,1,24736,Gender & Culture Issin Phy Act,Alastuey,Lisa L,10,0,0,0,0,0,0,3.967
+Fall 2022,PEP,6397,1,24738,Selected Topics in Human Perf,Walsh,David W,4,2,1,0,0,0,0,3.381
+Fall 2022,PEP,7397,1,24739,Adv Selected Topic Human Perf,Markofski,Melissa,5,1,0,0,0,0,0,3.888
+Fall 2022,PEP,7397,2,24740,Adv Selected Topic Human Perf,Ogunrinde,Joyce,2,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7397,3,24741,Adv Selected Topic Human Perf,Gorniak,Stacey,5,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7397,4,24742,Adv Selected Topic Human Perf,Johnston,Craig Allen,10,1,0,0,0,0,0,3.879
+Fall 2022,PEP,7397,5,24743,Adv Selected Topic Human Perf,Yoon,Cynthia Yursun,1,4,2,0,0,0,0,2.857
+Fall 2022,PSYC,3339,5,24744,Intro To Clinical Psychology,Li,Xinge,37,37,2,0,4,0,1,3.308
+Fall 2022,PSYC,4397,4,24746,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,0,2,
+Fall 2022,LAW,5335,1,24747,Land Use,Zale,Kellen B,16,13,2,0,0,4,0,3.356
+Fall 2022,LAW,5346,1,24748,State & Local Government Law,Zale,Kellen B,7,8,0,0,0,2,0,3.401
+Fall 2022,ENGL,3318,1,24749,The British Novel Since 1832,Chatterjee,Sreya,21,9,0,0,0,0,0,3.755
+Fall 2022,ENGL,3380,1,24750,Modern Indian Literature,Majumder,Auritro,20,10,0,0,1,0,0,3.463
+Fall 2022,ENGL,4383,1,24751,Poetic Forms,Charara,Hayan S,12,6,0,0,1,0,0,3.404
+Fall 2022,ENGL,4373,1,24752,"Film, Text, and Politics",Mikics,David,10,11,3,0,1,0,3,3.134
+Fall 2022,ENGL,4387,1,24754,SR Writing Proj CW: Fiction,Krajniak,Matthew J,4,2,0,0,0,0,0,3.667
+Fall 2022,ENGL,4396,1,24755,SR Experience Seminar Topics,Stock,Lorraine K,6,10,0,0,0,0,4,3.375
+Fall 2022,COMM,1303,5,24756,Writing for Communicators,Uhrick,Jan,15,2,1,0,1,0,1,3.579
+Fall 2022,PHLS,6320,1,24757,Sexual Counseling,McCoy,Leah,10,0,0,0,0,0,0,3.934
+Fall 2022,COMM,4303,6,24758,Communication Law and Ethics,Kirkland,Steven Earl,42,0,0,0,0,0,0,3.992
+Fall 2022,ARCH,3112,1,24761,Topics in Design Media,Kudless,Andrew Justin,8,6,0,0,0,0,0,3.571
+Fall 2022,ENGL,1370,3,24762,Composition II-Honors,Cooper,Carol B,3,1,1,0,0,0,0,3.334
+Fall 2022,ENGL,1370,4,24763,Composition II-Honors,Cooper,Carol B,4,0,1,0,1,0,0,2.89
+Fall 2022,ENGL,1370,5,24764,Composition II-Honors,Cremins,Robert Paul,3,1,0,0,0,0,0,3.503
+Fall 2022,ENGL,1370,6,24765,Composition II-Honors,Cremins,Robert Paul,5,1,0,0,0,0,0,3.778
+Fall 2022,ENGL,1370,7,24766,Composition II-Honors,Garner,Richard A,3,3,0,0,0,0,0,3.5
+Fall 2022,ENGL,1370,8,24767,Composition II-Honors,Lyke,Larry,1,4,0,0,0,0,0,3.398
+Fall 2022,ENGL,1370,9,24768,Composition II-Honors,Morrison,Iain P D,1,7,0,0,0,0,0,3.249
+Fall 2022,ENGL,1370,10,24769,Composition II-Honors,Rayneard,Max James Anthony,3,4,1,0,1,0,0,2.889
+Fall 2022,ENGL,1370,11,24770,Composition II-Honors,Rayneard,Max James Anthony,5,2,1,0,0,0,0,3.335
+Fall 2022,ENGL,1370,12,24771,Composition II-Honors,Vollrath,Lesli A,2,3,1,0,0,0,0,3.167
+Fall 2022,ENGL,1370,13,24772,Composition II-Honors,Vollrath,Lesli A,3,0,1,0,0,0,0,3.253
+Fall 2022,ENGL,1370,17,24776,Composition II-Honors,Vassiliou,Constantine,5,3,0,0,1,0,0,3.259
+Fall 2022,ARCH,3112,3,24781,Topics in Design Media,Noldt,Peter,14,1,0,0,0,0,0,3.757
+Fall 2022,SOCW,7304,10,24784,Brief Targeted Interventions,Parks,Steven Lee,25,1,0,0,0,0,0,3.962
+Fall 2022,MECT,3345,1,24785,Fund Power Generation Tech,Bose,Anima B,9,15,0,0,0,0,1,3.43
+Fall 2022,BUSI,1301,6,24787,Business Principles,Carvalho,Diogo,141,47,30,7,16,0,9,3.147
+Fall 2022,MECT,6397,30,24788,Selected Topics,Rypien,David V,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1370,21,24793,Composition II-Honors,Bland,Laura Elizabeth,4,4,0,0,0,0,0,3.459
+Fall 2022,ENGL,1370,22,24794,Composition II-Honors,Bland,Laura Elizabeth,3,1,0,0,0,0,1,3.75
+Fall 2022,ENGL,1370,23,24795,Composition II-Honors,Charara,Hayan S,4,3,0,0,0,0,1,3.619
+Fall 2022,ENGL,1370,24,24796,Composition II-Honors,Charara,Hayan S,4,4,0,0,0,0,0,3.335
+Fall 2022,ENGL,1370,25,24797,Composition II-Honors,Gish,Dustin,2,5,0,0,0,0,0,3.38
+Fall 2022,ENGL,1370,26,24798,Composition II-Honors,Gish,Dustin,0,3,0,0,1,0,0,2.333
+Fall 2022,ENGL,1370,27,24799,Composition II-Honors,Hallmark,Terrell L,3,4,0,0,0,0,0,3.523
+Fall 2022,ENGL,1370,28,24800,Composition II-Honors,Rainbow,David,2,2,0,0,1,0,0,2.734
+Fall 2022,ENGL,1370,29,24801,Composition II-Honors,Rainbow,David,3,3,0,0,0,0,0,3.555
+Fall 2022,ENGL,1370,30,24802,Composition II-Honors,Rainbow,Jesse J.,1,6,0,0,0,0,0,3.331
+Fall 2022,ENGL,1370,31,24803,Composition II-Honors,Sisman,Cengiz,7,0,0,0,0,0,0,3.764
+Fall 2022,ENGL,1370,32,24804,Composition II-Honors,Sisman,Cengiz,3,4,0,0,0,0,0,3.476
+Fall 2022,ENGL,1370,33,24805,Composition II-Honors,Sommers,Tamler S,4,2,0,0,0,0,1,3.612
+Fall 2022,ENGL,1370,34,24806,Composition II-Honors,Trninic,Marina,2,0,0,0,0,0,0,3.835
+Fall 2022,ENGL,1370,35,24807,Composition II-Honors,Trninic,Marina,1,2,0,0,1,0,0,2.583
+Fall 2022,ENGL,1370,36,24808,Composition II-Honors,Dawson,Cindy,2,4,2,0,0,0,0,2.959
+Fall 2022,ENGL,1370,37,24809,Composition II-Honors,Hallmark,Terrell L,4,2,1,0,0,0,0,3.429
+Fall 2022,ENGL,1370,38,24810,Composition II-Honors,Dawson,Cindy,4,3,3,0,1,0,0,2.728
+Fall 2022,LAW,5397,7,24811,Selected Topics,Bregant,Jessica Lynn,6,12,0,0,0,0,0,3.37
+Fall 2022,LAW,5231,1,24814,Health Legislation & Advocacy,Smith,Erin F,5,5,0,0,0,2,0,3.401
+Fall 2022,CHEE,6377,1,24815,Intro To Polymer Science,Robertson,Megan L,17,2,0,0,0,0,1,3.791
+Fall 2022,ENGL,2360,3,24816,Western World Lit I--Honors,Cooper,Carol B,6,4,0,1,1,0,0,3.028
+Fall 2022,ENGL,2360,4,24817,Western World Lit I--Honors,Cooper,Carol B,7,5,0,0,0,0,0,3.556
+Fall 2022,ENGL,2360,5,24818,Western World Lit I--Honors,Cremins,Robert Paul,9,4,0,0,1,0,0,3.358
+Fall 2022,ENGL,2360,6,24819,Western World Lit I--Honors,Cremins,Robert Paul,7,3,0,0,0,0,0,3.7
+Fall 2022,ENGL,2360,7,24820,Western World Lit I--Honors,Garner,Richard A,9,3,0,0,0,0,0,3.723
+Fall 2022,ENGL,2360,8,24821,Western World Lit I--Honors,Lyke,Larry,8,4,0,0,1,0,0,3.283
+Fall 2022,ENGL,2360,9,24822,Western World Lit I--Honors,Morrison,Iain P D,4,3,1,0,0,0,0,3.293
+Fall 2022,ENGL,2360,10,24823,Western World Lit I--Honors,Rayneard,Max James Anthony,6,0,2,0,0,0,0,3.17
+Fall 2022,ENGL,2360,11,24824,Western World Lit I--Honors,Rayneard,Max James Anthony,6,3,0,0,0,0,0,3.667
+Fall 2022,ENGL,2360,12,24825,Western World Lit I--Honors,Vollrath,Lesli A,5,6,1,0,0,0,0,3.223
+Fall 2022,ENGL,2360,13,24826,Western World Lit I--Honors,Vollrath,Lesli A,8,4,1,0,0,0,1,3.488
+Fall 2022,ENGL,2360,17,24830,Western World Lit I--Honors,Vassiliou,Constantine,6,1,0,0,0,0,1,3.81
+Fall 2022,ENGL,2360,21,24834,Western World Lit I--Honors,Bland,Laura Elizabeth,5,4,0,0,0,0,0,3.556
+Fall 2022,ENGL,2360,22,24835,Western World Lit I--Honors,Bland,Laura Elizabeth,6,7,0,0,0,0,0,3.512
+Fall 2022,ENGL,2360,23,24836,Western World Lit I--Honors,Charara,Hayan S,6,4,0,0,0,0,0,3.633
+Fall 2022,ENGL,2360,24,24837,Western World Lit I--Honors,Charara,Hayan S,6,3,0,0,0,0,1,3.557
+Fall 2022,ENGL,2360,25,24838,Western World Lit I--Honors,Gish,Dustin,4,2,0,0,0,0,1,3.557
+Fall 2022,ENGL,2360,26,24839,Western World Lit I--Honors,Gish,Dustin,4,4,0,0,0,0,0,3.541
+Fall 2022,ENGL,2360,27,24840,Western World Lit I--Honors,Hallmark,Terrell L,5,6,0,0,0,0,0,3.575
+Fall 2022,ENGL,2360,28,24841,Western World Lit I--Honors,Rainbow,David,4,7,0,0,0,0,1,3.334
+Fall 2022,ENGL,2360,29,24842,Western World Lit I--Honors,Rainbow,David,6,5,0,0,0,0,1,3.485
+Fall 2022,ENGL,2360,30,24843,Western World Lit I--Honors,Rainbow,Jesse J.,7,3,0,0,0,0,1,3.7
+Fall 2022,ENGL,2360,31,24844,Western World Lit I--Honors,Sisman,Cengiz,8,2,0,0,1,0,0,3.335
+Fall 2022,ENGL,2360,32,24845,Western World Lit I--Honors,Sisman,Cengiz,6,5,0,0,0,0,0,3.665
+Fall 2022,ENGL,2360,33,24846,Western World Lit I--Honors,Sommers,Tamler S,8,2,0,0,0,0,1,3.8
+Fall 2022,ENGL,2360,34,24847,Western World Lit I--Honors,Trninic,Marina,7,5,2,0,1,0,0,3.133
+Fall 2022,ENGL,2360,35,24848,Western World Lit I--Honors,Trninic,Marina,6,6,1,0,0,0,0,3.461
+Fall 2022,ENGL,2360,36,24849,Western World Lit I--Honors,Dawson,Cindy,5,5,0,0,0,0,0,3.467
+Fall 2022,ENGL,2360,37,24850,Western World Lit I--Honors,Hallmark,Terrell L,5,2,0,0,0,0,0,3.62
+Fall 2022,ENGL,2360,38,24851,Western World Lit I--Honors,Dawson,Cindy,3,3,2,0,0,0,0,3.043
+Fall 2022,CHEE,6322,1,24852,Tops in Colloid & Interfac Sci,Rimer,Jeffrey,24,1,0,0,0,0,0,3.907
+Fall 2022,LAW,5310,1,24853,White Collar Crime,Kwok,David Y,5,7,0,0,0,6,0,3.389
+Fall 2022,LAW,5379,1,24854,Copyright Law,Fagundes,Dave,11,20,5,0,0,0,0,3.185
+Fall 2022,THEA,6396,2,24858,Selected Topics Theatre,Coen,Elizabeth Manya,3,0,0,0,0,0,0,4.0
+Fall 2022,THEA,6398,1,24859,Independent Study,Young,John M,3,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,3112,4,24860,Topics in Design Media,Noldt,Peter,6,2,3,0,1,0,0,2.918
+Fall 2022,EGRP,1183,1,24861,Engineering Applications XIII,Luna Singh,Jennifer Austin,0,0,0,0,0,8,1,
+Fall 2022,THEA,6359,1,24862,Flat Patterning,Niederer,Barbara,2,0,0,0,0,0,0,3.835
+Fall 2022,ARCH,3112,5,24863,Topics in Design Media,Noldt,Peter,10,1,1,0,0,0,0,3.613
+Fall 2022,ENGL,3361,1,24866,Mexican American Lit,Guajardo,Paul,15,6,3,0,0,0,0,3.445
+Fall 2022,ENGL,3396,1,24868,Selected Topics,Ellis,Amanda,13,7,6,2,1,0,1,2.966
+Fall 2022,ARCH,3112,9,24871,Topics in Design Media,Martinez,Marcus E,6,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,6198,2,24876,Special Problems,Kudless,Andrew Justin,1,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,3312,3,24885,Topics in Design Media,Noldt,Peter,6,2,3,0,2,0,2,2.642
+Fall 2022,ARCH,3312,4,24886,Topics in Design Media,Smith,Joshua S,13,1,1,0,0,0,1,3.756
+Fall 2022,HLT,3380,2,24887,Culture and Health,Fedor Amador,Theresa Marie,28,22,6,3,0,0,1,3.271
+Fall 2022,ARCH,3312,5,24888,Topics in Design Media,Smith,Joshua S,11,2,1,0,0,0,0,3.691
+Fall 2022,LAST,3396,1,24889,Selected Tops-Latin Amer Study,Higgs,Elizabeth Wayne,0,0,0,0,0,0,0,
+Fall 2022,HON,3375,1,24890,Law & Ethics in Ancient Near E,Rainbow,Jesse J.,10,0,0,0,0,0,1,3.868
+Fall 2022,ENGI,1100,30,24891,Introduction To Engineering,Metrovich,Brian,24,20,9,1,5,0,1,2.837
+Fall 2022,HIST,3396,2,24892,Sel Top-Latin Amer Hist,Higgs,Elizabeth Wayne,2,0,0,0,0,0,2,4.0
+Fall 2022,RELS,3375,1,24893,Christianity and Ethics,Rainbow,Jesse J.,3,0,0,0,1,0,2,2.835
+Fall 2022,COSC,4315,1,24894,Programming Languages and Para,Ordonez,Carlos,12,21,17,6,0,0,12,2.667
+Fall 2022,COSC,6335,1,24895,Data Mining,Eick,Christoph F,9,12,2,0,0,0,1,3.247
+Fall 2022,COSC,6336,1,24896,Natural Language Processing,Solorio Martinez,Thamar Ivette,9,6,2,1,0,0,0,3.168
+Fall 2022,INDE,6333,2,24902,Probability Stat For Engineers,Chung,Christopher,0,32,7,8,4,0,4,2.314
+Fall 2022,INDE,3333,2,24903,Engineering Economy I,Wiggins,Nathanial David,9,0,0,1,0,0,0,3.568
+Fall 2022,KIN,4310,2,24912,Measurement Tech Human Perf,Parikh,Pranav J,26,18,0,0,0,0,1,3.531
+Fall 2022,PETR,7322,1,24914,Advanced Formation Evaluation,Myers,Michael Tolbert,3,2,0,0,0,0,0,3.666
+Fall 2022,GEOL,6341,1,24919,Geochemistry,Capuano,Regina M,5,3,1,0,0,0,1,3.518
+Fall 2022,COSC,1336,8,24922,Computer Science & Program,Subhlok,Jaspal,43,21,26,16,7,0,12,2.643
+Fall 2022,COSC,1336,4,24925,Computer Science & Program,Yun,Changhoon,39,29,21,11,9,0,17,2.685
+Fall 2022,COSC,1336,5,24926,Computer Science & Program,Yun,Changhoon,39,27,30,7,13,0,13,2.592
+Fall 2022,COMD,3383,1,25289,Language Disorders in Children,Schaff,Carrie Allyson,11,3,1,0,0,0,0,3.601
+Fall 2022,CUIN,4315,6,25291,Assessment of Children,Hernandez,Berky,21,5,1,0,0,0,0,3.716
+Fall 2022,POLS,3397,2,25354,Selected Topics in Public Law,Badas,Alex,3,8,5,1,4,0,1,2.207
+Fall 2022,CNST,4397,1,25364,Sel Tops in Construction Mgmt,Din,Zia Ud,4,9,2,0,0,0,0,3.111
+Fall 2022,LAW,5197,1,25387,Selected Topics,Brem,Katherine B,0,0,0,0,0,29,0,
+Fall 2022,LAW,5397,8,25388,Selected Topics,Hanson,Lawrence W,3,8,0,0,0,0,0,3.303
+Fall 2022,LAW,5297,4,25390,Selected Topics,Matlock,Gregory Michael,7,8,0,0,0,0,0,3.445
+Fall 2022,LAW,5397,9,25393,Selected Topics,Hester,Tracy,7,6,0,0,0,2,0,3.538
+Fall 2022,LAW,5409,2,25394,Contracts,Buckles,Johnny R,9,22,1,0,0,0,1,3.363
+Fall 2022,LAW,5409,3,25395,Contracts,Dow,David R,14,23,2,0,0,0,0,3.35
+Fall 2022,LAW,5409,4,25396,Contracts,Gebru,Aman Kidanemariam,13,22,1,0,0,0,1,3.388
+Fall 2022,LAW,5387,1,25397,International Tax,Wells,Douglas,3,8,0,0,0,1,1,3.303
+Fall 2022,LAW,5374,1,25398,Legal History,Siegel,Martin Jonathan,12,10,2,0,0,0,0,3.375
+Fall 2022,LAW,5261,1,25401,Real Estate Tax,Kroll,Daniel Harris,3,2,0,0,0,1,0,3.402
+Fall 2022,TLIM,4378,30,25410,Senior Project,Burns,Maria,38,0,0,0,0,0,0,3.983
+Fall 2022,ELET,6303,1,25416,Applied Neural Networks,Abdelhadi,Ahmed,7,2,0,0,0,0,0,3.778
+Fall 2022,CIS,6397,1,25433,Selected Topics,Conklin,William A,25,0,0,0,1,0,0,3.745
+Fall 2022,CIS,6397,2,25434,Selected Topics,Conklin,William A,3,0,0,0,0,0,0,4.0
+Fall 2022,CIS,6397,3,25436,Selected Topics,Wu,Xuqing,71,3,0,0,0,0,0,3.893
+Fall 2022,HLT,1353,4,25461,Personal Health,Proctor,Robin Ann,73,24,14,2,3,0,2,3.317
+Fall 2022,BZAN,6354,2,25483,DB Mgt Tools Bus Analytics,Grimes,George M,5,10,2,1,0,0,0,3.056
+Fall 2022,CIVE,6378,1,25490,Principles Enviromntl Modeling,Louie,Stacey M,12,3,1,0,0,0,2,3.543
+Fall 2022,CIVE,6378,2,25491,Principles Enviromntl Modeling,Louie,Stacey M,6,3,0,0,0,0,2,3.74
+Fall 2022,CIVE,6353,1,25492,Beh-Dsn Prestress Concr,Kalliontzis,Dimitrios,3,4,1,1,0,0,0,2.963
+Fall 2022,CIVE,6353,2,25493,Beh-Dsn Prestress Concr,Kalliontzis,Dimitrios,2,0,1,0,0,0,3,3.003
+Fall 2022,CIVE,6359,1,25494,SAR Remote Sensing,Milillo,Pietro,5,2,2,0,1,0,0,3.033
+Fall 2022,CIVE,6359,2,25495,SAR Remote Sensing,Milillo,Pietro,3,1,1,0,0,0,0,3.466
+Fall 2022,CIVE,6387,1,25496,Physicochem Treatment Process,Shaffer,Devin,3,4,0,0,0,0,0,3.476
+Fall 2022,CIVE,6387,2,25497,Physicochem Treatment Process,Shaffer,Devin,2,5,0,0,0,0,0,3.427
+Fall 2022,CIVE,6323,1,25498,Advanced Foundation Design,Vipulanandan,Cumaraswamy,10,3,0,0,0,0,0,3.693
+Fall 2022,CIVE,6323,2,25499,Advanced Foundation Design,Vipulanandan,Cumaraswamy,7,3,0,0,0,0,1,3.634
+Fall 2022,CIVE,2332,1,25503,Mechanics of Solids,Mansour,Mohamad Y,3,6,17,6,0,0,0,2.146
+Fall 2022,CIVE,6335,1,25505,Advanced Concrete Design,Belarbi,Abdeldjelil,8,8,2,0,0,0,0,3.333
+Fall 2022,ARTH,4310,1,25507,Human Body in Non-Western Art,Koontz,Rex A,10,3,0,0,1,0,0,3.476
+Fall 2022,ARTH,6341,1,25515,Human Body in Non-Western Art,Koontz,Rex A,10,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,3371,8,25516,Accounting Information Systems,Miles,Carolyn A,12,13,6,5,1,0,6,2.757
+Fall 2022,ACCT,3377,5,25519,Cost Accounting,Serrato,Darlene Marie  Bohac,15,13,7,8,0,0,6,2.776
+Fall 2022,CIVE,7397,3,25520,Selected Topics,Lee,Hyongki,13,1,0,0,0,0,0,3.787
+Fall 2022,CIVE,7397,4,25521,Selected Topics,Lee,Hyongki,4,0,0,0,0,0,0,3.753
+Fall 2022,CIVE,7397,5,25522,Selected Topics,Momen,Mostafa,6,5,0,0,0,0,0,3.515
+Fall 2022,CIVE,7397,7,25524,Selected Topics,Ferdowsi,Behrooz,6,0,0,0,0,0,0,3.89
+Fall 2022,CIVE,7397,8,25525,Selected Topics,Ferdowsi,Behrooz,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,7397,9,25526,Selected Topics,Hoskere,Vedhus,4,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,7397,10,25527,Selected Topics,Hoskere,Vedhus,0,1,0,0,0,0,1,3.33
+Fall 2022,CIVE,7397,11,25528,Selected Topics,Ballarini,Roberto,22,2,1,0,0,0,0,3.708
+Fall 2022,CIVE,7397,12,25529,Selected Topics,Ballarini,Roberto,5,3,1,0,1,0,1,3.133
+Fall 2022,ECE,5397,1,25534,Selected Topics,Nguyen,Hien V,5,7,1,0,0,0,2,3.232
+Fall 2022,ECE,5397,2,25535,Selected Topics,Han,Zhu,8,2,0,0,0,0,0,3.668
+Fall 2022,CIVE,6393,1,25536,Geostatistics,Lee,Hyongki,1,2,0,0,0,0,1,3.113
+Fall 2022,ECE,5397,3,25537,Selected Topics,Le,Hung Quang,0,1,0,0,0,0,1,3.0
+Fall 2022,CIVE,6393,2,25538,Geostatistics,Lee,Hyongki,3,4,0,0,0,0,0,3.287
+Fall 2022,ECE,5397,4,25539,Selected Topics,Shan,Xiaonan,3,0,0,0,0,0,0,3.89
+Fall 2022,ECE,5397,5,25540,Selected Topics,Mayerich,David Matthew,2,1,0,0,0,0,3,3.557
+Fall 2022,MECT,4326,1,25541,Fundamentals Offshore Systems,Al-Jamal,Helmi,1,13,5,0,0,0,2,2.946
+Fall 2022,SOC,3397,2,25546,Sel-Topics in Sociology,Langa,Neema Michael,5,0,1,0,0,0,1,3.612
+Fall 2022,SOCI,1301,18,25547,Introduction To Sociology,Dorsey,Patricia Lynne,44,10,2,2,2,0,0,3.495
+Fall 2022,SOCI,1301,20,25548,Introduction To Sociology,Colbert,Sharla Stettnisch,49,1,2,0,5,0,3,3.561
+Fall 2022,SOCI,1301,26,25549,Introduction To Sociology,Gallo,Joseph Ralph,42,9,2,4,2,0,0,3.441
+Fall 2022,SOC,3311,1,25550,Sociology of Law,Gallo,Joseph Ralph,31,9,3,10,3,0,1,2.982
+Fall 2022,SOC,3344,1,25552,Sociology of Aging,Davis,Mary A,42,6,5,2,4,0,0,3.317
+Fall 2022,MUSI,4317,1,25574,Anal of Jazz and Popular Music,Koozin,Timothy,8,0,0,0,1,0,0,3.519
+Fall 2022,MUSI,6317,1,25575,Analysis of Jazz & Pop Music,Koozin,Timothy,5,2,0,0,0,0,0,3.667
+Fall 2022,MANA,6A83,4,25703,Strategic Analysis,Celly,Nikhil,20,0,0,0,0,0,0,3.835
+Fall 2022,MIS,7397,4,25704,Selected Topics in MIS,Campbell,Phillip James,9,3,0,0,0,0,0,3.778
+Fall 2022,MIS,4397,6,25705,Selected Topics in MIS,Boren,Patrick,2,5,0,0,0,0,1,3.286
+Fall 2022,MIS,7397,5,25706,Selected Topics in MIS,Boren,Patrick,7,2,1,0,0,0,0,3.6
+Fall 2022,MUSI,4358,1,25709,Music of Bach and Handel,Dirst,Matthew C,2,0,0,0,0,0,0,3.67
+Fall 2022,MUSI,6358,1,25710,Music of Bach and Handel,Dirst,Matthew C,2,1,1,0,1,0,1,2.666
+Fall 2022,SCM,6A01,5,25712,SCM Concepts,Sahin,Funda,4,2,0,0,0,0,0,3.667
+Fall 2022,MUSI,4397,1,25715,Selected Topics in Music,Pollack,Howard J,5,0,1,0,0,0,0,3.557
+Fall 2022,FINA,7381,1,25718,Principles of Real Estate,Disch,Kathryn Annette,7,1,0,0,0,0,1,3.875
+Fall 2022,MUSI,6327,1,25719,Collab Skills for Organists I,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2022,SOC,3397,3,25720,Sel-Topics in Sociology,Brailey,Carla,40,5,1,0,7,0,2,3.346
+Fall 2022,CNST,2360,1,25721,Communication in Construction,Zerwas,Philip,7,6,4,0,0,0,0,3.176
+Fall 2022,MUSI,4365,1,25723,Contemporary Concert Music,Maroney,Marcus K,7,5,0,0,0,0,0,3.528
+Fall 2022,MUSI,6355,1,25724,Baroque Sonata,Dirst,Matthew C,7,0,0,0,0,0,0,3.859
+Fall 2022,MUSI,6367,1,25725,French Music 1830-1870,Bertagnolli,Paul A,5,5,0,0,0,0,0,3.401
+Fall 2022,MUSI,6397,2,25728,Selected Topics-Music,Snyder,John L,16,0,0,0,0,0,0,3.876
+Fall 2022,MIS,4397,7,25732,Selected Topics in MIS,Eierdam,Richard R,9,11,2,2,1,0,3,3.0
+Fall 2022,MIS,4397,8,25733,Selected Topics in MIS,Gonzalez Jr,Frederick,30,0,0,0,0,0,0,4.0
+Fall 2022,MIS,7397,6,25734,Selected Topics in MIS,Gonzalez Jr,Frederick,30,0,0,0,0,0,0,4.0
+Fall 2022,MUTX,2301,1,25738,Introduction to Music Therapy,Townsend,Jennifer Dawn,7,7,3,1,1,0,1,2.878
+Fall 2022,BTEC,2322,30,25744,Introduction to Biopython,Chitrala,Kumaraswamy Naidu,17,1,1,0,0,0,0,3.721
+Fall 2022,BTEC,4100,30,25748,Principles Bioinformatics Lab,Balan,Venkatesh,2,3,0,0,0,0,0,3.466
+Fall 2022,IART,3395,5,25749,Sel Topics in Interdis Arts,Chacin,Aisen Carolina,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,4397,3,25750,Sel Topics in Fine Arts,Chacin,Aisen Carolina,9,3,0,0,0,0,1,3.75
+Fall 2022,CNST,6399,5,25755,Thesis,Din,Zia Ud,2,0,0,0,0,0,0,3.835
+Fall 2022,MECT,4397,30,25757,Selected Topics in Met,Rypien,David V,16,15,0,0,0,0,0,3.612
+Fall 2022,POLS,1335,1,25758,World Politics,Sisman,Ozlem,9,21,3,7,3,0,2,2.528
+Fall 2022,GEOL,6379,1,25760,Applied Biostratigraphy,Van Nieuwenhuise,Donald S,1,1,0,0,0,0,0,3.665
+Fall 2022,GEOL,7301,3,25761,Capstone Project,Van Nieuwenhuise,Donald S,2,0,0,0,0,0,0,3.835
+Fall 2022,GEOL,7324,2,25762,Rock Physics,Castagna,John P,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7333,2,25763,Seismic Wave & Ray Theory,Thomsen,Leon A,0,1,0,0,0,0,0,3.33
+Fall 2022,GEOL,7341,1,25764,Geophysical Data Processing,Zhou,Hua-Wei,0,1,0,0,0,0,0,3.33
+Fall 2022,BIOE,6301,2,25768,Statistical Methods in BME,Gifford,Howard,15,34,0,0,0,0,2,3.252
+Fall 2022,SOC,3315,2,25770,Sexuality and Society,Haltom,Trenton Matthews,18,13,11,1,2,0,9,3.007
+Fall 2022,ARTS,3396,2,25776,Selected Tops Studio Practice,Leen,Noah,10,0,0,0,0,0,2,4.0
+Fall 2022,MARK,8335,1,25783,Marketing Models,Hui,Kachuen Sam,6,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,3321,3,25799,Analytical Methods Chem Engr,Grabow,Lars C,0,0,1,1,1,0,1,1.11
+Fall 2022,CHEE,3333,2,25800,Chem Engr Thermodyn II,Orman,Mehmet,0,1,0,0,1,0,2,1.5
+Fall 2022,CHEE,3363,2,25803,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,0,0,0,0,1,0,1,0.0
+Fall 2022,CHEE,3369,2,25809,Chemical Engr Transport Proc,Harold,Michael P,0,0,0,0,0,0,1,
+Fall 2022,DRAM,1310,15,25810,Introduction to Theatre,Egging,Jon Leo,53,17,9,3,13,0,3,2.951
+Fall 2022,CHEE,4367,2,25811,Chemical Reaction Engineering,Bollini,Praveen P,1,0,0,0,0,0,0,4.0
+Fall 2022,MAS,3346,1,25820,Latinas in the United States,Pino,Diana,8,4,6,0,1,0,0,2.878
+Fall 2022,CHEE,3462,1,25826,Unit Operations,Willson,Richard,8,11,3,1,0,0,0,3.116
+Fall 2022,CHEE,3462,3,25828,Unit Operations,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7A97,1,25831,Selected Topics in Finance,Susmel,Raul,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7A97,3,25833,Selected Topics in Finance,Rajmohan,Siddharth,4,0,0,0,0,0,1,3.918
+Fall 2022,NAVY,3302,1,25836,Naval Operations,Winters,Adam W,4,0,0,0,0,0,0,4.0
+Fall 2022,NAVY,3310,1,25837,Fund of Maneuver Warfare,Collins,Daniel W,4,0,1,0,0,0,0,3.6
+Fall 2022,FINA,7A62,1,25849,Retirement and Estate Planning,Lopez,John C,4,7,1,0,0,0,0,3.415
+Fall 2022,FINA,7A42,1,25851,Banking and Credit Analysis,Lara,Alexander J,14,4,3,0,0,0,0,3.461
+Fall 2022,MARK,7366,1,25852,Digital Marketing Analytics,Tirunillai,Seshadri N,20,0,0,0,0,0,0,3.934
+Fall 2022,IDNS,2197,5,25859,Top-Natrl Sci & Mth,Stokes,Donna,21,5,0,0,0,0,0,3.833
+Fall 2022,IDNS,2297,1,25860,Top-Natrl Sci & Mth,Stokes,Donna,20,0,0,0,0,0,1,4.0
+Fall 2022,MARK,4397,1,25861,Selected Topics in Mkt,Pogge,Joe M,14,12,5,0,0,0,1,3.29
+Fall 2022,POLS,3349,1,25862,American Political Thought,Koganzon,Rita,3,13,7,3,11,0,5,1.865
+Fall 2022,COMM,3318,3,25864,Multimedia Storytelling,Uhrick,Jan,19,1,0,0,0,0,0,3.901
+Fall 2022,ACCT,4332,5,25871,Corporate Taxation,Fernandez,Ramon,0,1,1,0,0,0,0,2.665
+Fall 2022,ACCT,5332,4,25872,Corporate Taxation,Fernandez,Ramon,0,1,0,0,0,0,0,3.0
+Fall 2022,ACCT,7375,3,25873,Corporate Taxation,Fernandez,Ramon,4,3,2,0,0,0,0,3.259
+Fall 2022,ACCT,4335,7,25874,Financial Statement Auditing,Kuruvilla,Mohan,7,15,8,6,0,0,2,2.749
+Fall 2022,ACCT,7360,2,25877,Partnership Taxation,King,Sheldon,11,6,1,0,0,0,0,3.501
+Fall 2022,ACCT,7367,1,25878,Advanced Internal Auditing,Brant Jr.,Robert Edward,7,5,0,0,0,0,0,3.693
+Fall 2022,GOVT,2305,19,25882,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,55,57,42,25,6,0,15,2.656
+Fall 2022,GEOL,6351,1,25883,Basin Modeling,Van Nieuwenhuise,Donald S,2,0,0,0,0,0,0,3.835
+Fall 2022,ELCS,6302,5,25885,Decision Making School Ldrs,Horner,Glenda Sue,11,1,0,0,0,0,1,3.917
+Fall 2022,WGSS,2350,20,25892,Intro To Women's Studies,Lakshmi,Aishwarya,14,9,6,0,1,0,0,3.222
+Fall 2022,ACCT,7385,1,25893,Fraud Examination,Ramey,Dan T,10,1,2,0,0,0,0,3.615
+Fall 2022,WGSS,4350,1,25896,Issues in Feminist Research,Young,Nancy Beck,3,1,1,0,0,0,0,3.334
+Fall 2022,LAW,5342,2,25897,Prof Writing Strategies,Davis,Megan Leigh-Wilson,3,6,0,0,0,3,0,3.37
+Fall 2022,CHEM,1311,6,25901,Fundamentals of Chemistry,Czader,Arkadiusz,11,11,10,8,12,0,16,1.962
+Fall 2022,ECE,6397,1,25902,Selected Topics,Shih,Wei-Chuan,7,0,0,0,0,0,0,3.764
+Fall 2022,ECE,6397,2,25903,Selected Topics,Le,Hung Quang,4,8,15,3,0,0,0,2.345
+Fall 2022,ECE,6397,3,25904,Selected Topics,Shan,Xiaonan,43,6,0,0,0,0,0,3.83
+Fall 2022,ECE,6360,1,25905,GPU/Heterogeneous Programming,Mayerich,David Matthew,12,5,0,0,0,0,1,3.589
+Fall 2022,MCL,1501,1,25908,Beginning Language I,Back,Eunkyung Lee,13,5,3,0,1,0,3,3.303
+Fall 2022,MCL,1501,3,25910,Beginning Language I,Back,Eunkyung Lee,12,6,6,3,1,0,1,2.869
+Fall 2022,NURS,4312,1,25913,Ldership and Mgmt in Prof Nur,Quintana,Danielle,51,10,0,0,0,0,0,3.836
+Fall 2022,MUSI,6350,3,25914,Applied Music Pedagogy,Robinson,Daryl Allen,3,0,0,0,0,0,0,3.89
+Fall 2022,ECE,6302,1,25915,Introductn To Neuroengineering,Sheth,Bhavin R.,3,2,3,1,0,0,0,2.814
+Fall 2022,NURS,6318,1,25916,Healthcare Delivery Sys & Orgn,Brohard,Cheryl L,3,1,0,0,0,0,0,3.75
+Fall 2022,NURS,6345,1,25917,Mgmt of Hlth Dsordrs in Wom/Ch,Varghese,Shainy B,2,2,1,0,0,0,0,3.2
+Fall 2022,NURS,6346,1,25918,Mgmt of Hlth Dsordrs in Wo/Ch,Varghese,Shainy B,0,0,0,0,0,4,0,
+Fall 2022,MATH,1300,1,25919,Fundamentals of Mathematics,Chang,James A,0,0,0,0,0,34,0,
+Fall 2022,ENGL,7399,6,25931,Essay,Mazella,David S,1,0,0,0,0,0,0,4.0
+Fall 2022,HDCS,3384,1,25932,Consumer Sales,Mudd,Blake Stevens,32,8,6,0,4,0,0,3.28
+Fall 2022,CIS,2334,31,25933,Information Systems Applicatns,Lendasse,Amaury,62,38,29,4,15,0,14,2.825
+Fall 2022,CIS,2348,31,25935,Info Systems Appl Development,Ratner,Edward,16,16,19,4,16,0,3,2.16
+Fall 2022,CIS,3320,1,25936,Information Visualization,Ratner,Edward,29,51,23,0,16,0,9,2.572
+Fall 2022,CNST,3210,1,25937,Safety for Industrial Projects,Zayas,Frederick A,8,5,10,0,1,0,0,2.737
+Fall 2022,THEA,3305,1,25940,Playwriting: Comedy,Shimko,Robert B,13,0,1,0,0,0,1,3.786
+Fall 2022,POLS,3395,1,25941,Selected Topics Am Gov,Kistner,Michael,5,4,2,0,2,0,0,2.845
+Fall 2022,CHEE,6397,2,25943,Selected Topics,Balakotaiah,Vemuri,4,0,0,0,0,0,0,4.0
+Fall 2022,INDE,3333,3,25945,Engineering Economy I,Wiggins,Nathanial David,11,2,0,0,1,0,0,3.524
+Fall 2022,ARTS,4392,2,25949,Sel Top in Contemporary Art,McCormick,Kelly,9,6,2,0,0,0,0,3.451
+Fall 2022,IART,3395,6,25957,Sel Topics in Interdis Arts,McCormick,Kelly,0,4,0,0,0,0,0,3.165
+Fall 2022,GOVT,2305,20,25958,"US Govt: Congress,Pres & Crts",Shor,Boris,10,58,55,23,26,0,25,1.983
+Fall 2022,LAW,5217,1,25959,Fraud and Abuse,Cordova,Laura Marie Kidd,6,3,0,0,0,0,1,3.52
+Fall 2022,FINA,7397,5,25963,Selected Topics in Finance,Khumawala,Saleha B,5,1,0,0,0,0,0,3.778
+Fall 2022,ACCT,7340,3,25964,Financial Statement Analysis,Lu,Tong,14,0,0,0,0,0,0,3.976
+Fall 2022,GENB,5303,5,25968,Prof Acct Communication,Newman,Michael Ray,2,2,0,0,0,0,0,3.5
+Fall 2022,GENB,7303,3,25969,Prof Accounting Communication,Newman,Michael Ray,21,0,0,0,0,0,0,3.969
+Fall 2022,ILAS,2360,1,25970,Cosmic Narratives,Wood,Barry Albert,9,3,2,0,0,0,1,3.429
+Fall 2022,MUSA,2300,9,25971,Applied Voice,Averyt,Zachary Benjamin,3,0,0,0,0,0,0,3.89
+Fall 2022,MUSA,4189,1,25972,Senior Recital,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4189,2,25973,Senior Recital,Wilkins,Blake M,1,0,0,0,0,0,0,3.67
+Fall 2022,BIOE,4303,2,25983,Biomaterials,Abidian,Mohammad Reza,15,2,0,0,0,0,1,3.785
+Fall 2022,BIOE,6303,2,25985,Biomaterials,Abidian,Mohammad Reza,14,3,0,0,0,0,0,3.688
+Fall 2022,ECON,4395,2,25989,Topics - Applied Econometrics,Boul,Ruxandra,12,5,0,1,5,0,9,2.74
+Fall 2022,IDNS,1141,7,25992,Chemistry I SEP Workshop,Pattison,Donna,1,0,2,1,1,0,4,1.8
+Fall 2022,PHLS,8398,1,25994,Special Problems,Fan,Weihua,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,1301,150,26001,First Year Writing I,McAlister,Susan Barbara,6,6,4,1,0,0,2,2.961
+Fall 2022,ENGL,1301,151,26002,First Year Writing I,Bass,Kasey Dawn,10,3,0,0,3,0,0,2.959
+Fall 2022,ENGL,1301,152,26004,First Year Writing I,Burns,William,7,5,2,1,0,0,0,3.024
+Fall 2022,ENGL,1301,153,26005,First Year Writing I,Chatham,Donna Marie,7,6,1,1,1,0,0,3.083
+Fall 2022,COSC,6345,1,26006,Programming Languages,Ordonez,Carlos,2,1,2,0,0,0,0,3.0
+Fall 2022,CHEE,5397,2,26008,Selected Topics,Balakotaiah,Vemuri,4,0,1,0,0,0,0,3.6
+Fall 2022,ECON,2301,4,26010,Principles of Macroeconomics,Mcgregor,Ryan P,12,40,44,21,18,0,22,2.101
+Fall 2022,ECON,2301,5,26011,Principles of Macroeconomics,Djima,Jesugnon Ezechias,18,30,41,16,32,0,16,1.874
+Fall 2022,ECON,2302,7,26012,Principles of Microeconomics,Musaico,Erika Michelle,56,59,27,15,4,0,9,2.794
+Fall 2022,ECON,2302,8,26013,Principles of Microeconomics,Oni,Mehedi Hasan,63,61,19,11,5,0,10,3.04
+Fall 2022,GHL,6343,1,26014,Beverage Management,Corsi,Aaron James,6,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7333,3,26015,Seismic Wave & Ray Theory,Li,Aibing,4,4,0,0,0,0,0,3.459
+Fall 2022,GEOL,7327,2,26016,Principles of Marine Geophysic,Sager,William W,5,0,0,0,0,0,0,4.0
+Fall 2022,BTEC,4101,30,26021,Principle of Bioprocessing Lab,Hosseinzadeh,Hemen,8,10,2,0,1,0,0,3.143
+Fall 2022,BTEC,4301,30,26022,Principles of Bioprocessing,Hosseinzadeh,Hemen,10,9,1,1,1,0,0,3.122
+Fall 2022,SOCW,7366,1,26023,Grief/Bereave Therapy,Rodgers,Beverly J,29,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,4397,5,26027,Selected Topics in Psychology,Miller,Audrey,9,6,2,1,2,0,0,2.934
+Fall 2022,PHYS,8698,1,26029,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,3,0,
+Fall 2022,PHYS,8698,2,26030,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,5,26033,Doctoral Research,Chen,Shuo,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,8,26036,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,11,26039,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,12,26040,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,13,26041,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,3,0,
+Fall 2022,PHYS,8698,15,26043,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,21,26049,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8698,23,26051,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,3,0,
+Fall 2022,PHYS,8698,26,26054,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,28,26056,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8698,32,26060,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Fall 2022,ACCT,4331,6,26062,Federal Income Tax-Individual,Fernandez,Ramon,3,25,9,0,0,0,2,2.936
+Fall 2022,PHYS,8998,2,26064,Doctoral Research,Bellwied,Rene,0,0,0,0,0,3,0,
+Fall 2022,PHYS,8998,6,26068,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,7,26069,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8998,8,26070,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,10,26072,Doctoral Research,Das,Mini,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,11,26073,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,3,0,
+Fall 2022,PHYS,8998,12,26074,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8998,15,26077,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8998,17,26079,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8998,19,26081,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,20,26082,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8998,21,26083,Doctoral Research,Pinsky,Lawrence S,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,22,26084,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,23,26085,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,5,0,
+Fall 2022,PHYS,8998,27,26089,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,2,0,
+Fall 2022,PHYS,8998,28,26090,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8998,29,26091,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Fall 2022,INAR,4501,1,26094,Interior Arch Studio VIII,Tucker de Vazquez,Sheryl,0,0,1,0,0,0,0,1.67
+Fall 2022,MUSA,4440,1,26095,Applied Trumpet,Vassallo,Jim Cates,3,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7398,5,26098,Special Problems,Voskuil,Lynn M,1,0,0,0,0,0,0,4.0
+Fall 2022,ECON,2301,6,26099,Principles of Macroeconomics,Rocha Campos,Felipe,8,33,35,18,39,0,17,1.679
+Fall 2022,ECON,2302,9,26100,Principles of Microeconomics,Sugiura,Ko,27,51,41,14,25,0,8,2.282
+Fall 2022,SPAN,3384,3,26102,Intro To Hispanic Literature,Hasbun,Rodrigo,8,2,3,1,0,0,0,3.144
+Fall 2022,MUSA,4442,1,26105,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8399,1,26106,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2022,CHEM,8999,30,26107,Doctoral Dissertation,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2022,MUSA,4426,1,26108,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,4.0
+Fall 2022,FINA,3332,7,26109,Prin of Financial Management,Chisholm,Darla,6,3,6,3,1,0,3,2.578
+Fall 2022,MANA,4397,1,26121,Selected Topics in Mana,Kroger,Edward John,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6204,2,26133,Conducting,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,6698,36,26141,Special Problems,Lee,T Randall,0,0,0,0,0,4,0,
+Fall 2022,SGNL,1302,3,26143,Elementary Sign Language II,Marcelle,John,0,12,7,1,0,0,0,2.55
+Fall 2022,CHEM,8999,31,26144,Doctoral Dissertation,Jacobson,Allan J,0,0,0,0,0,1,0,
+Fall 2022,PHIL,3386,1,26146,19th Century Philosophy,Werner,Andrew Timothy,7,9,3,2,0,0,6,2.906
+Fall 2022,PHIL,3383,1,26147,His of Ancient Phi,Werner,Andrew Timothy,7,9,4,1,1,0,1,2.954
+Fall 2022,MUSA,2322,1,26149,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Fall 2022,LAW,5130,1,26151,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,26,0,
+Fall 2022,ENGL,7398,6,26153,Special Problems,Boswell,Robert L,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7399,7,26155,Essay,Lee,Eunjeong,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4189,4,26158,Senior Recital,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8399,2,26161,Doctoral Dissertation,de Dios,Marcel A,0,0,0,0,0,2,0,
+Fall 2022,MUSI,4388,1,26162,Piano Literature,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8241,6,26163,Doctoral Recital II,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6388,1,26177,Piano Literature,Staupe,Andrew Paul,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6347,1,26181,Igor Stravinsky,Pollack,Howard J,1,1,0,0,0,0,0,3.5
+Fall 2022,PHLS,8699,12,26184,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,2,0,
+Fall 2022,FINA,7326,2,26185,Private Equity & Invest Bankin,Stewart,Marcus,17,16,1,0,0,0,0,3.451
+Fall 2022,HDFS,4318,3,26186,Parent-Child Relationships,Fraser,Camille,22,22,8,5,2,0,1,2.938
+Fall 2022,HDFS,4318,4,26187,Parent-Child Relationships,Boykin,Jelisa Denae,15,10,7,0,5,0,0,2.784
+Fall 2022,BIOE,6305,2,26191,Brain Machine Interfacing,Francis,Joseph Thachil,3,2,1,0,1,0,0,2.904
+Fall 2022,PSYC,4398,1,26192,Independent Study,Zvolensky,Michael J,18,0,0,0,0,0,1,4.0
+Fall 2022,SOC,3397,4,26197,Sel-Topics in Sociology,Tuthill,Zelma,10,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,3302,1,26200,Medieval Literature,Stock,Lorraine K,5,12,7,1,1,0,4,2.68
+Fall 2022,ENGL,8399,10,26202,Doctoral Dissertation,Gonzalez,Maria C,0,0,0,0,0,1,0,
+Fall 2022,ENGL,6398,1,26203,Rd&Research in Lang&Lit,Prufer,Kevin D,0,0,0,0,0,1,0,
+Fall 2022,BTEC,6399,30,26226,Thesis,Balan,Venkatesh,0,0,0,0,0,3,0,
+Fall 2022,PHOP,6257,18,26230,Research Practicum B,Twa,Michael D,0,0,0,0,0,0,0,
+Fall 2022,PHOP,6257,19,26231,Research Practicum B,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Fall 2022,TLIM,4340,30,26234,Commercializing Innovation,Crawley,David L,1,1,1,0,0,0,0,2.78
+Fall 2022,SOC,3349,2,26238,Sociology of Culture,Adams,Jennifer Lauren,35,13,3,1,1,0,1,3.435
+Fall 2022,PSYC,7399,2,26239,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8398,17,26241,Doctoral Research,Jiang,Xun,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8698,14,26242,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8699,3,26243,Doctoral Dissertation,Jiang,Xun,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,4398,2,26244,Independent Study,Khan,Shuhab D.,0,0,0,0,0,1,0,
+Fall 2022,GHL,4462,1,26245,Practical Project Mgmt in Hosp,Ramirez,Arlene D,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1334,3,26249,Applied Clarinet,Potiomkin,Alexander,4,0,0,0,0,0,0,4.0
+Fall 2022,SPAC,6298,1,26250,Special Problems,Bell,Larry S,2,2,0,0,0,0,0,3.665
+Fall 2022,LAW,5232,1,26251,Trade Secrets,Beebe,James L,10,15,0,0,0,0,0,3.426
+Fall 2022,PSYC,7398,2,26254,Statistics in PSYC Practicum,Gallagher,Matthew Ward,3,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6498,8,26255,Special Problems,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6598,10,26256,Special Problems,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2022,MARK,7366,2,26257,Digital Marketing Analytics,Tirunillai,Seshadri N,16,0,0,0,0,0,0,3.979
+Fall 2022,MUSA,6300,1,26259,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6300,3,26261,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,6300,5,26263,Applied Voice,Sonnenberg,Melanie,5,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6300,6,26264,Applied Voice,Vasquez,Hector A,3,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8199,8,26266,Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2022,LAST,4398,1,26267,Independent Study,Milanesio,Natalia,0,0,1,0,0,0,0,2.33
+Fall 2022,WCL,3367,1,26271,Nat Cinema in Glob Perspective,Carrera,Alessandro,2,1,0,0,0,0,0,3.777
+Fall 2022,MUSA,1300,3,26291,Applied Voice,Evans,Joseph,0,0,0,0,0,0,1,
+Fall 2022,LAW,7314,1,26292,WRS: Antidiscrimination,Areheart,Bradley Allan,5,7,0,0,0,0,0,3.444
+Fall 2022,SGNL,2301,6,26294,Intermediate Sign Language I,Brittain,Terrell,8,8,1,0,0,0,1,3.256
+Fall 2022,BIOE,4319,2,26297,Mass Transport Biosystems,Majd,Sheereen,6,2,1,0,0,0,0,3.592
+Fall 2022,BIOE,6319,2,26298,Mass Transport Bio Systems,Majd,Sheereen,4,3,3,0,1,0,0,2.758
+Fall 2022,ENGR,2301,4,26299,Mechanics I,Safa,Mahdi,3,8,9,0,2,0,2,2.455
+Fall 2022,HIST,3394,3,26300,Sel Tops-Us History,Pegoda,Andrew Joseph,9,2,2,0,1,0,1,3.239
+Fall 2022,PSYC,6393,9,26301,Clinical Research Practicum,Walker,Rheeda L,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,7398,1,26303,Independent Graduate Study,Hecker,Rachel G,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7A40,2,26304,Fixed Income I,Doshi,Hitesh B,6,4,0,0,0,0,0,3.666
+Fall 2022,ENGL,8399,11,26305,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Fall 2022,FINA,7A41,2,26306,Fixed Income II,Doshi,Hitesh B,4,1,0,0,0,0,0,3.602
+Fall 2022,SCLT,6397,4,26308,Selected Topics,Wang,Kailai,4,2,0,0,0,0,0,3.722
+Fall 2022,POLC,6312,2,26309,Public Finance,Obregon,Alexander Wade,14,1,0,0,0,0,0,3.889
+Fall 2022,MIS,7397,7,26311,Selected Topics in MIS,Boren,Patrick,2,2,0,0,0,0,0,3.5
+Fall 2022,ENGL,8399,12,26321,Doctoral Dissertation,Stock,Lorraine K,0,0,0,0,0,1,0,
+Fall 2022,PHLS,8399,4,26325,Doctoral Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Fall 2022,COMD,8391,1,26333,COMD Research,Bunta,Ferenc,0,0,0,0,0,1,0,
+Fall 2022,COMD,8391,2,26334,COMD Research,Castilla-Earls,Anny,0,0,0,0,0,1,0,
+Fall 2022,COMD,8391,3,26335,COMD Research,Dial,Heather Raye,0,0,0,0,0,1,0,
+Fall 2022,COMD,8391,4,26336,COMD Research,Maher,Lynn M,0,0,0,0,0,1,0,
+Fall 2022,COMD,8391,5,26337,COMD Research,Thiessen,Amber L,0,0,0,0,0,1,0,
+Fall 2022,COMD,8391,6,26338,COMD Research,Joshi,Ashwini,0,0,0,0,0,1,0,
+Fall 2022,ARTS,1311,4,26340,Fundamentals of Graphic Design,Williams,Celeste,16,9,1,0,0,0,1,3.602
+Fall 2022,PHIL,4398,1,26341,Independent Study,Loewenstein,Yael R,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,7397,1,26342,Selected Topics in Psychology,Vujanovic,Anka Anna,0,0,0,0,0,6,0,
+Fall 2022,PSYC,7397,2,26343,Selected Topics in Psychology,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7397,3,26344,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,3,0,
+Fall 2022,PSYC,7397,4,26345,Selected Topics in Psychology,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Fall 2022,ELET,4397,2,26346,Selected Topics in Elet,Bering,Edgar A,5,0,0,0,0,0,0,4.0
+Fall 2022,ELET,6313,1,26348,Network Security,Gurkan,Deniz,1,3,0,0,0,0,0,3.085
+Fall 2022,PSYC,6398,17,26349,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,2,0,
+Fall 2022,PSYC,7399,4,26350,Masters Thesis,Derrick,Jaye L,0,0,0,0,0,1,0,
+Fall 2022,PEP,8350,1,26351,HHP Candidacy Project Research,Layne,Charles S,0,0,0,0,0,0,0,
+Fall 2022,PEP,8350,3,26353,HHP Candidacy Project Research,Ogunrinde,Joyce,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,8350,4,26354,HHP Candidacy Project Research,Johnston,Craig Allen,0,0,0,0,1,0,0,0.0
+Fall 2022,MATH,2318,6,26355,Linear Algebra,Wu,Yingying,41,25,5,2,3,0,3,3.35
+Fall 2022,ENGL,8398,1,26356,Graduate English Resrch,Womble,David Avari Patrick,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8398,2,26357,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2022,ENGL,6398,2,26359,Rd&Research in Lang&Lit,Nelson,Antonya,0,0,0,0,0,2,0,
+Fall 2022,MUED,6301,1,26360,Intro to Research in Music Edu,McGinnis,Emily Jane,1,0,0,0,0,0,0,4.0
+Fall 2022,MUED,8311,1,26361,Educating Pre-Service Teachers,Hansen,Erin Melissa,2,1,0,0,0,0,0,3.667
+Fall 2022,ARTH,6394,2,26362,Sel Top in Art History,Lee,Kyoung Yong,4,1,0,0,0,0,0,3.668
+Fall 2022,ARTH,3378,1,26363,Global History of Photography,Lee,Kyoung Yong,7,14,14,9,8,0,6,2.064
+Fall 2022,ARTS,7398,2,26364,Independent Graduate Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Fall 2022,THEA,3375,1,26365,Costume Tech & Applied Crafts,Whittenton,Laura Lynn,8,2,0,0,0,0,0,3.8
+Fall 2022,ARTH,4379,1,26366,Art Since 1945,Bradley,Taylor,8,8,1,0,0,0,2,3.451
+Fall 2022,MUSA,3400,3,26369,Applied Voice,Laine,Eric G,3,0,0,0,0,0,0,3.78
+Fall 2022,ECON,3347,1,26372,Capital Market Economics,Jiu,Haibin Brett,7,17,7,6,2,0,1,2.513
+Fall 2022,MUSA,6310,1,26374,Applied Piano,Hester,Timothy E,9,0,0,0,0,0,0,3.817
+Fall 2022,MUSA,6310,2,26375,Applied Piano,Morgulis,Tali,2,1,0,0,1,0,0,2.668
+Fall 2022,MUSA,6310,3,26376,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,4354,1,26377,Software Development Practices,Rizk,Nouhad J,8,8,0,0,0,0,0,3.603
+Fall 2022,MUSA,3448,2,26378,Applied Euphonium,Kauk,Brian Keith,2,0,0,0,1,0,0,2.667
+Fall 2022,HLT,4307,5,26380,Research and Eval in Health,Carmack,Chakema,21,8,2,0,4,0,0,3.2
+Fall 2022,BZAN,7320,2,26381,Bus Modeling For Comp Adv,Murray,Michael J,5,9,1,0,0,0,1,3.113
+Fall 2022,MECT,6397,1,26383,Selected Topics,Al-Jamal,Helmi,0,1,0,0,0,0,0,2.67
+Fall 2022,IDNS,4397,1,26384,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,8,0,0,0,0,0,0,4.0
+Fall 2022,IDNS,4397,2,26385,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,8,0,0,0,0,0,0,3.918
+Fall 2022,HDFS,4325,3,26387,Theory to Practice in HDFS,Frankel,Leslie Ann,8,6,4,0,1,0,1,3.139
+Fall 2022,COSC,8298,102,26391,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Fall 2022,HIST,8688,3,26392,Dissertation Proposal,Ramos,Raul,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,1300,4,26394,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8399,13,26396,Doctoral Dissertation,Harris,Francine Julia,0,0,0,0,0,1,0,
+Fall 2022,CUIN,8397,3,26397,Selected Topics in C&I,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8399,7,26399,Doctoral Dissertation,Wellner,Julia S,1,0,0,0,0,1,0,4.0
+Fall 2022,BUSI,1301,7,26400,Business Principles,Thompson,Joseph Lee,216,19,4,3,3,0,3,3.795
+Fall 2022,GEOL,6399,9,26401,Masters Thesis,Capuano,Regina M,0,0,0,0,0,1,0,
+Fall 2022,ARTH,4394,1,26403,Sel Tops in Art History,Lee,Kyoung Yong,3,6,2,1,2,0,0,2.5
+Fall 2022,ARTH,6394,4,26404,Sel Top in Art History,Lee,Kyoung Yong,4,0,0,0,0,0,0,3.918
+Fall 2022,SCM,7380,2,26405,Analytics & Enterprise Opertns,Murray,Michael J,19,2,0,0,0,0,0,3.842
+Fall 2022,SCM,7390,2,26406,Global Supply Chain Strategy,Smith,Gordon D,5,6,3,0,0,0,0,3.214
+Fall 2022,COMD,3399,1,26411,Senior Honors Thesis,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,1,26414,Adv Special Problem Human Perf,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4422,1,26415,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Fall 2022,HRD,6396,1,26416,Internship in Human Res. Dev.,Greer,Tomika,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,8350,5,26419,HHP Candidacy Project Research,LaVoy,Emily Claire-Pyle,2,0,0,0,0,0,0,4.0
+Fall 2022,HIST,6398,1,26421,Special Problems,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8301,1,26423,Seminar in Perform Pedagogy,Cho,Eunghee,2,0,0,0,0,0,0,3.835
+Fall 2022,MIS,7397,8,26424,Selected Topics in MIS,Tan,Yinliang,23,11,0,0,0,0,0,3.531
+Fall 2022,COSC,4396,2,26425,Senior Research Project,Eick,Christoph F,1,0,0,0,0,0,0,4.0
+Fall 2022,LAW,6234,1,26427,Juvenile Representation II,Cepeda Hendrickson,Grecia,0,0,0,0,0,1,0,
+Fall 2022,LAW,6235,1,26428,Juvenile Representation,Cepeda Hendrickson,Grecia,2,0,0,0,0,1,0,3.67
+Fall 2022,MATH,3399,1,26429,Senior Honors Thesis,Onofrei,Daniel T,3,0,0,0,0,0,0,4.0
+Fall 2022,PHYS,8998,31,26430,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,
+Fall 2022,HIST,7399,1,26431,Masters Thesis,Zarnow,Leandra Ruth,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,6399,1,26432,Masters Thesis,Zarnow,Leandra Ruth,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,6111,3,26433,Graduate Seminar,Milillo,Pietro,0,0,0,0,0,11,0,
+Fall 2022,COMM,6395,1,26438,Comprehensive Examination,Ni,Lan,0,0,0,0,0,1,0,
+Fall 2022,SCLT,6397,5,26441,Selected Topics,Poisler,Marco A,4,0,0,0,0,0,0,4.0
+Fall 2022,FINA,4360,1,26446,International Financial Mgmt,Hitzemann,Steffen,3,9,5,0,1,0,0,2.759
+Fall 2022,COSC,8598,114,26449,Doctoral Research,Kakadiaris,Ioannis A.,0,0,0,0,0,1,0,
+Fall 2022,THEA,4397,1,26450,Drama Workshop,Wetzel,Molly Elizabeth,9,4,0,0,0,0,0,3.616
+Fall 2022,FINA,7360,1,26456,International Finance,Hitzemann,Steffen,5,1,0,0,0,0,0,3.723
+Fall 2022,SOC,7396,2,26457,Internship in Sociology,Karner,Tracy Xavia,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8242,4,26458,Doctoral Recital III,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2022,PHYS,1301,7,26461,College Physics I (lecture),Morrison,Gregory C,7,16,14,11,3,0,6,2.274
+Fall 2022,MUSA,4402,2,26462,Applied Composition,Smith,Robert Thomas,2,0,1,0,0,0,0,3.223
+Fall 2022,ENGL,8398,3,26463,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,PHIL,3399,2,26468,Senior Honors Thesis,Coates,Daniel J,0,0,0,0,0,0,0,
+Fall 2022,MUSI,4298,3,26469,Special Problems in Pedagogy,Wilkins,Blake M,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,8998,1,26471,Doctoral Research,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8330,1,26472,Doctoral Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8398,4,26473,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8398,5,26475,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,CIS,3368,3,26476,Adv Info Systems Development,Dobretsberger,Otto,29,13,3,1,5,0,7,3.17
+Fall 2022,ENGL,8398,6,26477,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8399,8,26479,Doctoral Dissertation,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2022,ELCS,8312,2,26485,Lab of Practice-Res Meth Devel,Butcher,Keith,1,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8398,8,26493,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8398,9,26495,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8398,10,26496,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,PSYC,4398,2,26498,Independent Study,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Fall 2022,HON,3397,7,26499,Honors Selected Topics,Stelzig,Donaji,18,0,0,0,0,0,0,4.0
+Fall 2022,ELED,7324,1,26502,Sci Instruction in Elem Grades,Bailer,Jill,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8395,1,26504,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,6,0,
+Fall 2022,ELCS,8395,2,26505,Doctoral Thesis,Davis,Bradley,1,0,0,0,0,4,0,4.0
+Fall 2022,ELCS,8395,3,26506,Doctoral Thesis,Freelon,Rhoda,0,0,0,0,0,1,0,
+Fall 2022,ELCS,8395,4,26507,Doctoral Thesis,Johnson PhD,Detra DeVerne,0,0,0,0,0,4,0,
+Fall 2022,ELCS,8395,5,26508,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,2,0,
+Fall 2022,ELCS,8395,6,26509,Doctoral Thesis,Lopez,Ruth Maria,0,0,0,0,0,0,0,
+Fall 2022,ELCS,8395,7,26510,Doctoral Thesis,Peters-Hawkins,April,0,0,0,0,0,2,0,
+Fall 2022,ELCS,8395,8,26511,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,4,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8695,1,26513,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,1,0,
+Fall 2022,ELCS,8695,2,26514,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,2,0,
+Fall 2022,ELCS,8695,5,26517,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,2,0,
+Fall 2022,ELCS,8695,6,26518,Doctoral Thesis,Lopez,Ruth Maria,0,0,0,0,0,0,0,
+Fall 2022,ELCS,8695,7,26519,Doctoral Thesis,Peters-Hawkins,April,0,0,0,0,0,1,0,
+Fall 2022,ELCS,8695,8,26520,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,3,0,4.0
+Fall 2022,CIS,6399,2,26522,Master's Thesis,Zhang,Yunpeng,0,1,0,0,0,0,0,3.33
+Fall 2022,SOC,3399,1,26528,Senior Honors Thesis,Anderson,Kathryn,1,0,0,0,0,0,0,4.0
+Fall 2022,SGNL,2301,3,26529,Intermediate Sign Language I,Warmack,Chris Kiskinis,6,9,6,1,0,0,0,2.864
+Fall 2022,FINA,4397,5,26530,Selected Topics in Finance,Bean,Gregory S.,9,0,0,0,0,0,0,4.0
+Fall 2022,MATH,6397,9,26531,Selected Topics in Math,Josic,Kresimir,15,3,0,0,0,0,0,3.778
+Fall 2022,MUSA,1310,4,26538,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2022,CLAS,3308,3,26541,Myths & Cult of the Greek Gods,Houlihan,James W,13,13,0,1,0,0,3,3.42
+Fall 2022,PHYS,8998,32,26543,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Fall 2022,MUSA,3410,2,26545,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2022,MECE,6368,6,26546,Mechanical Design Proj,Sharma,Pradeep,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,7397,3,26547,Selected Topics - Comm,Hudson-Gillan,Gail,3,0,0,0,0,0,0,4.0
+Fall 2022,PEP,6198,1,26549,Special Problems in Human Perf,Pearson,Demetrius W,0,0,0,0,0,1,0,
+Fall 2022,ANTH,3399,1,26551,Senior Honors Thesis,Rasmussen,Susan J,0,0,0,0,0,0,0,
+Fall 2022,BUSI,3302,4,26552,Connecting Bauer to Business,Belinne,Jamie King,80,53,16,3,6,0,6,3.253
+Fall 2022,PCEU,6198,1,26554,Special Problems,Chow,Diana Shu-Lian,4,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,8399,14,26555,Doctoral Dissertation,Parsons,Alexander M,0,0,0,0,0,1,0,
+Fall 2022,MECE,8399,41,26556,Doctoral Dissertation,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,39,26557,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Fall 2022,CHEM,7399,22,26559,Masters Thesis,Bittner,Eric R,0,0,0,0,0,0,0,
+Fall 2022,COMD,8193,1,26560,COMD Proseminar,Blake,Margaret T,2,0,0,0,0,0,0,4.0
+Fall 2022,IDNS,2197,6,26570,Top-Natrl Sci & Mth,Pattison,Donna,12,3,3,1,1,0,4,3.2
+Fall 2022,COMM,6395,2,26571,Comprehensive Examination,Liu,Wenlin,0,0,0,0,0,1,0,
+Fall 2022,PHLS,7398,1,26574,Candidacy Research,Kim,Han Joe,0,0,0,0,0,1,0,
+Fall 2022,INDS,4180,1,26576,Design Internship,Kimbrough,Mark S,4,0,0,0,0,0,0,4.0
+Fall 2022,INDS,4380,1,26577,Design Internship,Kimbrough,Mark S,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7699,6,26578,Thesis,Flynn,Nicholas,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8320,12,26580,Doctoral Applied Music,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,13,26581,Doctoral Applied Music,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,7141,1,26582,Pharmacological Liter. Review,Bond,Richard A,0,0,0,0,0,6,0,
+Fall 2022,POLS,6398,3,26583,Special Problems,Vassiliou,Constantine,0,0,0,0,0,0,0,
+Fall 2022,ECON,6394,4,26584,Tpcs-Eco of Socl Issue,Obrizan,Maksym,0,2,0,0,0,0,0,3.0
+Fall 2022,ECON,6394,5,26585,Tpcs-Eco of Socl Issue,Besedina,Elena,3,0,0,0,0,0,0,3.89
+Fall 2022,ECON,6691,1,26587,Master's Internship,Nivievskyi,Oleg,5,0,0,0,0,0,0,3.802
+Fall 2022,ECON,6693,1,26588,Master's Research Project,Kiiashko,Sergii,11,3,1,0,0,0,0,3.579
+Fall 2022,DIGM,4397,3,26589,Selected Tops in Digital Media,Rodwell,Elizabeth Ann,13,10,1,0,0,0,0,3.514
+Fall 2022,MATH,1324,8,26590,Finite Math with Applications,Sosa,Moses,16,18,10,6,20,0,0,2.067
+Fall 2022,POLS,3365,1,26591,"Polls, Public Opinion, Democra",Jenke,Elizabeth,7,5,2,1,1,0,1,2.959
+Fall 2022,ELET,6399,1,26592,Master's Thesis,Abdelhadi,Ahmed,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6324,2,26594,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6320,1,26595,Applied Violin,Yon,Kirsten A,4,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6320,2,26596,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,6306,4,26599,Social Work Practice Skills,White,Tamika Alonzo,28,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7398,1,26602,Masters Research,Capuano,Regina M,0,0,0,0,0,1,0,
+Fall 2022,ACCT,3367,6,26609,Intermediate Accounting I,Kuruvilla,Mohan,4,7,12,4,3,0,5,2.211
+Fall 2022,AAS,3394,2,26610,Selected Topics Afr Am Stdy,Langa,Neema Michael,5,3,1,0,0,0,0,3.481
+Fall 2022,ACCT,5372,2,26612,Intro-Data Analytics in ACCT,Miles,Carolyn A,2,0,1,0,0,0,0,3.113
+Fall 2022,ACCT,7320,2,26613,Intro to Data Analytics-Acct,Miles,Carolyn A,14,7,0,0,0,0,1,3.667
+Fall 2022,ARTS,3300,3,26614,Advanced Drawing,Safaitakhtehfooladi,Farima,16,0,1,0,0,0,3,3.824
+Fall 2022,ARTS,2316,4,26615,Fundamentals of Painting,Stern,Lindsey Rose,15,2,0,0,1,0,2,3.612
+Fall 2022,MUSI,6351,1,26616,Applied Music Pedagogy,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,4397,6,26618,Selected Topics in Finance,Susmel,Raul,1,0,0,1,0,0,2,2.5
+Fall 2022,ELCS,8398,1,26625,Independent Study,Zou,Yali,0,0,0,0,0,3,0,
+Fall 2022,ENGL,7324,2,26627,Writers On Literature,Divakaruni,Chitra B,9,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8296,1,26633,Doctoral Essay,Snyder,John L,0,0,0,0,0,1,0,
+Fall 2022,HIST,4398,3,26634,Independent Study,Milanesio,Natalia,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,6399,10,26637,Masters Thesis,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Fall 2022,GEOL,7398,2,26644,Masters Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,0,1,
+Fall 2022,GEOL,8399,9,26646,Doctoral Dissertation,Zheng,Yingcai,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6141,1,26647,Graduate Recital II,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,3198,3,26652,Independent Study,Jackson,Megan H,8,1,0,0,0,0,1,3.706
+Fall 2022,LAW,5197,2,26654,Selected Topics,Davis,Megan Leigh-Wilson,0,0,0,0,0,4,0,
+Fall 2022,ENGL,8398,11,26659,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,MUSA,1332,1,26663,Applied Oboe,Dinitz,Adam L,2,0,0,0,0,0,0,4.0
+Fall 2022,HLT,4310,4,26667,Program Planning for Hlt Prof,Behjat,Amirmohsen,5,9,10,1,0,0,1,2.654
+Fall 2022,ENGL,8398,12,26668,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,HIST,6399,2,26670,Masters Thesis,Neumann,Kristina Marie,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8398,132,26675,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Fall 2022,PHLS,8399,5,26680,Doctoral Dissertation,Margulis,Milena A,1,0,0,0,0,1,0,4.0
+Fall 2022,ARTH,3399,1,26684,Senior Honors Thesis,Zalman,Sandra,1,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,3301,2,26685,Life Drawing,Stern,Lindsey Rose,11,6,0,0,0,0,0,3.55
+Fall 2022,PSYC,6398,19,26688,Independent Studies,Bick,Johanna R,0,0,0,0,0,3,0,
+Fall 2022,COSC,6339,1,26689,Big Data Analytics,Yan,Feng,41,1,1,0,0,0,1,3.923
+Fall 2022,GEOL,3396,1,26690,Senior Research Project,Mann,Paul,0,1,0,0,0,0,0,3.0
+Fall 2022,MUSA,8320,14,26692,Doctoral Applied Music,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,7399,11,26702,Masters Thesis,Vujanovic,Anka Anna,0,0,0,0,0,1,0,
+Fall 2022,INDS,6198,1,26708,Independent Study,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4189,5,26709,Senior Recital,Maroney,Marcus K,1,0,0,0,0,0,0,4.0
+Fall 2022,HLT,3300,2,26710,Social Health and Wellness,Farmer,Jennifer,72,16,5,0,3,0,3,3.556
+Fall 2022,ARCH,3314,1,26712,Topics in Design Technology,Kyropoulou,Amygdalia,4,2,3,0,1,0,5,2.701
+Fall 2022,COMM,4398,1,26725,Independent Study,Huang,Yan,1,0,0,0,0,0,0,4.0
+Fall 2022,INDE,2331,4,26728,Computer Applications for IE,Wiggins,Nathanial David,6,1,0,0,0,0,0,3.763
+Fall 2022,INDE,2333,5,26729,Engineering Statistics I,Wiggins,Nathanial David,12,9,3,1,0,0,0,3.122
+Fall 2022,GHL,6172,1,26737,Mgmt Training Work Exp Prog I,Shepherd,Ashley,1,1,0,0,0,0,0,3.5
+Fall 2022,GHL,6317,3,26738,Innovative Hosp. Technologies,Lee,Minwoo,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6324,2,26739,Hosp. Busn Strategies in Amer,Kim,Jaewook,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6340,2,26740,Behavior and Hosp. Lead. Strat,Guchait,Priyanko,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6352,2,26741,Hospitality Market Analysis,McCaslin,Glynn Randle,1,0,0,0,0,0,0,4.0
+Fall 2022,ANTH,4331,1,26743,Medical Anthropology,Ghazali,Marwa,20,0,0,0,0,0,1,4.0
+Fall 2022,ANTH,6322,1,26744,Seminar in Medical Anth,Ghazali,Marwa,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,2348,2,26745,Digital Tools,Sawhney,Ashita,15,0,0,0,0,0,0,3.89
+Fall 2022,ENTR,7336,2,26748,Entrepreneurship Overview,Wilbur,Stephen,7,1,0,0,0,0,0,3.751
+Fall 2022,MUSA,4234,1,26749,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4189,6,26750,Senior Recital,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2022,PETR,3363,1,26751,Fluid Mechanics for PETR Engr,Sakhaee Pour,Ahmad,10,3,0,0,0,0,0,3.769
+Fall 2022,MUSA,8320,26,26753,Doctoral Applied Music,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Fall 2022,CORE,1101,11,26754,College Success,Pierson,Melissa E,23,5,1,2,3,0,1,3.245
+Fall 2022,ANTH,6332,1,26762,Migration/Borders/Citizenship,Small,Ivan Victor,1,0,0,0,0,0,0,4.0
+Fall 2022,ANTH,4361,1,26763,Migration / Borders / Citizens,Small,Ivan Victor,8,3,0,0,0,0,1,3.607
+Fall 2022,ANTH,4394,3,26764,Selected Topics in Ant,Small,Ivan Victor,5,3,1,0,0,0,0,3.444
+Fall 2022,ARTS,3313,3,26765,Silkscreen,Gates,Elizabeth Ann,11,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,28,26766,Doctoral Applied Music,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2022,DIGM,4398,1,26767,Independent Study,Liao,Tony Chung-Li,3,0,0,0,0,0,0,4.0
+Fall 2022,MIS,6A41,3,26772,Information Systems,Silva,Leiser O,26,4,0,0,0,0,1,3.647
+Fall 2022,ANTH,6395,1,26777,Selected Topics in Ant,Small,Ivan Victor,1,0,0,0,0,0,0,4.0
+Fall 2022,CIS,2337,31,26778,Fund of Information Security,Lee,Kyu In,24,23,8,3,1,0,1,3.012
+Fall 2022,ENGL,4300,2,26779,Intro-Study of Language,Nelms,Jodi Lynn,25,5,0,0,1,0,2,3.752
+Fall 2022,CNST,3205,2,26783,Construction Safety Management,Hart,Lee J,16,3,0,1,0,0,0,3.7
+Fall 2022,MECE,5363,1,26795,Fluid Mechanics,Chen,Xuemei,13,32,18,0,0,0,3,2.847
+Fall 2022,INDS,6197,2,26796,Selected Topics,Kimbrough,Mark S,1,0,0,0,0,0,0,4.0
+Fall 2022,MECT,6398,2,26797,Special Problems in MET,Zhu,Weihang,1,0,0,0,0,0,0,4.0
+Fall 2022,THEA,6398,2,26799,Independent Study,Noble,Adam S,2,0,0,0,0,0,0,3.67
+Fall 2022,THEA,6398,3,26800,Independent Study,Wetzel,Molly Elizabeth,1,2,0,0,0,0,0,3.553
+Fall 2022,MECE,6397,5,26803,Selected Topics,Prosperetti,Andrea,3,0,0,0,0,0,0,3.67
+Fall 2022,ELCS,8398,2,26809,Independent Study,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Fall 2022,SCM,3301,5,26813,SCM Fundamentals,Anderson Fletcher,Elizabeth,12,8,2,0,0,0,0,3.455
+Fall 2022,SCM,3301,6,26814,SCM Fundamentals,Anderson Fletcher,Elizabeth,16,5,0,0,0,0,1,3.762
+Fall 2022,PCEU,7142,1,26817,Pharmaceutic Literature Review,Bond,Richard A,0,0,0,0,0,9,0,
+Fall 2022,COSC,6397,2,26820,Topics Computer Science,Ordonez,Carlos,4,0,0,0,0,0,0,3.835
+Fall 2022,CIVE,3331,2,26821,Environmental Engineering,Kiaghadi,Amin,46,24,14,1,2,0,0,3.192
+Fall 2022,INDE,6372,2,26822,Advanced Linear Optimization,Lim,Gino Jinho,24,20,6,0,0,0,0,3.294
+Fall 2022,CIVE,3337,2,26824,Structural Analysis,Phatak,Tejasree Mohan,10,13,13,3,0,0,0,2.769
+Fall 2022,CIVE,3339,3,26826,Geotechnical Engineering,Phatak,Tejasree Mohan,7,12,15,3,0,0,0,2.675
+Fall 2022,ECE,3355,3,26828,Electronics,Ruchhoeft,Paul,21,16,3,0,0,0,0,3.45
+Fall 2022,CNST,6380,1,26831,Leed & Green Const Princ in CM,Chang,Chi Chung,1,0,0,0,0,0,0,4.0
+Fall 2022,CNST,6380,2,26832,Leed & Green Const Princ in CM,Chang,Chi Chung,8,1,0,0,0,0,0,3.852
+Fall 2022,GHL,6298,1,26833,Special Problems,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,3155,2,26834,Electronics Laboratory,Ruchhoeft,Paul,36,4,0,0,0,0,0,3.719
+Fall 2022,ECE,3317,3,26835,Applied Electromagnetic Waves,Chen,Jiefu,14,24,3,0,0,0,0,3.284
+Fall 2022,MECE,3345,3,26836,Materials Science,Ryou,Jae-Hyun,13,25,2,0,3,0,0,3.023
+Fall 2022,PSYC,8199,1,26837,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8199,2,26838,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,3,0,
+Fall 2022,MECE,3363,3,26839,Intro To Fluid Mechanics,Wang,Jiawen,8,11,12,3,2,0,0,2.446
+Fall 2022,MECE,3369,3,26840,Solid Mechanics,Wang,Jiawen,7,12,14,2,2,0,0,2.425
+Fall 2022,PCEU,6198,2,26841,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,2201,11,26842,Circuit Analysis I,Ramachandran,Deepa,15,25,23,6,4,0,6,2.553
+Fall 2022,PHLS,8399,6,26844,Doctoral Dissertation,Master,Allison,0,0,0,0,0,1,0,
+Fall 2022,NURS,8225,1,26847,Complex Health Deviations Sem,Dwyer,Carol Ann,0,0,0,0,0,6,0,
+Fall 2022,NURS,8326,1,26848,Complex Health Deviations Prac,Dwyer,Carol Ann,0,0,0,0,0,6,0,
+Fall 2022,PHYS,2325,7,26849,University Physics I (lecture),Chen,Shuo,6,8,2,0,2,0,2,2.944
+Fall 2022,SOCW,8695,1,26853,Pre-Dissertation Research,Leung,Yuk-Hi Patrick,1,0,0,0,0,0,0,4.0
+Fall 2022,CUIN,8999,2,26854,Doctoral Dissertation,McNeil,Sara G,0,0,0,0,0,1,0,
+Fall 2022,ANTH,4398,1,26857,Independent Study,Sen,Debarati,1,0,0,0,0,0,0,4.0
+Fall 2022,ELET,4397,3,26858,Selected Topics in Elet,Montero Hernandez,Samuel Antonio,2,4,5,0,0,0,1,2.787
+Fall 2022,PHOP,8499,3,26859,Doctoral Dissertation,Coulson-Thomas,Vivien J,0,1,0,0,0,0,0,3.0
+Fall 2022,MUSA,6312,1,26860,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,4398,3,26862,Independent Study,Houk,Keith R,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,4398,4,26863,Independent Study,Vardeman,Jennifer E,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,4397,3,26865,Selected Topics Communication,Carter,Nestor Gregory,16,2,0,1,0,0,1,3.737
+Fall 2022,COMM,7397,4,26868,Selected Topics - Comm,Harlow,Summer D,1,0,0,0,0,0,0,4.0
+Fall 2022,PCEU,6198,5,26872,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2022,MECE,8398,21,26875,Doctoral Research,Song,Gangbing,0,0,0,0,0,2,0,
+Fall 2022,BCHS,8898,1,26877,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8898,1,26880,Doctoral Research,Lekven,Arne,0,0,0,0,0,2,0,
+Fall 2022,PHLS,8396,1,26881,Doctoral Research,Margulis,Milena A,0,0,0,0,0,2,0,
+Fall 2022,BIOL,6698,1,26883,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2022,EDS,6333,1,26886,Probability and Statistics,Jegdic,Katarina Svetislav,53,23,13,5,3,0,3,3.227
+Fall 2022,ANTH,4398,2,26887,Independent Study,Brown,Kenneth L,1,0,0,0,0,0,0,4.0
+Fall 2022,EDS,6342,1,26888,Intro to Machine Learning,Jegdic,Katarina Svetislav,25,43,53,18,0,0,0,2.54
+Fall 2022,EDS,6397,1,26889,Selected Topics,Ratner,Edward,100,1,0,0,1,0,0,3.945
+Fall 2022,MUSA,6430,1,26894,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,3321,6,26900,Engineering Mathematics,West,James David,59,65,41,27,15,0,4,2.609
+Fall 2022,MATH,3363,6,26901,Introduction To Pde,Fitzgibbon,William E,33,39,14,0,1,0,0,3.15
+Fall 2022,PCOL,6298,4,26902,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Fall 2022,MUSI,6344,1,26903,Franz Schubert,Guez,Jonathan Charles,5,1,0,0,0,0,1,3.833
+Fall 2022,MUSI,4397,2,26904,Selected Topics in Music,Guez,Jonathan Charles,7,0,0,0,0,0,0,3.906
+Fall 2022,ARTS,1316,7,26909,Fundamentals of Drawing,Willis,William H,22,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,4341,1,26910,Queer Theory,Pegoda,Andrew Joseph,4,2,0,1,0,0,3,3.191
+Fall 2022,BZAN,6310,7,26911,Quant Analysis for Busn Dec,Wiley,Briceon C,5,5,5,0,2,0,0,2.511
+Fall 2022,HIST,6398,2,26915,Special Problems,Golubev,Alexey Valeryevich,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,6399,11,26919,Masters Thesis,Li,Aibing,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6798,1,26922,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8798,1,26923,Doctoral Research,Khurana,Seema,0,0,0,0,0,1,0,
+Fall 2022,HIST,2311,1,26924,Western Civilization to 1450,Patterson,Catherine F,13,12,7,1,1,0,1,3.0
+Fall 2022,ENGI,4398,24,26928,Independent Study,Claydon,Frank J,0,0,0,0,0,1,0,
+Fall 2022,MECE,8298,40,26930,Doctoral Research,Cescon,Marzia,0,0,0,0,0,3,0,
+Fall 2022,COMD,7392,6,26931,Adv Pract Sp & Lang Dis,Maher,Lynn M,2,1,0,0,0,0,0,3.557
+Fall 2022,ENGI,4198,3,26932,Independent Study,Burleson,Daniel W,0,0,0,0,0,12,0,
+Fall 2022,COMD,7392,7,26933,Adv Pract Sp & Lang Dis,Maher,Lynn M,3,0,0,0,0,0,0,4.0
+Fall 2022,ENGI,4198,4,26935,Independent Study,Burleson,Daniel W,0,0,0,0,0,15,1,
+Fall 2022,CHEE,4398,1,26936,Independent Study,Henderson,Jerrod A,3,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8398,27,26937,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2022,MUSA,2350,2,26940,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,6898,1,26941,Special Problems,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8898,2,26942,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2022,MIS,3376,5,26946,Busn Appls Database Mgmt I,Jiang,Lianlian,27,24,4,1,2,0,1,3.287
+Fall 2022,BIOL,8998,2,26947,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6698,1,26948,Special Problems,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2022,CIS,6321,40,26950,Principles of Cybersecurity,Bronk,Robert C.,9,2,2,0,0,0,0,3.462
+Fall 2022,CHEM,1112,25,26953,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,0,0,0,0,1,3.334
+Fall 2022,CHEM,1112,26,26954,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,8,0,0,0,0,2,3.333
+Fall 2022,GEOL,3399,2,26963,Senior Honors Thesis,Lapen,Thomas J,0,0,0,0,0,0,0,
+Fall 2022,MUSA,1320,1,26964,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4189,7,26965,Senior Recital,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4224,1,26966,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2022,CIS,6325,42,26969,Network Security,Gurkan,Deniz,5,3,2,1,2,0,1,2.565
+Fall 2022,PHLS,8699,13,26971,Doctoral Dissertation,de Dios,Marcel A,0,0,0,0,0,1,0,
+Fall 2022,BTEC,6399,31,26972,Thesis,Khan,Abdul Latif,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,8999,1,26974,Doctoral Dissertation,Azencott,Robert Guy,1,0,0,0,0,0,0,4.0
+Fall 2022,INDS,6398,5,26976,Independent Study,Kang,Chul Min,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,2425,7,26978,Computer Org & Architecture,Mantini,Pranav,45,27,4,0,0,0,4,3.557
+Fall 2022,COSC,2425,807,26980,Computer Org & Architecture,Mantini,Pranav,26,10,2,0,2,0,0,3.368
+Fall 2022,COSC,2425,901,26982,Computer Org & Architecture,Long,Kevin B,36,41,11,3,2,0,6,3.14
+Fall 2022,BIOL,6898,1,26985,Special Problems,Zufall,Rebecca A,0,0,0,0,0,2,0,
+Fall 2022,BIOL,8898,3,26987,Doctoral Research,Peng,Weiyi,0,0,0,0,0,3,0,
+Fall 2022,PCOL,6198,7,26988,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Fall 2022,TEPM,6301,40,27014,Project Management Principles,Sherman,Dennis Louis,20,2,0,0,0,0,0,3.894
+Fall 2022,TEPM,6302,40,27015,Leadership and Team Building,Hopkins,Ronald K.,7,1,0,0,0,0,0,3.669
+Fall 2022,TEPM,6304,40,27017,Quality Improvemnt in Proj Mgt,Kovach,Jamison,5,1,0,0,0,0,1,3.833
+Fall 2022,INDS,6398,6,27022,Independent Study,Feng,Jeff Feng,2,0,0,0,0,0,0,3.835
+Fall 2022,ARTS,1311,5,27023,Fundamentals of Graphic Design,Lopez,Jonathan Christopher,8,8,2,1,0,0,0,3.141
+Fall 2022,ANTH,6351,1,27026,Human Osteology,Bytheway,Joan A,1,0,0,0,0,0,0,4.0
+Fall 2022,ECON,8399,9,27028,Doctoral Dissertation,Szabo,Andrea,0,0,0,0,0,1,0,
+Fall 2022,MUSI,1140,3,27030,Orchestra,Longoria,Jose Isabel,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,2312,4,27032,Precalculus,Bhullar,Jasmine,32,16,10,6,6,0,8,2.867
+Fall 2022,MATH,2312,9,27033,Precalculus,Perepelitsa,Irina,22,18,8,6,14,0,12,2.402
+Fall 2022,MUSI,1140,5,27035,Orchestra,Longoria,Jose Isabel,2,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,8198,2,27039,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,
+Fall 2022,COMD,8291,1,27043,COMD Research,Castilla-Earls,Anny,0,0,0,0,0,1,0,
+Fall 2022,COMD,8291,2,27044,COMD Research,Joshi,Ashwini,0,0,0,0,0,1,0,
+Fall 2022,ELCS,6393,3,27045,Practicum,Davis,Tiffany J,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8399,9,27049,Doctoral Dissertation,Burns,Alan R,2,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6857,2,27050,Research Practicum B,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6457,4,27051,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Fall 2022,PHOP,8798,1,27052,Doctoral Research,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6267,5,27053,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6867,4,27054,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8998,1,27055,Doctoral Research,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6767,6,27056,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Fall 2022,PHOP,8798,2,27057,Doctoral Research,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8499,4,27058,Doctoral Dissertation,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8598,7,27059,Doctoral Research,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8398,3,27060,Doctoral Research,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8499,5,27061,Doctoral Dissertation,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8898,1,27062,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,6167,6,27063,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8798,3,27064,Doctoral Research,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8398,3,27066,Independent Study,Freelon,Rhoda,0,0,0,0,0,0,0,
+Fall 2022,BIOL,8998,3,27068,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Fall 2022,OPTO,5198,8,27070,Spec Prob - Clerkship,Dempsey,Robert L.,0,0,0,0,0,57,0,
+Fall 2022,OPTO,5298,1,27071,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,2,0,
+Fall 2022,OPTO,5298,2,27072,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,19,0,
+Fall 2022,OPTO,5298,3,27073,Spec Prob Phys Optics,Dempsey,Robert L.,0,0,0,0,0,1,0,
+Fall 2022,QSS,4393,3,27074,QSS Research Project,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,2,27075,Adv Special Problem Human Perf,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8298,2,27076,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,
+Fall 2022,CIVE,8498,2,27077,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,
+Fall 2022,BIOL,8998,4,27078,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,2,0,
+Fall 2022,BIOL,6898,2,27079,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6798,2,27080,Special Problems,Alward,Beau Andrew,0,0,0,0,0,1,0,
+Fall 2022,SPAC,6398,1,27081,Special Problems,Kennedy,Kriss Jon,4,5,0,0,0,0,0,3.554
+Fall 2022,FORE,6311,40,27082,Introduction to Foresight,Schultz,Wendy L,0,1,0,0,0,0,0,3.0
+Fall 2022,HLT,1353,5,27085,Personal Health,Shamblin,Angel Ann,87,22,5,5,1,0,0,3.487
+Fall 2022,MARK,6A61,6,27092,Marketing Administration,Krishnamurthy,Parthasarathy,19,0,1,0,0,0,0,3.867
+Fall 2022,BCHS,8998,1,27093,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8898,5,27094,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Fall 2022,ENGL,1301,154,27100,First Year Writing I,Yates,Kaitlyn,9,8,3,0,2,0,3,2.94
+Fall 2022,ENGL,1301,155,27101,First Year Writing I,Denton,Amy,14,4,1,2,3,0,0,2.945
+Fall 2022,ENGL,1301,156,27105,First Year Writing I,Denton,Amy,7,9,4,0,1,0,2,2.827
+Fall 2022,ENGL,1301,157,27108,First Year Writing I,Denton,Amy,7,6,3,2,3,0,3,2.477
+Fall 2022,ENGL,1301,158,27109,First Year Writing I,Penzien,Eugene Norman,3,10,0,3,8,0,1,1.82
+Fall 2022,ENGL,1301,159,27110,First Year Writing I,Penzien,Eugene Norman,4,6,3,0,5,0,7,2.131
+Fall 2022,ENGL,1301,160,27111,First Year Writing I,Yates,Kaitlyn,8,4,1,2,6,0,2,2.223
+Fall 2022,ENGL,1301,161,27113,First Year Writing I,Yates,Kaitlyn,8,5,4,0,3,0,5,2.668
+Fall 2022,ENGL,1301,162,27114,First Year Writing I,Penzien,Eugene Norman,7,4,1,1,10,0,1,1.783
+Fall 2022,ENGL,1301,163,27116,First Year Writing I,Yates,Kaitlyn,9,1,2,1,9,0,2,1.925
+Fall 2022,ENGL,1302,62,27119,First Year Writing II,Woleslagle,Julieta Margarita,5,6,2,5,5,0,2,1.943
+Fall 2022,ENGL,1302,63,27120,First Year Writing II,Stewart-Steele,Heather Marie,14,2,0,0,3,0,5,3.142
+Fall 2022,ENGL,1302,65,27122,First Year Writing II,Mansoor,Shaista,12,4,1,0,5,0,2,2.758
+Fall 2022,CIVE,8398,2,27127,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8398,3,27129,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Fall 2022,ECE,6397,4,27134,Selected Topics,Nguyen,Hien V,6,23,2,0,0,0,0,3.097
+Fall 2022,FINA,8397,1,27137,Selected Topics in Finance,Susmel,Raul,3,0,0,0,0,0,0,3.78
+Fall 2022,BIOL,6898,3,27139,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8398,4,27140,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Fall 2022,CIVE,8298,3,27141,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,5,0,
+Fall 2022,CIVE,8498,3,27142,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Fall 2022,PHOP,6557,4,27143,Research Practicum B,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8898,2,27145,Doctoral Research,Twa,Michael D,1,0,0,0,0,0,0,3.67
+Fall 2022,PHOP,6357,12,27146,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,8998,5,27147,Doctoral Research,Warner,Margaret,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8998,2,27148,Doctoral Research,Briggs,James M,0,0,0,0,0,1,0,
+Fall 2022,THEA,4397,2,27153,Drama Workshop,Carter,Nestor Gregory,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,4397,4,27154,Sel Topics in Fine Arts,Carter,Nestor Gregory,6,0,1,0,0,0,0,3.714
+Fall 2022,ENGL,8398,13,27155,Graduate English Resrch,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2022,CHEE,6398,2,27157,Research,Mountziaris,Triantafillos John,0,0,0,0,0,2,0,
+Fall 2022,MUSA,4424,1,27158,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6398,5,27159,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6198,4,27161,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2022,PHCA,6198,1,27162,Special Problems,Varkey,Divya A,3,0,0,0,0,0,0,4.0
+Fall 2022,PHCA,6198,2,27163,Special Problems,Varkey,Divya A,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,6398,29,27167,Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7399,8,27169,Masters Thesis,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,7399,12,27170,Masters Thesis,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Fall 2022,CHEM,1112,27,27171,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,5,1,0,0,0,1,3.332
+Fall 2022,FINA,8397,2,27174,Selected Topics in Finance,Jacobs,Kris,4,0,0,0,0,0,0,4.0
+Fall 2022,SCM,4362,3,27175,Demand and Supply Integration,Khumawala,Basheer M,20,21,9,0,0,0,0,3.227
+Fall 2022,SCM,4362,4,27176,Demand and Supply Integration,Khumawala,Basheer M,12,30,7,1,0,0,1,3.04
+Fall 2022,CIVE,8198,2,27177,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8398,14,27178,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,ENGL,8698,13,27179,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2022,CIS,3351,2,27181,Intrusion Detect & Incid Resp,Nsoh,Jovita T,17,14,5,1,2,0,4,3.119
+Fall 2022,ENGL,3316,2,27182,Lit of Victorian Age,Womble,David Avari Patrick,13,10,1,0,3,0,2,3.087
+Fall 2022,BIOL,8898,6,27193,Doctoral Research,Fujita,Masaya,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6998,1,27196,Special Problems,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Fall 2022,HIST,1302,7,27197,The U.S. Since 1877,Mizelle Jr,Richard M.,23,0,8,1,2,0,1,3.225
+Fall 2022,BIOE,8598,29,27198,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Fall 2022,BIOE,8398,28,27199,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Fall 2022,COSC,4397,2,27200,Sel Top-Computer Science,Ordonez,Carlos,9,5,0,0,0,0,1,3.619
+Fall 2022,ANTH,4399,1,27207,Senior Honors Thesis,Rasmussen,Susan J,1,0,0,0,0,0,0,3.67
+Fall 2022,TLIM,3363,3,27208,Technical Communications,Piercy,Penelope Junker,21,24,5,2,4,0,3,3.012
+Fall 2022,TLIM,3363,34,27209,Technical Communications,Tangeman,Anthony C,21,21,9,1,2,0,5,3.092
+Fall 2022,EDS,6340,1,27210,Introduction to Data Science,Lendasse,Amaury,73,30,0,0,2,0,0,3.55
+Fall 2022,MUSA,4400,9,27212,Applied Voice,Evans,Joseph,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8298,4,27213,Doctoral Research,Lee,Hyongki,0,0,0,0,0,4,0,
+Fall 2022,CIVE,8498,4,27214,Doctoral Research,Lee,Hyongki,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8398,5,27215,Doctoral Research,Lee,Hyongki,0,0,0,0,0,2,0,
+Fall 2022,GEOL,8698,15,27216,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,2,0,
+Fall 2022,HIST,4391,1,27218,Public History Internship,Young,Nancy Beck,2,0,0,0,0,0,1,4.0
+Fall 2022,BIOE,4350,2,27219,Genomic & Proteomic Engr,Wu,Tianfu,4,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8698,16,27220,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8698,17,27221,Doctoral Research,Murphy,Michael,0,0,0,0,0,2,0,
+Fall 2022,CIVE,8298,5,27222,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Fall 2022,CIVE,8298,6,27223,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,GEOL,7399,12,27226,Masters Thesis,Copeland,Peter,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6898,5,27228,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6398,20,27229,Independent Studies,Mehta,Paras D,0,2,4,0,0,0,0,2.388
+Fall 2022,CUIN,7368,2,27235,Digital Imaging in Education,Ahlf,Michael,17,3,0,0,0,0,0,3.883
+Fall 2022,ECE,7399,6,27237,Masters Thesis,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Fall 2022,ECE,8699,30,27238,Doctoral Dissertation,Malki,Heidar A,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8398,6,27242,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8598,2,27244,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8498,5,27246,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8398,21,27248,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8698,18,27251,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Fall 2022,THEA,6307,1,27255,Theatrical Project Planning,Vlahos,Kalliope,0,1,0,0,0,0,0,3.0
+Fall 2022,DIGM,1350,35,27257,Graphics for Digital Media,Beyl,Charles Eugene,14,11,4,0,2,0,1,3.108
+Fall 2022,COSC,6308,5,27259,Computer Architecture,Johnsson,Lennart,4,0,1,0,0,0,0,3.468
+Fall 2022,ARTS,2316,5,27260,Fundamentals of Painting,Meza,Edgar,17,0,0,0,0,0,2,4.0
+Fall 2022,POLS,8999,10,27261,Doctoral Dissertation,Cantu,Francisco,0,0,0,0,0,0,0,
+Fall 2022,POLS,8999,12,27263,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,1,0,
+Fall 2022,PCEU,6198,8,27265,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7399,13,27267,Masters Thesis,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Fall 2022,ENGL,1301,166,27269,First Year Writing I,Box,Anthony Joseph,10,3,1,1,5,0,3,2.518
+Fall 2022,ENGL,1301,167,27270,First Year Writing I,Penzien,Eugene Norman,5,8,3,3,5,0,1,2.071
+Fall 2022,ENGL,1301,168,27271,First Year Writing I,Horton,Lara,3,9,5,2,2,0,4,2.366
+Fall 2022,ENGL,1301,169,27272,First Year Writing I,Horton,Lara,7,7,3,0,4,0,3,2.525
+Fall 2022,ENGL,1301,170,27273,First Year Writing I,Horton,Lara,4,7,3,2,5,0,4,2.127
+Fall 2022,ENGL,1301,171,27274,First Year Writing I,Horton,Lara,5,5,4,0,5,0,6,2.176
+Fall 2022,ENGL,1301,172,27275,First Year Writing I,Fletcher,Larry L,2,5,7,1,5,0,2,1.9
+Fall 2022,ENGL,1301,173,27277,First Year Writing I,Fletcher,Larry L,7,4,3,3,5,0,1,2.197
+Fall 2022,ENGL,1301,174,27278,First Year Writing I,Braniger,Leslie,2,6,9,2,3,0,3,2.091
+Fall 2022,ENGL,1301,175,27279,First Year Writing I,Horning,Sarah-Marie D,11,1,1,2,8,0,1,2.117
+Fall 2022,ENGL,1301,176,27280,First Year Writing I,Horning,Sarah-Marie D,4,5,5,2,6,0,3,1.955
+Fall 2022,ENGL,1301,177,27281,First Year Writing I,Martinez,Jorge,1,7,5,2,4,0,4,1.93
+Fall 2022,ENGL,1302,66,27283,First Year Writing II,Worley,Sharon J,8,8,2,3,4,0,0,2.428
+Fall 2022,ENGL,1302,67,27284,First Year Writing II,Worley,Sharon J,9,6,2,2,4,0,2,2.551
+Fall 2022,ENGL,1302,68,27286,First Year Writing II,O'Neal,Penny M,13,6,3,1,1,0,1,3.14
+Fall 2022,ENGL,1302,69,27288,First Year Writing II,O'Neal,Penny M,11,8,3,0,0,0,3,3.319
+Fall 2022,TECH,4310,1,27293,Future of Energy & Environment,Breaux,James William,21,1,0,0,1,0,2,3.768
+Fall 2022,PCOL,6198,9,27294,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Fall 2022,PCOL,6198,10,27295,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2022,ELCS,8398,4,27296,Independent Study,Davis,Tiffany J,3,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7699,8,27299,Thesis,Peynado,Brenda,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8698,19,27300,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2022,ELCS,8198,1,27301,Independent Study,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Fall 2022,MECE,6399,5,27305,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Fall 2022,GHL,4398,1,27306,Independent Study,Kenyan,Erin Oeser,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,6798,5,27313,Special Problems,Sater,Amy,0,0,0,0,0,0,0,
+Fall 2022,MECE,8999,1,27314,Doctoral Dissertation,Sharma,Pradeep,1,0,0,0,0,0,0,4.0
+Fall 2022,PCEU,8199,1,27316,Dissertation,Hu,Ming,1,0,0,0,0,0,0,4.0
+Fall 2022,CIS,6325,3,27317,Network Security,Gurkan,Deniz,24,16,4,3,4,0,1,2.975
+Fall 2022,PSYC,6398,21,27318,Independent Studies,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8598,1,27319,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Fall 2022,MECE,8699,1,27320,Doctoral Dissertation,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2022,MUSA,4189,8,27321,Senior Recital,Smith,Robert Thomas,0,0,0,0,0,0,0,
+Fall 2022,ENGL,8399,15,27322,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Fall 2022,AAS,2320,7,27323,Intro To African American Stdy,Boyce,Stephanie,29,2,0,0,2,0,1,3.697
+Fall 2022,COMM,4398,6,27324,Independent Study,Crowe,Craig Warren,2,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,7398,3,27325,Independent Graduate Study,Reed,John G,2,0,0,0,0,0,0,4.0
+Fall 2022,EDS,6397,2,27329,Selected Topics,Grimes,George M,45,14,0,0,0,0,0,3.763
+Fall 2022,ENGL,8399,16,27330,Doctoral Dissertation,Tejada,Roberto Jose,0,0,0,0,0,1,0,
+Fall 2022,PEP,7398,3,27331,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,4,27332,Adv Special Problem Human Perf,Layne,Charles S,2,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,5,27333,Adv Special Problem Human Perf,Arellano,Christopher,2,0,0,0,0,0,0,4.0
+Fall 2022,ENGL,7398,7,27334,Special Problems,Womble,David Avari Patrick,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8398,5,27340,Independent Study,Davis,Bradley,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8598,2,27341,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Fall 2022,ELET,4398,1,27342,Independent Study,Lent,Marino Ricardo,2,0,0,0,0,0,0,4.0
+Fall 2022,OPTO,5198,9,27345,Spec Prob - Clerkship,Giannoni,Amber Gaume,0,0,0,0,0,2,0,
+Fall 2022,OPTO,5198,11,27347,Spec Prob - Clerkship,Dempsey,Robert L.,0,0,0,0,0,3,0,
+Fall 2022,PHLS,8999,5,27349,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2022,MUSA,6410,1,27350,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6140,7,27351,Graduate Recital I,Staupe,Andrew Paul,1,0,0,0,0,0,0,3.67
+Fall 2022,BCHS,6698,4,27352,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2022,MECE,8298,2,27353,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Fall 2022,BCHS,6898,2,27355,Special Problems,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Fall 2022,HIST,6398,3,27356,Special Problems,McNally,David Joseph,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8241,7,27358,Doctoral Recital II,Hughes,Mark Alan,0,0,0,0,0,0,0,
+Fall 2022,CIVE,8999,2,27359,Doctoral Dissertation,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2022,GEOL,7398,3,27361,Masters Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Fall 2022,COSC,8298,106,27362,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Fall 2022,PHYS,8598,4,27363,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Fall 2022,HLT,4320,3,27364,Admin of Health Services,Haq,Arooba A,10,17,7,0,0,0,1,3.02
+Fall 2022,PHCA,8698,1,27366,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2022,INTB,3355,5,27368,Global Environment of Business,Miljanic,Andra Olivia,52,65,30,20,18,0,5,2.591
+Fall 2022,MUSA,4260,1,27372,Applied Music,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8298,7,27373,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8498,6,27374,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2022,PEP,8350,6,27379,HHP Candidacy Project Research,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8398,7,27380,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Fall 2022,BIOL,8898,7,27381,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2022,CIVE,6398,1,27382,Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6898,7,27383,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8220,1,27384,Doctoral Applied Music,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,8898,4,27385,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Fall 2022,PCOL,8998,10,27387,Doctoral Research,Ruan,Ke-He,0,0,0,0,0,0,0,
+Fall 2022,SCM,4302,1,27390,Energy Supply Chain,Radhakrishnan,Suryanarayanan,12,38,3,0,0,0,0,3.182
+Fall 2022,DIGM,1300,31,27392,Introduction to Digital Media,Liao,Pamara F.,19,11,3,1,4,0,3,3.044
+Fall 2022,ELCS,8398,6,27394,Independent Study,Messa,Emily Alice,1,0,0,0,0,0,0,4.0
+Fall 2022,MIS,8999,2,27395,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,2,0,
+Fall 2022,MIS,8999,3,27396,Doctoral Dissertation in MIS,Chin,Wynne W,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8699,2,27397,Doctoral Dissertation,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,6345,3,27398,Fluid Dynamics 1,Yang,Di,4,6,2,0,0,0,2,3.167
+Fall 2022,MECE,6361,3,27399,Mechanical Behavior/Materials,Ryou,Jae-Hyun,12,7,1,0,0,0,0,3.534
+Fall 2022,CIVE,8598,4,27400,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,2,0,
+Fall 2022,MECE,6384,3,27401,Methods of Applied Math I,Kulkarni,Yashashree,1,1,6,3,1,0,2,1.888
+Fall 2022,MIS,4396,1,27403,MIS Internship,Johnson,Norman A.,0,0,0,0,0,2,0,
+Fall 2022,ARTS,3384,2,27405,Sound Art,Cone,Marcus Andrew,10,0,0,0,0,0,0,4.0
+Fall 2022,ARTS,6397,6,27407,Sel Topics/Studio Arts,Cone,Marcus Andrew,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8242,5,27408,Doctoral Recital III,Morgulis,Tali,0,0,0,0,0,0,0,
+Fall 2022,CIVE,8198,3,27409,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8998,4,27412,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8998,5,27413,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2022,OPTO,5198,12,27414,Spec Prob - Clerkship,Herring,Ralph Jay,0,0,0,0,0,2,0,
+Fall 2022,CIVE,8398,8,27418,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Fall 2022,CIVE,8298,8,27419,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8498,7,27420,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Fall 2022,PHLS,7398,2,27421,Candidacy Research,Arbona,Consuelo,0,0,0,0,0,2,0,
+Fall 2022,CIS,2336,33,27422,Internet Application Developmt,Nsoh,Jovita T,15,5,3,0,1,0,3,3.361
+Fall 2022,ELET,1400,4,27423,Circuit Theory and Lab I,Barbieri,Enrique,2,3,6,1,8,0,2,1.417
+Fall 2022,MUSA,8241,8,27425,Doctoral Recital II,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,6399,6,27427,Masters Thesis,Ghasemi,Hadi,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,7397,5,27429,Selected Topics - Comm,Archer,Allison Michelle Nam,1,0,0,0,0,0,0,4.0
+Fall 2022,COMD,8398,1,27430,Special Problems,Joshi,Ashwini,0,0,0,0,0,0,0,
+Fall 2022,GEOL,8998,30,27432,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8399,10,27433,Doctoral Dissertation,Wang,Guoquan,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8999,7,27434,Doctoral Dissertation,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8398,9,27435,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,2,0,
+Fall 2022,GEOL,6399,12,27436,Masters Thesis,Wellner,Julia S,0,0,0,0,0,1,0,
+Fall 2022,CNST,4302,1,27437,Construction Law and Ethics,Escobar,C Mauricio,8,3,0,2,1,0,0,3.024
+Fall 2022,CIVE,6398,2,27438,Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Fall 2022,COMM,4398,7,27439,Independent Study,Lee,Jaesub,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,10,27440,Doctoral Research,Zhao,Bo,0,0,0,0,0,2,0,
+Fall 2022,CIVE,8398,10,27445,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8220,3,27447,Doctoral Applied Music,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8243,5,27449,Doctoral Lecture Recital,Lange,Barbara Rose,0,0,0,0,0,0,0,
+Fall 2022,PHCA,8199,4,27452,Doctoral Dissertation Defense,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,6397,4,27453,Sel Top in Psychology,Kosten,Therese A,6,0,0,0,0,0,0,4.0
+Fall 2022,COMM,1303,6,27455,Writing for Communicators,Lyn,Robyn,28,4,3,0,4,0,4,3.35
+Fall 2022,PSYC,7399,14,27458,Masters Thesis,Spitzmuller,Christiane,2,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,8398,1,27459,Research,Derges,Julie D,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6450,1,27460,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,6698,5,27461,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Fall 2022,PCEU,6398,6,27462,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8598,10,27464,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2022,PSYC,7399,15,27465,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8298,41,27466,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8398,11,27467,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,0,0,
+Fall 2022,SOC,7395,1,27468,Internship in Sociology,Anderson,Kathryn,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEM,7399,23,27469,Masters Thesis,Zastrow,Melissa L,0,1,0,0,0,0,0,3.33
+Fall 2022,BCHS,8798,1,27470,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8220,4,27471,Doctoral Applied Music,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8420,4,27472,Doctoral Applied Music,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,5197,1,27473,Selected Topics,Mayerich,David Matthew,0,1,0,0,0,0,2,3.0
+Fall 2022,ARLD,6391,1,27475,Internship in Arts Organizatn,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6198,11,27479,Special Problems,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Fall 2022,CIVE,7399,2,27480,Master's Thesis,Lee,Hyongki,1,0,0,0,0,0,0,4.0
+Fall 2022,ELET,6396,1,27481,Master's Project,Zouridakis,George,1,0,0,0,0,0,0,4.0
+Fall 2022,MUED,2342,5,27483,Music for Children,Bigwood,Cora Morgan,11,5,0,0,0,0,1,3.584
+Fall 2022,CIVE,6198,1,27484,Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2022,ECE,2100,3,27485,Circuit Analysis Laboratory,Leigh,Kevin Benny,3,7,0,0,0,0,1,3.267
+Fall 2022,GEOL,6399,13,27486,Masters Thesis,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8399,2,27489,Doctoral Dissertation,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6998,2,27490,Special Problems,Feng,Qin,0,0,0,0,0,1,0,
+Fall 2022,PEP,8350,7,27492,HHP Candidacy Project Research,Walsh,David W,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,6,27493,Adv Special Problem Human Perf,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,8350,8,27494,HHP Candidacy Project Research,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,8699,5,27495,Doctoral Dissertation,Markofski,Melissa,0,0,0,0,0,0,0,
+Fall 2022,CUIN,8397,6,27497,Selected Topics in C&I,Lee,Mimi Miyoung,0,2,0,0,0,0,0,2.835
+Fall 2022,BIOE,6298,2,27499,Research,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8198,3,27501,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2022,CIVE,6398,3,27505,Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6898,8,27543,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8220,5,27544,Doctoral Applied Music,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,6698,4,27545,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2022,MIS,8999,4,27546,Doctoral Dissertation in MIS,Aron,Ravi,1,0,0,0,0,0,0,4.0
+Fall 2022,BCHS,6798,3,27549,Special Problems,Liu,Yu,0,0,0,0,0,1,0,
+Fall 2022,MUSA,8220,6,27550,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,7,27552,Adv Special Problem Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Fall 2022,PEP,7398,8,27553,Adv Special Problem Human Perf,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Fall 2022,THEA,4398,1,27559,Independent Study,Niederer,Barbara,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8396,1,27561,Research Practicum,Yerramilli,Vijay,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,6399,3,27563,Masters Thesis,Young,Nancy Beck,0,0,0,0,0,0,0,
+Fall 2022,GHL,8399,1,27564,Dissertation I in Hosp. Admin,Boger Jr,Carl A,0,0,0,0,0,0,0,
+Fall 2022,PSYC,8199,3,27569,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8999,2,27570,Doctoral Dissertation,Alfano,Candice A,0,0,0,0,0,1,0,
+Fall 2022,COMD,8191,1,27571,COMD Research,Bunta,Ferenc,0,0,0,0,0,1,0,
+Fall 2022,PSYC,6359,7,27573,Directed Rsch in Clinical Psyc,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4.0
+Fall 2022,COMD,8398,2,27574,Special Problems,Castilla-Earls,Anny,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,8199,4,27576,Doctoral Dissertation,Viana,Andres G,0,0,0,0,0,1,0,
+Fall 2022,INDE,8398,7,27577,Doctoral Research,Xiang,Yisha,0,0,0,0,0,3,0,
+Fall 2022,ENGL,8398,15,27578,Graduate English Resrch,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2022,PHYS,6399,1,27579,Masters Thesis,Freelon,Byron Kendall,0,0,0,0,0,1,0,
+Fall 2022,PHYS,7399,1,27580,Masters Thesis,Freelon,Byron Kendall,0,0,0,0,0,1,0,
+Fall 2022,MECE,4398,3,27581,Independent Study,Becker,Aaron T,1,0,0,0,0,0,0,3.67
+Fall 2022,DANC,2303,3,27582,Introduction to Dance,Bobet,Jacqueline A,10,24,20,6,32,0,16,1.667
+Fall 2022,COMM,4398,8,27583,Independent Study,Olson,Beth M,0,1,0,0,0,0,0,3.0
+Fall 2022,DRAM,1310,21,27584,Introduction to Theatre,Brincks,Alan,21,10,6,4,3,0,4,2.932
+Fall 2022,DRAM,1310,16,27585,Introduction to Theatre,Young,Courtney Leigh,27,8,5,1,5,0,1,3.102
+Fall 2022,PHLS,8396,2,27587,Doctoral Research,Arbona,Consuelo,0,0,0,0,0,3,0,
+Fall 2022,ENGL,6698,3,27590,Research,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2022,MARK,7A43,2,27591,Digital and Inside Sales,Herman,Carl,7,0,0,0,0,0,0,4.0
+Fall 2022,MARK,7A44,2,27592,Customer Relationship Mgt,Herman,Carl,7,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8241,9,27594,Doctoral Recital II,Yon,Kirsten A,0,0,0,0,0,0,0,
+Fall 2022,CIVE,8398,12,27595,Doctoral Research,Momen,Mostafa,0,0,0,0,0,2,0,
+Fall 2022,CIVE,7399,3,27596,Master's Thesis,Momen,Mostafa,1,0,0,0,0,0,0,3.67
+Fall 2022,MECE,8298,22,27598,Doctoral Research,Prosperetti,Andrea,0,0,0,0,0,1,0,
+Fall 2022,GHL,8699,1,27600,Dissertation II in Hosp. Admin,Lee,Minwoo,0,0,0,0,0,1,0,
+Fall 2022,GHL,8699,2,27603,Dissertation II in Hosp. Admin,Guchait,Priyanko,0,0,0,0,0,1,0,
+Fall 2022,GHL,8699,3,27604,Dissertation II in Hosp. Admin,Koh,Yoon,0,0,0,0,0,0,0,
+Fall 2022,GHL,8399,4,27605,Dissertation I in Hosp. Admin,Koh,Yoon,0,0,0,0,0,0,0,
+Fall 2022,GHL,8699,4,27607,Dissertation II in Hosp. Admin,Legendre,Jungyoung Shin,0,0,0,0,0,1,0,
+Fall 2022,HIST,8399,5,27608,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,0,0,
+Fall 2022,MUSI,6298,2,27612,Research,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2022,SOC,3398,1,27613,Ind Study in Soc,Tuthill,Zelma,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6106,6,27615,Grad Large Ensemble,Mueller,Jebediah Lee,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,8399,6,27617,Doctoral Dissertation,Romero,Todd,0,0,0,0,0,1,0,
+Fall 2022,SOC,7199,1,27618,Thesis,Monserud,Maria Aleksandrovna,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7698,1,27619,Masters Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Fall 2022,HIST,8999,7,27620,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Fall 2022,THEA,4398,2,27622,Independent Study,Shimko,Robert B,2,0,0,0,0,0,0,3.835
+Fall 2022,THEA,4398,3,27623,Independent Study,Rigdon,Kevin L,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,4398,9,27625,Independent Study,Houk,Keith R,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8298,103,27626,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2022,CIVE,7399,4,27627,Master's Thesis,Milillo,Pietro,0,0,0,0,0,0,0,
+Fall 2022,RELS,2350,3,27631,Introduction to Islam,Said,Karem Irene,7,5,0,0,2,0,0,3.048
+Fall 2022,GEOL,6398,3,27633,Special Problems,Copeland,Peter,2,0,0,0,0,0,1,4.0
+Fall 2022,CIVE,7399,5,27635,Master's Thesis,Kalliontzis,Dimitrios,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,8798,2,27636,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2022,MECE,4398,4,27640,Independent Study,Ryou,Jae-Hyun,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8396,2,27641,Research Practicum,Doshi,Hitesh B,0,0,0,0,0,1,0,
+Fall 2022,BCHS,8998,6,27642,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2022,BIOL,6898,9,27646,Special Problems,Warner,Margaret,0,0,0,0,0,1,0,
+Fall 2022,ACCT,8398,2,27647,Special Problems,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,5197,2,27649,Selected Topics,Nguyen,Hien V,1,0,0,0,0,0,1,4.0
+Fall 2022,BCHS,8798,2,27650,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Fall 2022,PHAR,5397,1,27652,Selected Topics in Pharmacy,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2022,SOCW,7397,1,27653,Selected Topics in Social Work,Ortiz,Lillian Aguirre,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7397,2,27654,Selected Topics in Social Work,Amtsberg,Donna K.,1,0,0,0,0,0,0,4.0
+Fall 2022,SCM,8399,1,27656,Dissertation,Sahin,Funda,0,0,0,0,0,1,0,
+Fall 2022,SOCW,7397,3,27657,Selected Topics in Social Work,Cheung,Monit,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,4197,2,27658,Selected Topics in Music,Fernando,Fleurette S,8,0,0,0,0,0,0,4.0
+Fall 2022,DANC,6298,1,27659,Special Problems,Estrada,Maria Gabriela,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7397,4,27660,Selected Topics in Social Work,Amtsberg,Donna K.,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,31,27662,Doctoral Applied Music,Witt,Woodrow W,1,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,6141,2,27663,Graduate Recital II,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,4398,1,27665,Independent Study,Alward,Beau Andrew,1,0,0,0,0,0,0,4.0
+Fall 2022,PCEU,6298,3,27666,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2022,MUSI,6198,31,27685,Research,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,8199,5,27695,Doctoral Dissertation,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8399,3,27696,Doctoral Dissertation,Wang,Keh-Han,0,0,0,0,0,1,0,
+Fall 2022,CIVE,6396,1,27697,Master's Research Project,Rixey,William G,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8598,109,27698,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2022,SOCW,8995,1,27699,Pre-Dissertation Research,Robbins,Susan P,0,0,0,0,0,3,0,
+Fall 2022,SOCW,8995,2,27700,Pre-Dissertation Research,Narendorf,Sarah C.,0,0,0,0,0,2,0,
+Fall 2022,SOCW,8995,3,27701,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,2,0,
+Fall 2022,SOCW,8995,4,27703,Pre-Dissertation Research,Jennings,Sheara Williams,0,0,0,0,0,1,0,
+Fall 2022,SOCW,8995,5,27704,Pre-Dissertation Research,Cheung,Monit,0,0,0,0,0,1,0,
+Fall 2022,PHIL,6398,1,27705,Special Problems,Buckner,Cameron J,1,0,0,0,0,0,0,3.67
+Fall 2022,SOCW,8995,6,27706,Pre-Dissertation Research,Berger Cardoso,Jodi A,0,0,0,0,0,1,0,
+Fall 2022,GHL,8398,2,27709,Research Proposal in Hosp Adm,Lee,Minwoo,0,0,0,0,0,1,0,
+Fall 2022,GHL,8398,3,27710,Research Proposal in Hosp Adm,Guchait,Priyanko,0,0,0,0,0,1,0,
+Fall 2022,GHL,8398,5,27712,Research Proposal in Hosp Adm,Legendre,Jungyoung Shin,0,0,0,0,0,1,0,
+Fall 2022,SOCW,8695,2,27713,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Fall 2022,ECON,8399,10,27715,Doctoral Dissertation,Nygaard,Vegard Mokleiv,0,0,0,0,0,1,0,
+Fall 2022,PHCA,6297,2,27716,Selected Topics,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,7399,16,27717,Masters Thesis,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8298,9,27718,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,3,0,
+Fall 2022,PHLS,7398,3,27719,Candidacy Research,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2022,COSC,8298,128,27720,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Fall 2022,PHLS,8396,3,27722,Doctoral Research,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2022,MECE,8698,1,27723,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Fall 2022,MECE,7399,11,27730,Masters Thesis,Wang,Su Su,0,0,0,0,0,0,0,
+Fall 2022,SOCW,8398,1,27731,Independent Study,Walton,Quenette,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,8398,2,27732,Independent Study,Pritzker,Suzanne,0,0,0,0,0,0,0,
+Fall 2022,SOCW,8398,3,27733,Independent Study,Dettlaff,Alan J,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8398,22,27734,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,1,0,
+Fall 2022,MUSI,6198,32,27735,Research,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8398,13,27736,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2022,MATH,8999,3,27737,Doctoral Dissertation,Josic,Kresimir,0,0,0,0,0,1,0,
+Fall 2022,PEP,7398,9,27741,Adv Special Problem Human Perf,LaVoy,Emily Claire-Pyle,1,0,0,0,0,0,0,4.0
+Fall 2022,COMD,7391,12,27744,Clinic in Speech Lang Disorder,Chapman,Amanda,4,0,0,0,0,0,0,3.67
+Fall 2022,COMD,7392,8,27747,Adv Pract Sp & Lang Dis,Eckert,Janet F,3,0,0,0,0,0,0,3.89
+Fall 2022,COMD,7392,9,27748,Adv Pract Sp & Lang Dis,Eckert,Janet F,2,1,0,0,0,0,0,3.557
+Fall 2022,COMD,7392,10,27749,Adv Pract Sp & Lang Dis,Eckert,Janet F,2,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8298,10,27750,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Fall 2022,CIVE,8498,8,27751,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Fall 2022,HIST,6198,1,27753,Special Problems,Chakrabarti,Pratik,1,0,0,0,0,0,0,4.0
+Fall 2022,INDE,7399,3,27754,Masters Thesis,Lin PhD,Ying,1,0,0,0,0,0,0,4.0
+Fall 2022,HIST,6298,1,27755,Special Problems,Chakrabarti,Pratik,1,0,0,0,0,0,0,4.0
+Fall 2022,ECE,6393,1,27756,Special Projects I,Hoskere,Vedhus,1,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,8398,1,27757,Special Problems,Santi,Kristi L,0,0,0,0,0,1,0,
+Fall 2022,ECE,6392,1,27758,Internship I,Jackson,David R,0,0,0,0,0,0,0,
+Fall 2022,HLT,4399,1,27759,Senior Honors Thesis,Carmack,Chakema,0,0,0,0,0,1,0,
+Fall 2022,SOCW,7397,5,27761,Selected Topics in Social Work,Pritzker,Suzanne,0,0,0,0,0,0,0,
+Fall 2022,COSC,4398,2,27762,Independent Study,Chen,Guoning,0,0,0,0,0,1,0,
+Fall 2022,HLT,4392,3,27765,Field Work in Community Health,Solari Williams,Kayce D.,10,6,1,0,0,0,0,3.568
+Fall 2022,PHLS,8399,7,27766,Doctoral Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8999,8,27767,Doctoral Dissertation,Wang,Guoquan,1,0,0,0,0,0,0,4.0
+Fall 2022,RELS,3398,1,27768,Independent Study,Eberhart,Christian,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8399,8,27769,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Fall 2022,MECE,8398,23,27770,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8398,23,27771,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Fall 2022,MECE,4398,5,27772,Independent Study,Franchek,Matthew,0,1,0,0,0,0,0,3.33
+Fall 2022,FINA,8398,4,27773,Special Problems,Liu,Zesong,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8396,3,27774,Research Practicum,Liu,Zesong,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6298,6,27775,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,8398,5,27776,Special Problems,Susmel,Raul,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,8398,3,27778,Special Problems,Chen,Xi,1,0,0,0,0,0,0,4.0
+Fall 2022,ELET,6325,1,27781,Practicum in Engineering Tech,Lent,Marino Ricardo,0,1,0,0,0,0,0,3.0
+Fall 2022,MUSA,4189,9,27783,Senior Recital,Morgulis,Tali,0,0,0,0,0,0,0,
+Fall 2022,PHLS,8398,3,27784,Special Problems,Wiesner,Margit F,1,0,0,0,0,0,0,3.67
+Fall 2022,ELET,6396,2,27785,Master's Project,Pollonini,Luca,0,0,0,0,0,0,1,
+Fall 2022,PEP,7398,10,27787,Adv Special Problem Human Perf,Pearson,Demetrius W,0,0,0,0,0,2,0,
+Fall 2022,MECE,6198,1,27788,Research,Bannova,Olga,0,0,0,0,0,1,0,
+Fall 2022,ANTH,4389,1,27789,Ethnographic Field Work I,Picozza,Fiorenza,6,1,0,0,1,0,0,3.251
+Fall 2022,ECE,8398,33,27790,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2022,CIVE,8398,14,27792,Doctoral Research,Zhang,Ruda,0,0,0,0,0,0,0,
+Fall 2022,PSYC,7399,17,27793,Masters Thesis,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,ACCT,5368,1,27794,Intermediate Accounting II,Muslu,Volkan,0,1,0,0,0,0,0,2.67
+Fall 2022,COMM,4398,11,27795,Independent Study,Xiao,Zhiwen,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8399,7,27797,Doctoral Dissertation,Carales,Vincent D,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8298,11,27798,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,0,0,
+Fall 2022,CIVE,8498,9,27799,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,0,0,
+Fall 2022,SCM,8399,2,27800,Dissertation,Robinson Jr,Powell Ersell,0,0,0,0,0,1,0,
+Fall 2022,CIVE,6298,1,27801,Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2022,PSYC,4398,3,27802,Independent Study,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7397,6,27803,Selected Topics in Social Work,Dettlaff,Alan J,0,0,0,0,0,0,0,
+Fall 2022,MUSA,6342,2,27806,Applied French Horn,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,7354,1,27807,Financial Econometrics,Susmel,Raul,3,1,0,0,0,0,0,3.75
+Fall 2022,FINA,7354,2,27808,Financial Econometrics,Susmel,Raul,1,0,0,0,0,0,3,4.0
+Fall 2022,GEOL,8999,9,27809,Doctoral Dissertation,Mann,Paul,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7698,2,27810,Masters Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Fall 2022,GENB,6398,2,27811,Research,Wilbur,Stephen,1,0,0,0,0,0,0,3.67
+Fall 2022,DIGM,4398,2,27812,Independent Study,Rodwell,Elizabeth Ann,3,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8199,1,27814,Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Fall 2022,GEOL,8698,20,27815,Doctoral Research,Bissada,Kadry K,0,0,0,0,0,1,0,
+Fall 2022,COMM,4399,1,27820,Senior Honors Thesis,Camaj,Lindita,0,0,0,0,0,0,1,
+Fall 2022,BIOL,8998,7,27821,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2022,ACCT,8398,4,27825,Special Problems,Li,Bin,0,0,0,0,0,0,0,
+Fall 2022,ACCT,8699,2,27826,Doctoral Dissertation,Li,Bin,0,0,0,0,0,0,0,
+Fall 2022,PHIL,6398,2,27827,Special Problems,Loewenstein,Yael R,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,2155,1,27829,Event Implementation,Haskell,Rebecca Erin,3,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8242,8,27830,Doctoral Recital III,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2022,INDE,8598,8,27831,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,3,0,
+Fall 2022,MUSI,8296,2,27832,Doctoral Essay,Dirst,Matthew C,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8320,32,27833,Doctoral Applied Music,Mueller,Jebediah Lee,0,0,0,0,0,0,0,
+Fall 2022,INDE,8398,9,27835,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Fall 2022,INDE,8498,8,27836,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Fall 2022,MUSA,6304,4,27837,Conducting,Mueller,Jebediah Lee,0,0,0,0,0,0,0,
+Fall 2022,MECE,6399,7,27838,Masters Thesis,Kulkarni,Yashashree,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,8298,113,27844,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Fall 2022,MECE,8999,2,27845,Doctoral Dissertation,Agrawal,Ashutosh,0,0,0,0,0,0,0,
+Fall 2022,HON,4298,3,27846,Independent Study,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Fall 2022,CIVE,8298,12,27847,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Fall 2022,SOC,3300,3,27852,Intro to Sociological Theory,Grigorian,Stella,2,2,1,1,1,0,3,2.381
+Fall 2022,ELCS,8398,7,27853,Independent Study,Louis,Dave A,0,0,0,0,0,0,0,
+Fall 2022,COMM,3399,1,27856,Senior Honors Thesis,Camaj,Lindita,1,0,0,0,0,0,0,3.67
+Fall 2022,COMM,4398,12,27857,Independent Study,Trigg,Katishia Leonna,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOE,3399,1,27858,Senior Honors Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Fall 2022,PHIL,6398,3,27859,Special Problems,Rainbow,Jesse J.,1,0,0,0,0,0,0,4.0
+Fall 2022,ECON,3399,1,27861,Senior Honor Thesis,Yi,Kei-Mu,0,0,0,0,0,0,0,
+Fall 2022,PSYC,4398,4,27862,Independent Study,Grigorenko,Elena L,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6198,33,27864,Research,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,8420,5,27865,Doctoral Applied Music,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4132,1,27866,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2022,BIOL,4398,3,27867,Independent Study,Cheek,Ann Oliver,1,0,0,0,0,0,0,4.0
+Fall 2022,CHEE,4398,2,27868,Independent Study,Rimer,Jeffrey,1,0,0,0,0,0,0,4.0
+Fall 2022,FINA,3399,1,27872,Senior Honor Thesis,Rude,Dale,0,0,0,0,0,0,0,
+Fall 2022,HON,4398,7,27873,Independent Study,Frankel,Leslie Ann,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4210,1,27874,Applied Piano,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2022,SPEC,6396,2,27876,Clinical Teaching II,Thompson,Amber M,0,0,0,0,0,2,0,
+Fall 2022,CHEM,3396,3,27877,Senior Research Project,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6424,2,27883,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,6143,1,27884,Graduate Recital IV,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2022,MATH,3396,1,27886,Senior Research Project,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Fall 2022,ARTS,6398,1,27887,Special Problems,Reed,John G,1,0,0,0,0,0,0,4.0
+Fall 2022,PCEU,8998,5,27888,Doctoral Research,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2022,ARCH,6398,4,27893,Special Problems,Colaco,Joseph P,3,0,0,0,0,0,0,3.89
+Fall 2022,MECE,8698,2,27896,Doctoral Research,Ostilla Monico,Rodolfo,0,0,0,0,0,1,0,
+Fall 2022,PHOP,8298,8,27897,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2022,PHOP,8698,1,27898,Doctoral Research,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8399,11,27899,Doctoral Dissertation,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2022,MECE,7399,2,27900,Masters Thesis,Kulkarni,Yashashree,1,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,4398,1,27901,Independent Study,Colaco,Joseph P,2,2,1,0,0,0,0,3.2
+Fall 2022,ARCH,4398,2,27902,Independent Study,Taylor,Rives,3,2,0,0,0,0,0,3.6
+Fall 2022,ARCH,3198,4,27903,Independent Study,Martinez,Marcus E,5,0,0,0,0,0,0,4.0
+Fall 2022,ARCH,3198,5,27905,Independent Study,Kudless,Andrew Justin,1,2,0,0,0,0,1,3.443
+Fall 2022,ARCH,3198,6,27908,Independent Study,Noldt,Peter,6,1,0,1,0,0,0,3.211
+Fall 2022,BCHS,8798,3,27909,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2022,ARCH,3198,7,27910,Independent Study,Noldt,Peter,2,2,0,0,0,0,0,3.583
+Fall 2022,ARCH,3198,8,27912,Independent Study,Noldt,Peter,7,2,0,0,0,0,0,3.594
+Fall 2022,COMM,4398,13,27915,Independent Study,Crowe,Craig Warren,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,8698,3,27916,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Fall 2022,COSC,4398,3,27917,Independent Study,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2022,MUSI,6100,3,27921,Chamber Music,Suits,Brian J,5,0,0,0,0,0,0,4.0
+Fall 2022,MUSI,6100,4,27922,Chamber Music,Lo,Mann-Wen,10,0,0,0,0,0,0,4.0
+Fall 2022,PHAR,5297,1,27927,Selected Topics in Pharmacy,Liu,Xinli,0,0,0,0,0,0,0,
+Fall 2022,PHAR,5297,2,27928,Selected Topics in Pharmacy,Nguyen,Kimberly A,0,0,0,0,0,0,0,
+Fall 2022,PHYS,8199,2,27930,Dissertation,Varghese,Oomman K,1,0,0,0,0,0,0,4.0
+Fall 2022,BTEC,6399,33,27935,Thesis,Iyer,Rupa S,0,0,0,0,0,0,0,
+Fall 2022,GEOL,8698,21,27942,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2022,ENTR,6398,1,27943,Research,Wilbur,Stephen,1,0,0,0,0,0,0,3.67
+Fall 2022,MUSA,8243,6,27945,Doctoral Lecture Recital,Pollack,Howard J,0,0,0,0,0,0,0,
+Fall 2022,SOCW,8695,3,27946,Pre-Dissertation Research,Narendorf,Sarah C.,0,0,0,0,0,1,0,
+Fall 2022,CHEE,4198,1,27947,Independent Study,Henderson,Jerrod A,0,0,0,0,0,0,0,
+Fall 2022,MUSA,8420,6,27949,Doctoral Applied Music,Yon,Kirsten A,0,0,0,0,0,0,1,
+Fall 2022,GEOL,8398,25,27952,Doctoral Research,Bissada,Kadry K,0,0,0,0,0,1,0,
+Fall 2022,MUSA,2342,3,27953,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6172,2,27955,Mgmt Training Work Exp Prog I,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Fall 2022,MUSA,4442,3,27956,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8398,26,27959,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2022,PSYC,8999,4,27960,Doctoral Dissertation,Spitzmuller,Christiane,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,8999,10,27961,Doctoral Dissertation,Sun,Jiajia,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8395,11,27962,Doctoral Thesis,Davis,Bradley,1,0,0,0,0,0,0,4.0
+Fall 2022,ELCS,8398,8,27963,Independent Study,Carales,Vincent D,0,0,0,0,0,0,0,
+Fall 2022,DRAM,1310,22,27964,Introduction to Theatre,Egging,Jon Leo,28,8,1,2,6,0,2,3.096
+Fall 2022,SPEC,6395,2,27965,Clinical Teaching I,Culpepper,Shea Mosley,0,0,0,0,0,1,0,
+Fall 2022,ENGI,4198,5,27967,Independent Study,Claydon,Frank J,0,0,0,0,0,1,0,
+Fall 2022,MECE,8298,8,27980,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,
+Fall 2022,MIS,4396,2,27981,MIS Internship,Johnson,Norman A.,0,0,0,0,0,1,0,
+Fall 2022,PHOP,8698,2,27982,Doctoral Research,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Fall 2022,PSYC,4198,1,27986,Independent Study,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Fall 2022,COMM,4398,14,27991,Independent Study,Uhrick,Jan,1,0,0,0,0,0,0,4.0
+Fall 2022,PCOL,6498,4,27992,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2022,HON,3399,50,27993,Senior Honors Thesis,Rhoden,Brenda,0,0,0,0,0,0,0,
+Fall 2022,ENGI,4198,6,27999,Independent Study,Kowal,Marsha Christine,0,0,0,0,0,1,0,
+Fall 2022,GHL,6198,1,28002,Special Problems,Legendre,Jungyoung Shin,1,0,0,0,0,0,0,4.0
+Fall 2022,PHLS,8199,10,28004,Dissertation,Margulis,Milena A,0,0,0,0,0,1,0,
+Fall 2022,PHLS,8193,3,28005,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,1,0,
+Fall 2022,MANA,4398,2,28007,Independent Study,Celly,Nikhil,3,0,0,0,0,0,0,4.0
+Fall 2022,GHL,6398,1,28008,Special Problems,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Fall 2022,TLIM,4398,1,28009,Independent Study,Burns,Maria,1,0,0,0,0,0,0,4.0
+Fall 2022,COSC,4398,501,28011,Independent Study,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2022,DRAM,1310,23,28014,Introduction to Theatre,Brincks,Alan,11,6,4,3,1,0,1,2.96
+Fall 2022,PHYS,8199,3,28021,Dissertation,Koerner,Lisa Whitehead,1,0,0,0,0,0,0,4.0
+Fall 2022,CNST,4398,1,28024,Independent Study,Coble,Lana Kay,0,0,0,0,0,0,0,
+Fall 2022,NUTR,6308,2,28025,Clinical Nutrition Practice I,Haubrick,Kevin,0,0,0,0,0,1,0,
+Fall 2022,BIOE,8399,24,28030,Doctoral Dissertation,Litvinov,Dmitri,1,0,0,0,0,0,0,4.0
+Fall 2022,SOCW,7329,1,28031,SW Practice for Policy Change,Lucas,Virginia,1,0,0,0,0,0,0,4.0
+Fall 2022,POLS,3355,1,28032,Judicial Process,Jackson,Jerald W,1,0,0,0,0,0,0,4.0
+Fall 2022,GEOL,7398,1,28033,Masters Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2022,BIOL,4398,4,28034,Independent Study,Pennings,Steven C,0,0,0,0,0,1,0,
+Fall 2022,COSC,8398,629,28035,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2022,PSYC,4398,5,28038,Independent Study,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2022,MECE,3399,2,28040,Senior Honors Thesis,Cescon,Marzia,0,0,0,0,0,0,0,
+Fall 2022,BIOE,6399,19,28051,Masters Thesis,Ince,Nuri Firat,1,0,0,0,0,0,0,4.0

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2023-01 (Spring 2023).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2023-01 (Spring 2023).csv
@@ -1,0 +1,6832 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Spring 2023,SOCW,7325,1,10002,Assessment in SW Practice,Parks,Steven Lee,17,0,0,0,0,0,0,3.981
+Spring 2023,PHIL,1301,1,10243,Intro To Philosophy,Aiman,Edwin E,44,24,3,1,3,0,1,3.343
+Spring 2023,PHIL,1301,3,10245,Intro To Philosophy,Haaga,Curtis W,47,25,4,2,4,0,6,3.309
+Spring 2023,PHIL,1301,4,10246,Intro To Philosophy,Oliveira,Luis RG,70,34,10,2,2,0,1,3.393
+Spring 2023,PHIL,1305,1,10247,Intro To Ethics,Coates,Daniel J,72,31,12,0,1,0,4,3.514
+Spring 2023,PHIL,1305,2,10248,Intro To Ethics,Aiman,Edwin E,18,42,6,0,6,0,3,2.94
+Spring 2023,PHIL,1305,3,10249,Intro To Ethics,Sommers,Tamler S,71,14,13,2,6,0,10,3.302
+Spring 2023,PHIL,1321,2,10250,Logic I,Buckner,Cameron J,25,35,19,6,7,0,23,2.717
+Spring 2023,PHIL,1321,3,10251,Logic I,Haaga,Curtis W,19,23,10,14,10,0,23,2.316
+Spring 2023,PHIL,1321,4,10252,Logic I,Haaga,Curtis W,11,11,8,4,5,0,9,2.436
+Spring 2023,PHIL,1321,5,10254,Logic I,Loewenstein,Yael R,36,21,16,14,20,0,11,2.309
+Spring 2023,PHIL,1361,1,10257,Philosophy and the Arts,Drapela,Nick Gerard,16,24,5,3,1,0,0,3.054
+Spring 2023,PHIL,1361,2,10258,Philosophy and the Arts,Drapela,Nick Gerard,16,16,9,5,2,0,2,2.812
+Spring 2023,PHIL,1361,3,10259,Philosophy and the Arts,Drapela,Nick Gerard,18,13,12,2,2,0,2,2.873
+Spring 2023,PHIL,1361,4,10260,Philosophy and the Arts,Drapela,Nick Gerard,15,17,10,4,0,0,3,2.942
+Spring 2023,PHIL,3386,1,10261,19th Century Philosophy,Werner,Andrew Timothy,10,5,2,1,0,0,1,3.315
+Spring 2023,PHIL,3358,1,10262,Classics in Hist of Ethics,Phillips,David K,14,7,3,0,1,0,3,3.267
+Spring 2023,ARCH,4324,1,10267,High-Rise Structures,Colaco,Joseph P,0,2,4,0,0,0,1,2.388
+Spring 2023,ARCH,6324,1,10268,High Rise Structures,Colaco,Joseph P,10,5,0,0,0,0,0,3.557
+Spring 2023,AAS,2320,1,10270,Intro To African American Stdy,Smith,Marlon Antoine,14,12,5,2,1,0,0,3.059
+Spring 2023,AAS,2320,2,10271,Intro To African American Stdy,Wiggins,Gretchen Flowers,8,14,2,0,1,0,9,3.08
+Spring 2023,AAS,4370,1,10272,Sem. African American Studies,Shinault,Carley Michelle,12,6,1,0,1,0,1,3.4
+Spring 2023,ACCT,2301,1,10273,Prin of Financial Accounting,Farrar,Felicia,6,4,3,1,2,0,3,2.77
+Spring 2023,ACCT,2302,1,10274,Prin of Managerial Accounting,Weber,Catherine K,99,44,28,9,2,0,5,3.293
+Spring 2023,ACCT,3368,1,10275,Intermediate Accounting II,Wang,Yu,1,6,2,1,0,0,2,2.601
+Spring 2023,ACCT,4331,1,10276,Federal Income Tax-Individual,Fernandez,Ramon,8,22,7,0,0,0,2,3.116
+Spring 2023,ACCT,4331,2,10277,Federal Income Tax-Individual,Small,Randolph Christopher,8,11,4,2,0,0,0,3.0
+Spring 2023,ACCT,4396,1,10279,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,30,0,
+Spring 2023,ACCT,5330,1,10280,Advanced Accounting,Ramaswamy,Vinita,1,3,1,0,0,0,0,3.132
+Spring 2023,ACCT,5337,1,10281,Management Accounting,Serrato,Darlene Marie  Bohac,2,4,1,0,0,0,1,3.19
+Spring 2023,ACCT,5368,1,10282,Intermediate Accounting II,Wang,Yu,2,4,0,0,0,0,3,3.223
+Spring 2023,ACCT,6331,1,10283,Financial Accounting,Li,Bin,8,9,0,0,0,0,0,3.529
+Spring 2023,ACCT,7330,1,10284,Advanced Accounting,Ramaswamy,Vinita,5,1,1,0,0,0,0,3.571
+Spring 2023,ACCT,7330,2,10285,Advanced Accounting,Ramaswamy,Vinita,6,2,1,0,0,0,0,3.519
+Spring 2023,ACCT,7340,1,10286,Financial Statement Analysis,Crawford,Steven,4,2,0,0,0,0,0,3.722
+Spring 2023,ACCT,7340,2,10287,Financial Statement Analysis,Crawford,Steven,19,12,0,0,0,0,1,3.645
+Spring 2023,ACCT,8699,1,10288,Doctoral Dissertation,Lobo,Gerald,1,0,0,0,0,1,0,4.0
+Spring 2023,ACCT,8999,1,10289,Doctoral Dissertation,Lu,Tong,0,0,0,0,0,1,0,
+Spring 2023,AFSC,1202,1,10290,Foundations of the USAF II,O'Connor,Anthony,2,1,0,0,0,0,0,3.667
+Spring 2023,AFSC,1202,2,10291,Foundations of the USAF II,O'Connor,Anthony,5,3,0,0,0,0,1,3.378
+Spring 2023,AFSC,2202,2,10294,Evolution of Air Power II,O'Connor,Anthony,6,0,0,0,0,0,0,3.89
+Spring 2023,AFSC,3302,1,10296,Air Force Leadership II,Williams,Randi,3,0,0,0,0,0,1,4.0
+Spring 2023,ANTH,2346,1,10298,Introduction to Anthropology,Higgs,Elizabeth Wayne,31,23,3,1,1,0,4,3.44
+Spring 2023,ANTH,2351,1,10299,Intro to Cultural Anthropology,Higgs,Elizabeth Wayne,36,24,7,1,1,0,2,3.405
+Spring 2023,ANTH,2302,1,10300,Introduction to Archeology,Brown,Kenneth L,22,26,16,1,0,0,4,3.077
+Spring 2023,ANTH,4310,1,10305,Theories of Culture,Rasmussen,Susan J,20,5,5,0,2,0,3,3.168
+Spring 2023,ANTH,7399,2,10336,Masters Thesis,Brown,Kenneth L,0,0,0,0,0,3,0,
+Spring 2023,ARAB,1502,1,10341,Beginning Arabic II,Sabre,Asmaa,5,3,1,0,0,0,1,3.518
+Spring 2023,ARAB,2312,1,10342,Intermediate Arabic II,Sayyid,Huda,19,3,2,0,0,0,0,3.708
+Spring 2023,ARCH,1501,1,10343,Arc/Int Arc Design Studio II,Logan,Jason,6,8,2,1,0,0,1,3.176
+Spring 2023,ARCH,1501,5,10347,Arc/Int Arc Design Studio II,Plauche',Roya,7,11,0,0,0,0,0,3.389
+Spring 2023,ARCH,1501,7,10349,Arc/Int Arc Design Studio II,Wienert,Ross George,9,7,1,1,0,0,0,3.333
+Spring 2023,ARCH,1501,9,10351,Arc/Int Arc Design Studio II,Lutz,Shawn M,5,4,3,1,0,0,1,3.076
+Spring 2023,ARCH,2351,1,10355,Hist of the Built Environmt II,Ramaswamy,Deepa,49,91,11,2,1,0,3,3.171
+Spring 2023,ARCH,2501,1,10362,Architecture Design Studio IV,Beneytez-Duran,Rafael,9,7,0,0,0,0,0,3.583
+Spring 2023,ARCH,2501,3,10364,Architecture Design Studio IV,Jacobs,Daniel,8,7,2,0,0,0,0,3.353
+Spring 2023,ARCH,2501,7,10366,Architecture Design Studio IV,Gonzales,Michael A,9,4,3,1,0,0,0,3.274
+Spring 2023,ARCH,3347,1,10368,Evolution of Arch Interiors,Thomas,James B,20,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3501,1,10369,Architecture Design Studio VI,Self,Ronnie L,3,10,1,0,0,0,0,3.19
+Spring 2023,ARCH,3501,5,10371,Architecture Design Studio VI,Rivers,Paul Joseph,4,8,2,0,0,0,0,3.143
+Spring 2023,ARCH,3501,7,10373,Architecture Design Studio VI,Wienert,Ross George,6,6,3,0,0,0,0,3.266
+Spring 2023,ARCH,4351,1,10375,Readings & Criticism in Arch,Turner,Drexel,8,5,2,0,0,0,1,3.466
+Spring 2023,ARCH,4355,1,10376,Houston Architecture,Fox,Stephen,14,1,0,0,0,0,2,3.713
+Spring 2023,ARCH,4367,1,10377,Case Studies in Sustain Design,Taylor,Rives,5,10,0,0,1,0,0,3.166
+Spring 2023,ARCH,5500,1,10378,Architecture Design Studio IX,Perez Lopez,Elena Maria,7,4,2,0,0,0,0,3.207
+Spring 2023,ARCH,6341,1,10380,Architectural Hist Survey II,Ramaswamy,Deepa,6,5,0,0,0,0,0,3.485
+Spring 2023,ARCH,6351,1,10382,Criticism in Architecture,Turner,Drexel,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6360,1,10383,Practice of Arch,Jacobs,Daniel,13,19,1,0,0,0,0,3.364
+Spring 2023,ARCH,6604,1,10384,Architecture Design Studio IV,Plauche',Roya,7,2,0,0,0,0,0,3.594
+Spring 2023,ARCH,6604,3,10386,Architecture Design Studio IV,Hager,Jesse,9,0,0,0,0,0,0,3.89
+Spring 2023,ARCH,7601,1,10388,Architecture Design Studio VI,Borden,Gail,5,4,0,0,0,0,0,3.519
+Spring 2023,BCHS,3201,1,10392,Biochemistry I Laboratory,Pattison,Donna,11,9,1,0,1,0,2,3.363
+Spring 2023,BCHS,3201,2,10393,Biochemistry I Laboratory,Pattison,Donna,9,10,3,0,0,0,1,3.318
+Spring 2023,BCHS,3201,3,10394,Biochemistry I Laboratory,Pattison,Donna,4,9,3,3,3,0,0,2.379
+Spring 2023,BCHS,3304,1,10396,General Biochemistry I,Scott,Sean-Patrick,47,45,32,9,7,0,6,2.789
+Spring 2023,BCHS,3305,1,10397,General Biochemistry II,Fujita,Masaya,15,15,11,2,0,0,1,2.946
+Spring 2023,BCHS,4399,1,10400,Senior Honors Thesis,Sen,Mehmet,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6113,1,10401,Graduate Biochemistry Seminar,Briggs,James M,0,0,0,0,0,25,0,
+Spring 2023,BCHS,6231,1,10402,Grad Biochem Lab Rotation II,Widger,William R,5,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,6111,1,10406,Grad Bioengineering Seminar,Larin,Kirill,0,0,0,0,0,63,0,
+Spring 2023,BIOL,2102,1,10407,Anatomy & Physiology II (lab),Gill,Tejendra,4,12,4,2,0,0,1,2.863
+Spring 2023,BIOL,2102,2,10408,Anatomy & Physiology II (lab),Gill,Tejendra,11,3,6,1,0,0,2,3.064
+Spring 2023,BIOL,2102,3,10409,Anatomy & Physiology II (lab),Gill,Tejendra,10,11,1,0,0,0,1,3.499
+Spring 2023,BIOL,2102,4,10410,Anatomy & Physiology II (lab),Gill,Tejendra,5,15,3,0,1,0,0,3.013
+Spring 2023,BIOL,2102,5,10411,Anatomy & Physiology II (lab),Gill,Tejendra,4,9,6,1,0,0,4,2.8
+Spring 2023,BIOL,2102,6,10412,Anatomy & Physiology II (lab),Gill,Tejendra,9,11,2,0,1,0,1,3.088
+Spring 2023,BIOL,2102,7,10413,Anatomy & Physiology II (lab),Gill,Tejendra,3,13,3,3,1,0,1,2.695
+Spring 2023,BIOL,2102,8,10414,Anatomy & Physiology II (lab),Gill,Tejendra,4,12,5,2,1,0,0,2.667
+Spring 2023,BIOL,2102,9,10415,Anatomy & Physiology II (lab),Gill,Tejendra,2,8,6,5,2,0,1,2.116
+Spring 2023,BIOL,2102,10,10416,Anatomy & Physiology II (lab),Gill,Tejendra,4,11,4,2,0,0,1,2.888
+Spring 2023,BIOL,1107,1,10417,Biology for Science Majors II,Medrano,Ana I,15,6,2,0,0,0,0,3.537
+Spring 2023,BIOL,1107,2,10418,Biology for Science Majors II,Medrano,Ana I,16,3,1,1,1,0,1,3.425
+Spring 2023,BIOL,1107,3,10419,Biology for Science Majors II,Medrano,Ana I,14,5,1,2,0,0,1,3.349
+Spring 2023,BIOL,1107,4,10420,Biology for Science Majors II,Medrano,Ana I,18,2,4,0,0,0,0,3.583
+Spring 2023,BIOL,1107,5,10421,Biology for Science Majors II,Medrano,Ana I,14,7,0,0,0,0,2,3.667
+Spring 2023,BIOL,1107,6,10422,Biology for Science Majors II,Medrano,Ana I,15,7,2,0,0,0,0,3.569
+Spring 2023,BIOL,1107,7,10423,Biology for Science Majors II,Medrano,Ana I,16,3,2,0,1,0,2,3.455
+Spring 2023,BIOL,1107,8,10424,Biology for Science Majors II,Medrano,Ana I,4,8,4,0,3,0,4,2.474
+Spring 2023,BIOL,1107,9,10425,Biology for Science Majors II,Medrano,Ana I,13,2,4,0,2,0,2,3.127
+Spring 2023,BIOL,1107,10,10426,Biology for Science Majors II,Medrano,Ana I,20,1,0,0,1,0,1,3.788
+Spring 2023,BIOL,1107,11,10427,Biology for Science Majors II,Medrano,Ana I,15,6,1,2,0,0,0,3.458
+Spring 2023,BIOL,1107,12,10428,Biology for Science Majors II,Medrano,Ana I,14,4,4,0,1,0,0,3.276
+Spring 2023,BIOL,1107,13,10429,Biology for Science Majors II,Medrano,Ana I,19,3,1,0,0,0,0,3.754
+Spring 2023,BIOL,1107,14,10430,Biology for Science Majors II,Medrano,Ana I,17,5,0,1,0,0,1,3.623
+Spring 2023,BIOL,1107,15,10431,Biology for Science Majors II,Medrano,Ana I,9,10,2,1,1,0,1,3.13
+Spring 2023,BIOL,1107,16,10432,Biology for Science Majors II,Medrano,Ana I,22,1,1,0,0,0,0,3.861
+Spring 2023,BIOL,1107,17,10433,Biology for Science Majors II,Medrano,Ana I,19,4,0,0,1,0,0,3.612
+Spring 2023,BIOL,1107,18,10434,Biology for Science Majors II,Medrano,Ana I,16,1,3,0,0,0,3,3.568
+Spring 2023,BIOL,1107,19,10435,Biology for Science Majors II,Medrano,Ana I,10,9,1,0,0,0,3,3.483
+Spring 2023,BIOL,1107,20,10436,Biology for Science Majors II,Medrano,Ana I,19,2,2,0,0,0,1,3.753
+Spring 2023,BIOL,1107,21,10437,Biology for Science Majors II,Medrano,Ana I,10,6,4,1,3,0,0,2.792
+Spring 2023,BIOL,1107,22,10438,Biology for Science Majors II,Medrano,Ana I,18,3,3,0,0,0,0,3.639
+Spring 2023,BIOL,2301,1,10439,Anatomy & Physiology I (lect),Gill,Tejendra,59,151,92,10,21,0,33,2.612
+Spring 2023,BIOL,2302,1,10440,Anatomy & Physiology II (lect),Wayne,Chad M,43,81,91,44,15,0,21,2.333
+Spring 2023,BIOL,1307,1,10441,Biology for Science Majors II,Medrano,Ana I,12,22,29,17,9,0,14,2.131
+Spring 2023,BIOL,1307,2,10442,Biology for Science Majors II,Cheek,Ann Oliver,93,81,46,26,23,0,10,2.772
+Spring 2023,BIOL,1307,4,10443,Biology for Science Majors II,Gifford,Jenifer Beth,73,93,72,20,16,0,9,2.669
+Spring 2023,BIOL,3306,1,10444,Evolutionary Biology,Frankino,William A,32,42,40,11,3,0,0,2.695
+Spring 2023,BIOL,3324,1,10445,Human Physiology,Ogletree-Hughes,Monique L,21,46,39,20,3,0,17,2.447
+Spring 2023,BIOL,3341,1,10446,Human Genetics,Feng,Qin,30,20,4,0,1,0,0,3.37
+Spring 2023,BIOL,3399,1,10448,Senior Honors Thesis,Trivedi PhD,Meghana,0,0,0,0,0,0,0,
+Spring 2023,BIOL,3399,2,10449,Senior Honors Thesis,Azevedo,Ricardo,0,0,0,0,0,0,0,
+Spring 2023,BIOL,3399,4,10450,Senior Honors Thesis,McKeon,Frank D,0,0,0,0,0,0,0,
+Spring 2023,BIOL,4347,1,10456,Animal Behavior,Cole,Blaine J,12,17,16,7,3,0,4,2.539
+Spring 2023,BIOL,4396,1,10457,Senior Research Project,Frankino,William A,13,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6110,1,10459,Biology Seminar,Sater,Amy,0,0,0,0,0,11,0,
+Spring 2023,BIOL,7167,1,10460,Population Biology Seminar,Graur,Dan,0,0,0,0,0,6,0,
+Spring 2023,CHEE,2332,1,10463,Chem Engr Thermodyn I,Malamataris,Nikolaos,9,11,13,6,4,0,21,2.341
+Spring 2023,CHEE,3300,1,10464,Materials Science & Engr I,Wen,Mingjian,18,16,18,1,2,0,2,2.849
+Spring 2023,CHEE,3367,1,10465,Process Modeling and Control,Kaspar,Michael,11,25,8,1,1,0,1,2.942
+Spring 2023,CHEE,3369,1,10466,Chemical Engr Transport Proc,Zerze,Hasan,4,33,3,0,0,0,13,3.05
+Spring 2023,CHEE,3466,1,10467,Bio & Physical Chemistry,Vekilov,Peter,17,11,18,3,2,0,4,2.609
+Spring 2023,CHEE,4361,1,10469,Chm Engr Practices,Cirino,Patrick C,35,8,1,0,0,0,0,3.683
+Spring 2023,CHEE,6111,1,10472,Graduate Seminar,Mountziaris,Triantafillos John,0,0,0,0,0,81,0,
+Spring 2023,CHEE,6337,1,10473,Advanced Reactor Engr,Harold,Michael P,6,5,0,0,0,0,1,3.455
+Spring 2023,CHEE,8399,1,10475,Doctoral Dissertation,Balakotaiah,Vemuri,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,2,10476,Doctoral Dissertation,Bollini,Praveen P,3,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,3,10477,Doctoral Dissertation,Cirino,Patrick C,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8399,4,10478,Doctoral Dissertation,Conrad,Jacinta C,0,0,0,0,0,4,0,
+Spring 2023,CHEE,8399,5,10479,Doctoral Dissertation,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8399,6,10480,Doctoral Dissertation,Economou,Demetre J,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8399,7,10481,Doctoral Dissertation,Grabow,Lars C,2,0,0,0,0,1,0,4.0
+Spring 2023,CHEE,8399,8,10482,Doctoral Dissertation,Harold,Michael P,3,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,9,10483,Doctoral Dissertation,Karim,Alamgir,9,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,10,10484,Doctoral Dissertation,Krishnamoorti,Ramanan,1,0,0,0,0,2,0,4.0
+Spring 2023,CHEE,8399,11,10485,Doctoral Dissertation,Nikolaou,Michael,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,12,10486,Doctoral Dissertation,Orman,Mehmet,3,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,13,10487,Doctoral Dissertation,Palmer,Jeremy,3,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8399,14,10488,Doctoral Dissertation,Rimer,Jeffrey,1,0,0,0,0,5,0,4.0
+Spring 2023,CHEM,1105,1,10489,Foundations of Chem Lab,Zaitsev,Vladimir G,4,9,4,0,0,0,1,3.097
+Spring 2023,CHEM,1105,2,10490,Foundations of Chem Lab,Zaitsev,Vladimir G,7,9,1,0,0,0,1,3.314
+Spring 2023,CHEM,1111,1,10491,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,3,2,1,0,0,2.796
+Spring 2023,CHEM,1111,3,10492,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,10,3,0,0,0,4,2.951
+Spring 2023,CHEM,1111,4,10493,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,1,0,0,0,0,3.175
+Spring 2023,CHEM,1111,5,10494,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,0,0,0,0,0,3.242
+Spring 2023,CHEM,1111,6,10495,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,3,0,0,0,1,2.982
+Spring 2023,CHEM,1111,7,10496,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,4,0,0,0,1,3.019
+Spring 2023,CHEM,1111,9,10497,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,5,1,0,0,0,1,3.389
+Spring 2023,CHEM,1111,10,10498,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,3,0,0,0,2,3.024
+Spring 2023,CHEM,1111,11,10499,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,0,0,0,0,2,3.222
+Spring 2023,CHEM,1111,17,10500,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,2,1,0,0,2,3.021
+Spring 2023,CHEM,1112,1,10501,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,9,1,0,0,0,1,3.279
+Spring 2023,CHEM,1112,2,10502,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,1,0,0,0,3,3.311
+Spring 2023,CHEM,1112,3,10503,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,14,1,0,0,0,0,3.239
+Spring 2023,CHEM,1112,4,10504,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,10,2,0,0,0,0,3.3
+Spring 2023,CHEM,1112,7,10505,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,3,0,0,0,2,3.019
+Spring 2023,CHEM,1112,8,10506,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,4,0,0,0,1,3.192
+Spring 2023,CHEM,1112,9,10507,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,2,1,0,0,1,3.137
+Spring 2023,CHEM,1112,10,10508,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,2,0,1,0,1,2.902
+Spring 2023,CHEM,1112,12,10510,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,1,0,1,0,0,3.084
+Spring 2023,CHEM,1112,13,10511,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,1,0,0,0,2,3.157
+Spring 2023,CHEM,1112,14,10512,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,2,0,0,0,0,3.157
+Spring 2023,CHEM,1112,15,10513,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,1,0,0,0,1,3.222
+Spring 2023,CHEM,1112,16,10514,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,9,2,1,0,0,0,2.975
+Spring 2023,CHEM,1112,17,10515,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,0,0,0,0,1,3.195
+Spring 2023,CHEM,1112,18,10516,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,6,1,0,0,0,0,3.278
+Spring 2023,CHEM,1112,19,10517,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,10,3,0,0,0,2,2.979
+Spring 2023,CHEM,1112,20,10518,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,2,0,0,0,2,3.105
+Spring 2023,CHEM,1112,22,10519,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,2,1,0,0,4,3.019
+Spring 2023,CHEM,1112,23,10520,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,0,0,1,0,0,2.965
+Spring 2023,CHEM,1112,25,10521,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,10,0,1,2,0,0,2.571
+Spring 2023,CHEM,1311,2,10522,Fundamentals of Chemistry,Larsen,Russell Gene,19,66,71,38,45,0,62,1.912
+Spring 2023,CHEM,1312,1,10523,Fundamentals of Chemistry 2,Halasyamani,P Shiv,68,64,58,29,26,0,52,2.487
+Spring 2023,CHEM,1312,2,10524,Fundamentals of Chemistry 2,Carrasquillo M,Edwin,17,22,25,18,32,0,39,1.76
+Spring 2023,CHEM,3119,1,10525,Anlytical Chemistry Lab,Czader,Arkadiusz,3,4,2,0,1,0,1,2.899
+Spring 2023,CHEM,2123,1,10526,Organic Chemistry Lab I,Bean,Mary B,2,11,9,0,1,0,1,2.58
+Spring 2023,CHEM,2123,2,10527,Organic Chemistry Lab I,Bean,Mary B,4,13,2,1,0,0,2,3.017
+Spring 2023,CHEM,2123,4,10528,Organic Chemistry Lab I,Bean,Mary B,2,7,4,1,1,0,6,2.555
+Spring 2023,CHEM,2123,5,10529,Organic Chemistry Lab I,Bean,Mary B,5,7,9,1,0,0,1,2.712
+Spring 2023,CHEM,2123,6,10530,Organic Chemistry Lab I,Bean,Mary B,3,10,6,0,0,0,1,2.773
+Spring 2023,CHEM,2123,7,10531,Organic Chemistry Lab I,Bean,Mary B,3,11,6,0,0,0,2,2.801
+Spring 2023,CHEM,2123,10,10532,Organic Chemistry Lab I,Bean,Mary B,1,14,3,0,0,0,3,2.816
+Spring 2023,CHEM,2123,11,10533,Organic Chemistry Lab I,Bean,Mary B,3,12,5,0,0,0,4,2.801
+Spring 2023,CHEM,2123,12,10534,Organic Chemistry Lab I,Bean,Mary B,2,11,6,0,0,0,3,2.772
+Spring 2023,CHEM,2123,14,10535,Organic Chemistry Lab I,Bean,Mary B,3,11,8,0,0,0,0,2.743
+Spring 2023,CHEM,2125,1,10536,Organic Chemistry Lab II,Bean,Mary B,3,9,8,1,1,0,1,2.575
+Spring 2023,CHEM,2125,2,10537,Organic Chemistry Lab II,Bean,Mary B,4,11,4,0,0,0,0,2.965
+Spring 2023,CHEM,2125,3,10538,Organic Chemistry Lab II,Bean,Mary B,7,13,2,1,0,0,1,3.059
+Spring 2023,CHEM,2125,4,10539,Organic Chemistry Lab II,Bean,Mary B,6,8,4,1,0,0,2,2.913
+Spring 2023,CHEM,2125,6,10540,Organic Chemistry Lab II,Bean,Mary B,7,10,5,0,0,0,1,3.001
+Spring 2023,CHEM,2125,8,10541,Organic Chemistry Lab II,Bean,Mary B,6,9,5,1,0,0,1,2.905
+Spring 2023,CHEM,2125,9,10542,Organic Chemistry Lab II,Bean,Mary B,8,9,5,0,0,0,1,3.151
+Spring 2023,CHEM,2125,10,10543,Organic Chemistry Lab II,Bean,Mary B,3,8,2,0,0,0,2,3.102
+Spring 2023,CHEM,2125,11,10544,Organic Chemistry Lab II,Bean,Mary B,3,8,3,0,0,0,1,2.929
+Spring 2023,CHEM,2125,13,10545,Organic Chemistry Lab II,Bean,Mary B,5,11,7,0,0,0,0,2.927
+Spring 2023,CHEM,2125,14,10546,Organic Chemistry Lab II,Bean,Mary B,4,13,5,0,0,0,1,2.925
+Spring 2023,CHEM,2125,15,10547,Organic Chemistry Lab II,Bean,Mary B,6,6,7,2,1,0,0,2.621
+Spring 2023,CHEM,2125,16,10548,Organic Chemistry Lab II,Bean,Mary B,4,6,4,0,0,0,1,2.976
+Spring 2023,CHEM,2125,17,10549,Organic Chemistry Lab II,Bean,Mary B,3,8,2,1,0,0,2,2.952
+Spring 2023,CHEM,2323,1,10550,Organic Chemistry I,Daugulis,Olafs,51,70,45,58,25,0,74,2.231
+Spring 2023,CHEM,2323,2,10551,Organic Chemistry I,Young,Crystal Ann,6,22,26,35,49,0,54,1.256
+Spring 2023,CHEM,2325,2,10552,Organic Chemistry II,Bean,Mary B,38,34,36,22,14,0,22,2.375
+Spring 2023,CHEM,2325,1,10553,Organic Chemistry II,Bean,Mary B,76,68,66,19,21,0,45,2.6
+Spring 2023,CHEM,3369,1,10554,Analytical Chemistry 1,Czernuszewicz,Roman S,11,17,12,3,2,0,3,2.704
+Spring 2023,CHEM,4229,1,10556,Instrmntl Mthd-Anly Lab,Czader,Arkadiusz,3,6,0,0,0,0,0,3.223
+Spring 2023,CHEM,6111,1,10559,Graduate Colloquium,Comito,Robert Joseph,0,0,0,0,0,37,0,
+Spring 2023,CHEM,6112,1,10560,Graduate Seminar,Brgoch,Jakoah,0,0,0,0,0,8,0,
+Spring 2023,CHEM,6112,2,10561,Graduate Seminar,Yang,Ding-Shyue,0,0,0,0,0,4,0,
+Spring 2023,CHEM,6112,3,10562,Graduate Seminar,Daugulis,Olafs,0,0,0,0,0,23,0,
+Spring 2023,CHEM,6115,1,10563,Sem in Chm Lab Instruct,Zaitsev,Vladimir G,0,0,0,0,0,13,0,
+Spring 2023,CHEM,6115,2,10564,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,5,0,
+Spring 2023,CHEM,8399,10,10611,Doctoral Dissertation,Guloy,Arnold M,0,0,0,0,0,2,0,
+Spring 2023,CHEM,8399,11,10612,Doctoral Dissertation,Jacobson,Allan J,1,0,0,0,0,0,0,3.67
+Spring 2023,CHEM,8399,12,10613,Doctoral Dissertation,Cai,Chengzhi,0,0,0,0,0,1,0,
+Spring 2023,CHEM,8999,2,10641,Doctoral Dissertation,Teets,Thomas,2,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,8999,3,10642,Doctoral Dissertation,Lee,T Randall,0,0,0,0,0,3,0,
+Spring 2023,CHEM,8999,6,10645,Doctoral Dissertation,Gilbertson,Scott R,2,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,8999,9,10648,Doctoral Dissertation,Comito,Robert Joseph,2,0,0,0,0,2,0,4.0
+Spring 2023,CHEM,8999,15,10654,Doctoral Dissertation,May,Jeremy A,0,0,0,0,0,1,0,
+Spring 2023,CHEM,8999,16,10655,Doctoral Dissertation,Miljanic,Ognjen S,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,8999,18,10657,Doctoral Dissertation,Cuny,Gregory D,0,0,0,0,0,1,0,
+Spring 2023,CHEM,8999,19,10658,Doctoral Dissertation,Chen,Tai-Yen,0,0,0,0,0,2,0,
+Spring 2023,CIVE,3337,1,10660,Structural Analysis,Zhang,Ruda,7,25,3,1,1,0,1,2.937
+Spring 2023,CIVE,4369,1,10661,Foundation Engineering,Vipulanandan,Cumaraswamy,5,26,42,1,0,0,0,2.455
+Spring 2023,CIVE,8399,4,10662,Doctoral Dissertation,Rodrigues,Debora Frigi,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8399,8,10664,Doctoral Dissertation,Wang,Keh-Han,0,0,0,0,0,0,0,
+Spring 2023,CIVE,8999,1,10666,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,1,0,
+Spring 2023,CNST,1330,1,10667,Graphics I,Lyon,Eva Yaneth,20,20,6,0,2,0,2,3.174
+Spring 2023,CNST,2341,1,10668,Construction Documents,Vecera,Robert Gerard,17,51,17,1,0,0,1,2.996
+Spring 2023,COMD,6321,1,10670,Swallowing Disorders,Daniels,Stephanie K,9,12,2,0,0,0,0,3.233
+Spring 2023,COMD,7391,1,10672,Clinic in Speech Lang Disorder,Chapman,Amanda,1,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,7,10673,Clinic in Speech Lang Disorder,Tragesser,Bridgid Jane,1,1,0,0,0,0,0,3.5
+Spring 2023,COMD,7391,8,10674,Clinic in Speech Lang Disorder,Degge,Mary Chistine,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,9,10675,Clinic in Speech Lang Disorder,Devore,Danielle R,2,0,0,0,0,0,0,3.835
+Spring 2023,COMD,7391,10,10676,Clinic in Speech Lang Disorder,Devore,Danielle R,1,1,0,0,0,0,0,3.5
+Spring 2023,COMD,7391,11,10677,Clinic in Speech Lang Disorder,Devore,Danielle R,1,1,0,0,0,0,0,3.5
+Spring 2023,COMD,7392,8,10678,Adv Pract Sp & Lang Dis,Degge,Mary Chistine,3,0,0,0,0,0,0,4.0
+Spring 2023,COMD,7392,2,10679,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,4,0,0,0,0,0,0,3.835
+Spring 2023,COMD,7399,3,10681,Masters Thesis,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,1302,1,10682,Intro To Comm Theory,Lee,Jaesub,6,12,15,7,3,0,6,2.271
+Spring 2023,COMM,2300,1,10683,Communication Research Methods,Lyn,Robyn,14,0,7,1,3,0,5,2.906
+Spring 2023,COMM,2311,1,10684,Writing for Print and Digital,Crixell,Charles A,4,10,7,0,1,0,1,2.682
+Spring 2023,COMM,3311,1,10685,Editing Print & Digital Media,Crixell,Charles A,8,9,6,0,0,0,0,3.058
+Spring 2023,COMM,3314,1,10686,Intermediate Reporting,Sewing,Joy,11,4,1,0,0,0,2,3.522
+Spring 2023,COMM,3316,1,10688,Electronic News,Perez,Felicia Russell,9,7,2,1,0,0,0,3.385
+Spring 2023,COMM,3320,1,10689,Audio Production,Newlin,Julye G,11,6,3,1,2,0,1,2.914
+Spring 2023,COMM,3326,1,10691,Graphics Applications,Economou-Clarke,Ann M,17,1,2,0,0,0,0,3.668
+Spring 2023,COMM,3361,1,10693,Advertising Copywriting,Clark,Thomas R,12,3,1,0,0,0,1,3.688
+Spring 2023,COMM,3369,1,10694,Strategic Comm. Writing,Rougeau,Rose,10,7,0,1,1,0,1,3.176
+Spring 2023,COMM,3370,1,10695,History of Cinema,Houk,Keith R,65,4,1,0,1,0,0,3.845
+Spring 2023,COMM,3380,1,10696,Electronic Field Production,Newlin,Julye G,6,8,3,0,1,0,2,2.89
+Spring 2023,COMM,3380,2,10697,Electronic Field Production,Crowe,Craig Warren,6,11,3,0,0,0,0,3.15
+Spring 2023,COMM,3382,1,10698,TV II & Sports Production,Crowe,Craig Warren,7,6,0,0,0,0,0,3.335
+Spring 2023,COMM,3383,1,10700,Non-linear Editing,Newlin,Julye G,37,5,9,1,3,0,0,3.267
+Spring 2023,COMM,4303,1,10701,Communication Law and Ethics,Bundage Juvane,Stephanie,26,0,0,0,0,0,1,3.987
+Spring 2023,COMM,4303,2,10702,Communication Law and Ethics,Kirkland,Steven Earl,29,1,0,0,0,0,0,3.956
+Spring 2023,COMM,4361,1,10704,Adv. Campaign Competition,Thorp,Charles Arthur,18,0,0,0,0,0,0,4.0
+Spring 2023,COMM,6371,1,10707,Public Relations Theory,Liu,Wenlin,8,2,0,0,0,0,0,3.734
+Spring 2023,COSC,3340,1,10715,Intro. to Automata and Comp.,Leiss,Ernst L,70,89,28,5,3,0,10,3.077
+Spring 2023,COSC,3360,1,10716,Operating Systems,Paris,Jehan-Francois,28,43,29,5,6,0,6,2.742
+Spring 2023,COSC,4351,1,10717,Fundamentals of Software Engr,Hilford,Victoria,70,45,5,0,0,0,0,3.506
+Spring 2023,COSC,6110,1,10718,Graduate Colloquium,Leiss,Ernst L,0,0,0,0,0,3,0,
+Spring 2023,CUIN,3310,1,10719,Bilingual Education,Leon,Maredil Josefina,8,1,1,0,0,0,0,3.7
+Spring 2023,CUIN,7337,1,10721,Current Issues/Soc Stud,Manchac,Samantha Lynn,4,0,0,0,0,0,0,4.0
+Spring 2023,ECE,2100,1,10722,Circuit Analysis Laboratory,Ramachandran,Deepa,13,0,0,0,0,0,0,4.0
+Spring 2023,ECE,2100,2,10723,Circuit Analysis Laboratory,Trombetta,Leonard P,23,6,0,0,1,0,1,3.601
+Spring 2023,ECE,2201,1,10724,Circuit Analysis I,Trombetta,Leonard P,6,6,3,4,0,0,5,2.719
+Spring 2023,ECE,3318,1,10725,Applied Elec & Magnetism,Jackson,David R,8,17,2,1,0,0,0,3.155
+Spring 2023,ECE,3331,1,10726,Program Appl in Elec Comp Engr,Hebert,Thomas James,15,21,19,10,1,0,6,2.601
+Spring 2023,ECE,3364,1,10727,Circuits and Systems,Hebert,Thomas James,5,7,4,1,0,0,0,2.98
+Spring 2023,ECE,3456,1,10728,Analog Electronics,Aksu,Gulin Tulunay,8,8,6,0,0,0,1,3.091
+Spring 2023,ECE,4115,1,10729,Control Systems Laboratory I,Provence,Robert S,13,12,2,0,0,0,1,3.359
+Spring 2023,ECE,4375,1,10730,Automatic Control Systems,Provence,Robert S,9,10,8,3,0,0,1,2.8
+Spring 2023,ECE,5318,1,10731,Antenna Engineering,Long,Stuart A,3,8,3,0,0,0,2,2.976
+Spring 2023,ECE,5440,1,10732,Advanced Digital Design,Chen,Yuhua,39,2,2,0,0,0,0,3.845
+Spring 2023,ECE,6111,1,10733,Graduate Research Seminar,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2023,ECE,6111,2,10734,Graduate Research Seminar,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Spring 2023,ECE,6352,1,10735,Antenna Engineering,Long,Stuart A,4,3,0,0,0,0,0,3.43
+Spring 2023,ECE,6364,1,10736,Digital Imag Processing,Hebert,Thomas James,4,4,0,0,0,0,0,3.541
+Spring 2023,ECE,6370,1,10737,Advanced Digital Design,Chen,Yuhua,19,2,1,0,0,0,0,3.803
+Spring 2023,ECE,6399,8,10745,Masters Thesis,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,1,
+Spring 2023,ECE,6399,19,10756,Masters Thesis,Prasad,Saurabh,0,0,0,0,0,0,0,
+Spring 2023,ECE,6399,26,10763,Masters Thesis,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Spring 2023,ECE,8399,3,10771,Doctoral Dissertation,Becker,Aaron T,2,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8399,6,10774,Doctoral Dissertation,Chen,Jiefu,1,0,0,0,0,1,0,4.0
+Spring 2023,ECE,8399,9,10777,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8399,10,10778,Doctoral Dissertation,Han,Zhu,4,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8399,12,10780,Doctoral Dissertation,Fu,Xin,2,0,0,0,0,1,0,4.0
+Spring 2023,ECE,8399,13,10781,Doctoral Dissertation,Chen,Yuhua,0,0,0,0,0,0,0,
+Spring 2023,ECE,8399,15,10783,Doctoral Dissertation,Roysam,Badrinath,0,0,0,0,0,1,0,
+Spring 2023,ECE,8399,17,10785,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,0,0,0,0,0,3,0,
+Spring 2023,ECE,8399,21,10789,Doctoral Dissertation,Le,Hung Quang,0,0,0,0,0,1,0,
+Spring 2023,ECE,8399,23,10791,Doctoral Dissertation,Wolfe,John C,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8399,25,10793,Doctoral Dissertation,Li,Xingpeng,2,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8399,31,10799,Doctoral Dissertation,Contreras-Vidal,Jose Luis,2,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8399,32,10800,Doctoral Dissertation,Chen,Ji,0,0,0,0,0,1,0,
+Spring 2023,ECE,8399,34,10801,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,4,0,
+Spring 2023,ECE,8399,35,10802,Doctoral Dissertation,Shireen,Wajiha,0,0,0,0,0,2,0,
+Spring 2023,ECE,8699,2,10804,Doctoral Dissertation,Shan,Xiaonan,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8699,4,10806,Doctoral Dissertation,Chen,Ji,0,0,0,0,0,1,0,
+Spring 2023,ECE,8699,7,10809,Doctoral Dissertation,Rajashekara,Kaushik,3,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8999,1,10810,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Spring 2023,ECON,2302,1,10811,Principles of Microeconomics,Musaico,Erika Michelle,55,55,26,5,8,0,8,2.949
+Spring 2023,ECON,2302,5,10812,Principles of Microeconomics,Mcgregor,Ryan P,34,36,12,2,3,0,4,3.077
+Spring 2023,ECON,2302,6,10813,Principles of Microeconomics,Sugiura,Ko,29,54,30,22,12,0,11,2.424
+Spring 2023,ECON,2301,3,10814,Principles of Macroeconomics,Vidogbena,Yabo Gwladys,15,34,42,24,20,0,14,2.024
+Spring 2023,ECON,3332,2,10815,Intermediate Microeconomics,Saboury,Piruz,7,7,6,2,4,0,4,2.398
+Spring 2023,ECON,3334,1,10816,Intermediate Macroeconomics,Thornton,Rebecca Achee,5,5,5,7,7,0,10,1.736
+Spring 2023,ECON,3370,1,10817,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,17,11,1,3,6,0,1,2.746
+Spring 2023,ECON,7342,1,10818,Microeconomic Theory II,Maheshri,Vikram,7,8,0,0,0,0,0,3.423
+Spring 2023,ECON,8362,1,10819,Workshop Research Methods IV,Liu,Elaine Meichen,8,0,0,0,0,0,0,4.0
+Spring 2023,ECON,8399,2,10820,Doctoral Dissertation,Chin,Aimee,2,0,0,0,0,1,0,4.0
+Spring 2023,ECON,8399,3,10821,Doctoral Dissertation,Cubas Norando,German,2,0,0,0,0,0,0,4.0
+Spring 2023,ECON,8399,4,10822,Doctoral Dissertation,Craig,Steven G,0,0,0,0,0,2,0,
+Spring 2023,ECON,8399,5,10823,Doctoral Dissertation,Maheshri,Vikram,1,0,0,0,0,0,0,4.0
+Spring 2023,ECON,8399,6,10824,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,5,0,
+Spring 2023,EDUC,4315,1,10826,Student Teaching Sec,Culpepper,Shea Mosley,16,4,0,0,0,0,0,3.751
+Spring 2023,EDUC,4317,1,10827,Student Tch Art Sec,Culpepper,Shea Mosley,6,0,0,0,0,0,0,4.0
+Spring 2023,EDUC,4318,1,10828,Student Tch Music Elem,McGinnis,Emily Jane,23,3,0,0,1,0,0,3.741
+Spring 2023,EDUC,4319,1,10829,Student Tch Music Sec,McGinnis,Emily Jane,23,3,0,0,1,0,0,3.741
+Spring 2023,EDUC,4324,1,10830,Student Teaching Tech Middle,Thompson,Amber M,20,1,1,0,0,0,0,3.819
+Spring 2023,EDUC,4325,1,10831,Student Teaching 4-8 2Nd 7 Wks,Culpepper,Shea Mosley,37,2,0,0,0,0,0,3.906
+Spring 2023,ELED,3322,2,10832,Elem Reading Phonics Instructn,Alba,Celeste,20,3,3,0,0,0,0,3.527
+Spring 2023,ELET,2105,1,10833,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,12,5,2,1,0,0,0,3.384
+Spring 2023,ELET,2303,1,10834,Digital Systems,Abdelhadi,Ahmed,12,15,12,0,1,0,0,2.884
+Spring 2023,ELET,2305,1,10835,Semicond Devices & Circuits,Talusani,Pratap Reddy,12,14,4,0,0,0,1,3.201
+Spring 2023,ELET,2307,1,10836,Electrical-Electronic Circuits,Moges,Mequanint A,4,19,19,1,2,0,0,2.474
+Spring 2023,ELET,3112,2,10837,Rotating Machine Controls Lab,Fan,Lei,13,4,1,0,1,0,0,3.439
+Spring 2023,ELET,3301,1,10838,Linear Systems Analysis,Barbieri,Enrique,4,4,33,4,3,0,9,1.911
+Spring 2023,ELET,3312,1,10839,Plc's & Motor Control Systems,Fan,Lei,13,6,2,0,1,0,0,3.394
+Spring 2023,ELET,3402,1,10840,Communications Circuits,Velusamy,Gandhimathi,6,8,5,1,0,0,0,2.884
+Spring 2023,ELET,3403,1,10842,Sensor Applications,Yuan,Xiaojing,2,16,10,0,3,0,0,2.356
+Spring 2023,ELET,3405,1,10844,Microprocessor Architecture,Soneja,Chandrayee,8,21,7,0,1,0,3,2.964
+Spring 2023,ELET,3425,1,10847,Embedded Systems,Moges,Mequanint A,6,7,9,1,2,0,0,2.441
+Spring 2023,ELET,4208,1,10849,Senior Project Laboratory,Moges,Mequanint A,14,19,0,0,0,0,0,3.394
+Spring 2023,ELET,4302,1,10850,Data Communication Systems,Abdelhadi,Ahmed,18,12,1,0,0,0,1,3.474
+Spring 2023,ELET,4303,1,10851,Power Distribution & Transmiss,Shireen,Wajiha,8,14,0,0,2,0,0,3.028
+Spring 2023,ELET,4308,1,10853,Senior Project,Moges,Mequanint A,5,6,0,0,0,0,0,3.575
+Spring 2023,ELET,4319,1,10854,Elec Power Sys & Industry Prac,Fan,Lei,8,8,4,3,1,0,0,2.833
+Spring 2023,ELET,4325,1,10855,Advanced Microcomputer Netwrks,Small,Damon Jonathan,5,3,1,0,1,0,0,3.1
+Spring 2023,ELET,4421,1,10857,Computer Networks,Gurkan,Deniz,5,13,9,0,2,0,1,2.598
+Spring 2023,ENGI,2304,11,10859,Technical Communications,Wilson,Chad A,8,4,1,0,1,0,1,3.262
+Spring 2023,ENGI,2304,1,10860,Technical Communications,Wilson,Chad A,19,1,0,0,2,0,0,3.591
+Spring 2023,ENGL,1301,11,10866,First Year Writing I,Bose,Godhuly,10,7,0,1,3,0,3,2.952
+Spring 2023,ENGL,1301,12,10867,First Year Writing I,Decarion,Andrew P,5,0,1,2,9,0,5,1.392
+Spring 2023,ENGL,1302,1,10868,First Year Writing II,Anderson,Claire F,13,3,1,0,2,0,0,3.229
+Spring 2023,ENGL,1302,2,10869,First Year Writing II,Sicinski,Michael J,13,6,0,0,0,0,0,3.632
+Spring 2023,ENGL,1302,3,10870,First Year Writing II,Sicinski,Michael J,10,8,0,0,1,0,0,3.316
+Spring 2023,ENGL,1302,7,10871,First Year Writing II,Johnston,Leah Beth,18,0,0,0,1,0,0,3.789
+Spring 2023,ENGL,1302,8,10872,First Year Writing II,Fletcher,Larry L,1,3,7,2,4,0,0,1.667
+Spring 2023,ENGL,1302,9,10873,First Year Writing II,Penzien,Eugene Norman,10,3,0,0,3,0,2,3.021
+Spring 2023,ENGL,1302,10,10874,First Year Writing II,Kroger,Ann Gabriel,7,10,0,0,0,0,2,3.334
+Spring 2023,ENGL,1302,14,10875,First Year Writing II,Koulen,Marisa Theresa,13,3,1,0,1,0,1,3.427
+Spring 2023,ENGL,1302,16,10876,First Year Writing II,Koulen,Marisa Theresa,15,2,0,0,0,0,2,3.824
+Spring 2023,ENGL,1302,23,10877,First Year Writing II,Fletcher,Larry L,0,11,4,3,0,0,1,2.426
+Spring 2023,ENGL,1302,26,10878,First Year Writing II,Christopherson,Alissa N,14,3,1,0,1,0,0,3.439
+Spring 2023,ENGL,1302,27,10879,First Year Writing II,Arayilakath Mohammed,Ibrahim Badshah,9,1,4,0,2,0,4,2.855
+Spring 2023,ENGL,1302,28,10880,First Year Writing II,Colchado,Lea,7,8,2,2,0,0,0,2.966
+Spring 2023,ENGL,1302,30,10881,First Year Writing II,Colchado,Lea,6,9,1,2,1,0,0,2.773
+Spring 2023,ENGL,1302,57,10883,First Year Writing II,Rajkumar,Nidhi,11,5,2,0,3,0,4,2.953
+Spring 2023,ENGL,1302,60,10884,First Year Writing II,Anderson,Claire F,22,2,0,0,1,0,0,3.747
+Spring 2023,ENGL,1302,77,10885,First Year Writing II,Kozma,Andrew,12,7,4,0,0,0,2,3.391
+Spring 2023,ENGL,1302,86,10887,First Year Writing II,Sicinski,Michael J,8,9,0,0,0,0,2,3.432
+Spring 2023,ENGL,1302,88,10888,First Year Writing II,Moore,Kelly L,6,4,2,2,1,0,0,2.712
+Spring 2023,ENGL,1302,91,10889,First Year Writing II,McAlister,Susan Barbara,8,8,0,0,0,0,0,3.356
+Spring 2023,ENGL,1302,98,10890,First Year Writing II,Edens,Jenifer,5,10,0,0,0,0,0,3.245
+Spring 2023,ENGL,1302,99,10891,First Year Writing II,Edens,Jenifer,7,6,2,0,1,0,0,3.001
+Spring 2023,ENGL,2306,1,10893,Intro To Poetry,Williams,Adele E,9,4,0,1,0,0,0,3.476
+Spring 2023,ENGL,2307,2,10894,Intro To Drama,Alcorn III,Charles William,23,5,2,0,0,0,0,3.59
+Spring 2023,ENGL,2361,1,10895,Western World Lit II--Honors,Charara,Hayan S,4,1,0,0,0,0,1,3.866
+Spring 2023,ENGL,2361,2,10896,Western World Lit II--Honors,Charara,Hayan S,2,1,0,0,2,0,0,2.2
+Spring 2023,ENGL,3330,1,10897,Beg Creative Writing-Fiction,Kennedy,Daniel Peter,11,2,1,1,0,0,1,3.467
+Spring 2023,ENGL,4390,1,10898,Professional Internship,Zentz,Lauren R,0,0,0,0,0,3,0,
+Spring 2023,ENGL,4399,1,10899,Senior Honors Thesis,Lecourt,Sebastian Joseph,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,1,10900,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,5,0,
+Spring 2023,ENTR,3310,1,10901,Entrepreneurship,Ortega,Carlos Alberto,170,18,7,1,3,0,0,3.744
+Spring 2023,ENTR,3310,2,10902,Entrepreneurship,Ortega,Carlos Alberto,168,20,2,3,4,0,1,3.709
+Spring 2023,ENTR,3310,3,10903,Entrepreneurship,Wilbur,Stephen,130,96,30,6,8,0,2,3.205
+Spring 2023,ENTR,3312,1,10904,Corporate Entrepreneurship,Karonika,John R,31,15,2,0,0,0,2,3.542
+Spring 2023,ENTR,3312,3,10905,Corporate Entrepreneurship,Karonika,John R,30,12,2,1,0,0,2,3.46
+Spring 2023,ENTR,4320,1,10906,Entrepreneurial Revenue,Boles,James Read,12,16,0,0,0,0,0,3.299
+Spring 2023,ENTR,4330,1,10907,Entrepreneurial Costs/Budgets,Blair,Edward A,11,17,0,0,0,0,0,3.251
+Spring 2023,ENTR,4360,1,10908,Business Plan & Implementation,Rassin,Keith David,24,5,1,0,0,0,0,3.734
+Spring 2023,FINA,3332,2,10909,Prin of Financial Management,Chisholm,Darla,20,36,47,42,25,0,35,1.848
+Spring 2023,FINA,3332,4,10910,Prin of Financial Management,Chisholm,Darla,3,11,19,9,5,0,14,1.901
+Spring 2023,FINA,4320,1,10911,Investment Management,Pederzoli,Paola,37,12,4,0,0,0,2,3.629
+Spring 2023,FINA,4350,1,10913,Derivatives I: Options,Rabinovitch,Ramon,6,5,3,0,3,0,1,2.589
+Spring 2023,FINA,4354,1,10914,Risk Management,Kapatos,Nick Gus,14,17,12,7,0,0,7,2.74
+Spring 2023,FINA,4355,1,10915,International Risk Management,Kapatos,Nick Gus,6,7,1,0,0,0,0,3.357
+Spring 2023,FINA,4358,1,10916,Commercial Property,Kapatos,Nick Gus,16,24,8,4,0,0,4,3.006
+Spring 2023,FINA,4359,1,10917,Energy Insurance and Risk Mgmt,Hughes,James F,13,12,1,0,0,0,1,3.55
+Spring 2023,FINA,8699,2,10922,Doctoral Dissertation,Jacobs,Kris,1,0,0,0,0,0,0,4.0
+Spring 2023,FREN,1501,1,10928,Elementary French I,Wilson,Celine Madeleine Alice,5,6,5,1,0,0,2,2.902
+Spring 2023,FREN,1501,3,10930,Elementary French I,Wilson,Celine Madeleine Alice,7,4,8,2,3,0,3,2.334
+Spring 2023,FREN,1502,1,10932,Elementary French II,Gnanwo Hounfodji,Raymond,6,9,6,1,1,0,2,2.668
+Spring 2023,FREN,1502,7,10936,Elementary French II,Wilson,Celine Madeleine Alice,8,7,10,2,0,0,1,2.802
+Spring 2023,FREN,2311,1,10938,Intermediate French I,Chalhoub,Rania Maria,10,6,2,0,0,0,0,3.334
+Spring 2023,FREN,2312,1,10939,Intermediate French II,Green,Viola V,1,3,6,3,0,0,0,2.205
+Spring 2023,GEOL,1103,2,10940,Physical Geology Lab,Hauptvogel,Daniel William,16,5,0,0,0,0,0,3.652
+Spring 2023,GEOL,1103,3,10941,Physical Geology Lab,Hauptvogel,Daniel William,15,3,0,0,0,0,1,3.815
+Spring 2023,GEOL,1103,4,10942,Physical Geology Lab,Hauptvogel,Daniel William,13,4,0,1,1,0,2,3.386
+Spring 2023,GEOL,1103,5,10943,Physical Geology Lab,Hauptvogel,Daniel William,18,2,2,0,0,0,0,3.667
+Spring 2023,GEOL,1103,6,10944,Physical Geology Lab,Hauptvogel,Daniel William,9,7,3,0,1,0,1,3.183
+Spring 2023,GEOL,3345,1,10945,Structural Geology,Murphy,Michael,16,7,3,0,1,0,0,3.297
+Spring 2023,GEOL,7330,1,10946,Potntl Fld Mtds-Geophys,Sun,Jiajia,12,1,0,0,0,0,0,3.796
+Spring 2023,GERM,1502,1,10947,Beginning German II,Bandmann,Tanya,8,3,3,2,0,0,0,3.021
+Spring 2023,GERM,2312,2,10951,Intermediate German II,Kleinheider,Julia D,4,5,4,1,0,0,0,2.786
+Spring 2023,HDCS,1300,1,10952,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,46,4,4,0,1,0,1,3.667
+Spring 2023,HDCS,1300,2,10953,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,41,5,3,2,2,0,0,3.472
+Spring 2023,HDCS,3300,1,10954,Org Decisions,Stewart,Quentin K,21,9,2,1,1,0,0,3.412
+Spring 2023,HDCS,3303,1,10955,Retailing and Consumer Science,Jacobs,Karen S,11,7,1,0,2,0,0,3.08
+Spring 2023,HDCS,4300,1,10956,Research Concepts in Hdcs,Gatterson,Beverly,13,23,3,5,3,0,1,2.773
+Spring 2023,HDCS,4302,1,10957,Apparel Analysis,Gatterson,Beverly,37,7,3,1,3,0,0,3.38
+Spring 2023,HDCS,4386,1,10958,Communication Strategies,Hitchman Sr,Cal M,26,12,4,0,0,0,2,3.422
+Spring 2023,HDCS,4394,1,10959,Internship in RCS,Ezell,Shirley D,2,1,0,0,0,0,0,3.667
+Spring 2023,HDFS,1300,1,10960,Dev of Contemporary Families,Jordan,Erica F,108,27,17,1,5,0,1,3.368
+Spring 2023,HDFS,3350,1,10964,Observation and Assessment,Schroder,Kathleen Anne,27,8,0,0,0,0,0,3.715
+Spring 2023,HDFS,4393,1,10966,Internship in HDFS,Conston,Toya,33,7,8,1,1,0,0,3.393
+Spring 2023,HIST,1301,2,10967,The U.S. to 1877,Clavin,Matthew J,11,34,38,20,23,0,8,1.884
+Spring 2023,HIST,1302,50,10969,The U.S. Since 1877,Modaff,Abigail,13,4,1,0,2,0,3,3.284
+Spring 2023,HIST,3378,1,10970,The Modern Middle East,Al-Sowayel,Dina,21,5,4,1,1,0,0,3.293
+Spring 2023,HIST,8399,1,10971,Doctoral Dissertation,Neumann,Kristina Marie,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8399,3,10972,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,0,0,
+Spring 2023,HIST,8699,1,10973,Doctoral Dissertation,Ramos,Raul,0,0,0,0,0,0,0,
+Spring 2023,HIST,8699,2,10974,Doctoral Dissertation,Mizelle Jr,Richard M,0,0,0,0,0,1,0,
+Spring 2023,HIST,8999,2,10976,Doctoral Dissertation,Goldberg,Mark A,0,0,0,0,0,1,0,
+Spring 2023,HIST,8999,3,10977,Doctoral Dissertation,Schafer Jr,James A,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8999,4,10978,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Spring 2023,HIST,8999,5,10979,Doctoral Dissertation,Perales,Monica,0,0,0,0,0,1,0,
+Spring 2023,HIST,8999,8,10980,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2023,HIST,8999,12,10981,Doctoral Dissertation,Clavin,Matthew J,1,0,0,0,0,0,0,4.0
+Spring 2023,HLT,1353,1,10982,Personal Health,Rafique,Kiran Sajid,89,21,5,1,3,0,1,3.55
+Spring 2023,HLT,3300,1,10983,Social Health and Wellness,Farmer,Jennifer,83,10,3,1,3,0,0,3.66
+Spring 2023,HLT,3301,1,10984,Health Behavior Theories,Correa-Fernandez,Virmarie,29,35,8,1,1,0,1,3.234
+Spring 2023,HLT,4307,1,10986,Research and Eval in Health,Haq,Arooba A,11,11,10,2,1,0,1,2.791
+Spring 2023,HLT,4392,1,10987,Field Work in Community Health,Solari Williams,Kayce D,40,5,0,0,2,0,1,3.716
+Spring 2023,HON,2101,1,10989,The Human Situation:Modernity,Charara,Hayan S,156,62,4,1,4,0,3,3.55
+Spring 2023,HON,2101,2,10990,The Human Situation:Modernity,Church,Jeffrey,176,69,5,0,5,0,4,3.565
+Spring 2023,HON,4398,1,10991,Independent Study,LeVeaux,Christine,1,0,0,0,0,0,0,4.0
+Spring 2023,HON,4398,2,10992,Independent Study,Stelzig,Donaji,3,0,0,0,0,0,0,4.0
+Spring 2023,HON,4399,1,10993,Senior Honors Thesis,Dunsmore,Julie C,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,1301,1,10995,Hospitality Technology,Morosan,Cristian,14,19,6,2,4,0,5,2.8
+Spring 2023,GHL,1337,1,10996,Intro To Hospitality Industry,Doudna,Simone P,28,14,3,0,4,0,0,3.218
+Spring 2023,GHL,2340,1,10997,System of Accts in Hospitality,DeFranco,Agnes L,13,6,5,0,0,0,0,3.278
+Spring 2023,GHL,1345,1,10998,"Safety, Sanitation in Hosp Ind",Beiza,Alberto,12,15,7,2,4,0,1,2.717
+Spring 2023,GHL,1367,1,10999,Lodging Management,Popa,Iuliana,14,7,4,2,3,0,0,2.856
+Spring 2023,GHL,3160,1,11000,Hospitality Practicum II,Doudna,Simone P,1,1,0,0,0,0,0,3.335
+Spring 2023,GHL,3336,1,11001,Beverage Management,Corsi,Aaron James,16,3,1,0,0,0,0,3.8
+Spring 2023,GHL,3341,1,11002,Hospitality Managerial Acct,Johnson,Tucker A,16,14,0,2,0,0,0,3.365
+Spring 2023,GHL,3341,2,11003,Hospitality Managerial Acct,Johnson,Tucker A,14,10,10,0,5,0,1,2.709
+Spring 2023,GHL,2343,1,11004,Hospitality Cost Controls,Haskell,Rebecca Erin,25,17,6,6,1,0,1,3.013
+Spring 2023,GHL,3345,1,11005,Wine Appreciation,Taylor,David C,25,4,5,0,2,0,1,3.389
+Spring 2023,GHL,3352,1,11007,Human Resource Management,Gip,Huy,18,9,6,0,1,0,1,3.245
+Spring 2023,GHL,3352,2,11008,Human Resource Management,Guchait,Priyanko,25,10,6,3,3,0,2,2.98
+Spring 2023,GHL,3358,1,11009,Hospitality Industry Law,Abbott,Jeanna L,36,8,3,0,1,0,1,3.556
+Spring 2023,GHL,3364,1,11010,Hotel Sales,Kenyan,Erin Oeser,36,4,0,2,0,0,2,3.77
+Spring 2023,GHL,4353,1,11011,Leadership in Hospitality Ind,Maneethai,Dustin,29,11,7,1,1,0,2,3.32
+Spring 2023,GHL,6360,1,11012,Graduate Directed Practicum,Back,KiJoon,20,0,0,0,0,0,0,4.0
+Spring 2023,INDE,2333,1,11013,Engineering Statistics I,Wang,Yaping,31,28,16,7,2,0,6,2.921
+Spring 2023,INDE,3333,1,11014,Engineering Economy I,Wiggins,Nathanial David,67,10,1,0,1,0,1,3.718
+Spring 2023,INDE,3362,1,11015,Cad/Cam,Kamrani,Ali K,11,18,8,1,0,0,0,3.052
+Spring 2023,INDE,3381,1,11017,Linear Optimization,Lim,Gino Jinho,12,12,10,0,1,0,1,2.868
+Spring 2023,INDE,4331,1,11018,Anlysis-Ind Activties I,Schulze,Lawrence John Henry,1,27,5,0,0,0,0,2.849
+Spring 2023,INDE,4334,1,11019,Engineering Systems Design,Wiggins,Nathanial David,18,14,0,0,0,0,0,3.47
+Spring 2023,INDE,4369,1,11020,Facilities Planning & Design,Wang,Yaping,12,16,5,0,0,0,0,3.222
+Spring 2023,INDE,4372,1,11021,Operation Control,Rypien,David V,25,2,0,0,0,0,0,3.938
+Spring 2023,INDE,6111,1,11022,Graduate Seminar,Peng PhD,Jiming Ouyang,0,0,0,0,0,58,0,
+Spring 2023,INDE,8198,1,11028,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,1,0,
+Spring 2023,INDE,8298,2,11032,Doctoral Research,Xiang,Yisha,0,0,0,0,0,2,0,
+Spring 2023,INDE,8398,2,11035,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,3,0,
+Spring 2023,INDE,8398,3,11036,Doctoral Research,Peng PhD,Jiming Ouyang,0,0,0,0,0,1,0,
+Spring 2023,INDE,8398,4,11037,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,3,0,
+Spring 2023,INDE,8498,4,11042,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Spring 2023,INDE,8598,1,11043,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,
+Spring 2023,INDE,8598,3,11045,Doctoral Research,Lin PhD,Ying,0,0,0,0,0,2,0,
+Spring 2023,INDE,8598,4,11046,Doctoral Research,Xiang,Yisha,0,0,0,0,0,2,0,
+Spring 2023,INDE,8999,2,11052,Doctoral Dissertation,Peng PhD,Jiming Ouyang,1,0,0,0,0,0,0,4.0
+Spring 2023,INDE,8999,3,11053,Doctoral Dissertation,Lim,Gino Jinho,1,0,0,0,0,0,0,4.0
+Spring 2023,INDS,2341,1,11055,Computer Aided Indus Design I,Chow,George K,10,14,0,0,0,0,0,3.43
+Spring 2023,INDS,2356,1,11056,Design History II,Ramirez,Enrique,14,7,3,0,0,0,0,3.486
+Spring 2023,INDS,2501,1,11057,Industrial Design Studio IV,Kimbrough,Mark S,10,3,2,0,0,0,0,3.511
+Spring 2023,INDS,3501,1,11059,Industrial Design Studio VI,Chow,George K,7,8,1,0,0,0,0,3.334
+Spring 2023,INDS,4365,1,11061,Design Practice and Business,McCormick,Kelly,4,0,0,0,0,0,0,3.835
+Spring 2023,INDS,4501,1,11062,Industrial Design Studio VIII,Feng,Jeff Feng,5,2,0,0,0,0,0,3.714
+Spring 2023,ITAL,2312,1,11064,Intermediate Italian II,Nicosia,Alda,11,8,1,1,2,0,0,3.015
+Spring 2023,ITEC,1301,1,11065,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,14,16,4,5,7,0,3,2.551
+Spring 2023,KIN,1304,1,11066,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,263,19,6,5,3,0,2,3.819
+Spring 2023,KIN,3304,1,11067,Human Structure & Phys Perform,Breslin,Whitney L,24,41,39,10,2,0,1,2.601
+Spring 2023,KIN,3305,1,11068,Sport Sociology,Graham,Marilynn Hadassah,169,35,8,1,5,0,4,3.624
+Spring 2023,KIN,3350,1,11069,Psych Aspects Sport Exercise,Gray,Jon Phillip,203,30,8,2,2,0,4,3.719
+Spring 2023,KIN,4310,1,11070,Measurement Tech Human Perf,Thrasher,Timothy Adam,19,42,27,15,8,0,6,2.456
+Spring 2023,KIN,4350,1,11071,Sport Marketing,Lee,Dong Hun,13,13,6,2,0,0,0,3.088
+Spring 2023,KIN,4355,1,11072,Adm of Sport & Phys Activity,Walsh,David W,14,33,9,1,0,0,1,3.087
+Spring 2023,KIN,4365,1,11073,Legal/Ethical Aspects of Sport,Ogunrinde,Joyce,3,20,13,4,3,0,3,2.403
+Spring 2023,KIN,4390,1,11074,Internship in PE,Betts,Randi Jill,3,0,1,0,0,0,0,3.5
+Spring 2023,LAW,5103,1,11075,Health Law Journal,Mantel,Jessica,0,0,0,0,0,8,0,
+Spring 2023,LAW,5104,1,11076,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,6,0,
+Spring 2023,LAW,5110,1,11077,Law Review,Sanders,Joseph,0,0,0,0,0,3,0,
+Spring 2023,LAW,5147,1,11078,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,9,1,
+Spring 2023,LAW,5198,1,11079,Special Rsch & Writing,Vetter,Greg R,5,1,0,0,0,1,0,3.778
+Spring 2023,LAW,5210,1,11080,Law Review,Sanders,Joseph,0,0,0,0,0,12,0,
+Spring 2023,LAW,5247,1,11081,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,19,0,
+Spring 2023,LAW,5298,1,11082,Special Rsch & Writing,Vetter,Greg R,4,0,0,0,0,0,0,3.835
+Spring 2023,LAW,5303,1,11083,Criminal Law,Thompson,Sandra Guerra,27,38,3,0,0,0,0,3.324
+Spring 2023,LAW,5303,2,11084,Criminal Law,Kwok,David Y,32,35,2,0,0,0,1,3.397
+Spring 2023,LAW,5303,4,11085,Criminal Law,Crump,David L,29,41,2,0,0,0,0,3.37
+Spring 2023,LAW,5322,2,11086,Pretrial Litigation,Goranson,Mark D,3,16,0,0,0,3,0,3.401
+Spring 2023,LAW,5339,1,11088,Trusts and Wills,Sanders,Pannal Alan,5,10,0,0,0,2,0,3.333
+Spring 2023,LAW,5381,1,11090,Legal Negotiation,Abbott,Jeanna L,17,26,0,0,0,3,0,3.38
+Spring 2023,LAW,5386,1,11091,Trial Advocacy,Baldassano,Steven L,9,15,0,0,0,4,0,3.403
+Spring 2023,LAW,5398,2,11092,Special Research and Writing,Vetter,Greg R,5,1,0,0,0,0,0,3.723
+Spring 2023,LAW,5400,1,11093,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,1,0,
+Spring 2023,LAW,5405,1,11094,Immigration Clinic,Messer,Teresa Pham,3,2,1,0,0,0,0,3.113
+Spring 2023,LAW,5408,1,11096,Property,Fagundes,Dave,28,42,7,0,0,0,1,3.238
+Spring 2023,LAW,5408,2,11097,Property,Zale,Kellen B,31,39,2,0,0,0,0,3.384
+Spring 2023,LAW,5410,1,11098,Law Review,Sanders,Joseph,0,0,0,0,0,14,0,
+Spring 2023,LAW,5414,1,11099,Immigration Clinic II,Messer,Teresa Pham,1,0,0,0,0,0,0,3.67
+Spring 2023,LAW,5415,1,11100,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,1,0,
+Spring 2023,LAW,5421,1,11102,Business Organizations,Nelson,James D,32,48,0,0,0,10,0,3.396
+Spring 2023,LAW,5488,1,11103,Constitutional Law,Chandler,Seth J,25,39,4,1,0,0,0,3.294
+Spring 2023,LAW,5488,2,11104,Constitutional Law,Morales,Daniel I,21,47,4,0,0,0,0,3.209
+Spring 2023,LAW,5488,3,11105,Constitutional Law,Berman,Emily,23,48,0,0,0,0,1,3.398
+Spring 2023,LAW,6209,2,11106,Health Law Journal,Mantel,Jessica,0,0,0,0,0,10,0,
+Spring 2023,LAW,6211,1,11107,Houston Buiness/Tax Journal,Wells,Douglas,0,0,0,0,0,10,0,
+Spring 2023,LAW,6300,1,11108,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,3,0,
+Spring 2023,LAW,6318,1,11111,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,14,0,
+Spring 2023,LAW,6354,1,11113,Houston Journal of Int'l Law,Berman,Emily,0,0,0,0,0,24,0,
+Spring 2023,LAW,6355,1,11114,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,1,0,
+Spring 2023,LAW,6356,1,11115,Law Review,Sanders,Joseph,0,0,0,0,0,22,0,
+Spring 2023,LAW,6358,1,11116,Health Law Journal,Mantel,Jessica,0,0,0,0,0,14,0,
+Spring 2023,MANA,3335,1,11117,Intro Org Behavior and Mgmt,Rude,Dale,13,6,0,0,0,0,1,3.632
+Spring 2023,MANA,3335,2,11118,Intro Org Behavior and Mgmt,Tabesh,Pooya,25,8,4,1,1,0,0,3.393
+Spring 2023,MANA,3335,3,11119,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,198,42,9,0,0,0,1,3.726
+Spring 2023,MANA,4330,1,11120,Intro to Strategic HR Mgt,Phillips,James S,106,89,8,1,1,0,4,3.372
+Spring 2023,MANA,4353,1,11122,Mgmt Training and Career Devel,Bozeman,Dennis,44,11,0,0,0,0,2,3.83
+Spring 2023,MANA,8399,1,11124,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,1,0,
+Spring 2023,MANA,8399,2,11125,Doctoral Dissertation,Atwater,Leanne E,1,0,0,0,0,0,0,4.0
+Spring 2023,MARK,3336,1,11132,Introduction to Marketing,Patrick-Ralhan,Vanessa M,444,50,4,0,0,0,1,3.854
+Spring 2023,MARK,3336,2,11133,Introduction to Marketing,Patrick-Ralhan,Vanessa M,382,78,6,4,4,0,0,3.706
+Spring 2023,MARK,3336,3,11134,Introduction to Marketing,Koch,Steven F,9,10,2,0,0,0,0,3.318
+Spring 2023,MARK,3336,4,11135,Introduction to Marketing,Koch,Steven F,20,57,31,12,3,0,0,2.64
+Spring 2023,MARK,4373,1,11136,Advanced Professional Selling,Bremer,Justin,23,4,0,0,0,0,0,3.815
+Spring 2023,MARK,4374,1,11137,Sales Management,Webb,James R,27,1,0,0,0,0,0,3.917
+Spring 2023,MARK,4374,2,11138,Sales Management,Webb,James R,27,2,0,0,0,0,0,3.92
+Spring 2023,MARK,4375,1,11139,Key Account Selling,Webb,James R,14,1,0,0,0,0,1,3.801
+Spring 2023,MARK,4376,1,11140,Sales CRM,Suki,Yara D,25,2,0,0,0,0,0,3.877
+Spring 2023,MARK,4376,2,11141,Sales CRM,Herman,Carl,18,7,0,2,0,0,0,3.531
+Spring 2023,MARK,4398,1,11142,Independent Study,Pingel,John W,1,0,0,0,0,0,0,4.0
+Spring 2023,MAS,2340,1,11143,Intro Mexican American Studies,Pino,Diana,5,10,5,3,1,0,1,2.556
+Spring 2023,MAS,3340,1,11144,Mexican Amer Urban Communities,Pino,Diana,8,14,1,2,3,0,0,2.786
+Spring 2023,MATH,1314,8,11145,College Algebra,Hafeez,Shahinda,21,23,34,8,50,0,37,1.626
+Spring 2023,MATH,1324,1,11146,Finite Math with Applications,Sosa,Moses,128,120,84,24,52,0,100,2.543
+Spring 2023,MATH,1324,4,11147,Finite Math with Applications,Sosa,Moses,152,110,76,12,22,0,62,2.927
+Spring 2023,MATH,1324,7,11148,Finite Math with Applications,Hong,Yuqi,12,24,2,2,4,0,2,2.819
+Spring 2023,MATH,1325,2,11150,Calc for Bus & Social Sciences,Constante,Beatrice,108,92,48,10,28,0,50,2.809
+Spring 2023,MATH,2312,3,11151,Precalculus,Chang,James A,128,72,42,34,26,0,88,2.782
+Spring 2023,MATH,2312,4,11152,Precalculus,Perepelitsa,Irina,94,96,70,22,46,0,38,2.476
+Spring 2023,MATH,2312,6,11153,Precalculus,Constante,Beatrice,114,74,92,24,36,0,50,2.555
+Spring 2023,MATH,2312,7,11154,Precalculus,May,Jennifer Ruhnow,108,72,80,24,24,0,74,2.626
+Spring 2023,MATH,2451,1,11155,Accelerated Calculus II,Wang,Min,3,3,4,2,0,0,0,2.666
+Spring 2023,MATH,1342,3,11156,Elementary Statistical Methods,Caputo,Matthew G,124,128,116,44,48,0,66,2.444
+Spring 2023,MATH,1342,5,11157,Elementary Statistical Methods,Ryan,John M,66,88,84,60,52,0,58,2.122
+Spring 2023,MATH,3304,1,11158,Mathematical Analysis,George,Rebecca Ann,25,18,5,2,1,0,0,3.307
+Spring 2023,MATH,3321,1,11159,Engineering Mathematics,Etgen,Garret J,17,26,17,14,20,0,29,2.053
+Spring 2023,MATH,3331,2,11161,Differential Equations,Sanders,Richard,17,9,4,3,1,0,6,3.04
+Spring 2023,MATH,3336,1,11162,Discrete Mathematics,Winkle,James J,62,38,38,38,0,0,6,2.708
+Spring 2023,MATH,3336,2,11163,Discrete Mathematics,Douglas,Casey,148,92,66,20,18,0,14,2.936
+Spring 2023,MATH,4332,1,11165,Intro to Real Analysis II,Kalantar,Mehrdad,4,1,3,1,2,0,0,2.424
+Spring 2023,MATH,4378,1,11166,Advanced Linear Algebra II,Mamonov,Alexander V,2,4,5,3,2,0,1,2.001
+Spring 2023,MATH,4380,1,11167,Mathematical Intro To Options,Kao,Edward P,2,25,0,0,0,0,1,3.025
+Spring 2023,MATH,4389,1,11168,Survey of Undergraduate Math,Almus,Melahat,24,18,11,4,0,0,0,3.036
+Spring 2023,MATH,4399,3,11174,Senior Honors Thesis,Onofrei,Daniel T,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,5332,1,11175,Differential Equations,Etgen,Garret J,7,5,0,0,0,0,2,3.501
+Spring 2023,MATH,6303,1,11176,Modern Algebra,Heier,Gordon,8,0,0,0,0,0,0,3.876
+Spring 2023,MATH,6315,1,11177,Masters Tutorial,Etgen,Garret J,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,6315,3,11179,Masters Tutorial,Ji,Shanyu,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,6321,1,11181,Func Real Variable,Vershynina,Anna,3,3,2,0,0,0,0,3.084
+Spring 2023,MATH,6371,1,11183,Numerical Analysis,Olshanskiy,Maxim Alexandrovich,12,4,0,0,0,0,0,3.668
+Spring 2023,MATH,6383,1,11184,Statistics,Jun,Mikyoung,11,6,1,0,0,0,0,3.574
+Spring 2023,MATH,6398,5,11188,Special Problems,Timofeyev,Ilya,0,0,0,0,0,2,0,
+Spring 2023,MATH,6398,6,11189,Special Problems,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Spring 2023,MATH,6398,8,11191,Special Problems,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Spring 2023,MATH,6398,10,11193,Special Problems,Ru,Min,0,0,0,0,0,2,0,
+Spring 2023,MATH,6398,11,11194,Special Problems,Heier,Gordon,0,0,0,0,0,1,0,
+Spring 2023,MATH,7315,8,11212,Masters Tutorial,Nicol,Matthew J,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8398,1,11214,Doctoral Research,Vershynina,Anna,0,0,0,0,0,1,0,
+Spring 2023,MATH,8398,2,11215,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Spring 2023,MATH,8399,1,11217,Doctoral Dissertation,Heier,Gordon,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8399,2,11218,Doctoral Dissertation,Mang,Andreas,0,0,0,0,0,2,0,
+Spring 2023,MATH,8399,4,11219,Doctoral Dissertation,Josic,Kresimir,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8699,2,11236,Doctoral Dissertation,Heier,Gordon,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8999,1,11256,Doctoral Dissertation,Kalantar,Mehrdad,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,2361,1,11257,Intro Mechanical Design,Chang,Christiana,17,28,37,1,1,0,0,2.691
+Spring 2023,MECE,3245,1,11260,Materials Science Laboratory,Chen,Xuemei,26,67,15,0,0,0,2,3.114
+Spring 2023,MECE,3336,1,11261,Mechanics II,Franchek,Matthew,6,9,5,0,0,0,0,3.034
+Spring 2023,MECE,3360,1,11262,Experimental Methods,Chen,Xuemei,22,57,20,1,2,0,1,2.925
+Spring 2023,MECE,3400,1,11264,Intro To Mechanics,Agrawal,Ashutosh,14,33,10,0,1,0,4,3.034
+Spring 2023,MECE,4364,1,11265,Heat Transfer,Xu,Ben,14,28,42,9,5,0,6,2.31
+Spring 2023,MECE,4371,1,11266,Thermal-Fluids Laboratory,Love,Holley Carole,103,1,0,0,0,0,2,3.968
+Spring 2023,MECE,8111,1,11269,Graduate Seminar,Sharma,Pradeep,0,0,0,0,0,48,0,
+Spring 2023,MECT,1364,30,11270,Materials & Processes,Wari,Ezra Tsegaye,8,14,4,3,1,0,2,2.69
+Spring 2023,MECT,3155,1,11272,Strength Materials Lab,Basaran,Burak,12,4,4,0,0,0,0,3.367
+Spring 2023,MECT,3155,2,11273,Strength Materials Lab,Basaran,Burak,6,3,2,2,0,0,0,2.924
+Spring 2023,MECT,3331,30,11274,Applied Thermodynamics,El Nahas,Medhat A,0,2,2,0,2,0,1,1.722
+Spring 2023,MECT,3341,1,11275,Computer-Aided Drafting,Ray,Kyle A,57,87,24,2,6,0,4,3.029
+Spring 2023,MECT,3342,1,11277,Elements of Plant Design,El Nahas,Medhat A,1,10,14,0,0,0,0,2.44
+Spring 2023,MECT,3358,30,11280,Dynamics of Mechanisms,Basaran,Burak,0,3,18,5,3,0,6,1.667
+Spring 2023,MECT,3360,30,11282,Automated Manufacturing System,Risal,Sandesh,9,27,9,3,0,0,3,2.889
+Spring 2023,MECT,3365,1,11285,Computer-Aided Design I,El Nahas,Medhat A,1,8,22,2,2,0,0,2.011
+Spring 2023,MECT,3367,30,11287,Quality Control Technology,Rypien,David V,18,10,4,0,1,0,0,3.393
+Spring 2023,MSCI,1126,1,11288,Phys Readiness Training,Comiskey,Melissa C,8,0,0,0,0,0,1,4.0
+Spring 2023,MSCI,1131,1,11289,Intermediate Physical Fitness,Comiskey,Melissa C,1,0,0,0,0,0,0,4.0
+Spring 2023,MSCI,2220,1,11290,Doctrine & Team Development,Comiskey,Melissa C,8,0,0,0,0,0,0,4.0
+Spring 2023,MSCI,2220,2,11291,Doctrine & Team Development,Comiskey,Melissa C,3,0,0,0,0,0,0,4.0
+Spring 2023,MSCI,4320,2,11294,Company Grade Leadership,Comiskey,Melissa C,13,1,0,0,0,0,0,3.929
+Spring 2023,MSCI,4398,1,11296,Independent Study,Comiskey,Melissa C,4,1,0,0,0,0,0,3.734
+Spring 2023,NUTR,2133,1,11297,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,13,3,1,0,1,0,1,3.5
+Spring 2023,NUTR,2133,2,11298,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,8,4,2,2,2,0,0,2.796
+Spring 2023,NUTR,2332,1,11299,Intro To Human Nutrition,Alastuey,Lisa L,95,56,26,7,5,0,10,3.161
+Spring 2023,NUTR,2333,1,11300,Comm Food Prod I,Svendsen-Sanchez,Ann Carol,25,7,1,1,3,0,1,3.209
+Spring 2023,NUTR,3334,1,11301,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,94,68,15,4,8,0,5,3.17
+Spring 2023,NUTR,4347,1,11302,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,10,11,5,3,1,0,3,2.812
+Spring 2023,OPTO,5112,1,11303,Optics Lab II,Cheng,Han,20,4,0,0,0,0,0,3.833
+Spring 2023,OPTO,5112,2,11304,Optics Lab II,Cheng,Han,21,4,0,0,0,0,0,3.84
+Spring 2023,OPTO,5112,3,11305,Optics Lab II,Cheng,Han,16,6,1,0,0,0,0,3.652
+Spring 2023,OPTO,5112,4,11306,Optics Lab II,Cheng,Han,17,7,0,0,0,0,0,3.708
+Spring 2023,OPTO,5135,1,11307,Ocular Anatomy Lab,Ostrin,Lisa,23,2,0,0,0,0,0,3.92
+Spring 2023,OPTO,5135,2,11308,Ocular Anatomy Lab,Ostrin,Lisa,24,2,0,0,0,0,0,3.923
+Spring 2023,OPTO,5135,3,11309,Ocular Anatomy Lab,Ostrin,Lisa,14,6,2,0,0,0,0,3.545
+Spring 2023,OPTO,5135,4,11310,Ocular Anatomy Lab,Ostrin,Lisa,17,5,2,0,0,0,0,3.625
+Spring 2023,OPTO,5172,1,11311,Clinic Practicum II,Berntsen,David A,13,7,4,0,0,0,0,3.375
+Spring 2023,OPTO,5172,2,11312,Clinic Practicum II,Berntsen,David A,12,11,0,0,1,0,0,3.375
+Spring 2023,OPTO,5172,3,11313,Clinic Practicum II,Berntsen,David A,5,18,2,0,0,0,0,3.12
+Spring 2023,OPTO,5172,4,11314,Clinic Practicum II,Berntsen,David A,5,11,6,0,1,0,0,2.826
+Spring 2023,OPTO,5194,1,11315,Ophthalmic Optics Lab,Tucker,Ashley,16,7,0,0,0,0,0,3.696
+Spring 2023,OPTO,5194,2,11316,Ophthalmic Optics Lab,Tucker,Ashley,23,0,2,0,0,0,0,3.84
+Spring 2023,OPTO,5194,3,11317,Ophthalmic Optics Lab,Tucker,Ashley,19,5,0,0,0,0,0,3.792
+Spring 2023,OPTO,5194,4,11318,Ophthalmic Optics Lab,Tucker,Ashley,18,5,1,0,0,0,0,3.708
+Spring 2023,OPTO,5221,1,11319,Vision Science II,Applegate,Raymond A,25,44,21,4,2,0,0,2.896
+Spring 2023,OPTO,5250,1,11320,Seminar Scientific Investigatn,Frishman,Laura J,3,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,5272,1,11321,Optometry II,Dempsey,Robert L,66,28,2,0,0,0,0,3.667
+Spring 2023,OPTO,5282,1,11322,Community Health Optometry,Dempsey,Robert L,97,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,5315,1,11323,Optics II,Porter,Jason,31,41,18,4,4,0,0,2.929
+Spring 2023,OPTO,5331,1,11324,General Pathology & Medicine,Frishman,Laura J,32,44,15,5,1,0,0,3.099
+Spring 2023,OPTO,5335,1,11325,Ocular Anatomy and Physiology,Ostrin,Lisa,54,27,13,3,0,0,0,3.361
+Spring 2023,OPTO,6151,1,11326,Pediatric Optometry I Lab,Ho,Hong Dieu,19,3,0,0,0,0,0,3.864
+Spring 2023,OPTO,6151,2,11327,Pediatric Optometry I Lab,Ho,Hong Dieu,18,6,0,0,0,0,0,3.75
+Spring 2023,OPTO,6151,3,11328,Pediatric Optometry I Lab,Ho,Hong Dieu,22,3,0,0,0,0,0,3.88
+Spring 2023,OPTO,6151,5,11329,Pediatric Optometry I Lab,Ho,Hong Dieu,24,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,6174,1,11330,Contact Lens Lab,Giannoni,Amber Gaume,23,3,0,0,0,0,0,3.885
+Spring 2023,OPTO,6174,3,11331,Contact Lens Lab,Giannoni,Amber Gaume,22,1,0,0,0,0,0,3.957
+Spring 2023,OPTO,6174,4,11332,Contact Lens Lab,Giannoni,Amber Gaume,24,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,6174,5,11333,Contact Lens Lab,Giannoni,Amber Gaume,23,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,6251,1,11335,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,17,0,
+Spring 2023,OPTO,6291,1,11337,General Clinic II,Dempsey,Robert L,0,0,0,0,0,96,0,
+Spring 2023,OPTO,6312,1,11338,Optics IV,Ritchey,Eric R,73,20,3,0,0,0,0,3.729
+Spring 2023,OPTO,6333,1,11339,Ocular Pharm and Therapeutics,Dempsey,Robert L,20,58,21,0,2,0,0,2.882
+Spring 2023,OPTO,6335,1,11340,Ocular Pathology II,Harrison,Wendy W,33,52,13,0,1,0,0,3.235
+Spring 2023,OPTO,6351,1,11341,Pediatric Optometry I,Dempsey,Robert L,31,55,9,0,0,0,0,3.232
+Spring 2023,OPTO,6374,1,11342,Contact Lens I,Dempsey,Robert L,23,63,11,0,0,0,0,3.124
+Spring 2023,OPTO,7120,1,11343,Opt III Rounds/Case Discussn,Dempsey,Robert L,76,12,0,0,0,0,0,3.864
+Spring 2023,OPTO,7130,1,11344,"Laser, Refract & Surg Lab",Patel,Nimesh Bhikhu,23,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,7130,2,11345,"Laser, Refract & Surg Lab",Lambreghts,Kimberly,22,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,7130,5,11346,"Laser, Refract & Surg Lab",Patel,Nimesh Bhikhu,22,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,7130,6,11347,"Laser, Refract & Surg Lab",Lambreghts,Kimberly,22,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,7162,1,11348,Vision Rehabilitative Lab,Modi,Swati,21,2,0,0,0,1,0,3.913
+Spring 2023,OPTO,7162,2,11349,Vision Rehabilitative Lab,Modi,Swati,22,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,7162,3,11350,Vision Rehabilitative Lab,Modi,Swati,20,2,0,0,0,0,0,3.909
+Spring 2023,OPTO,7162,4,11351,Vision Rehabilitative Lab,Modi,Swati,23,0,0,0,0,0,0,4.0
+Spring 2023,OPTO,7253,1,11352,Pediatric Optometry III,Manny,Ruth,6,34,52,0,0,0,0,2.5
+Spring 2023,OPTO,7262,1,11353,Rehabilitative Optometry,Dempsey,Robert L,52,31,6,0,0,0,0,3.517
+Spring 2023,OPTO,7330,1,11354,"Lasers, Refract Proced, Surg",Patel,Nimesh Bhikhu,62,24,3,0,0,0,0,3.67
+Spring 2023,OPTO,7337,1,11355,Ocular Pathology IV,Dempsey,Robert L,20,39,29,0,2,0,0,2.833
+Spring 2023,OPTO,7383,1,11356,Practice Management I,Cass,Peter John,67,23,0,0,0,0,0,3.671
+Spring 2023,OPTO,7495,1,11357,General Clinic IIIc,Dempsey,Robert L,0,0,0,0,0,77,0,
+Spring 2023,OPTO,8992,1,11359,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,62,0,
+Spring 2023,OPTO,8993,1,11360,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,62,0,
+Spring 2023,PCOL,7142,1,11362,Pharmacological Lit Review,Bond,Richard A,0,0,0,0,0,12,0,
+Spring 2023,PETR,6302,1,11364,Reservoir Engineering II,Thakur,Ganesh Chandra,9,7,0,0,0,0,0,3.521
+Spring 2023,PHAR,5642,1,11365,Emergency Medicine,Truong,Mabel,6,2,0,0,0,0,0,3.75
+Spring 2023,PHAR,5663,1,11367,Pharmacy Management,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5664,1,11368,Legal & Regulatory Affairs,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5670,1,11369,Community Pharmaceutical Care,Tolleson,Shane Russell,9,2,0,0,0,0,0,3.818
+Spring 2023,PHAR,5675,1,11370,Disease State Management,Tolleson,Shane Russell,29,7,0,0,0,0,0,3.806
+Spring 2023,PHAR,5678,1,11371,Transplant Therapeutics,Truong,Mabel,3,1,0,0,0,0,0,3.75
+Spring 2023,PHAR,5680,1,11372,Oncology,Truong,Mabel,4,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5683,1,11374,Cardiology,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5685,1,11375,Critical Care,Truong,Mabel,11,1,1,0,0,0,0,3.769
+Spring 2023,PHAR,5690,1,11377,Internal Medicine,Truong,Mabel,22,10,0,0,0,0,0,3.688
+Spring 2023,PHAR,5690,3,11378,Internal Medicine,Sherer,Jeffrey T,2,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5692,1,11380,Advanced Hospital Pharmacy,Truong,Mabel,28,5,0,0,0,0,0,3.848
+Spring 2023,PHAR,5693,1,11381,Advanced Community Pharmacy,Tolleson,Shane Russell,30,3,0,0,0,0,0,3.909
+Spring 2023,PHAR,5694,1,11382,Pediatrics,Truong,Mabel,3,1,1,0,0,0,0,3.4
+Spring 2023,PHAR,5695,1,11383,Geriatrics,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5696,1,11384,Ambulatory Care - Primary Care,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,6298,1,11385,Special Problems,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,14,11387,Spec Prob-Physio Optics,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Spring 2023,PHOP,8398,7,11397,Doctoral Research,Das,Vallabh E,2,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8399,3,11406,Doctoral Dissertation,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8399,7,11410,Doctoral Dissertation,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8399,8,11411,Doctoral Dissertation,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8399,10,11413,Doctoral Dissertation,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8598,7,11429,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8598,11,11433,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,2125,1,11450,University Physics Lab I,Wood,Lowell T,1,13,4,1,0,0,0,2.702
+Spring 2023,PHYS,2125,2,11451,University Physics Lab I,Wood,Lowell T,0,15,5,0,0,0,0,2.717
+Spring 2023,PHYS,2126,1,11452,University Physics Lab II,Wood,Lowell T,1,12,9,0,0,0,0,2.681
+Spring 2023,PHYS,2126,2,11453,University Physics Lab II,Wood,Lowell T,1,15,7,0,0,0,0,2.653
+Spring 2023,PHYS,1301,1,11454,College Physics I (lecture),Portillo Vazquez,Israel,9,25,28,14,6,0,16,2.215
+Spring 2023,PHYS,1301,2,11455,College Physics I (lecture),Maric,Sladjana,12,28,19,7,9,0,10,2.378
+Spring 2023,PHYS,1302,1,11456,College Physics II (lecture),Portillo Vazquez,Israel,19,31,40,15,13,0,12,2.201
+Spring 2023,PHYS,1302,2,11457,College Physics II (lecture),Miller,John H,64,44,32,4,0,0,11,3.116
+Spring 2023,PHYS,2325,1,11458,University Physics I (lecture),McElhenny,Brian Patrick,45,74,66,10,11,0,20,2.572
+Spring 2023,PHYS,4198,4,11465,Independent Study,Bering,Edgar A,0,0,0,0,0,11,0,
+Spring 2023,PHYS,4398,4,11474,Independent Study,Bering,Edgar A,0,0,0,0,0,1,0,
+Spring 2023,PHYS,4398,5,11475,Independent Study,Cherdack,Daniel David,0,0,0,0,0,1,0,
+Spring 2023,PHYS,6327,1,11486,Statistical Physics,Hosur,Pavan R,10,17,0,0,0,0,0,3.431
+Spring 2023,PHYS,8398,4,11504,Doctoral Research,Bering,Edgar A,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8398,5,11505,Doctoral Research,Chen,Shuo,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8398,10,11509,Doctoral Research,Curran,Seamus A,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8398,17,11513,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8398,30,11522,Doctoral Research,Ratti,Claudia,0,0,0,0,0,3,0,
+Spring 2023,PHYS,8398,31,11523,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8398,32,11524,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8399,3,11529,Doctoral Dissertation,Bellwied,Rene,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8399,16,11538,Doctoral Dissertation,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8399,20,11541,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8399,25,11545,Doctoral Dissertation,Morrison,Gregory C,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8399,27,11547,Doctoral Dissertation,Pinsky,Lawrence S,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8399,28,11548,Doctoral Dissertation,Ratti,Claudia,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8399,32,11552,Doctoral Dissertation,Timmins,Anthony Robert,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8699,16,11572,Doctoral Dissertation,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Spring 2023,POLS,3310,3,11584,Intro to Political Theory,Hawley,Michael C,9,15,5,2,5,0,5,2.547
+Spring 2023,POLS,4198,1,11585,Independent Study,Cross,Renee D,0,0,0,0,0,1,0,
+Spring 2023,POLS,4390,1,11587,Government Internship,Cross,Renee D,29,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8399,2,11588,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,1,0,
+Spring 2023,PSYC,2301,2,11591,Introduction to Psychology,Agan,Herb W,143,32,6,0,1,0,1,3.707
+Spring 2023,PSYC,2317,1,11592,Intro to Psychology Statistics,Browne,Lindsay J,23,27,13,2,4,0,8,2.908
+Spring 2023,PSYC,2320,1,11593,Abnormal Psychology,Lebeaut,Antoine M,24,17,3,2,0,0,2,3.362
+Spring 2023,PSYC,6302,1,11594,Expermental Dsgn,Burling,Joseph Michael,2,20,0,0,0,0,0,3.001
+Spring 2023,PSYC,6357,1,11595,Clinical Assessment II,Williams,Michael W,14,3,0,0,0,0,0,3.804
+Spring 2023,PSYC,6393,2,11596,Clinical Research Practicum,Alfano,Candice A,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7392,2,11597,Psychology Practicum,Tamber-Rosenau,Benjamin J,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8121,1,11599,Clinical Psychology Internship,Vincent,John P,0,0,0,0,0,10,0,
+Spring 2023,PSYC,8190,1,11600,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,2,0,
+Spring 2023,PSYC,8321,1,11601,Clinical Psyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8390,1,11602,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8399,1,11604,Doctoral Dissertation,Zvolensky,Michael J,6,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8399,2,11605,Doctoral Dissertation,Vujanovic,Anka Anna,0,0,0,0,0,4,0,
+Spring 2023,PSYC,8399,3,11606,Doctoral Dissertation,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8399,14,11607,Doctoral Dissertation,Babcock,Julia,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8699,2,11608,Doctoral Dissertation,Viana,Andres G,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8999,1,11611,Doctoral Dissertation,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Spring 2023,RELS,1301,1,11612,Intro To Religious Studies,Mummert,Claire Elizabeth,21,13,3,2,4,0,2,3.054
+Spring 2023,SOC,6311,1,11613,Qualitative Soc Methods,Katz,Sheila,12,0,0,0,0,0,0,3.918
+Spring 2023,SOCW,3330,1,11614,Nonprofit Financial Management,Crespo,Deysi M,7,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7330,1,11615,Fiscal Managmnt&Budgtng,Crespo,Deysi M,14,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7366,1,11616,Grief/Bereave Therapy,Rodgers,Beverly J,26,2,0,0,0,0,1,3.929
+Spring 2023,SOCW,7384,1,11617,Field Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,30,0,
+Spring 2023,SOCW,7385,1,11618,Field Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,150,1,
+Spring 2023,SOCW,7388,1,11619,Field Practicum III Macro,Gonzales,Shelley A,0,0,0,0,0,16,0,
+Spring 2023,SOCW,7391,1,11620,Field Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,34,1,
+Spring 2023,SOCW,8322,1,11621,Research Methods II,Acquati,Chiara,4,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,8333,1,11622,Social Science Theories,Ali,Samira Bano,5,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,1501,1,11624,Elementary Spanish I,Besovic,Helena,6,4,2,1,1,0,4,2.905
+Spring 2023,SPAN,1501,3,11626,Elementary Spanish I,Lumbierres,M Pilar,7,3,7,0,2,0,1,2.684
+Spring 2023,SPAN,1501,13,11630,Elementary Spanish I,Ruffino,Gustavo,13,4,4,0,2,0,1,3.044
+Spring 2023,SPAN,1502,11,11632,Elementary Spanish II,Scalzo,Dillon S,19,6,1,0,0,0,0,3.667
+Spring 2023,SPAN,1502,19,11634,Elementary Spanish II,Cervantes Figueroa,Ana Silvia,18,7,1,0,0,0,1,3.641
+Spring 2023,SPAN,1502,21,11636,Elementary Spanish II,Sanchez Carbajo,Maria,8,9,7,0,2,0,2,2.782
+Spring 2023,SPAN,1505,1,11638,Intensive Elementary Spanish,Hernandez,Stephanie,4,9,3,3,2,0,1,2.492
+Spring 2023,SPAN,2311,1,11640,Intermediate Spanish I,Patron Rivera,Mauricio,7,10,3,1,1,0,2,2.835
+Spring 2023,SPAN,2311,3,11641,Intermediate Spanish I,Patron Rivera,Mauricio,9,9,6,0,0,0,0,3.098
+Spring 2023,SPAN,2311,6,11642,Intermediate Spanish I,Morales Utria,Yordanis,5,8,4,1,1,0,1,2.737
+Spring 2023,SPAN,2312,3,11643,Intermediate Spanish II,Mejia Lara,Airy Sindik,5,10,6,1,3,0,1,2.507
+Spring 2023,SPAN,2312,9,11644,Intermediate Spanish II,Mejia Lara,Airy Sindik,2,8,5,1,0,0,0,2.564
+Spring 2023,SPAN,2308,1,11646,Span for Heritage Learners II,Martinez,Raquel,6,5,2,0,1,0,0,2.954
+Spring 2023,SPAN,3301,1,11647,Span Oral Comm for Crit Think,Sisk,Christina L,8,1,0,0,0,0,2,3.779
+Spring 2023,SPAN,3302,2,11648,Adv Span for Non-Heritage,Serrano,Paloma A,17,1,0,0,0,0,1,3.908
+Spring 2023,SPAN,3307,1,11649,Public Speaking in Spanish,Quintanilla,Guadalupe C,12,3,0,0,0,0,0,3.69
+Spring 2023,SPAN,3308,2,11650,Written Com-Hisp Herit Learner,Quintanilla,Guadalupe C,13,4,1,0,0,0,0,3.52
+Spring 2023,SPAN,3384,2,11651,Intro To Hispanic Literature,Hasbun,Rodrigo,10,4,2,0,0,0,0,3.5
+Spring 2023,SPAN,3384,3,11652,Intro To Hispanic Literature,Cuesta,Mabel,15,4,1,0,3,0,1,3.189
+Spring 2023,SPAN,6398,1,11653,Special Problems,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,6398,2,11654,Special Problems,Fairclough,Marta A,2,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,6398,6,11655,Special Problems,Rivera Garza,Cristina,2,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,6398,9,11657,Special Problems,Zubiate,Maria Laura,0,1,0,0,0,0,0,3.33
+Spring 2023,SPAN,7398,1,11661,Reading & Research,Fairclough,Marta A,0,0,0,0,0,1,0,
+Spring 2023,SPAN,7398,3,11663,Reading & Research,Gutierrez,Manuel J,0,0,0,0,0,1,0,
+Spring 2023,SPAN,8399,1,11666,Dissertation,Rivera Garza,Cristina,1,0,0,0,0,1,0,4.0
+Spring 2023,SPAN,8399,2,11667,Dissertation,Fairclough,Marta A,1,0,0,0,0,1,0,4.0
+Spring 2023,SPAN,8399,3,11668,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,1,0,
+Spring 2023,SPAN,8399,4,11669,Dissertation,Gutierrez,Manuel J,2,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,8399,6,11671,Dissertation,Solino,Maria Elena,1,0,0,0,0,1,0,4.0
+Spring 2023,SPAN,8399,8,11673,Dissertation,Kanellos,Nicolas,0,0,0,0,0,3,0,
+Spring 2023,SPAN,8699,1,11674,Dissertation,Rivera Garza,Cristina,4,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,8699,2,11675,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,1,0,
+Spring 2023,SPAN,8699,3,11676,Dissertation,Fairclough,Marta A,1,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,8699,4,11677,Dissertation,Gutierrez,Manuel J,2,0,0,0,0,0,0,4.0
+Spring 2023,TECH,3365,1,11679,Appl of Discrete Mthds in Tech,Telles,John E,14,6,7,2,5,0,5,2.599
+Spring 2023,TECH,3365,2,11680,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,23,17,1,4,1,0,2,3.282
+Spring 2023,VIET,1502,1,11682,Elementary Vietnamese II,DANG,THONG Q,21,1,1,0,0,0,0,3.855
+Spring 2023,VIET,2302,1,11684,Intermediate Vietnamese II,DANG,THONG Q,18,0,0,0,0,0,0,3.982
+Spring 2023,MATH,2318,1,11686,Linear Algebra,Sherf,Nimrod,6,5,7,2,5,0,11,2.213
+Spring 2023,PHYS,4322,1,11687,Int Electromagnetic Theory II,Cherdack,Daniel David,12,8,3,0,0,0,0,3.334
+Spring 2023,PHYS,1101,1,11688,College Physics I (lab),Wood,Lowell T,3,11,7,0,1,0,1,2.607
+Spring 2023,PHYS,1101,2,11689,College Physics I (lab),Wood,Lowell T,1,7,6,0,0,0,1,2.666
+Spring 2023,PHYS,1101,3,11690,College Physics I (lab),Wood,Lowell T,3,13,1,0,2,0,3,2.668
+Spring 2023,PHYS,1101,4,11691,College Physics I (lab),Wood,Lowell T,1,7,2,1,0,0,4,2.667
+Spring 2023,PHYS,1101,5,11692,College Physics I (lab),Wood,Lowell T,2,13,5,0,0,0,2,2.718
+Spring 2023,PHYS,1101,6,11693,College Physics I (lab),Wood,Lowell T,1,9,3,1,0,0,0,2.691
+Spring 2023,GEOL,3372,1,11694,Petrography,Copeland,Peter,8,10,6,0,0,0,0,3.07
+Spring 2023,GEOL,3374,1,11695,Sedimentary Petrogenesis,Voarintsoa,Ny Riavo Gilbertinie,10,7,2,2,0,0,1,3.096
+Spring 2023,PHYS,1101,7,11696,College Physics I (lab),Wood,Lowell T,2,14,5,0,1,0,0,2.682
+Spring 2023,PHYS,1101,8,11697,College Physics I (lab),Wood,Lowell T,3,10,8,0,0,0,1,2.652
+Spring 2023,PHYS,1101,9,11698,College Physics I (lab),Wood,Lowell T,0,7,7,0,0,0,1,2.641
+Spring 2023,PHYS,1101,10,11699,College Physics I (lab),Wood,Lowell T,3,8,8,0,0,0,2,2.772
+Spring 2023,PHYS,1101,11,11700,College Physics I (lab),Wood,Lowell T,1,13,5,0,0,0,2,2.703
+Spring 2023,PHYS,1102,1,11701,College Physics II (lab),Wood,Lowell T,1,12,10,0,0,0,0,2.623
+Spring 2023,PHYS,1102,2,11702,College Physics II (lab),Wood,Lowell T,1,16,3,1,1,0,0,2.622
+Spring 2023,PHYS,1102,3,11703,College Physics II (lab),Wood,Lowell T,1,13,6,0,0,0,2,2.651
+Spring 2023,PHYS,1102,4,11704,College Physics II (lab),Wood,Lowell T,3,13,5,0,2,0,0,2.667
+Spring 2023,PHYS,1102,5,11705,College Physics II (lab),Wood,Lowell T,1,9,9,0,0,0,0,2.701
+Spring 2023,PHYS,1102,6,11706,College Physics II (lab),Wood,Lowell T,4,11,8,0,0,0,0,2.726
+Spring 2023,PHYS,1102,7,11707,College Physics II (lab),Wood,Lowell T,3,9,7,0,1,0,2,2.568
+Spring 2023,PHYS,1102,8,11708,College Physics II (lab),Wood,Lowell T,1,12,9,1,0,0,0,2.608
+Spring 2023,PHYS,1102,9,11709,College Physics II (lab),Wood,Lowell T,3,14,4,0,1,0,0,2.743
+Spring 2023,PHYS,1102,10,11710,College Physics II (lab),Wood,Lowell T,2,6,4,0,0,0,1,2.751
+Spring 2023,SPAN,3305,1,11712,Spanish Grammar Review,Gutierrez,Manuel J,9,3,2,2,0,0,0,3.126
+Spring 2023,ENTR,3312,4,11713,Corporate Entrepreneurship,Lish,Alan D,36,55,9,0,0,0,0,3.28
+Spring 2023,MARK,4389,1,11714,Marketing Strategy & Planning,Beveridge,Ivana,28,4,0,0,0,0,0,3.803
+Spring 2023,MARK,4389,3,11715,Marketing Strategy & Planning,Randazzo,Gary W,31,1,0,0,0,0,0,3.866
+Spring 2023,COMM,4331,1,11716,Persuasion,Graham,Catherine Burch,19,4,0,0,0,0,1,3.769
+Spring 2023,COMM,4354,1,11717,Organizational Crisis Comm.,Uhrick,Jan,18,2,1,0,1,0,0,3.531
+Spring 2023,GHL,4343,1,11718,Financial Admin for Hosp.Ind.,Mao-Clark,Xiaodan,10,3,3,0,0,0,0,3.396
+Spring 2023,BIOE,3341,1,11720,Biothermodynamics,Larin,Kirill,5,7,2,0,0,0,0,3.214
+Spring 2023,NUTR,3101,1,11722,Dietetics As a Profession,Vollrath,Kirstin,20,2,1,0,1,0,0,3.625
+Spring 2023,ENGI,2304,2,11723,Technical Communications,Contos,Ashlie Meghan,16,7,0,1,1,0,1,3.427
+Spring 2023,PSYC,4344,1,11724,Cultural Psychology,Hernandez Ortiz,Jessica G,42,16,7,2,5,0,4,3.273
+Spring 2023,MATH,5330,1,11727,Abstract Algebra,Haynes,Alan K,9,0,0,0,0,0,0,3.963
+Spring 2023,CHEE,3333,1,11728,Chem Engr Thermodyn II,Zerze,Gul,8,15,5,5,1,0,3,2.706
+Spring 2023,TEPM,6302,2,11729,Leadership and Team Building,Hopkins,Ronald K,10,0,0,0,0,0,0,3.967
+Spring 2023,CNST,4381,1,11730,Reinforced Conc & Bldg Codes,Elzafraney,Mohamed,43,15,0,0,0,0,0,3.719
+Spring 2023,LAW,5408,3,11731,Property,Bregant,Jessica Lynn,28,37,3,0,0,0,0,3.363
+Spring 2023,HDFS,4317,1,11733,Intro to Early Child Dev,Storch,Jill Frenchman,17,11,8,1,6,0,2,2.713
+Spring 2023,HDFS,4394,3,11735,Internship in HDFS,Conston,Toya,48,0,1,0,1,0,0,3.867
+Spring 2023,ACCT,4330,1,11736,Advanced Accounting,Ramaswamy,Vinita,3,0,0,0,0,0,0,3.89
+Spring 2023,COSC,6309,1,11737,Intro Automata & Computability,Leiss,Ernst L,5,1,0,0,0,0,1,3.723
+Spring 2023,COSC,6310,1,11738,Fundamentals of Operating Syst,Paris,Jehan-Francois,1,0,0,1,0,0,0,2.5
+Spring 2023,BCHS,4311,1,11740,Biochemistry Lab II,Pattison,Donna,42,15,11,2,2,0,0,3.305
+Spring 2023,CHEM,4270,1,11741,Physical Chemistry Lab I,Czader,Arkadiusz,0,6,4,0,0,0,0,2.534
+Spring 2023,CHEM,4270,2,11742,Physical Chemistry Lab I,Czader,Arkadiusz,1,10,0,0,0,0,0,3.121
+Spring 2023,MARK,4373,2,11743,Advanced Professional Selling,Pingel,John W,22,5,0,0,0,0,0,3.79
+Spring 2023,MECT,4275,1,11744,Senior Design Project I,Zhu,Weihang,24,15,0,0,0,0,0,3.59
+Spring 2023,MECT,3318,30,11745,Fluid Mechanics Applications,Al-Jamal,Helmi,2,7,9,15,4,0,3,1.667
+Spring 2023,MECT,3118,1,11746,Fluid Mechanic Application Lab,Taylor,Gordon D,2,7,2,0,1,0,0,2.723
+Spring 2023,MECT,3118,2,11747,Fluid Mechanic Application Lab,Taylor,Gordon D,6,7,4,0,1,0,1,2.871
+Spring 2023,MECE,3345,1,11748,Materials Science,Sun,Li,21,22,25,2,7,0,4,2.632
+Spring 2023,BCHS,3201,5,11750,Biochemistry I Laboratory,Pattison,Donna,11,8,3,0,1,0,1,3.117
+Spring 2023,BCHS,3201,6,11751,Biochemistry I Laboratory,Pattison,Donna,8,10,4,0,1,0,0,2.986
+Spring 2023,PSYC,8999,2,11756,Doctoral Dissertation,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Spring 2023,BCHS,3201,7,11757,Biochemistry I Laboratory,Pattison,Donna,4,15,3,1,0,0,1,2.928
+Spring 2023,BCHS,3201,8,11758,Biochemistry I Laboratory,Pattison,Donna,3,16,3,0,1,0,1,2.841
+Spring 2023,GHL,2365,1,11765,Tourism,Draper,Jason A,18,7,0,1,0,0,2,3.577
+Spring 2023,PSYC,8399,18,11769,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2023,SPAN,1502,5,11770,Elementary Spanish II,Gonzalez,Viviannette,11,9,2,1,2,0,0,3.0
+Spring 2023,INDE,6332,1,11772,Egr Project Mgt,Chung,Christopher,17,25,3,3,0,0,2,3.167
+Spring 2023,MATH,8398,5,11779,Doctoral Research,Cappanera,Loic,0,0,0,0,0,1,0,
+Spring 2023,MATH,6313,1,11783,Introduction to Real Analysis,Kalantar,Mehrdad,3,2,0,0,0,0,0,3.468
+Spring 2023,MATH,6309,1,11784,Advanced Linear Algebra II,Mamonov,Alexander V,5,7,3,0,0,0,0,3.111
+Spring 2023,BIOL,3306,2,11785,Evolutionary Biology,Frankino,William A,33,60,42,21,5,0,5,2.594
+Spring 2023,BIOL,3311,1,11786,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,58,24,8,3,6,0,4,3.239
+Spring 2023,BIOL,3311,2,11787,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,36,15,13,0,3,0,3,3.204
+Spring 2023,BCHS,4307,1,11796,Proteins,Widger,William R,23,39,27,1,3,0,3,2.828
+Spring 2023,GEOL,1103,7,11797,Physical Geology Lab,Hauptvogel,Daniel William,8,9,1,1,1,0,1,3.133
+Spring 2023,GEOL,3340,1,11798,Geologic Field Methods,Robinson,Alexander C,13,18,4,2,0,0,1,3.091
+Spring 2023,FINA,4370,1,11800,Energy Trading,Smith III,Edwin A,7,2,1,0,0,0,2,3.6
+Spring 2023,MARK,4389,4,11801,Marketing Strategy & Planning,Lish,Alan D,25,14,0,0,0,0,1,3.565
+Spring 2023,CIVE,8198,1,11805,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8198,2,11806,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Spring 2023,ACCT,2302,2,11807,Prin of Managerial Accounting,Newman,Michael Ray,21,3,0,0,0,0,0,3.848
+Spring 2023,ACCT,6331,2,11808,Financial Accounting,Larson,Chad R,10,12,2,0,2,0,1,3.026
+Spring 2023,CIVE,8298,1,11809,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8298,2,11810,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8298,3,11811,Doctoral Research,Lee,Hyongki,0,0,0,0,0,4,0,
+Spring 2023,CIVE,8298,4,11812,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8298,5,11813,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,5,0,
+Spring 2023,CIVE,8398,1,11814,Doctoral Research,Milillo,Pietro,0,0,0,0,0,5,0,
+Spring 2023,CIVE,8398,2,11815,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8398,3,11816,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8398,4,11817,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Spring 2023,CIVE,8398,5,11818,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8398,6,11819,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8398,7,11820,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8498,1,11821,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8498,2,11822,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8598,1,11823,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Spring 2023,CIVE,8598,2,11824,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8598,3,11825,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,3,0,
+Spring 2023,CIVE,8598,4,11826,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8598,5,11827,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Spring 2023,GHL,2350,2,11828,Mgmt Principles in Hospitality,Boger Jr,Carl A,31,7,9,2,0,0,0,3.219
+Spring 2023,MIS,3370,1,11829,Info Systems Development Tools,Knighton,William B,17,13,16,3,1,0,14,2.84
+Spring 2023,MIS,3371,1,11830,Transaction Processing Sys I,Messinger,Jacob Nelson,117,57,19,3,1,0,5,3.418
+Spring 2023,MIS,4374,1,11831,Info Technology Project Mgmt,Scott,Carl P,29,12,0,0,0,0,0,3.627
+Spring 2023,MIS,4378,1,11832,Admin of Computer-Based MIS,Porra,Jaana,41,1,0,0,0,0,0,3.968
+Spring 2023,STAT,3331,1,11833,Statistical Anal Bus Appl I,Wiley,Briceon C,4,6,1,5,2,0,9,2.278
+Spring 2023,SCM,3301,1,11834,SCM Fundamentals,Anderson Fletcher,Elizabeth,12,9,0,0,0,0,0,3.634
+Spring 2023,SCM,3301,2,11835,SCM Fundamentals,Miller,Bradley D,270,226,33,11,4,0,5,3.35
+Spring 2023,GHL,6345,1,11836,Wine Appreciation,Taylor,David C,0,1,0,1,1,0,0,1.333
+Spring 2023,NUTR,4312,1,11838,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,8,29,6,3,1,0,1,2.865
+Spring 2023,NUTR,4346,1,11839,Research in Nutrition,Ledoux,Tracey A,12,15,9,1,0,0,2,3.027
+Spring 2023,NUTR,4348,1,11840,Intro to NUTR Counseling,Honig,Caryn A,21,8,0,0,0,0,0,3.61
+Spring 2023,FREN,2311,2,11841,Intermediate French I,Chalhoub,Rania Maria,9,9,1,0,1,0,0,3.217
+Spring 2023,WCL,2352,2,11843,World Cinema,Centeno,Daniel,11,16,3,0,0,0,0,3.201
+Spring 2023,WCL,2351,2,11844,World Cultures Thru Lit & Arts,Ambikaipaker,Mohan,7,1,1,0,1,0,2,3.234
+Spring 2023,ENGL,7324,1,11845,Writers On Literature,Turchi,Peter D,14,0,0,0,0,0,0,4.0
+Spring 2023,HDCS,4374,1,11847,Entrepreneurial E-Tailing,Johnson,Olivia,6,8,4,4,0,0,0,2.727
+Spring 2023,LAW,5409,1,11849,Contracts,Bush,Darren,21,25,0,0,0,0,0,3.442
+Spring 2023,GHL,4132,1,11850,Bev Mgmt & Mktg Internship,Taylor,David C,3,0,0,0,1,0,0,3.0
+Spring 2023,CHEE,6398,1,11851,Research,Karim,Alamgir,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8198,1,11852,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8298,2,11854,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,
+Spring 2023,CHEE,8298,4,11856,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,4,0,
+Spring 2023,CHEE,8298,5,11857,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8298,7,11859,Doctoral Research,Grabow,Lars C,0,0,0,0,0,5,0,
+Spring 2023,CHEE,8298,8,11860,Doctoral Research,Harold,Michael P,0,0,0,0,0,3,0,
+Spring 2023,CHEE,8298,9,11861,Doctoral Research,Karim,Alamgir,0,0,0,0,0,10,0,
+Spring 2023,CHEE,8298,10,11862,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8298,12,11864,Doctoral Research,Orman,Mehmet,0,0,0,0,0,3,0,
+Spring 2023,CHEE,8298,13,11865,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8298,14,11866,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,5,0,
+Spring 2023,CHEE,8298,16,11867,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8399,15,11868,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,3,0,
+Spring 2023,CHEE,8398,2,11875,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8398,4,11877,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,4,0,
+Spring 2023,CHEE,8398,5,11878,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8398,7,11880,Doctoral Research,Grabow,Lars C,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8398,8,11881,Doctoral Research,Harold,Michael P,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8398,9,11882,Doctoral Research,Karim,Alamgir,0,0,0,0,0,9,0,
+Spring 2023,CHEE,8398,12,11885,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8398,13,11886,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8398,14,11887,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,5,0,
+Spring 2023,CHEE,8398,15,11888,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8498,1,11889,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8498,10,11898,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,2,11905,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,3,11906,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,4,11907,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,7,11910,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,8,11911,Doctoral Research,Harold,Michael P,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,9,11912,Doctoral Research,Karim,Alamgir,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,10,11913,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8598,11,11914,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8598,12,11915,Doctoral Research,Orman,Mehmet,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8598,13,11916,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,
+Spring 2023,CHEE,8598,14,11917,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,6,0,
+Spring 2023,CHEE,8598,15,11918,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,
+Spring 2023,POLS,4398,1,11919,Independent Study,Cross,Renee D,13,1,0,0,0,1,0,3.952
+Spring 2023,ARCH,6367,1,11920,Case Studies Sustainable Arch,Taylor,Rives,4,1,0,0,0,0,0,3.668
+Spring 2023,MECT,1330,30,11921,Engineering Graphics,Fan,Zheng,15,21,7,1,0,0,3,3.166
+Spring 2023,MECT,4372,1,11923,Materials Technology,Robles Hernandez,Francisco C,3,3,4,1,0,0,0,2.727
+Spring 2023,MECT,4172,1,11924,Materials Tech Lab,Taylor,Gordon D,4,8,0,0,0,0,0,3.416
+Spring 2023,ECE,6398,2,11926,Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Spring 2023,ECE,6398,7,11931,Research,Chen,Ji,0,0,0,0,0,2,0,
+Spring 2023,ECE,6398,11,11934,Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,12,11935,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,16,11939,Research,Jackson,David R,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,18,11941,Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,19,11942,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,20,11943,Research,Pan,Miao,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,22,11945,Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2023,ECE,6398,29,11952,Research,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2023,CNST,3205,1,11953,Construction Safety Management,Hart,Lee J,33,4,1,1,1,0,0,3.675
+Spring 2023,ECE,8198,10,11965,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Spring 2023,ECE,8198,11,11966,Doctoral Research,Han,Zhu,0,0,0,0,0,4,0,
+Spring 2023,ECE,8198,13,11968,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Spring 2023,ECE,8198,21,11975,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2023,ECE,8198,22,11976,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Spring 2023,ECE,8198,31,11985,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Spring 2023,ECE,8198,33,11987,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Spring 2023,ECE,8198,35,11989,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Spring 2023,ECE,8198,37,11991,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Spring 2023,ECE,8198,38,11992,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,2,11994,Doctoral Research,Chen,Ji,0,0,0,0,0,1,0,
+Spring 2023,ECE,8298,3,11995,Doctoral Research,Chen,Jiefu,0,0,0,0,0,5,0,
+Spring 2023,ECE,8298,4,11996,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Spring 2023,ECE,8298,5,11997,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,6,11998,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2023,ECE,8298,7,11999,Doctoral Research,Jackson,David R,0,0,0,0,0,3,0,
+Spring 2023,ECE,8298,8,12000,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,10,12002,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2023,ECE,8298,12,12004,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Spring 2023,ECE,8298,13,12005,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Spring 2023,ECE,8298,14,12006,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,16,12008,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,5,0,
+Spring 2023,ECE,8298,17,12009,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,27,12017,Doctoral Research,Pan,Miao,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,31,12021,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Spring 2023,ECE,8298,36,12025,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8298,39,12028,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,1,12029,Doctoral Research,Li,Xingpeng,0,0,0,0,0,4,0,
+Spring 2023,ECE,8398,2,12030,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,6,12034,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,7,12035,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,10,12038,Doctoral Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,11,12039,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Spring 2023,ECE,8398,13,12041,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,14,12042,Doctoral Research,Han,Zhu,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,15,12043,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,16,12044,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,17,12045,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,21,12049,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,4,0,
+Spring 2023,ECE,8398,22,12050,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,24,12052,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Spring 2023,ECE,8398,27,12055,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,28,12056,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,3,0,
+Spring 2023,ECE,8398,30,12057,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,1,12058,Doctoral Research,Li,Xingpeng,0,0,0,0,0,6,0,
+Spring 2023,ECE,8498,2,12059,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8498,4,12061,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,5,12062,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,2,0,
+Spring 2023,ECE,8498,6,12063,Doctoral Research,Chen,Ji,0,0,0,0,0,3,0,
+Spring 2023,ECE,8498,7,12064,Doctoral Research,Chen,Jiefu,0,0,0,0,0,5,0,
+Spring 2023,ECE,8498,8,12065,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,9,12066,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,10,12067,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,11,12068,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,12,12069,Doctoral Research,Fu,Xin,0,0,0,0,0,3,0,
+Spring 2023,ECE,8498,13,12070,Doctoral Research,Han,Zhu,0,0,0,0,0,3,1,
+Spring 2023,ECE,8498,14,12071,Doctoral Research,Jackson,David R,0,0,0,0,0,4,0,
+Spring 2023,ECE,8498,15,12072,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,16,12073,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,17,12074,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,3,0,
+Spring 2023,ECE,8498,18,12075,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Spring 2023,ECE,8498,19,12076,Doctoral Research,Pan,Miao,0,0,0,0,0,2,0,
+Spring 2023,ECE,8498,21,12078,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,22,12079,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,23,12080,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,2,0,
+Spring 2023,ECE,8498,24,12081,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Spring 2023,ECE,8498,25,12082,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8498,26,12083,Doctoral Research,Wolfe,John C,0,0,0,0,0,1,0,
+Spring 2023,ECE,8498,27,12084,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8598,1,12086,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,3,12088,Doctoral Research,Becker,Aaron T,0,0,0,0,0,3,0,
+Spring 2023,ECE,8598,5,12090,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Spring 2023,ECE,8598,8,12092,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,10,12094,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Spring 2023,ECE,8598,12,12096,Doctoral Research,Fu,Xin,0,0,0,0,0,3,0,
+Spring 2023,ECE,8598,13,12097,Doctoral Research,Han,Zhu,0,0,0,0,0,6,0,
+Spring 2023,ECE,8598,14,12098,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,15,12099,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,5,0,
+Spring 2023,ECE,8598,16,12100,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,17,12101,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,18,12102,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,19,12103,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Spring 2023,ECE,8598,20,12104,Doctoral Research,Pan,Miao,0,0,0,0,0,2,0,
+Spring 2023,ECE,8598,22,12106,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,23,12107,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Spring 2023,ECE,8598,25,12109,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Spring 2023,ECE,8598,28,12112,Doctoral Research,Wolfe,John C,0,0,0,0,0,1,0,
+Spring 2023,COMM,4382,1,12115,Narrative Non-Linear Editing,Houk,Keith R,15,5,0,0,2,0,1,3.349
+Spring 2023,BIOL,4206,1,12116,Ecology & Evolution Laboratory,Cheek,Ann Oliver,15,6,1,0,1,0,0,3.507
+Spring 2023,BIOL,4206,2,12117,Ecology & Evolution Laboratory,Cheek,Ann Oliver,12,4,1,1,2,0,2,3.167
+Spring 2023,PHCA,6298,2,12118,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,6298,3,12119,Special Problems,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6398,1,12127,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6498,1,12130,Special Problems,Chung,Sanghyuk,0,0,0,0,0,5,0,
+Spring 2023,BCHS,8698,1,12134,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,2,0,
+Spring 2023,CHEM,6198,1,12135,Special Problems,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Spring 2023,CHEM,6198,2,12136,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6198,4,12137,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6198,5,12138,Special Problems,Harth,Eva M,0,0,0,0,0,2,0,
+Spring 2023,CHEM,6198,7,12140,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6198,8,12141,Special Problems,Teets,Thomas,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6198,10,12143,Special Problems,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6198,11,12144,Special Problems,Carrow,Bradley,0,0,0,0,0,5,0,
+Spring 2023,CHEM,6198,13,12146,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6398,2,12153,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6398,12,12163,Special Problems,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6398,13,12164,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6398,16,12167,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,2,12172,Special Problems,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Spring 2023,CHEM,6698,3,12173,Special Problems,Do,Loi H,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,5,12175,Special Problems,Teets,Thomas,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,6,12176,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,7,12177,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,8,12178,Special Problems,Harth,Eva M,0,0,0,0,0,4,0,
+Spring 2023,CHEM,6698,9,12179,Special Problems,Lee,T Randall,0,0,0,0,0,3,0,
+Spring 2023,CHEM,6698,10,12180,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,11,12181,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,13,12183,Special Problems,Xu,Shoujun,0,0,0,0,0,2,0,
+Spring 2023,CHEM,6698,15,12185,Special Problems,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,16,12186,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,17,12187,Special Problems,Chiang,Naihao,0,0,0,0,0,2,0,
+Spring 2023,CHEM,6698,18,12188,Special Problems,Carrow,Bradley,0,0,0,0,0,5,0,
+Spring 2023,CHEM,6698,19,12189,Special Problems,Bittner,Eric R,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6698,20,12190,Special Problems,Comito,Robert Joseph,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6998,8,12197,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Spring 2023,CHEM,6998,14,12203,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Spring 2023,CHEM,8998,2,12248,Doctoral Research,Harth,Eva M,0,0,0,0,0,2,0,
+Spring 2023,CHEM,8998,4,12250,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,2,0,
+Spring 2023,CHEM,8998,5,12251,Doctoral Research,Teets,Thomas,0,0,0,0,0,4,0,
+Spring 2023,CHEM,8998,6,12252,Doctoral Research,Lee,T Randall,0,0,0,0,0,2,0,
+Spring 2023,CHEM,8998,7,12253,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,3,0,
+Spring 2023,CHEM,8998,9,12255,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Spring 2023,CHEM,8998,12,12258,Doctoral Research,Do,Loi H,0,0,0,0,0,1,0,
+Spring 2023,CHEM,8998,13,12259,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,2,0,
+Spring 2023,CHEM,8998,17,12263,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,3,0,
+Spring 2023,CHEM,8998,20,12266,Doctoral Research,May,Jeremy A,0,0,0,0,0,5,0,
+Spring 2023,PSYC,2316,1,12267,Psychology of Personality,Fetterman,Adam Kent,27,15,2,0,1,0,0,3.526
+Spring 2023,PSYC,4344,2,12268,Cultural Psychology,Beltran-Najera,Ilex,48,22,6,1,2,0,1,3.493
+Spring 2023,PSYC,3331,1,12269,Psychology of Gender,Kehoe,Caitlin,39,24,10,3,1,0,2,3.345
+Spring 2023,ELET,3112,1,12270,Rotating Machine Controls Lab,Fan,Lei,3,0,2,0,0,0,0,3.134
+Spring 2023,PCEU,6498,2,12272,Special Problems,Hu,Ming,0,0,0,0,0,2,0,
+Spring 2023,ENGL,7398,1,12273,Special Problems,Wingard,Jennifer L,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,6376,1,12275,Organometallic Chemistry,Daugulis,Olafs,4,9,0,0,0,0,0,3.282
+Spring 2023,CUIN,8398,9,12276,Independent Study,Hale,Margaret Ann,1,0,1,0,0,0,0,3.0
+Spring 2023,ACCT,8398,1,12277,Special Problems,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5681,1,12278,Infectious Diseases,Truong,Mabel,8,3,0,0,0,0,0,3.727
+Spring 2023,BTEC,3301,30,12279,Genomics/Proteomics & Bioinfo.,Flavier,Albert B,16,20,14,3,2,0,1,2.764
+Spring 2023,POLS,4498,1,12281,Independent Study,Cross,Renee D,0,0,0,0,0,7,0,
+Spring 2023,ENGL,4398,1,12282,Independent Study,Snediker,Michael,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8598,16,12283,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,4,0,
+Spring 2023,CHEE,8498,16,12284,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6298,1,12285,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6398,1,12286,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2023,POLS,4598,1,12288,Independent Study,Cross,Renee D,0,1,0,0,0,7,0,3.0
+Spring 2023,ENGI,2304,3,12289,Technical Communications,Estrada,Carl,8,10,4,1,0,0,2,3.073
+Spring 2023,NUTR,3336,2,12290,Nutritional Pathophysiology,Vollrath,Kirstin,36,13,6,0,1,0,1,3.358
+Spring 2023,COSC,4354,1,12293,Software Development Practices,Subramaniam,Venkat,12,9,8,1,0,0,0,3.122
+Spring 2023,ECON,3332,1,12294,Intermediate Microeconomics,Chin,Aimee,16,12,2,1,7,0,4,2.711
+Spring 2023,ECON,4349,1,12295,Introduction To Game Theory,Ujhelyi,Gergely,6,7,10,4,0,0,2,2.519
+Spring 2023,GEOL,6396,1,12296,Graduate Seminar,Jiang,Xun,15,0,0,0,0,1,0,4.0
+Spring 2023,MATH,1351,3,12297,Intro to Geometric Reasoning,Chang,James A,54,46,50,6,26,0,14,2.466
+Spring 2023,MATH,1342,6,12298,Elementary Statistical Methods,Caputo,Matthew G,56,146,120,12,28,0,52,2.474
+Spring 2023,MATH,3338,3,12299,Probability,Papadakis,Emanuel Ioannis,12,11,1,2,6,0,7,2.698
+Spring 2023,KIN,4190,1,12300,Sport Administration Seminar,Walsh,David W,14,7,1,1,0,0,0,3.493
+Spring 2023,FINA,4330,2,12301,Corporate Finance,Liu,Zesong,17,16,11,0,0,0,1,3.166
+Spring 2023,GEOL,1347,1,12302,Introduction To Meteorology,Jiang,Xun,207,80,9,2,1,0,3,3.544
+Spring 2023,ARCH,6355,1,12303,Houston Architecture,Fox,Stephen,2,0,0,0,0,0,0,3.835
+Spring 2023,ARCH,6347,1,12304,Evolution of Arch Interiors,Thomas,James B,3,0,0,0,0,0,0,4.0
+Spring 2023,COMM,3316,2,12305,Electronic News,Perez,Felicia Russell,10,3,1,0,0,0,0,3.619
+Spring 2023,COMM,4363,1,12306,Integrated Comm. Campaigns,Clark,Thomas R,10,1,0,0,0,0,0,3.909
+Spring 2023,COMM,4366,1,12307,Advertising Account Planning,Safinya,Nader,10,8,0,0,0,0,0,3.501
+Spring 2023,COSC,6385,1,12308,Computer Architecture,Shi,Weidong,20,9,0,0,0,0,1,3.61
+Spring 2023,KIN,4690,1,12309,Internship in Sport Admin 1,Walsh,David W,14,6,2,1,0,0,0,3.492
+Spring 2023,KIN,4691,1,12310,Internship in Sport Admin 2,Walsh,David W,23,8,0,0,0,0,0,3.763
+Spring 2023,PUBL,6415,1,12311,Decision Sci. for Publ Affairs,Yuasa,Toshiyuki,0,2,5,0,0,0,2,2.333
+Spring 2023,BIOL,4103,1,12312,Integration Biol Knowledge,Wayne,Chad M,61,24,7,0,2,0,1,3.528
+Spring 2023,ENTR,3310,4,12313,Entrepreneurship,Ortega,Carlos Alberto,162,22,6,3,3,0,2,3.666
+Spring 2023,HRD,6302,1,12314,Design & Management E-Learning,Nair,Maya,11,3,0,0,0,0,0,3.597
+Spring 2023,PHCA,7301,1,12315,Advanced Regression,Johnson,Michael L,3,3,0,0,0,0,0,3.5
+Spring 2023,ACCT,2302,3,12316,Prin of Managerial Accounting,Weber,Catherine K,32,31,22,9,2,0,7,2.909
+Spring 2023,CUIN,4350,1,12317,Multiple Teaching Strategies,Segura,Perri F,9,2,1,0,0,0,0,3.694
+Spring 2023,ECE,5114,1,12318,Antenna Engineering Laboratory,Long,Stuart A,0,0,0,0,0,0,1,
+Spring 2023,PSYC,3310,1,12319,Indstrl-Orgnztnl Psy,Van Egdom,Drake Alexander,46,7,3,0,2,0,1,3.649
+Spring 2023,PSYC,3350,1,12320,Intro to Cognitive Psychology,Hernandez,Arturo E,59,31,8,0,0,0,5,3.483
+Spring 2023,CHEE,3363,1,12321,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,4,13,17,5,2,0,7,2.317
+Spring 2023,LAW,5418,1,12322,Torts,Koch,Valerie Gutmann,9,26,1,0,0,0,0,3.25
+Spring 2023,COMD,3385,1,12323,Speech Science,Bunta,Ferenc,24,2,3,1,1,0,3,3.41
+Spring 2023,HDFS,1300,7,12326,Dev of Contemporary Families,Jordan,Erica F,94,42,8,3,5,0,4,3.36
+Spring 2023,MANA,4338,1,12327,Performance Management Systems,Sullivan,David Walter,28,22,8,0,0,0,0,3.413
+Spring 2023,CUIN,3350,1,12328,Knowing/Learning Science-Math,Latiolais,Cheryl S,5,0,1,0,1,0,0,3.096
+Spring 2023,CUIN,3350,2,12329,Knowing/Learning Science-Math,Segura,Perri F,5,6,1,0,0,0,0,3.443
+Spring 2023,MIS,3360,1,12330,Systems Analysis and Design,Skinner,Richard James,16,30,16,1,0,0,1,2.968
+Spring 2023,MIS,3360,2,12331,Systems Analysis and Design,Skinner,Richard James,17,34,11,1,0,0,1,3.063
+Spring 2023,GERM,3381,1,12332,German Cinema,Glass,Hildegard,5,7,1,4,3,0,5,2.301
+Spring 2023,ACCT,7385,1,12333,Fraud Examination,Ramey,Dan T,15,7,0,0,0,0,1,3.772
+Spring 2023,FINA,6387,2,12334,Managerial Analysis,Basu,Swati,48,14,0,0,0,0,1,3.764
+Spring 2023,SOCW,7340,1,12335,Clinical Practice with Child,Olson,Lindamarie E,27,1,0,0,0,0,0,3.964
+Spring 2023,PHYS,3327,1,12336,Thermal Physics,Morrison,Gregory C,6,3,6,0,0,0,1,3.0
+Spring 2023,KIN,4340,1,12337,Sport Governance,Hawkins,Billy J,22,24,0,0,0,0,0,3.5
+Spring 2023,TEPM,6395,1,12338,Integration Project,Carden,Lila L,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,7378,1,12339,Info.Tech Management & Control,Porra,Jaana,28,1,0,0,0,0,2,3.966
+Spring 2023,SOCW,7389,1,12340,Field Practicum IV Macro,Gonzales,Shelley A,0,0,0,0,0,36,0,
+Spring 2023,PUBL,6311,1,12341,Public Admin and Policy Impl,Koelling,Peter,9,0,0,0,0,0,0,3.78
+Spring 2023,COMD,4382,1,12342,Aural Rehabilitation,Andrews,Chereece N,58,3,0,0,0,0,0,3.891
+Spring 2023,PSYC,8399,6,12345,Doctoral Dissertation,Spitzmuller,Christiane,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,2102,11,12346,Anatomy & Physiology II (lab),Gill,Tejendra,8,11,3,1,0,0,1,3.087
+Spring 2023,BIOL,2102,12,12348,Anatomy & Physiology II (lab),Gill,Tejendra,5,14,3,1,0,0,1,3.0
+Spring 2023,CNST,6360,1,12349,Computer Applications in CM,Song,Lingguang,41,9,1,0,0,0,0,3.752
+Spring 2023,CNST,6360,2,12350,Computer Applications in CM,Song,Lingguang,18,3,1,1,0,0,0,3.638
+Spring 2023,CNST,6380,1,12351,Leed & Green Const Princ in CM,Chang,Chi Chung,10,6,1,0,0,0,0,3.51
+Spring 2023,EDUC,4314,1,12354,Student Teaching Sec,Thompson,Amber M,13,3,0,0,0,0,1,3.771
+Spring 2023,CNST,4341,1,12355,Project Controls,Bouhou,Nour-El Imane,13,36,10,3,1,0,2,2.905
+Spring 2023,HDFS,3350,3,12356,Observation and Assessment,Schroder,Kathleen Anne,16,5,2,0,6,0,1,2.794
+Spring 2023,CUIN,8398,11,12358,Independent Study,Chung,Sheng Kuan,2,1,0,0,0,0,0,3.777
+Spring 2023,BIOL,2102,13,12359,Anatomy & Physiology II (lab),Gill,Tejendra,6,11,4,1,0,0,2,2.925
+Spring 2023,PCEU,7142,1,12361,Pharmaceutic Literature Review,Bond,Richard A,0,0,0,0,0,10,0,
+Spring 2023,BIOL,2102,15,12362,Anatomy & Physiology II (lab),Gill,Tejendra,9,9,2,0,0,0,1,3.35
+Spring 2023,COMD,7692,1,12365,Advanced Practicum,Blake,Margaret T,9,0,0,0,0,0,0,3.817
+Spring 2023,PSYC,6392,1,12371,Intervention Practicum,Vincent,John P,0,0,0,0,0,16,0,
+Spring 2023,SOCW,8699,1,12373,Dissertation,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Spring 2023,CNST,3351,1,12375,Construction Estimating II,Siddiqui,Muhammad Ali,22,19,5,2,1,0,0,3.17
+Spring 2023,ARCH,3342,1,12376,Shape of the City,Turner,Drexel,7,4,2,0,0,0,0,3.283
+Spring 2023,ARCH,6342,1,12377,Shape of the City,Turner,Drexel,2,0,0,0,0,0,0,4.0
+Spring 2023,FREN,1501,5,12379,Elementary French I,Chalhoub,Rania Maria,5,6,2,3,3,0,3,2.334
+Spring 2023,CHEE,8598,17,12383,Doctoral Research,Vekilov,Peter,0,0,0,0,0,5,0,
+Spring 2023,FINA,8398,2,12385,Special Problems,Yerramilli,Vijay,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8398,4,12386,Special Problems,Susmel,Raul,1,0,0,0,0,0,0,4.0
+Spring 2023,MSCI,1220,1,12387,Agile & Adaptive Leadership,Comiskey,Melissa C,4,0,0,0,0,0,1,3.753
+Spring 2023,MSCI,1220,3,12389,Agile & Adaptive Leadership,Comiskey,Melissa C,2,2,0,0,1,0,0,2.932
+Spring 2023,ECON,6340,1,12390,Health Economics,Zhivan,Natalia A,7,1,0,0,0,0,0,3.793
+Spring 2023,ECON,6345,1,12391,Energy Economics,Kelly,Robert C,11,0,0,0,0,0,0,3.88
+Spring 2023,MATH,4309,1,12392,Mathematical Biology,Azevedo,Ricardo,2,4,0,0,0,0,1,3.443
+Spring 2023,MIS,4374,2,12394,Info Technology Project Mgmt,Campbell,Phillip James,19,13,2,0,0,0,0,3.5
+Spring 2023,GEOL,1103,8,12395,Physical Geology Lab,Hauptvogel,Daniel William,13,1,0,0,0,0,1,3.905
+Spring 2023,KIN,3370,1,12396,Sport Facility Management,Cho,Minseok,28,17,1,2,0,0,0,3.424
+Spring 2023,FINA,7352,1,12397,Energy Derivatives,Pirrong,Stephen Craig,15,0,0,0,0,0,0,3.736
+Spring 2023,CHEE,3321,1,12398,Analytical Methods Chem Engr,Grabow,Lars C,14,5,13,5,8,0,13,2.259
+Spring 2023,GENB,5305,1,12399,Commercial Law,Hopkins,Troy D,4,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,4340,1,12400,Research Methods,Ekeoba,Jacqueline Njideka,2,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,4309,1,12401,Mathematical Biology,Azevedo,Ricardo,2,1,0,0,0,0,0,3.667
+Spring 2023,COSC,4359,1,12402,Intermediate Game Development,Yun,Changhoon,13,12,0,0,0,0,0,3.546
+Spring 2023,COSC,6359,1,12403,Intermediate Game Development,Yun,Changhoon,6,0,0,0,0,0,0,3.945
+Spring 2023,PSYC,2305,2,12404,Intro to Methods in Psychology,Foss,Donald J,14,11,6,3,3,0,8,2.838
+Spring 2023,PSYC,6337,1,12406,Grant Writing,Neighbors,Clayton T,16,2,0,0,0,0,0,3.907
+Spring 2023,COMM,3319,1,12407,Preproduction Management,Newlin,Julye G,19,2,2,0,1,0,0,3.528
+Spring 2023,MARK,6361,1,12408,Marketing Administration,Koch,Steven F,7,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,6115,3,12409,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,6,0,
+Spring 2023,ITAL,1502,1,12411,Elementary Italian II,Ercolani,Monica,11,2,1,0,0,0,0,3.667
+Spring 2023,ITAL,1502,3,12413,Elementary Italian II,Nicosia,Alda,3,4,2,0,0,0,0,3.111
+Spring 2023,PSYC,2305,4,12415,Intro to Methods in Psychology,Foss,Donald J,13,17,5,2,4,0,4,2.829
+Spring 2023,BIOL,3368,1,12417,Ecology,Pennings,Steven C,27,34,34,6,4,0,19,2.689
+Spring 2023,BIOL,4354,1,12418,Endocrinology,Warner,Margaret,63,15,3,0,0,0,2,3.741
+Spring 2023,TECH,4310,1,12419,Future of Energy & Environment,Breaux,James William,29,6,1,2,0,0,1,3.623
+Spring 2023,TECH,6360,1,12420,Exp Design & Data Analysis,Schroeder,Susan L,13,6,0,0,1,0,3,3.5
+Spring 2023,HDFS,2320,1,12421,Research Methods in HDFS,Rab,Saira,24,10,2,1,2,0,1,3.359
+Spring 2023,HDFS,3317,1,12422,Prenatal and Infant Developmt,Wang,Jennifer L,31,10,2,1,1,0,0,3.46
+Spring 2023,ACCT,3366,1,12425,Financial Reporting Frameworks,Harris,Kathleen L,14,6,3,2,1,0,6,3.205
+Spring 2023,ACCT,3366,2,12426,Financial Reporting Frameworks,Harris,Kathleen L,13,8,2,3,1,0,6,3.074
+Spring 2023,GENB,7305,3,12427,Commercial Law,Hopkins,Troy D,3,4,0,0,0,0,0,3.381
+Spring 2023,KIN,3360,1,12428,Professional Prep for Sp Admin,Pearson,Demetrius W,10,15,21,4,4,0,3,2.414
+Spring 2023,ACCT,5331,1,12429,Federal Income Tax-Individual,Fernandez,Ramon,2,4,5,0,0,0,1,2.907
+Spring 2023,TEPM,6301,1,12430,Project Management Principles,Sherman,Dennis Louis,23,4,0,0,0,0,0,3.864
+Spring 2023,ENGL,1302,24,12431,First Year Writing II,Downey,Carlton M,18,0,0,0,1,0,0,3.737
+Spring 2023,MECE,4341,1,12432,Mechanical Engr Capstone II,Chang,Christiana,84,43,4,0,0,0,1,3.543
+Spring 2023,LAW,5200,1,12433,Depositions,Morfey,Michael D,3,4,0,0,0,4,0,3.523
+Spring 2023,GHL,6330,1,12434,Statistical Analysis in Hosp.,Draper,Jason A,10,2,1,0,0,0,0,3.667
+Spring 2023,GHL,6364,1,12435,Hosp. Managerial Accounting,Johnson,Tucker A,5,1,0,0,0,0,0,3.833
+Spring 2023,NUTR,4334,1,12436,Community Nutrition,Cepni,Aliye Beyza,54,51,22,8,9,0,3,2.866
+Spring 2023,PEP,6321,2,12437,Sport in Cont Society,Pearson,Demetrius W,3,6,2,0,0,0,1,3.121
+Spring 2023,BIOL,1307,5,12438,Biology for Science Majors II,Farmer,Lisa M,61,88,79,28,16,0,10,2.537
+Spring 2023,MECE,4372,1,12439,Mechs-Cntrls-Vibrtn Lab,Song,Gangbing,15,31,7,0,0,0,0,3.126
+Spring 2023,AAS,2320,5,12440,Intro To African American Stdy,Raynor,Autumn Fawn,30,5,1,0,1,0,2,3.676
+Spring 2023,CHEE,2331,1,12441,Chemical Processes,Kowal,Marsha Christine,10,10,12,3,4,0,2,2.462
+Spring 2023,AFSC,4302,1,12443,National Security Affairs II,Manning,Matthew,4,0,0,0,0,0,0,3.753
+Spring 2023,MARK,7368,1,12445,Integrated Marketng Commncatns,Morabito,Philip A,30,10,0,0,0,0,0,3.659
+Spring 2023,POLS,3311,1,12446,Intro Compar Politics,Jung,Jae Hee,29,3,3,1,2,0,0,3.422
+Spring 2023,CNST,1315,1,12447,Project Drawings and Graphics,Clark,Peter J,16,8,6,0,2,0,2,3.094
+Spring 2023,CNST,2345,1,12448,Contract Doc Capital Projects,Beadle,Dwight D,24,7,1,0,0,0,1,3.719
+Spring 2023,CNST,3365,1,12449,Cost Estimating Capital Projec,Glumac,Carmel,5,6,6,1,0,0,1,2.888
+Spring 2023,FINA,3332,1,12450,Prin of Financial Management,Blanchfield,Craig,17,5,2,0,0,0,0,3.666
+Spring 2023,ACCT,3366,3,12451,Financial Reporting Frameworks,Parthasarathy,Kiran M,48,12,9,7,2,0,8,3.239
+Spring 2023,MECE,4331,1,12452,Design of Machine Elements,Wang,Su Su,16,30,22,3,0,0,7,2.822
+Spring 2023,FINA,4320,2,12454,Investment Management,Gargano,Antonio,4,3,0,0,0,0,0,3.571
+Spring 2023,ENGL,2306,2,12455,Intro To Poetry,Priest,Joy M,21,0,1,0,2,0,2,3.556
+Spring 2023,BCHS,3201,10,12458,Biochemistry I Laboratory,Pattison,Donna,11,8,2,1,2,0,0,2.987
+Spring 2023,CNST,2325,1,12463,Process and Industrial Subsyst,Zayas,Frederick A,0,12,7,2,0,0,0,2.602
+Spring 2023,ELED,3322,3,12464,Elem Reading Phonics Instructn,Alba,Celeste,21,3,2,0,0,0,0,3.731
+Spring 2023,PHOP,8399,13,12465,Doctoral Dissertation,Patel,Nimesh Bhikhu,2,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,1101,12,12474,College Physics I (lab),Wood,Lowell T,1,13,9,0,0,0,0,2.738
+Spring 2023,PHYS,1101,13,12475,College Physics I (lab),Wood,Lowell T,0,10,9,0,0,0,3,2.683
+Spring 2023,ECE,5320,1,12476,Intro to Nanomatierials Engr,Bao,Jiming,2,2,0,0,0,0,0,3.5
+Spring 2023,CNST,6390,1,12479,Leadership for Const Managers,Connors,Jayme P,20,1,0,0,1,0,0,3.773
+Spring 2023,DIGM,4396,30,12480,Internship in Digital Media,Liao,Tony Chung-Li,13,2,0,0,0,0,0,3.801
+Spring 2023,ELET,2103,1,12483,Digital Systems Laboratory,Abdelhadi,Ahmed,9,8,1,0,0,0,0,3.426
+Spring 2023,ENGI,2304,4,12485,Technical Communications,Ellis,Kelly Ann,20,1,1,2,1,0,0,3.414
+Spring 2023,ACCT,7398,2,12487,Research,Kilic,Emre,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,5500,11,12491,Architecture Design Studio IX,Lutz,Shawn M,13,2,0,0,0,0,0,3.691
+Spring 2023,PHAR,5668,1,12493,Managed Care Pharmacy,Tolleson,Shane Russell,3,1,0,0,0,0,0,3.75
+Spring 2023,ELET,2300,1,12494,Introductn To C++ Programming,Hu,Bin,10,12,14,6,3,0,4,2.393
+Spring 2023,ECON,8361,1,12496,Workshop Research Methods III,Maheshri,Vikram,8,0,0,0,0,0,0,4.0
+Spring 2023,MATH,3339,3,12497,Statistics for the Sciences,Labate,Demetrio,20,8,8,2,7,0,4,2.711
+Spring 2023,ARCH,5500,5,12499,Architecture Design Studio IX,Story,Jon Kevin,18,0,0,0,0,0,1,3.963
+Spring 2023,INDS,4180,1,12501,Design Internship,McEuen,Aaron Ross,3,0,0,0,0,0,1,4.0
+Spring 2023,INDE,6361,1,12502,Prod Planning & Invent Control,Rypien,David V,76,5,0,0,0,0,0,3.942
+Spring 2023,SPAN,1502,9,12503,Elementary Spanish II,Perez Vigil De Mostaccero,Sylvia Rossana,7,5,6,1,4,0,0,2.492
+Spring 2023,FREN,2312,2,12505,Intermediate French II,Green,Viola V,3,8,3,1,2,0,1,2.491
+Spring 2023,PHAR,5672,1,12506,Clinical Pharmaceutical Resch,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5660,1,12507,Pharmaceutical Industry,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5663,2,12508,Pharmacy Management,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5673,1,12509,Veterinary Pharmaceutical Care,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,1302,1,12511,Intro To Global Climate Change,Wang,Yuxuan,96,197,34,0,4,0,11,3.138
+Spring 2023,SCM,4301,1,12512,Logistics Management,Tibodeau,Dale,11,36,2,1,0,0,2,3.153
+Spring 2023,SCM,4330,1,12513,Bus Modeling and Dec Analysis,Cossick,Kathy L,2,2,0,0,0,0,2,3.583
+Spring 2023,SCM,4330,2,12514,Bus Modeling and Dec Analysis,Chin,Wynne W,21,16,8,8,2,0,5,2.812
+Spring 2023,SCM,4351,1,12515,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,35,10,2,0,0,0,0,3.674
+Spring 2023,SCM,4351,2,12516,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,33,14,2,0,0,0,1,3.612
+Spring 2023,GEOL,4331,1,12517,Geospatial Analysis & App.,Khan,Shuhab D,12,18,4,0,0,0,3,3.245
+Spring 2023,GEOL,6388,1,12518,Geospatial Analysis,Khan,Shuhab D,10,1,0,0,0,0,0,3.909
+Spring 2023,BIOL,4340,1,12519,Research Methods,Ekeoba,Jacqueline Njideka,7,1,0,0,0,0,0,3.834
+Spring 2023,CUIN,3347,2,12521,Reading in the Content Area,Schorzman,Emma,34,0,0,0,0,0,1,3.961
+Spring 2023,SPAN,3307,2,12522,Public Speaking in Spanish,Quintanilla,Guadalupe C,10,5,0,0,0,0,0,3.557
+Spring 2023,CUIN,4361,1,12523,Second Language Methodology,Elshafie,Marwa,34,3,1,0,0,0,0,3.825
+Spring 2023,CUIN,4375,5,12524,Classroom Management,Snead,Lauren Oropeza,22,3,1,0,0,0,0,3.795
+Spring 2023,PUBL,6325,1,12525,Capstone Problem Project,Koelling,Peter,0,0,0,0,0,0,0,
+Spring 2023,BIOL,2321,1,12526,Microbiology for Science Major,Knapp,Richard D,36,37,31,19,8,0,9,2.547
+Spring 2023,INTB,3355,1,12527,Global Environment of Business,Thompson,Joseph Lee,23,0,1,0,0,0,0,3.917
+Spring 2023,ELED,4310,1,12528,Reading/Language in Elementary,Tyson,Eleanore S,28,4,0,0,0,0,0,3.782
+Spring 2023,SOCW,8327,1,12529,Grant Writing,Gearing,Robin Edward,7,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,2301,2,12530,Prin of Financial Accounting,Goble,Samuel,16,23,15,4,1,0,10,2.92
+Spring 2023,BIOL,1307,3,12531,Biology for Science Majors II,Gifford,Jenifer Beth,88,87,54,35,10,0,8,2.753
+Spring 2023,SOCW,7324,2,12533,Clinical Apps of DSM in SW,Charles,Janea Nicole Adams,29,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7324,3,12534,Clinical Apps of DSM in SW,Brown,Marcus D,22,5,0,0,0,0,0,3.815
+Spring 2023,MIS,3370,2,12535,Info Systems Development Tools,Oladeji,Oyebisi Olufoyeke,18,13,13,4,1,0,15,2.878
+Spring 2023,GEOL,1103,1,12536,Physical Geology Lab,Hauptvogel,Daniel William,10,5,2,0,2,0,1,3.123
+Spring 2023,EDUC,1301,2,12537,Intro to Teaching Profession,Ronduen,Lionnel Ganir,16,5,5,2,2,0,1,2.934
+Spring 2023,SOCW,7325,2,12538,Assessment in SW Practice,Parks,Steven Lee,17,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7334,1,12539,Social Work Leadership,Pang,Melanie Espinosa,23,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,2302,4,12541,Prin of Managerial Accounting,Seltz,Joe D,21,10,6,1,2,0,2,3.2
+Spring 2023,NUTR,4333,1,12542,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,8,9,2,1,1,0,3,2.969
+Spring 2023,ECE,3155,1,12543,Electronics Laboratory,Wolfe,John C,44,0,0,1,0,0,0,3.823
+Spring 2023,HRD,3351,1,12544,Instructional Design for HRD,Pereira-Leon,Maura Josefina,11,15,9,3,1,0,0,2.854
+Spring 2023,PHYS,2326,1,12546,University Physics II(lecture),Chen,Shuo,17,25,31,4,4,0,12,2.523
+Spring 2023,MATH,1314,10,12548,College Algebra,Constante,Beatrice,15,4,3,4,4,0,7,2.711
+Spring 2023,MATH,1324,10,12549,Finite Math with Applications,Sosa,Moses,36,16,16,28,24,0,30,2.067
+Spring 2023,MATH,2312,8,12550,Precalculus,Chang,James A,22,8,8,18,22,0,44,1.829
+Spring 2023,MATH,1342,7,12551,Elementary Statistical Methods,Caputo,Matthew G,30,36,24,10,20,0,34,2.372
+Spring 2023,PSYC,2305,6,12553,Intro to Methods in Psychology,Wang,Carol,36,12,2,4,2,0,3,3.328
+Spring 2023,PETR,2313,1,12554,Reservoir Fluids,Dindoruk,Birol,4,2,1,0,0,0,1,3.523
+Spring 2023,PETR,3321,1,12555,Petr Pressure Trans Testing,Ehlig-Economides,Christine A,4,8,4,0,0,0,0,3.021
+Spring 2023,BIOE,6298,1,12558,Research,Akay PhD,Metin,0,0,0,0,0,0,0,
+Spring 2023,BIOE,8198,1,12563,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8298,1,12565,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8298,2,12566,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8398,1,12567,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,3,0,
+Spring 2023,BIOE,8398,2,12568,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8399,1,12569,Doctoral Dissertation,Akay PhD,Metin,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8399,2,12570,Doctoral Dissertation,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8598,1,12572,Doctoral Research,Akay PhD,Metin,0,0,0,0,0,4,0,
+Spring 2023,BIOE,8598,2,12573,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Spring 2023,COMD,4382,2,12577,Aural Rehabilitation,Andrews,Chereece N,49,3,1,0,0,0,0,3.85
+Spring 2023,CHEE,8598,18,12578,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2023,SCLT,2362,32,12581,Intro To Logistics Technology,Kidd,Margaret A,12,18,15,3,2,0,0,2.634
+Spring 2023,SCLT,2380,30,12582,Distribution Channels,Hu,Minxiang,57,24,2,1,6,0,3,3.264
+Spring 2023,GHL,2350,1,12583,Mgmt Principles in Hospitality,Liu,Wenfang,16,3,1,0,0,0,0,3.651
+Spring 2023,GHL,4355,1,12584,Event Administration,Kenyan,Erin Oeser,15,1,0,0,0,0,0,3.917
+Spring 2023,HON,4315,1,12585,Artists and Their Regions,Cremins,Robert Paul,14,0,2,0,0,0,0,3.709
+Spring 2023,CNST,1301,1,12586,Constructn Materials & Methods,Zaheri,Mohammad J,49,50,10,1,4,0,1,3.196
+Spring 2023,CNST,2321,1,12587,Mechanical & Electrical System,Beadle,Dwight D,60,19,5,0,0,0,1,3.655
+Spring 2023,CNST,2351,1,12588,Construction Estimating I,Liggin,Gregory G,11,42,13,2,0,0,1,2.912
+Spring 2023,CNST,3265,1,12589,Construction Layout & Site Dvp,Moghaddam,Hassan,5,27,11,0,0,0,2,2.868
+Spring 2023,CNST,4302,1,12590,Construction Law and Ethics,Ducran,Denis George,30,43,15,0,1,0,1,3.124
+Spring 2023,CNST,4331,1,12591,Construction Management II,Khan,Taimoor,6,3,0,0,0,0,1,3.593
+Spring 2023,CIS,2332,2,12593,Info Tech Hdwr & Systems Sftwr,Ratner,Edward,138,60,22,8,14,0,2,3.199
+Spring 2023,CIS,2334,30,12594,Information Systems Applicatns,Lendasse,Amaury,83,47,31,9,14,0,18,2.892
+Spring 2023,CIS,2337,30,12596,Fund of Information Security,Lee,Kyu In,67,45,13,2,7,0,3,3.155
+Spring 2023,CIS,2348,1,12597,Info Systems Appl Development,Ratner,Edward,14,20,13,5,8,0,3,2.362
+Spring 2023,CIS,3343,31,12598,Info Systems Analysis & Design,Faiyaz,Sajida,13,18,5,0,0,0,1,3.341
+Spring 2023,CIS,3347,31,12599,IS Infrastructure and Networks,Peddoju,Suresh Kumar,14,17,6,3,1,0,2,2.976
+Spring 2023,SCLT,3384,31,12601,Logistics Tech and Processes,Bian,Zheyong,42,9,3,0,1,0,0,3.631
+Spring 2023,SCLT,3387,30,12602,Procurement,Elliott,Stephen Dwight,26,19,5,1,1,0,1,3.308
+Spring 2023,ENGL,2305,1,12603,Intro To Fiction,Julian,Jennifer La'Vonne,22,4,1,0,0,0,3,3.802
+Spring 2023,MIS,4378,2,12604,Admin of Computer-Based MIS,Porra,Jaana,40,1,0,0,0,0,0,3.96
+Spring 2023,ENGL,1302,4,12605,First Year Writing II,Worley,Sharon J,10,6,2,1,2,0,3,2.953
+Spring 2023,SCLT,4312,30,12606,Inventory & Materials Handling,Hu,Minxiang,29,20,4,2,2,0,0,3.188
+Spring 2023,TEPM,6307,1,12607,Advanced Project Management,Sherman,Dennis Louis,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,3321,1,12608,Single Camera Studio Productn,Houk,Keith R,23,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,2301,1,12610,Intro to Physical Anthropology,McElvaney,Katherine Anne,15,7,7,4,1,0,1,2.912
+Spring 2023,PHYS,1101,14,12611,College Physics I (lab),Wood,Lowell T,0,15,3,2,0,0,4,2.65
+Spring 2023,PHYS,1101,15,12612,College Physics I (lab),Wood,Lowell T,0,13,6,0,1,0,2,2.6
+Spring 2023,PHYS,1101,16,12613,College Physics I (lab),Wood,Lowell T,2,8,9,0,1,0,2,2.583
+Spring 2023,BIOL,4103,2,12614,Integration Biol Knowledge,Wayne,Chad M,72,20,3,0,1,0,1,3.701
+Spring 2023,BIOL,2121,1,12615,Microbiology for Science Major,Knapp,Richard D,5,8,6,0,0,0,1,3.034
+Spring 2023,BIOL,2121,2,12616,Microbiology for Science Major,Knapp,Richard D,14,4,2,0,0,0,1,3.468
+Spring 2023,BIOL,2121,3,12617,Microbiology for Science Major,Knapp,Richard D,16,6,2,0,0,0,0,3.556
+Spring 2023,BIOL,2121,4,12618,Microbiology for Science Major,Knapp,Richard D,8,14,0,1,0,0,0,3.261
+Spring 2023,BIOL,2121,5,12619,Microbiology for Science Major,Knapp,Richard D,9,7,2,0,0,0,0,3.462
+Spring 2023,BIOL,2121,6,12620,Microbiology for Science Major,Knapp,Richard D,11,3,6,0,1,0,1,3.095
+Spring 2023,BIOL,2121,7,12621,Microbiology for Science Major,Knapp,Richard D,12,4,4,0,0,0,1,3.334
+Spring 2023,BIOL,2121,8,12622,Microbiology for Science Major,Knapp,Richard D,17,5,2,0,0,0,0,3.611
+Spring 2023,CHEM,2123,8,12623,Organic Chemistry Lab I,Bean,Mary B,2,10,8,0,0,0,2,2.717
+Spring 2023,CHEM,1112,27,12624,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,3,0,1,0,1,2.867
+Spring 2023,CHEM,3119,2,12627,Anlytical Chemistry Lab,Czader,Arkadiusz,1,9,0,0,0,0,0,3.067
+Spring 2023,BIOL,1107,23,12628,Biology for Science Majors II,Medrano,Ana I,17,2,2,2,0,0,0,3.478
+Spring 2023,BIOL,1107,24,12629,Biology for Science Majors II,Medrano,Ana I,19,5,0,0,0,0,0,3.778
+Spring 2023,BIOL,1107,25,12630,Biology for Science Majors II,Medrano,Ana I,21,3,0,0,0,0,0,3.889
+Spring 2023,BIOL,1107,26,12631,Biology for Science Majors II,Medrano,Ana I,16,4,3,0,1,0,0,3.389
+Spring 2023,BIOL,1107,27,12632,Biology for Science Majors II,Medrano,Ana I,19,4,0,1,0,0,0,3.695
+Spring 2023,BIOL,1107,28,12633,Biology for Science Majors II,Medrano,Ana I,17,6,0,0,0,0,1,3.753
+Spring 2023,BIOL,1107,29,12634,Biology for Science Majors II,Medrano,Ana I,18,5,0,0,0,0,0,3.797
+Spring 2023,BIOL,1107,30,12635,Biology for Science Majors II,Medrano,Ana I,19,4,1,0,0,0,0,3.709
+Spring 2023,BIOL,1107,31,12636,Biology for Science Majors II,Medrano,Ana I,17,5,1,0,1,0,0,3.528
+Spring 2023,BIOL,1107,32,12637,Biology for Science Majors II,Medrano,Ana I,13,3,3,0,0,0,4,3.439
+Spring 2023,CHEM,1105,3,12638,Foundations of Chem Lab,Zaitsev,Vladimir G,1,12,0,0,0,0,5,3.077
+Spring 2023,CHEM,1105,4,12639,Foundations of Chem Lab,Zaitsev,Vladimir G,3,11,3,0,0,0,0,3.155
+Spring 2023,ACCT,5367,1,12640,Intermediate Accounting I,Kuruvilla,Mohan,2,4,1,0,0,0,1,3.237
+Spring 2023,CHEM,1111,12,12641,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,2,1,0,0,0,3.14
+Spring 2023,CHEM,1111,13,12642,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,2,0,0,0,2,3.104
+Spring 2023,CHEM,1111,15,12643,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,8,1,1,2,0,3,2.729
+Spring 2023,CHEM,1112,28,12644,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,2,1,1,0,1,2.825
+Spring 2023,CHEM,1112,29,12645,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,2,0,0,0,2,3.095
+Spring 2023,CHEM,1112,30,12646,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,7,4,0,1,0,2,2.711
+Spring 2023,CHEM,1112,31,12647,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,8,1,0,0,0,4,3.091
+Spring 2023,CHEM,1112,34,12648,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,0,0,1,0,1,3.297
+Spring 2023,BIOL,1107,33,12649,Biology for Science Majors II,Medrano,Ana I,11,9,1,0,0,0,2,3.492
+Spring 2023,BIOL,1107,34,12650,Biology for Science Majors II,Medrano,Ana I,16,5,0,0,1,0,2,3.546
+Spring 2023,BIOL,1107,35,12651,Biology for Science Majors II,Medrano,Ana I,20,4,0,0,0,0,0,3.792
+Spring 2023,BIOL,1107,36,12652,Biology for Science Majors II,Medrano,Ana I,15,6,1,1,0,0,1,3.479
+Spring 2023,BIOL,2102,14,12653,Anatomy & Physiology II (lab),Gill,Tejendra,4,6,8,3,1,0,2,2.409
+Spring 2023,BIOL,2102,16,12654,Anatomy & Physiology II (lab),Gill,Tejendra,6,10,5,0,1,0,2,2.954
+Spring 2023,BIOL,1107,37,12655,Biology for Science Majors II,Medrano,Ana I,20,1,1,0,1,0,1,3.681
+Spring 2023,BIOL,1107,38,12656,Biology for Science Majors II,Medrano,Ana I,12,11,0,0,1,0,0,3.306
+Spring 2023,BIOL,1107,40,12657,Biology for Science Majors II,Medrano,Ana I,21,0,1,0,0,0,1,3.864
+Spring 2023,BIOL,1107,39,12658,Biology for Science Majors II,Medrano,Ana I,18,3,1,1,1,0,0,3.514
+Spring 2023,PHCA,8698,2,12661,Doctoral Dissertation Research,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8698,3,12662,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8698,4,12663,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Spring 2023,HON,3361,1,12664,Global Engagement and Research,Miljanic,Andra Olivia,7,4,1,0,0,0,0,3.5
+Spring 2023,BIOL,1107,41,12665,Biology for Science Majors II,Medrano,Ana I,17,4,0,0,0,0,2,3.731
+Spring 2023,BIOL,1107,42,12666,Biology for Science Majors II,Medrano,Ana I,19,1,2,0,1,0,0,3.637
+Spring 2023,BIOL,1107,43,12667,Biology for Science Majors II,Medrano,Ana I,16,4,3,0,1,0,0,3.389
+Spring 2023,BIOL,1107,44,12668,Biology for Science Majors II,Medrano,Ana I,10,7,2,0,0,0,3,3.404
+Spring 2023,ENGL,2305,5,12670,Intro To Fiction,Zamora,Lois,7,7,3,2,6,0,1,2.201
+Spring 2023,ENGL,1302,5,12671,First Year Writing II,Anderson,Claire F,9,7,0,0,1,0,2,3.295
+Spring 2023,ENGL,1302,6,12672,First Year Writing II,Kroger,Ann Gabriel,7,7,1,0,1,0,3,3.064
+Spring 2023,ENGL,1302,13,12674,First Year Writing II,Alcorn III,Charles William,17,0,0,0,2,0,0,3.492
+Spring 2023,ENGL,1302,29,12675,First Year Writing II,Rizzo,Kaitlin M,18,1,0,0,0,0,0,3.947
+Spring 2023,SPAN,1501,17,12678,Elementary Spanish I,Miranda Moreno,Sujaila Abigail,14,3,5,0,3,0,1,2.947
+Spring 2023,ECE,2201,2,12682,Circuit Analysis I,Shattuck,David P,10,20,9,12,2,0,8,2.453
+Spring 2023,SCM,4380,1,12683,Enterprise Resource Planning,Pendyala,Raja,21,32,11,0,0,0,1,3.161
+Spring 2023,CIS,6396,1,12684,Internship in Infor. Security,Conklin,William A,1,0,0,0,0,0,0,4.0
+Spring 2023,KIN,4398,3,12688,Independent Study,Cottingham,Michael,4,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8999,3,12689,Doctoral Dissertation,Alfano,Candice A,0,0,0,0,0,2,0,
+Spring 2023,RELS,2310,1,12690,Bible and Western Culture I,Tamber-Rosenau,Caryn M,14,9,2,1,2,0,1,3.072
+Spring 2023,EDUC,4314,2,12691,Student Teaching Sec,Evans,Paige K,28,6,0,0,1,0,1,3.686
+Spring 2023,PSYC,8399,24,12693,Doctoral Dissertation,Gallagher,Matthew Ward,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8398,36,12694,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Spring 2023,ENGL,1301,2,12697,First Year Writing I,Brown,Erika J,6,3,3,0,7,0,6,2.087
+Spring 2023,ENGL,1302,31,12698,First Year Writing II,Rizzo,Kaitlin M,14,1,0,0,2,0,2,3.432
+Spring 2023,BIOE,6398,3,12700,Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Spring 2023,MATH,3363,1,12711,Introduction To Pde,Caglar,Atife,12,10,13,9,7,0,8,2.145
+Spring 2023,ECON,3370,2,12713,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,9,5,0,1,1,0,1,3.168
+Spring 2023,ECON,3371,1,12714,Economics of Money & Banking,Dasari,Babu,16,17,6,1,1,0,2,3.058
+Spring 2023,ECON,7301,1,12715,Seminar in Microecon Research,Chin,Aimee,0,0,0,0,0,11,0,
+Spring 2023,ECON,7302,1,12716,Seminar in Macroecon Research,Cubas Norando,German,0,0,0,0,0,10,0,
+Spring 2023,ECON,8363,1,12717,Workshop in Research Methods V,Cubas Norando,German,14,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,3306,2,12718,Intro Study Span Language,Goodin-Mayeda,Carrie Elizabeth,9,8,5,1,1,0,1,2.917
+Spring 2023,ARCH,5500,7,12719,Architecture Design Studio IX,Diehl,Tom,0,14,1,0,0,0,0,3.087
+Spring 2023,BIOL,4374,1,12721,Cell Biology,Gifford,Jenifer Beth,31,26,5,2,1,0,1,3.282
+Spring 2023,ITAL,3304,1,12722,Culture Italy,Nicosia,Alda,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,1112,35,12723,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,4,0,1,0,0,2.877
+Spring 2023,CHEM,1112,37,12724,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,8,4,0,1,0,3,2.666
+Spring 2023,CHEM,1112,40,12725,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,2,0,0,0,2,3.312
+Spring 2023,CHEM,1112,42,12726,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,6,3,0,0,0,3,3.266
+Spring 2023,CHEM,1112,43,12727,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,1,1,0,0,2,3.133
+Spring 2023,CHEM,6332,1,12729,Inorganic Material Analysis,Meen,James K,6,7,0,0,0,0,0,3.487
+Spring 2023,ARAB,3302,1,12730,Adv Modern Standard Arabic II,Sabre,Asmaa,5,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2317,2,12731,Intro to Psychology Statistics,Saiyed,Amna Shabbir,60,3,1,0,0,0,0,3.855
+Spring 2023,PSYC,3350,2,12732,Intro to Cognitive Psychology,Saiyed,Amna Shabbir,60,7,1,1,1,0,0,3.767
+Spring 2023,CHEM,2123,13,12733,Organic Chemistry Lab I,Bean,Mary B,3,8,8,0,0,0,2,2.702
+Spring 2023,CHEM,2123,15,12734,Organic Chemistry Lab I,Bean,Mary B,3,8,7,0,0,0,2,2.741
+Spring 2023,CHEM,2123,16,12735,Organic Chemistry Lab I,Bean,Mary B,4,6,7,2,0,0,3,2.51
+Spring 2023,CHEM,2123,17,12736,Organic Chemistry Lab I,Bean,Mary B,2,17,3,0,0,0,1,2.955
+Spring 2023,BIOL,4315,1,12737,Neuroscience,Ziburkus,Jokubas,55,26,9,0,0,0,7,3.493
+Spring 2023,COSC,4368,1,12738,Artificial Intelligence,Eick,Christoph F,20,31,22,3,1,0,7,2.84
+Spring 2023,BIOL,1307,50,12739,Biology for Science Majors II,Cheek,Ann Oliver,23,2,4,0,0,0,1,3.689
+Spring 2023,ELET,1400,1,12740,Circuit Theory and Lab I,Barbieri,Enrique,10,4,7,6,6,0,3,2.172
+Spring 2023,ELET,1401,1,12743,Circuit Theory and Lab II,Shi,Jian,7,25,5,0,0,0,0,3.072
+Spring 2023,PHAR,5644,1,12746,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5645,1,12747,Pharmacy Informatics,Truong,Mabel,1,1,0,0,0,0,0,3.5
+Spring 2023,PETR,3318,1,12748,Drilling Engineering I,Soliman,Mohamed Yousef,6,5,4,0,0,0,0,3.155
+Spring 2023,INDE,4315,1,12749,Supply Chain Design Management,Wang,Yaping,5,6,3,0,0,0,0,3.166
+Spring 2023,SCM,4350,1,12752,Strategic Supply Management,Wayhan,Victor Brian,17,27,15,4,0,0,2,2.868
+Spring 2023,SCM,4390,1,12753,Supply Chain Strategy,Smith,Gordon D,12,42,6,1,0,0,0,3.082
+Spring 2023,HRD,4344,1,12754,Designing E-Learning,Bennett,LaTasha,32,9,0,0,0,0,0,3.716
+Spring 2023,RELS,1301,2,12755,Intro To Religious Studies,Mummert,Claire Elizabeth,15,15,1,1,3,0,4,3.123
+Spring 2023,FINA,4320,3,12756,Investment Management,Gargano,Antonio,16,5,0,0,0,0,0,3.699
+Spring 2023,FINA,4357,1,12758,Commercial Liability,Kapatos,Nick Gus,4,6,3,0,0,0,1,3.102
+Spring 2023,FINA,7376,1,12759,Energy Trading,Smith III,Edwin A,8,1,0,0,0,0,0,3.852
+Spring 2023,MIS,4381,1,12760,Mgmt of Information Security,Cooper,Randolph B,7,4,7,1,0,0,0,2.895
+Spring 2023,MIS,4390,1,12761,Energy Trading Systems,Pena,Juan F,161,38,7,0,1,0,4,3.723
+Spring 2023,HDFS,1311,1,12762,Personal Dev and College Succ,Kamdar-Sharif,Amber,18,3,1,1,1,0,1,3.418
+Spring 2023,MIS,7381,1,12763,Management of Info Security,Cooper,Randolph B,3,1,1,0,0,0,0,3.4
+Spring 2023,MANA,4356,1,12764,Managing Diversity,Walker,William A,15,6,3,0,0,0,2,3.555
+Spring 2023,HDFS,3317,3,12765,Prenatal and Infant Developmt,Wang,Jennifer L,21,12,2,2,3,0,0,3.109
+Spring 2023,HDFS,3318,2,12766,Human Ecol of Adult Developmt,Schoger,Kimberly,27,11,2,1,1,0,0,3.468
+Spring 2023,HLT,2320,2,12767,Introduction to Public Health,Proctor,Robin Ann,32,23,4,3,0,0,0,3.339
+Spring 2023,HLT,3381,2,12768,Hlt Promotn & Disease Preventn,Brown,Korey J,66,15,3,0,0,0,0,3.66
+Spring 2023,HLT,4302,1,12769,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,76,24,8,1,4,0,4,3.452
+Spring 2023,HLT,4320,1,12770,Admin of Health Services,Markowitz,Eliz,18,9,3,1,0,0,2,3.366
+Spring 2023,ILAS,2350,1,12771,Knowledge and Methods,Oliva,Luca,21,3,8,0,12,0,7,2.485
+Spring 2023,PSYC,6316,1,12772,Interventions-Clinical Psyc II,Walker,Rheeda L,7,1,0,0,0,0,0,3.875
+Spring 2023,AAS,3301,1,12775,Hip Hop History and Culture,Chiles IV,John Ritchie,18,0,0,2,0,0,0,3.667
+Spring 2023,DIGM,2352,34,12776,Digital Photography,Waite,Jerry J,61,41,10,3,1,0,7,3.314
+Spring 2023,SCLT,3385,30,12777,Transport Economics and Policy,Henson,Alfred Bernard,23,20,8,2,2,0,0,3.019
+Spring 2023,COMD,4333,1,12778,Neuroscience for COMD,Dial,Heather Raye,24,9,0,2,0,0,0,3.515
+Spring 2023,COMD,4489,2,12779,Clinical Procedures,Ivey,Michelle L,26,1,0,0,0,0,1,3.914
+Spring 2023,ASLI,4368,1,12780,ASL and English Linguistics,Gietz,Merrilee Ruth,6,2,0,0,0,0,0,3.668
+Spring 2023,HIST,3367,1,12781,Japan Since 1600,Cong,Xiaoping,7,18,6,1,1,0,0,2.979
+Spring 2023,AAS,6307,1,12782,Seminar On Mlk Jr. & Malcolm X,Edwards,Crystal Latanya,6,6,0,0,0,0,0,3.445
+Spring 2023,BTEC,4319,30,12783,Microbial Biotechnology,Flavier,Albert B,3,4,11,2,3,0,3,2.001
+Spring 2023,BTEC,3321,30,12784,Good Manufacturing Practices,Gerwin,Ashley Sarah,30,12,5,0,1,0,0,3.417
+Spring 2023,CIS,3343,32,12785,Info Systems Analysis & Design,Greenfield,Brandon Scott,5,14,9,3,2,0,1,2.455
+Spring 2023,SPAN,3339,1,12786,Span for Global Professions,Zubiate,Maria Laura,8,4,3,0,1,0,1,3.063
+Spring 2023,HON,3301,1,12787,Readings in Medicine & Society,Brown,Erika J,24,1,0,0,0,0,0,3.934
+Spring 2023,GHL,2340,2,12788,System of Accts in Hospitality,DeFranco,Agnes L,6,13,11,4,2,0,2,2.454
+Spring 2023,SOCW,7367,2,12790,Social Policy Analysis,Pang,Melanie Espinosa,28,0,0,0,0,0,0,4.0
+Spring 2023,RELS,2311,1,12791,Bible and Western Culture II,Eberhart,Christian,9,2,0,1,0,0,0,3.528
+Spring 2023,PHAR,5662,1,12792,Academic Scholarship,Wallace,David A,3,1,0,0,0,0,0,3.75
+Spring 2023,PHAR,5674,1,12793,Nutritional Support,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5675,2,12794,Disease State Management,Asias-Dinh,Bernadette De Leon,3,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,3315,1,12795,Modern Physics,Wood,Lowell T,5,2,3,0,3,0,2,2.411
+Spring 2023,PHYS,2326,3,12796,University Physics II(lecture),Varghese,Oomman K,14,26,36,6,3,0,10,2.401
+Spring 2023,POLS,3313,1,12798,Intro Internatl Relatns,Chatagnier,John Tyson,17,15,5,2,4,0,0,2.922
+Spring 2023,CHEM,2131,1,12800,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,11,5,
+Spring 2023,COMD,6326,1,12801,Motor Speech Disorders,Wynn,Camille Jane,7,15,0,0,0,0,0,3.318
+Spring 2023,CHEM,2132,1,12802,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,0,1,
+Spring 2023,CHEM,2132,2,12803,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,7,0,
+Spring 2023,ASLI,2335,1,12804,Privilege & Equity in ASLI,Hill,Sharon Grigsby,10,0,0,0,0,0,0,3.769
+Spring 2023,ASLI,3433,1,12805,Simultaneous Interpreting I,Hill,Sharon Grigsby,4,4,0,0,0,0,0,3.335
+Spring 2023,ASLI,4489,1,12806,Service Learning - Internship,Hill,Sharon Grigsby,5,0,0,0,0,0,0,3.934
+Spring 2023,CNST,3210,1,12807,Safety for Industrial Projects,Zayas,Frederick A,1,6,4,2,0,0,0,2.436
+Spring 2023,BTEC,3317,30,12808,Biotech Regulatory Environment,Flavier,Albert B,10,10,17,4,1,0,0,2.579
+Spring 2023,LAW,5254,1,12810,Tax Controversy & Litigation,Lowy,Peter A,3,4,0,0,0,0,0,3.476
+Spring 2023,LAW,5202,1,12811,Entrpr Community Dev Clinic II,Heard,Christopher D,0,1,0,0,0,0,0,3.33
+Spring 2023,SOCW,7329,2,12812,SW Practice for Policy Change,Ortiz,Lillian Aguirre,22,2,0,0,0,0,0,3.917
+Spring 2023,CNST,3372,1,12814,Soil Mechanics & Foundations,Meyer,Joseph Ray,6,46,24,3,1,0,1,2.757
+Spring 2023,COMM,3353,1,12816,Information & Comm Tech I,Liu,Youmei,22,15,7,0,1,0,2,3.325
+Spring 2023,PHCA,8298,2,12819,Doctoral Dissertation Research,Aparasu,Rajender R,2,0,0,0,0,0,0,4.0
+Spring 2023,PUBL,6350,1,12820,Public Management,Thurmond,James H,7,2,0,0,0,0,1,3.704
+Spring 2023,CUIN,6375,2,12821,Classroom Mgt,Auzenne-Curl,Chestin,4,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8377,1,12823,Reading for Comps Exams,Perales,Monica,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7699,1,12824,Thesis,Divakaruni,Chitra B,1,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,8699,6,12825,Dissertation,Solino,Maria Elena,1,0,0,0,0,1,0,4.0
+Spring 2023,SPAN,8699,7,12826,Dissertation,Goodin-Mayeda,Carrie Elizabeth,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,3351,2,12831,Class Interact Science-Math,Latiolais,Cheryl S,10,0,1,0,0,0,0,3.758
+Spring 2023,CNST,4385,1,12833,Field Operations Capital Proj,Molina,Mariel,4,6,1,0,0,0,0,3.303
+Spring 2023,MTLS,6111,1,12834,Materials Engineering Seminar,Yao,Yan,0,0,0,0,0,30,0,
+Spring 2023,HON,4298,1,12835,Independent Study,LeVeaux,Christine,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8398,6,12838,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Spring 2023,MECT,4172,2,12839,Materials Tech Lab,Taylor,Gordon D,13,2,0,0,0,0,0,3.625
+Spring 2023,PHYS,8399,35,12846,Doctoral Dissertation,Varghese,Oomman K,1,0,0,0,0,1,0,4.0
+Spring 2023,BCHS,4396,1,12856,Senior Research Project,Frankino,William A,2,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8298,4,12860,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6230,1,12863,Grad Biochem Lab Rotation I,Widger,William R,1,0,0,0,0,0,0,3.67
+Spring 2023,MATH,8398,13,12866,Doctoral Research,Josic,Kresimir,0,0,0,0,0,2,0,
+Spring 2023,MATH,8398,15,12868,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,2,0,
+Spring 2023,MATH,4365,1,12870,Numerical Methods for Diff Equ,He,Jiwen,22,2,0,0,2,0,2,3.603
+Spring 2023,CUIN,3317,1,12872,Kindergarten/Elem Curr & Instr,Wilson,Jahnette,29,4,0,0,0,0,0,3.839
+Spring 2023,CUIN,3317,2,12873,Kindergarten/Elem Curr & Instr,Wilson,Jahnette,30,5,0,0,0,0,0,3.819
+Spring 2023,CUIN,3317,4,12874,Kindergarten/Elem Curr & Instr,Henderson,Linda Fay,13,2,1,0,0,0,0,3.668
+Spring 2023,CUIN,3346,1,12875,Teaching the Writing Process,Pauloski,Gwendolyn Jordan,17,4,0,0,0,0,1,3.731
+Spring 2023,CUIN,4315,1,12876,Assessment of Children,Siller Escudero,Patricia,26,6,1,0,0,0,0,3.638
+Spring 2023,CUIN,4315,2,12877,Assessment of Children,Siller Escudero,Patricia,25,9,0,0,0,0,0,3.667
+Spring 2023,CUIN,4315,3,12878,Assessment of Children,Hernandez,Berky,27,1,3,0,0,0,0,3.732
+Spring 2023,CUIN,4315,4,12879,Assessment of Children,Harris,Deborah,5,4,0,0,0,0,0,3.372
+Spring 2023,CUIN,3316,1,12880,Prekindergarten Curr & Instr,Katz,Denise Annette,27,1,0,0,0,0,0,3.941
+Spring 2023,CUIN,3316,2,12881,Prekindergarten Curr & Instr,Katz,Denise Annette,22,4,0,1,0,0,0,3.716
+Spring 2023,CUIN,4375,4,12882,Classroom Management,Snead,Lauren Oropeza,13,2,0,0,0,0,0,3.889
+Spring 2023,MATH,3364,1,12884,Intro Complex Analysis,Timofeyev,Ilya,6,1,2,1,0,0,3,3.2
+Spring 2023,ENGL,6320,1,12885,Poetic Forms,Belieu,Erin Colleen,7,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,3342,1,12886,Principles of Air Pollution,Rappenglueck,Bernhard,18,4,2,1,0,0,0,3.454
+Spring 2023,MATH,3325,2,12887,Transition to Advanced Math,Leger,Nicholas M,10,6,4,2,4,0,3,2.641
+Spring 2023,PSYC,2301,4,12888,Introduction to Psychology,Capuozzo,Kristen Irene,6,8,5,2,1,0,1,2.772
+Spring 2023,PSYC,2330,1,12889,Biological Psychology,Kosten,Therese A,24,17,6,0,2,0,0,3.171
+Spring 2023,ELED,4315,2,12890,Mathematics in Elem School II,Cutler,Carrie Sybil,24,2,0,0,0,0,0,3.898
+Spring 2023,ECON,2302,4,12891,Principles of Microeconomics,Pei,Yang,15,9,2,1,2,0,2,3.081
+Spring 2023,GEOL,4330,1,12895,Intro To Geophysics,Li,Aibing,5,6,4,3,0,0,2,2.777
+Spring 2023,CUIN,7304,1,12896,Professional Seminar II,Brower,Samuel Richard,23,3,2,0,2,0,0,3.511
+Spring 2023,CUIN,7304,2,12897,Professional Seminar II,Brower,Samuel Richard,28,2,0,0,0,0,0,3.944
+Spring 2023,CUIN,7304,3,12898,Professional Seminar II,Culpepper,Shea Mosley,14,3,0,0,2,0,1,3.299
+Spring 2023,PSYC,2301,5,12899,Introduction to Psychology,Capuozzo,Kristen Irene,15,10,5,0,0,0,0,3.333
+Spring 2023,GEOL,1303,7,12900,Physical Geology,Lytwyn,Jennifer N,63,78,57,10,9,0,21,2.793
+Spring 2023,GEOL,1340,3,12901,Earth Systems,Lytwyn,Jennifer N,51,66,55,19,16,0,13,2.559
+Spring 2023,CHEM,1305,1,12905,Foundations of Chemistry,Czernuszewicz,Roman S,12,28,30,21,21,0,8,1.922
+Spring 2023,PSYC,4344,3,12907,Cultural Psychology,Haddad,Sana,46,11,7,3,2,0,1,3.372
+Spring 2023,PSYC,2317,4,12908,Intro to Psychology Statistics,Le,Giang Xuan,36,25,7,6,3,0,2,3.082
+Spring 2023,PHYS,6316,1,12909,Quantum Mechanics II,Ratti,Claudia,10,18,0,0,0,0,0,3.416
+Spring 2023,COMM,3361,2,12910,Advertising Copywriting,Clark,Thomas R,5,1,4,1,1,0,1,2.667
+Spring 2023,BIOL,3301,1,12911,Mendelian and Pop Genetics,Lekven,Arne,33,82,38,11,6,0,4,2.698
+Spring 2023,PHYS,1301,4,12912,College Physics I (lecture),McElhenny,Brian Patrick,21,29,36,7,4,0,21,2.628
+Spring 2023,LAW,5378,1,12913,Statutory Interpretation & Rea,Bush,Darren,32,36,0,0,0,0,0,3.403
+Spring 2023,LAW,5378,2,12914,Statutory Interpretation & Rea,Michaels,Andrew Charles,25,44,0,0,0,0,1,3.401
+Spring 2023,LAW,5378,3,12915,Statutory Interpretation & Rea,Bray,Zachary Andrew,6,9,0,0,0,0,0,3.4
+Spring 2023,PSYC,3339,1,12917,Intro To Clinical Psychology,Szafranski,Derek D,70,5,2,1,1,0,1,3.777
+Spring 2023,LAW,6237,1,12918,Doing Deals,Moll,Douglas Keith,10,13,0,0,0,13,0,3.42
+Spring 2023,COSC,3380,1,12919,Database Systems,Ramamurthy,Uma,15,44,20,3,2,0,5,2.743
+Spring 2023,HIST,1302,1,12920,The U.S. Since 1877,Johnson,Michele R,145,106,52,23,22,0,8,2.927
+Spring 2023,FORE,6371,1,12921,World Futures,Hines,Andrew Lewis,17,3,0,0,1,0,2,3.541
+Spring 2023,TMTH,3360,5,12922,Applied Technical Statistics,Schroeder,Susan L,11,21,9,1,2,0,4,2.841
+Spring 2023,FORE,6395,1,12923,Master's Project in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Spring 2023,ASLI,4335,1,12924,Advanced ASL Interpreting,Gietz,Merrilee Ruth,5,0,0,0,0,0,0,3.736
+Spring 2023,COMD,2338,2,12925,Phonetics,Townsend,Alayna,18,9,1,0,0,0,2,3.643
+Spring 2023,PHYS,8399,39,12926,Doctoral Dissertation,Stokes,Donna,0,0,0,0,0,1,0,
+Spring 2023,MANA,4355,1,12929,Selection and Staffing,Phillips,James S,30,22,7,0,0,0,1,3.457
+Spring 2023,MANA,7332,1,12930,Effective Negotiating,Abbott,Jeanna L,34,2,0,0,0,0,0,3.926
+Spring 2023,MANA,6A25,1,12931,Ethical Leadrshp & Crit Reason,Celly,Nikhil,19,0,0,0,0,0,1,3.983
+Spring 2023,MANA,6A32,1,12932,Organizational Behavior & Mgt,Rude,Dale,9,10,0,0,0,0,1,3.439
+Spring 2023,MANA,6A32,2,12933,Organizational Behavior & Mgt,Krylova,Ksenia O,33,0,0,1,1,0,0,3.696
+Spring 2023,SCM,6A01,1,12935,SCM Concepts,Hossain,Md Mahbub,24,0,0,0,0,0,1,3.918
+Spring 2023,SCM,3301,3,12936,SCM Fundamentals,Anderson Fletcher,Elizabeth,14,7,0,0,0,0,0,3.714
+Spring 2023,SCM,4362,1,12937,Demand and Supply Integration,Li,Meng,34,25,7,0,0,0,0,3.389
+Spring 2023,SCM,4367,1,12938,Process and Quality Management,Miller,Bradley D,21,16,18,2,0,0,0,2.954
+Spring 2023,AAS,2320,3,12939,Intro To African American Stdy,Gary,Lindsay Cecilia,14,17,1,0,3,0,0,3.105
+Spring 2023,PHAR,5690,2,12941,Internal Medicine,Fernandez,Julianna M,2,0,0,0,0,0,0,4.0
+Spring 2023,FINA,6387,3,12942,Managerial Analysis,Basu,Swati,12,0,0,0,0,0,0,3.945
+Spring 2023,FINA,7373,1,12943,Petrochem and Refining Econ,Singh,Rajiv,7,6,0,0,1,0,0,3.333
+Spring 2023,MARK,4396,1,12944,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,18,0,
+Spring 2023,MANA,4396,1,12945,Management Internship,Carlin,Barbara A,0,0,0,0,0,5,0,
+Spring 2023,FINA,4396,1,12946,Finance Internship,Kumar,Praveen,0,0,0,0,0,16,0,
+Spring 2023,HIST,3390,1,12947,Middle East: Pictures & Words,Al-Sowayel,Dina,13,5,4,1,1,0,1,3.084
+Spring 2023,INTB,3355,2,12948,Global Environment of Business,Pennebaker,Matt,235,8,3,3,0,0,1,3.906
+Spring 2023,INTB,3355,3,12949,Global Environment of Business,Thompson,Joseph Lee,234,11,3,0,0,0,1,3.926
+Spring 2023,HRD,3340,30,12950,Principles of HRD,Hattier,Beth,10,13,5,2,1,0,2,2.978
+Spring 2023,MECT,4188,1,12953,Ethics in Engineering Tech,Bose,Anima B,29,9,0,0,0,0,0,3.685
+Spring 2023,ACCT,2301,3,12954,Prin of Financial Accounting,Sykes,Mary Reeves,33,23,10,2,0,0,2,3.367
+Spring 2023,LAW,6207,1,12955,Lawyering Skills & Strategy II,Swift,Kenneth Richard,8,12,0,0,0,0,0,3.4
+Spring 2023,LAW,6207,2,12956,Lawyering Skills & Strategy II,Gomez,Alissa R,6,7,2,0,0,0,0,3.267
+Spring 2023,LAW,6207,3,12957,Lawyering Skills & Strategy II,Reed,Hilary S,10,8,1,0,0,0,0,3.422
+Spring 2023,LAW,6207,4,12958,Lawyering Skills & Strategy II,Brantley,Maikieta Antoinette,7,8,1,0,0,0,0,3.375
+Spring 2023,LAW,6207,5,12959,Lawyering Skills & Strategy II,Brantley,Maikieta Antoinette,7,10,0,0,0,0,1,3.392
+Spring 2023,LAW,6207,6,12960,Lawyering Skills & Strategy II,Gomez,Alissa R,10,9,0,1,0,0,0,3.301
+Spring 2023,LAW,6207,7,12961,Lawyering Skills & Strategy II,Heard,Whitney W,8,10,0,0,0,0,0,3.389
+Spring 2023,LAW,6207,8,12962,Lawyering Skills & Strategy II,Brem,Katherine B,5,9,0,0,0,0,0,3.381
+Spring 2023,LAW,6207,9,12963,Lawyering Skills & Strategy II,Brem,Katherine B,6,11,1,0,0,0,0,3.388
+Spring 2023,LAW,6207,10,12964,Lawyering Skills & Strategy II,Heard,Whitney W,7,11,0,0,0,0,0,3.334
+Spring 2023,LAW,6207,11,12965,Lawyering Skills & Strategy II,Reed,Hilary S,8,8,1,0,0,0,0,3.354
+Spring 2023,ENGL,4386,1,12966,Short Story Writing,Howell,Robert Houston,15,0,0,0,0,0,1,4.0
+Spring 2023,MIS,4386,1,12967,Busn Appls Database Mgmt II,Scamell,Richard W,12,12,4,1,0,0,6,3.241
+Spring 2023,ACCT,2302,5,12968,Prin of Managerial Accounting,Newman,Michael Ray,22,4,0,0,0,0,0,3.833
+Spring 2023,ECE,2100,3,12971,Circuit Analysis Laboratory,Trombetta,Leonard P,11,1,0,0,2,0,1,3.239
+Spring 2023,ACCT,4105,1,12973,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,1,1,
+Spring 2023,ACCT,4106,1,12974,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,3,1,
+Spring 2023,ECE,4335,2,12977,Electrical Comp Engr Design I,Verret,Douglas,27,13,6,0,0,0,0,3.442
+Spring 2023,ECE,4336,1,12978,Electrical Comp Engr Design II,Pei,Shin-Shem Steven,73,1,0,0,0,0,0,3.924
+Spring 2023,MARK,6A61,1,12980,Marketing Administration,Galvani,Paul,2,5,0,0,0,0,0,3.38
+Spring 2023,MARK,6A61,2,12981,Marketing Administration,Lish,Alan D,7,4,4,0,1,0,1,2.938
+Spring 2023,ACCT,7396,1,12982,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,3,0,
+Spring 2023,DIGM,3353,32,12983,Visual Communications Tech,Bravo,Gina C,31,8,3,2,3,0,0,3.249
+Spring 2023,CIS,3365,2,12984,Database Management,Detillier,Bret James,2,12,32,4,4,0,0,2.123
+Spring 2023,CIS,4338,2,12985,Database Admin & Implementatn,Miertschin,Susan L,18,20,24,0,8,0,5,2.515
+Spring 2023,CIS,4375,2,12986,Project Management & Practice,Detillier,Bret James,6,19,30,1,0,0,0,2.565
+Spring 2023,CIS,6357,1,12987,Control Systems Security,Conklin,William A,8,2,1,0,0,0,1,3.666
+Spring 2023,MANA,6A32,3,12988,Organizational Behavior & Mgt,Rude,Dale,6,4,0,0,0,0,0,3.567
+Spring 2023,MIS,4477,1,12989,Network & Security Infrastruct,Messinger,Jacob Nelson,29,8,1,1,0,0,1,3.616
+Spring 2023,MIS,6A41,1,12991,Information Systems,Silva,Leiser O,19,0,0,0,0,0,1,3.931
+Spring 2023,MIS,6A41,2,12992,Information Systems,Silva,Leiser O,28,0,0,0,1,0,0,3.782
+Spring 2023,GENB,7334,1,12993,Brainstorming to Bankrolling,Khumawala,Saleha B,5,1,1,0,0,0,1,3.571
+Spring 2023,GENB,5303,1,12994,Prof Acct Communication,Newman,Michael Ray,0,4,0,0,0,0,0,3.083
+Spring 2023,GENB,7303,1,12995,Prof Accounting Communication,Newman,Michael Ray,27,5,0,0,0,0,0,3.803
+Spring 2023,INAR,3501,1,12996,Interior Arch Studio VI,Tucker de Vazquez,Sheryl,12,9,0,0,0,0,0,3.65
+Spring 2023,INAR,3310,1,12998,Materials/Methods of Int Arch,Mantz,Ophelia,7,11,1,0,0,0,0,3.298
+Spring 2023,ARCH,7601,3,12999,Architecture Design Studio VI,Longoria,Rafael R,8,2,0,0,0,0,0,3.734
+Spring 2023,KIN,4301,1,13001,Workplace Wellness,Alastuey,Lisa L,25,6,5,1,1,0,1,3.403
+Spring 2023,HON,3330,1,13002,Leadership Theory and Practice,Rhoden,Brenda,6,2,0,0,0,0,0,3.709
+Spring 2023,HON,4130,1,13003,E-Portfolio,Rayder,Benjamin Taylor,7,1,0,0,0,0,0,3.793
+Spring 2023,ACCT,2302,6,13004,Prin of Managerial Accounting,Seltz,Joe D,7,10,10,2,3,0,2,2.552
+Spring 2023,NUTR,4349,1,13006,Public Policy in Nutrition,Vollrath,Kirstin,40,35,8,1,1,0,2,3.267
+Spring 2023,ENGL,2307,1,13007,Intro To Drama,Brooks,Stuart,22,2,0,0,6,0,0,3.023
+Spring 2023,ENGL,1301,13,13009,First Year Writing I,Valcin,Mariot,10,6,4,0,3,0,0,2.755
+Spring 2023,ENGL,1302,15,13010,First Year Writing II,Rizzo,Kaitlin M,22,1,0,1,0,0,1,3.82
+Spring 2023,IRW,1300,1,13011,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,22,1,
+Spring 2023,FORE,6333,1,13012,Systems Thinking,Schultz,Wendy L,16,3,1,0,0,0,1,3.734
+Spring 2023,KIN,1352,10,13013,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,216,25,4,2,1,0,1,3.819
+Spring 2023,KIN,1352,11,13014,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,208,28,8,3,2,0,0,3.727
+Spring 2023,KIN,1352,16,13018,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,197,28,12,3,5,0,1,3.667
+Spring 2023,BIOE,4366,1,13020,Biomolecular Engr Fundamentals,Varadarajan,Navin,0,1,1,0,0,0,0,2.5
+Spring 2023,PSYC,2301,7,13021,Introduction to Psychology,Ravey,Eriksen,46,25,6,1,2,0,0,3.379
+Spring 2023,FINA,4373,1,13025,Petrochem & Refining Economics,Singh,Rajiv,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2330,2,13026,Biological Psychology,Kosten,Therese A,21,24,10,2,0,0,4,3.105
+Spring 2023,CIVE,3339,3,13027,Geotechnical Engineering,Ferdowsi,Behrooz,8,9,5,0,0,0,0,3.106
+Spring 2023,CHEM,1111,18,13029,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,3,0,0,0,3,3.185
+Spring 2023,CHEM,1111,19,13030,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,4,2,1,1,0,1,2.858
+Spring 2023,CHEM,1111,22,13031,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,2,0,2,0,0,2.706
+Spring 2023,MSCI,3320,3,13032,Applied Leadership,Comiskey,Melissa C,7,0,0,0,0,0,0,4.0
+Spring 2023,EDUC,4316,1,13033,Student Teach Art Elem,Thompson,Amber M,2,0,0,0,0,0,0,4.0
+Spring 2023,HLT,3301,3,13034,Health Behavior Theories,Haq,Arooba A,18,22,8,0,1,0,0,3.116
+Spring 2023,CUIN,4337,1,13037,Soc Stud in Middle Grades Gen,Manchac,Samantha Lynn,9,7,2,0,0,0,0,3.407
+Spring 2023,CNST,4335,1,13038,Capital Projects Development,Bolander,Larry A,6,3,0,0,0,0,1,3.667
+Spring 2023,POLS,8999,10,13055,Doctoral Dissertation,Kennedy,Ryan P,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8999,10,13060,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,0,0,
+Spring 2023,BIOE,8598,4,13065,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,2,0,
+Spring 2023,COSC,4353,1,13067,Software Design,Singh,Raj Kumar,107,10,0,1,0,0,0,3.881
+Spring 2023,BIOE,8298,4,13068,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,0,0,
+Spring 2023,BIOE,8398,4,13075,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8398,7,13078,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8398,10,13081,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8398,11,13082,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Spring 2023,BIOE,8598,6,13086,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8598,10,13090,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8598,13,13093,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,2,0,
+Spring 2023,MTLS,6320,1,13097,Nanomaterials Engineering,Bao,Jiming,1,0,0,0,0,0,0,3.67
+Spring 2023,CHEM,1111,23,13100,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,8,1,1,0,0,2,3.241
+Spring 2023,FORE,6398,1,13101,Special Problems in Foresight,Hines,Andrew Lewis,5,0,0,0,0,0,0,3.736
+Spring 2023,POLS,3310,1,13106,Intro to Political Theory,Ouellette,Jordan,4,16,11,3,4,0,3,2.325
+Spring 2023,POLS,8999,12,13110,Doctoral Dissertation,Clifford,Scott,0,0,0,0,0,1,0,
+Spring 2023,HIST,8399,2,13111,Doctoral Dissertation,Takriti,Abdel Razzaq,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8398,18,13115,Doctoral Research,Labate,Demetrio,0,0,0,0,0,1,0,
+Spring 2023,ENGL,2305,3,13116,Intro To Fiction,Bose,Godhuly,18,4,0,0,2,0,0,3.459
+Spring 2023,ECON,3334,2,13127,Intermediate Macroeconomics,Thornton,Rebecca Achee,14,9,3,4,5,0,4,2.61
+Spring 2023,PSYC,2301,1,13129,Introduction to Psychology,Agan,Herb W,117,48,10,1,3,0,1,3.464
+Spring 2023,INDS,1501,1,13130,Industrial Design Studio II,McEuen,Aaron Ross,3,5,0,0,0,0,2,3.293
+Spring 2023,ARCH,2328,1,13132,Technology 2,Chlebus,David,50,59,26,6,1,0,1,3.061
+Spring 2023,ARCH,3328,1,13134,Technology 4,Taylor,Rives,88,24,1,0,2,0,0,3.638
+Spring 2023,ARCH,3501,9,13136,Architecture Design Studio VI,Burrow,Robert W,4,3,6,0,0,0,0,2.922
+Spring 2023,ARCH,4328,1,13138,Technology 6 Practice of ARCH,Jacobs,Daniel,61,32,9,0,0,0,1,3.487
+Spring 2023,INAR,2501,1,13139,Interior Arch Design Studio IV,LaRose,Katherine Gail,14,0,0,0,0,0,0,3.859
+Spring 2023,ARCH,4354,1,13141,Ideas and Buildings,Self,Ronnie L,6,5,2,0,0,0,1,3.333
+Spring 2023,ARCH,4321,1,13142,Design of Construction Details,Story,Jon Kevin,9,12,4,0,0,0,0,3.121
+Spring 2023,INAR,4360,1,13143,Practice of Interior Arch,Yu,Maria H,5,4,0,0,0,0,0,3.519
+Spring 2023,INAR,4501,1,13144,Interior Arch Studio VIII,Handanovic,Dijana,3,3,1,0,0,0,0,3.191
+Spring 2023,INDS,6345,1,13146,Advanced Human Factors,Vos,Gordon A,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,4377,3,13148,Advanced Linear Algebra I,Quaini,Annalisa,3,4,2,3,0,0,3,2.528
+Spring 2023,MATH,6308,2,13149,Advanced Linear Algebra I,Quaini,Annalisa,9,1,1,0,1,0,0,3.362
+Spring 2023,BCHS,3304,2,13150,General Biochemistry I,Scott,Sean-Patrick,25,40,23,7,4,0,7,2.748
+Spring 2023,BIOL,4374,3,13151,Cell Biology,Rea,Michael A,18,24,25,5,5,0,12,2.58
+Spring 2023,BIOL,6374,2,13152,Cell Biology,Farmer,Lisa M,3,0,0,0,0,0,0,3.78
+Spring 2023,BIOL,6374,3,13153,Cell Biology,Rea,Michael A,0,2,0,0,0,0,0,3.165
+Spring 2023,BCHS,4313,1,13154,Cell Biochemistry,Gifford,Jenifer Beth,4,5,0,0,0,0,1,3.444
+Spring 2023,BCHS,4313,2,13155,Cell Biochemistry,Farmer,Lisa M,2,7,1,0,0,0,0,3.232
+Spring 2023,LAW,6207,12,13156,Lawyering Skills & Strategy II,Swift,Kenneth Richard,9,7,1,0,0,0,0,3.412
+Spring 2023,LAW,6207,15,13157,Lawyering Skills & Strategy II,Simpson,Lauren J,5,15,0,0,0,0,0,3.399
+Spring 2023,LAW,6207,16,13158,Lawyering Skills & Strategy II,Simpson,Lauren J,5,11,0,0,0,0,0,3.395
+Spring 2023,INDE,6363,1,13159,Statistical Process Control,Keedy,Elias,19,36,13,0,0,0,0,3.069
+Spring 2023,CUIN,3316,3,13160,Prekindergarten Curr & Instr,Siller Escudero,Patricia,14,0,0,0,0,0,0,3.976
+Spring 2023,CUIN,3316,4,13161,Prekindergarten Curr & Instr,Siller Escudero,Patricia,5,0,0,0,0,0,0,3.802
+Spring 2023,CUIN,3317,3,13162,Kindergarten/Elem Curr & Instr,Harris,Deborah,6,3,0,0,0,0,0,3.593
+Spring 2023,INDE,4111,1,13163,Industrial Engineering Seminar,Peng PhD,Jiming Ouyang,4,0,0,0,0,0,0,4.0
+Spring 2023,HDFS,3310,1,13165,Introduction to Child Life,Fraser,Camille,27,4,1,2,1,0,0,3.543
+Spring 2023,COMM,3315,1,13166,News and Social Media,Bhat,Nandikoor R Prashanth,11,1,0,0,0,0,0,3.862
+Spring 2023,COMM,3332,1,13167,Effective Meeting Management,Hudson-Gillan,Gail,17,17,4,0,0,0,1,3.264
+Spring 2023,LAW,6218,1,13168,Client Interviewng & Counselng,Dao,Andrew,3,4,0,0,0,3,0,3.381
+Spring 2023,LAW,6223,1,13171,Drafng & Negotng Int'l Oil Gas,Nadorff,Norman J,9,10,1,0,0,0,0,3.433
+Spring 2023,CUIN,4332,4,13173,Literacy Assess Rdg Writing,Reis,Nancy,36,0,0,0,0,0,0,3.973
+Spring 2023,ELED,4314,3,13174,Mathematics in Elem School I,Burris,Justin T,15,3,0,0,0,0,2,3.778
+Spring 2023,BIOE,6342,1,13175,Biomedical Signal Processing,Ince,Nuri Firat,9,4,2,0,0,0,1,3.489
+Spring 2023,ELED,4314,4,13176,Mathematics in Elem School I,Cutler,Carrie Sybil,24,0,1,0,0,0,0,3.907
+Spring 2023,BIOE,4336,1,13177,Capstone Design II,Schultz,Jerome S,33,6,0,0,1,0,0,3.692
+Spring 2023,BIOE,6346,1,13179,Advanced Medical Imaging,Gifford,Howard,1,1,0,0,0,0,0,3.335
+Spring 2023,PSYC,2319,1,13180,Intro to Social Psychology,Fetterman,Adam Kent,26,10,5,2,1,0,1,3.348
+Spring 2023,PSYC,3310,2,13181,Indstrl-Orgnztnl Psy,Schoolfield,Lucy,45,14,6,3,6,0,4,3.229
+Spring 2023,PSYC,2316,2,13182,Psychology of Personality,Inman,Tonya N,35,14,6,4,3,0,3,3.162
+Spring 2023,PSYC,2316,3,13183,Psychology of Personality,Inman,Tonya N,46,18,10,0,1,0,4,3.405
+Spring 2023,PSYC,2320,2,13184,Abnormal Psychology,Babcock,Julia,10,16,12,1,10,0,0,2.279
+Spring 2023,SPAN,3302,1,13185,Adv Span for Non-Heritage,Ruisanchez Serra,Jose Ramon,4,0,0,0,0,0,0,3.835
+Spring 2023,LAW,5362,1,13186,Employment Discrimination,Areheart,Bradley Allan,22,12,7,0,0,4,0,3.35
+Spring 2023,BIOL,2121,9,13187,Microbiology for Science Major,Knapp,Richard D,16,4,2,0,1,0,0,3.45
+Spring 2023,LAW,6201,1,13188,Sexual Orientation and the Law,Devine,Corey Edward,5,8,1,0,0,3,0,3.427
+Spring 2023,BIOL,2121,10,13189,Microbiology for Science Major,Knapp,Richard D,14,8,1,0,0,0,1,3.608
+Spring 2023,LAW,5459,1,13190,Federal Income Tax,Buckles,Johnny R,2,12,0,0,0,15,0,3.261
+Spring 2023,BIOL,2102,17,13191,Anatomy & Physiology II (lab),Gill,Tejendra,7,12,4,1,0,0,0,3.028
+Spring 2023,BIOL,2102,18,13192,Anatomy & Physiology II (lab),Gill,Tejendra,4,12,5,2,0,0,0,2.783
+Spring 2023,POLS,3316,1,13194,Stats for Political Scientists,Kistner,Michael,12,8,5,4,4,0,4,2.556
+Spring 2023,CHEE,3321,2,13195,Analytical Methods Chem Engr,Grabow,Lars C,1,1,0,1,0,0,0,2.447
+Spring 2023,HRD,3340,2,13197,Principles of HRD,Shirmohammadi,Melika,25,3,0,1,2,0,0,3.527
+Spring 2023,HRD,3346,1,13198,Performance Assessment & Eval,Del Grande,Lisa,52,4,0,0,0,0,0,3.893
+Spring 2023,COSC,6364,1,13199,Adv Numerical Analysis,Tsekos,Nikolaos V,36,27,2,1,0,0,0,3.39
+Spring 2023,HIST,3389,1,13200,China Since 1600,Cong,Xiaoping,6,7,3,0,5,0,2,2.381
+Spring 2023,POLS,4343,1,13201,Causes and Politics of War,Zwald,Zachary J,9,14,1,0,2,0,0,3.09
+Spring 2023,POLS,3313,3,13202,Intro Internatl Relatns,Zwald,Zachary J,10,17,4,1,0,0,1,3.104
+Spring 2023,MANA,3335,4,13203,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,69,14,4,2,0,0,0,3.645
+Spring 2023,ENGL,3349,1,13204,Native American Literature,Wood,Barry Albert,24,4,0,0,0,0,1,3.633
+Spring 2023,MANA,7336,1,13205,Strategic Human Resource Mgt,Fernandez,Alejandro,26,2,0,0,0,0,0,3.881
+Spring 2023,MIS,3360,3,13206,Systems Analysis and Design,Skinner,Richard James,16,30,15,0,0,0,2,3.011
+Spring 2023,BZAN,7320,1,13207,Bus Modeling For Comp Adv,Hess,James D,10,0,0,0,0,0,0,3.901
+Spring 2023,POLS,3310,4,13208,Intro to Political Theory,Vassiliou,Constantine,10,11,0,0,0,0,0,3.398
+Spring 2023,ECE,3340,1,13209,Numerical Methods for ECE,Mayerich,David Matthew,15,16,2,0,1,0,2,3.226
+Spring 2023,ECE,3337,2,13210,Signals and Systems Analysis,Reddy,Rohith Krishna,1,2,0,0,0,0,1,3.443
+Spring 2023,BZAN,6310,1,13211,Quant Analysis for Busn Dec,Wiley,Briceon C,8,10,1,0,0,0,0,3.299
+Spring 2023,BZAN,6310,2,13212,Quant Analysis for Busn Dec,Wiley,Briceon C,6,13,10,0,1,0,2,2.679
+Spring 2023,CUIN,7369,1,13214,Affective Learning and Instru,Snead,Lauren Oropeza,2,2,0,0,0,0,0,3.583
+Spring 2023,POLS,3358,1,13215,Judicial Behavior,Badas,Alex,4,7,5,1,2,0,7,2.509
+Spring 2023,BZAN,7320,2,13216,Bus Modeling For Comp Adv,Murray,Michael J,12,3,3,0,0,0,1,3.39
+Spring 2023,HDCS,1300,3,13217,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,41,6,1,0,1,0,1,3.775
+Spring 2023,HDCS,1300,4,13218,Human Ecosystems & Tech Change,Selzer,Lori Michele,5,22,10,3,0,0,9,2.808
+Spring 2023,HDCS,3300,2,13219,Org Decisions,Hitchman Sr,Cal M,27,13,2,0,4,0,4,3.261
+Spring 2023,CUIN,3302,1,13220,Social Education,Thomas,Dustine J,18,0,0,0,0,0,0,4.0
+Spring 2023,ELED,3320,2,13221,Survey Literature Child Adol,Tyson,Eleanore S,17,6,3,0,0,0,1,3.475
+Spring 2023,ELED,4315,3,13222,Mathematics in Elem School II,Cutler,Carrie Sybil,25,1,0,0,0,0,0,3.911
+Spring 2023,PHYS,3312,1,13223,Modern Optics,Forrest,Rebecca L,8,9,1,3,2,0,1,2.768
+Spring 2023,PHYS,3110,1,13224,Sem-Adv Lab Analysis,Timmins,Anthony Robert,4,4,1,0,1,0,0,2.967
+Spring 2023,GEOL,1102,2,13225,Intro to Climate Change Lab,Wang,Yuxuan,19,5,0,0,0,0,0,3.682
+Spring 2023,ACCT,3366,4,13226,Financial Reporting Frameworks,Harris,Kathleen L,16,13,6,0,0,0,9,3.276
+Spring 2023,FINA,7A23,2,13227,Portfolio Theory and Practice,Wu,Guojun,35,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7A30,1,13228,Advanced Corporate Finance,Povel,Paul,14,4,3,0,1,0,1,3.274
+Spring 2023,CNST,4315,1,13229,Steel Construction,Chang,Chi Chung,21,35,9,0,0,0,1,3.149
+Spring 2023,SCLT,3340,30,13230,Geography for GSC,Henson,Alfred Bernard,14,9,9,2,3,0,0,2.766
+Spring 2023,MECE,3381,1,13232,Finite Elements for Mech Engr,Rao,Jagannatha R,29,48,31,4,1,0,12,2.838
+Spring 2023,FORE,6311,1,13233,Introduction to Foresight,Sweeney,John Arthur,10,0,0,0,1,0,1,3.636
+Spring 2023,COMM,6300,1,13242,Quantitative Research Methods,Huang,Yan,13,3,0,0,0,0,0,3.813
+Spring 2023,CUIN,3111,2,13243,Educational Tech Elem Teachers,Tran,Hien Thi,22,1,0,0,2,0,0,3.614
+Spring 2023,HON,3305,1,13244,Medicine in Performance,Lambeth,Laurie Regine Clements,11,4,4,1,0,0,0,3.234
+Spring 2023,SCM,4390,2,13245,Supply Chain Strategy,Smith,Gordon D,1,22,18,3,0,0,0,2.53
+Spring 2023,ELED,4315,5,13247,Mathematics in Elem School II,Cutler,Carrie Sybil,21,5,0,0,0,0,0,3.82
+Spring 2023,CIS,2336,30,13248,Internet Application Developmt,Nsoh,Jovita T,46,13,1,0,0,0,4,3.7
+Spring 2023,CUIN,7390,1,13249,Instructional Design,Dogan,Bulent,10,0,0,0,0,0,0,4.0
+Spring 2023,MARK,4338,1,13250,Marketing Research,Wang,Yu,14,15,1,1,0,0,0,3.365
+Spring 2023,MIS,3360,4,13251,Systems Analysis and Design,Harkness,Carol Louise,22,31,6,2,1,0,2,3.145
+Spring 2023,MECE,3336,2,13252,Mechanics II,Chen,Zheng,15,26,21,2,2,0,11,2.668
+Spring 2023,TEPM,6307,2,13253,Advanced Project Management,Sherman,Dennis Louis,11,1,0,0,0,0,0,3.889
+Spring 2023,CNST,6380,2,13254,Leed & Green Const Princ in CM,Chang,Chi Chung,27,11,0,0,0,0,0,3.658
+Spring 2023,GHL,2343,2,13255,Hospitality Cost Controls,Haskell,Rebecca Erin,17,11,2,1,1,0,1,3.251
+Spring 2023,GHL,2160,1,13256,Professional Development,Doudna,Simone P,72,3,1,0,1,0,3,3.849
+Spring 2023,FINA,7A20,2,13258,Capital Markets,Wu,Guojun,19,0,0,0,0,0,1,4.0
+Spring 2023,KIN,3303,1,13259,Sports Communication,Walsh,David W,6,18,4,1,0,0,0,2.954
+Spring 2023,LAW,5283,1,13263,Mediation Externship,Willis,Tasha L,0,0,0,0,0,9,0,
+Spring 2023,LAW,5183,1,13264,Mediation Process,Willis,Tasha L,1,8,0,0,0,0,0,3.368
+Spring 2023,CHEM,1112,41,13267,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,1,0,0,0,3,3.222
+Spring 2023,CHEM,1112,50,13268,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,1,2,0,1,0,3,2.667
+Spring 2023,CHEM,1112,52,13269,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,3,1,0,0,1,2.867
+Spring 2023,CHEM,1112,54,13271,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,0,0,0,0,0,3.177
+Spring 2023,CHEM,1111,14,13273,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,7,4,1,1,0,3,2.625
+Spring 2023,IDNS,1101,1,13275,Physics 1301 Workshop,Pattison,Donna,12,4,6,1,0,0,1,3.203
+Spring 2023,IDNS,1102,1,13276,Physics 1302 Workshop,Pattison,Donna,15,3,5,1,1,0,2,3.147
+Spring 2023,BTEC,3200,30,13277,Biotech Research Methods,Hosseinzadeh,Hemen,6,15,2,1,1,0,0,2.934
+Spring 2023,ENGL,4371,1,13278,Literature and Medicine,Liddell,Robert B,22,4,0,0,0,0,0,3.833
+Spring 2023,BTEC,4350,30,13279,Biotech Capstone Experience,Khan,Abdul Latif,25,7,3,1,0,0,2,3.601
+Spring 2023,ENGL,3301,1,13280,Intro To Literary Studies,Majumder,Auritro,6,11,1,0,0,0,2,3.388
+Spring 2023,MATH,3339,1,13281,Statistics for the Sciences,Wang,Wenshuang,81,39,31,20,7,0,12,2.936
+Spring 2023,HLT,3325,1,13282,Medical Terminology,Bloom,Joel A,142,6,2,0,0,0,0,3.887
+Spring 2023,PEP,7307,1,13284,Implmtng Leg Strat Sprts/Fit,Cottingham,Michael,6,2,0,0,1,0,0,3.297
+Spring 2023,AAS,2330,1,13286,Black Liberation Theology,Johnson,Alexander Emmitt Maurice,20,12,3,0,0,0,2,3.439
+Spring 2023,BIOE,5317,1,13290,Intro to Biomedical Imaging,Gifford,Howard,2,0,0,0,0,0,0,4.0
+Spring 2023,GRET,6335,2,13291,Regional Retail Markets,Ezell,Shirley D,4,0,0,0,1,0,0,3.2
+Spring 2023,GRET,6333,2,13292,Retail Mgmt Cross-Cultural,Gatterson,Beverly,10,0,1,0,0,0,0,3.818
+Spring 2023,PHYS,1101,17,13293,College Physics I (lab),Wood,Lowell T,2,11,8,0,0,0,3,2.714
+Spring 2023,PHYS,1101,18,13294,College Physics I (lab),Wood,Lowell T,1,10,8,0,1,0,4,2.566
+Spring 2023,PHYS,1102,11,13295,College Physics II (lab),Wood,Lowell T,0,15,4,0,0,0,2,2.737
+Spring 2023,PHYS,1102,12,13296,College Physics II (lab),Wood,Lowell T,1,8,4,0,0,0,1,2.642
+Spring 2023,PHYS,1102,13,13297,College Physics II (lab),Wood,Lowell T,1,11,7,1,0,0,0,2.699
+Spring 2023,PHYS,2125,3,13298,University Physics Lab I,Wood,Lowell T,1,12,7,1,0,0,0,2.666
+Spring 2023,PHYS,2125,4,13299,University Physics Lab I,Wood,Lowell T,1,13,5,0,0,0,1,2.755
+Spring 2023,PHYS,2125,5,13300,University Physics Lab I,Wood,Lowell T,4,8,7,0,1,0,0,2.601
+Spring 2023,PHYS,2125,6,13301,University Physics Lab I,Wood,Lowell T,2,13,4,0,0,0,1,2.791
+Spring 2023,PHYS,2126,3,13302,University Physics Lab II,Wood,Lowell T,0,11,8,0,0,0,3,2.701
+Spring 2023,PHYS,2126,4,13303,University Physics Lab II,Wood,Lowell T,2,16,5,0,0,0,0,2.812
+Spring 2023,CIVE,6111,2,13309,Graduate Seminar,Kalliontzis,Dimitrios,0,0,0,0,0,3,0,
+Spring 2023,MECE,3363,1,13313,Intro To Fluid Mechanics,Yang,Di,27,60,23,0,0,0,5,3.015
+Spring 2023,ENGL,1301,15,13316,First Year Writing I,Murray,Christopher Brean,12,4,1,0,4,0,2,2.874
+Spring 2023,PUBL,6349,1,13317,Seminar in Non-Profit Mgmt,Glaus Late,Kimberly,0,0,0,0,0,0,0,
+Spring 2023,PSYC,6393,1,13318,Clinical Research Practicum,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Spring 2023,ATP,6293,1,13319,Clinical Experience III,Harrison,Layci,15,0,0,0,0,0,0,4.0
+Spring 2023,SCLT,4389,30,13320,Practicum in Supply Chain,Kidd,Margaret A,13,2,0,0,0,0,0,3.779
+Spring 2023,SCM,4367,2,13321,Process and Quality Management,Miller,Bradley D,35,22,14,4,0,0,0,3.112
+Spring 2023,ATP,6123,1,13322,Upper Extremity Evaluation Lab,Harrison,Layci,15,0,0,0,0,0,0,4.0
+Spring 2023,ATP,6323,1,13323,Upper Extremity Evaluation,Harrison,Layci,12,3,0,0,0,0,0,3.8
+Spring 2023,PCOL,6345,1,13324,Drug Design and Discovery,Cuny,Gregory D,5,7,0,0,0,0,0,3.527
+Spring 2023,BIOE,8298,14,13326,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,3,0,
+Spring 2023,BIOE,8699,4,13327,Doctoral Dissertation,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Spring 2023,BIOE,6399,5,13328,Masters Thesis,Majd,Sheereen,0,0,0,0,0,0,0,
+Spring 2023,CHEM,8998,22,13330,Doctoral Research,Xu,Shoujun,0,0,0,0,0,1,0,
+Spring 2023,NAVY,1302,1,13331,Seapower and Maritime Affairs,Konoza,Emily M,3,1,0,0,0,0,0,3.503
+Spring 2023,NAVY,3301,1,13332,Navigation,Winters,Adam W,1,0,0,0,0,0,0,4.0
+Spring 2023,NAVY,4301,1,13333,Naval Weapons- Ship Systems II,Konoza,Emily M,2,0,0,0,0,0,0,4.0
+Spring 2023,NAVY,4302,1,13334,Leadership and Ethics,Konoza,Emily M,8,1,0,0,0,0,0,3.816
+Spring 2023,MATH,8698,3,13340,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Spring 2023,SPAN,2308,4,13342,Span for Heritage Learners II,Martinez,Raquel,12,8,4,0,1,0,0,3.094
+Spring 2023,MATH,1342,1,13343,Elementary Statistical Methods,Weber,Thomas Christian,82,104,68,40,68,0,46,2.225
+Spring 2023,ELET,1400,4,13344,Circuit Theory and Lab I,Abraham,Yonas B,7,6,6,1,0,0,2,2.884
+Spring 2023,PHOP,6667,3,13349,Research Practicum A,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5683,2,13352,Cardiology,Wang,Elisabeth,1,1,0,0,0,0,0,3.5
+Spring 2023,PHAR,5675,4,13353,Disease State Management,De La Cruz,Austin Isaac,0,1,1,0,0,0,0,2.5
+Spring 2023,PHAR,5691,2,13354,Drug Information,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,1301,16,13357,First Year Writing I,Murray,Christopher Brean,9,7,2,0,3,0,4,2.842
+Spring 2023,LAW,5103,25,13358,Health Law Journal,Mantel,Jessica,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8598,14,13372,Doctoral Research,Larin,Kirill,0,0,0,0,0,6,0,
+Spring 2023,MECE,6364,1,13374,Phase Transform in Materials,Selvamanickam,Venkat,4,3,0,0,0,0,1,3.524
+Spring 2023,AAS,2320,4,13375,Intro To African American Stdy,Poindexter-Sylvers,Carole Jean,24,1,2,0,0,0,5,3.631
+Spring 2023,ENGL,1301,17,13376,First Year Writing I,Murray,Christopher Brean,5,5,5,0,6,0,4,2.08
+Spring 2023,ENGL,1302,32,13377,First Year Writing II,Fletcher,Larry L,3,4,5,2,2,0,3,2.209
+Spring 2023,ENGL,1301,18,13380,First Year Writing I,Murray,Christopher Brean,9,7,2,1,4,0,2,2.595
+Spring 2023,ENGI,2304,5,13381,Technical Communications,Anderson,Roshawnda M,15,6,3,1,1,0,1,3.282
+Spring 2023,FORE,6319,1,13383,Proseminar in Foresight,McBride,Yasamina,23,2,0,0,0,0,0,3.867
+Spring 2023,CHEE,8298,15,13384,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,
+Spring 2023,MATH,8398,19,13385,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,
+Spring 2023,PHYS,1101,19,13387,College Physics I (lab),Wood,Lowell T,1,10,5,0,0,0,7,2.647
+Spring 2023,GEOL,3145,1,13388,Strctrl Geology Lab,Murphy,Michael,6,2,5,2,1,0,0,2.604
+Spring 2023,CUIN,8393,4,13389,Adv Internship & Prac,Chung,Sheng Kuan,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,1111,27,13390,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,8,3,1,0,0,1,2.927
+Spring 2023,CHEM,1111,28,13391,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,12,1,0,0,0,1,3.089
+Spring 2023,CHEE,8298,18,13392,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2023,MATH,8698,5,13394,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,1,0,
+Spring 2023,MATH,8398,20,13395,Doctoral Research,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Spring 2023,ENGL,1301,19,13396,First Year Writing I,Pan,Weijia,12,4,1,0,5,0,3,2.683
+Spring 2023,BIOE,8398,14,13397,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,3,0,
+Spring 2023,BIOE,8398,15,13398,Doctoral Research,Larin,Kirill,0,0,0,0,0,6,0,
+Spring 2023,ENGI,2304,6,13401,Technical Communications,Estrada,Carl,18,2,3,0,1,0,1,3.349
+Spring 2023,ENGL,1302,35,13403,First Year Writing II,Yates,Kaitlyn,17,7,1,0,0,0,0,3.587
+Spring 2023,HLT,4310,1,13404,Program Planning for Hlt Prof,Behjat,Amirmohsen,8,15,2,0,0,0,1,3.148
+Spring 2023,MATH,8398,21,13406,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Spring 2023,MATH,8698,7,13409,Doctoral Research,Papadakis,Emanuel Ioannis,0,0,0,0,0,1,0,
+Spring 2023,MATH,8698,9,13412,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Spring 2023,ELET,2300,2,13415,Introductn To C++ Programming,Soneja,Chandrayee,16,27,13,0,0,0,1,3.012
+Spring 2023,MATH,1314,9,13416,College Algebra,Xhabli,Blerina,16,7,7,4,21,0,16,1.825
+Spring 2023,MATH,1324,11,13417,Finite Math with Applications,Sosa,Moses,32,30,30,12,42,0,40,1.95
+Spring 2023,MATH,1342,8,13418,Elementary Statistical Methods,Caputo,Matthew G,30,38,22,18,20,0,18,2.318
+Spring 2023,MATH,2312,9,13419,Precalculus,Almus,Melahat,22,18,14,2,18,0,24,2.244
+Spring 2023,MATH,4364,1,13420,Intro to Numerical Analysis,Pan,Tsorng-Whay,30,16,10,0,0,0,2,3.339
+Spring 2023,ECON,2301,2,13421,Principles of Macroeconomics,Djima,Jesugnon Ezechias,20,38,37,18,24,0,15,2.097
+Spring 2023,CUIN,8370,1,13423,Intro to Educational Research,Li,Miao,7,0,0,0,0,0,0,3.953
+Spring 2023,GEOL,1102,3,13424,Intro to Climate Change Lab,Wang,Yuxuan,19,4,0,0,0,0,1,3.812
+Spring 2023,GEOL,1147,2,13425,Introductory Meteorology Lab,Jiang,Xun,3,9,5,2,0,0,1,2.511
+Spring 2023,ARCH,1501,13,13426,Arc/Int Arc Design Studio II,Olwi,Asmaa,0,2,0,1,0,0,0,2.333
+Spring 2023,ARCH,2501,11,13428,Architecture Design Studio IV,Hilchey,Jacob Travis,11,4,2,0,0,0,0,3.568
+Spring 2023,PSYC,2330,4,13430,Biological Psychology,Zegel,Maya,39,1,0,0,0,0,0,3.917
+Spring 2023,GEOL,1303,8,13431,Physical Geology,Lytwyn,Jennifer N,51,72,41,13,14,0,25,2.658
+Spring 2023,PSYC,7393,1,13432,Field Practicum in Psychology,Vincent,John P,0,0,0,0,0,25,0,
+Spring 2023,ARCH,6A23,1,13433,Construction Technology 2,Thaddeus,David J,5,5,1,0,0,0,0,3.364
+Spring 2023,ARCH,6A21,1,13434,Environmental Technology 2,Kyropoulou,Amygdalia,10,0,1,0,0,0,0,3.848
+Spring 2023,ARCH,6A51,1,13435,Construction Technology 4,Thaddeus,David J,7,8,12,0,0,0,0,2.631
+Spring 2023,ARCH,6A49,1,13436,Environmental Technology 4,Kyropoulou,Amygdalia,27,1,0,0,0,0,0,3.929
+Spring 2023,GEOL,1340,2,13437,Earth Systems,Lytwyn,Jennifer N,95,93,56,18,16,0,14,2.826
+Spring 2023,PSYC,2308,2,13438,Child Development,Griep,Christina Diaz,52,23,2,2,0,0,1,3.549
+Spring 2023,BIOL,2102,19,13439,Anatomy & Physiology II (lab),Gill,Tejendra,4,10,6,2,1,0,0,2.58
+Spring 2023,BIOL,2102,20,13440,Anatomy & Physiology II (lab),Gill,Tejendra,10,11,2,1,0,0,0,3.264
+Spring 2023,CHEM,1311,1,13441,Fundamentals of Chemistry,Guloy,Arnold M,19,36,78,43,58,0,50,1.589
+Spring 2023,PHYS,4340,1,13442,Research Methods,Ekeoba,Jacqueline Njideka,16,2,0,0,0,0,0,3.834
+Spring 2023,SPAN,2610,1,13444,Intensive Intermediate Spanish,Santos-Guevara,Criseida,2,14,9,0,4,0,0,2.368
+Spring 2023,SPAN,2610,4,13445,Intensive Intermediate Spanish,Romero Jurado,Neysi,6,12,8,0,2,0,2,2.703
+Spring 2023,ILAS,3350,1,13446,Power Writing,Smith,Nathan D,3,4,2,0,2,0,2,2.545
+Spring 2023,INDS,7301,1,13447,Design Thesis II,Feng,Jeff Feng,2,0,0,0,0,0,0,3.835
+Spring 2023,SOC,4394,1,13449,Internship in Sociology,Karner,Tracy Xavia,5,1,0,0,0,0,0,3.778
+Spring 2023,MATH,1314,3,13450,College Algebra,Caputo,Matthew G,26,22,45,14,20,0,34,2.082
+Spring 2023,COMM,1307,1,13452,Media and Society,Lyn,Robyn,29,6,1,0,0,0,1,3.759
+Spring 2023,ELCS,6334,1,13454,Assessment & Eval in Higher Ed,Hernandez,Belkis Pamela,15,2,0,0,0,0,0,3.882
+Spring 2023,PSYC,2320,3,13456,Abnormal Psychology,Ridgely,Natalie,36,28,8,1,2,0,4,3.24
+Spring 2023,FINA,3332,3,13457,Prin of Financial Management,Lopez,John C,45,78,59,21,8,0,13,2.746
+Spring 2023,COMM,3360,1,13458,Principles of Strategic Comm,Huang,Yan,16,7,0,0,0,0,0,3.724
+Spring 2023,FINA,4330,3,13459,Corporate Finance,Allena,Rohit,9,6,1,0,0,0,2,3.5
+Spring 2023,FINA,4356,1,13460,Insurance Operations,Hughes,James F,16,21,5,1,0,0,1,3.278
+Spring 2023,GENB,6A50,2,13461,Business Communications,Pettiette,Michael R,12,1,0,0,0,0,0,3.872
+Spring 2023,GENB,6A50,3,13462,Business Communications,Pettiette,Michael R,6,1,0,0,0,0,0,3.763
+Spring 2023,PSYC,3350,3,13463,Intro to Cognitive Psychology,Yoruk,Harun,60,12,2,0,2,0,3,3.654
+Spring 2023,BIOL,6374,1,13464,Cell Biology,Gifford,Jenifer Beth,5,3,0,0,0,0,0,3.749
+Spring 2023,MANA,4346,1,13465,Leadership Development,Evans,Klavdia Markelova,41,13,2,1,2,0,1,3.481
+Spring 2023,MANA,7339,1,13466,Leadership Development,Atwater,Leanne E,28,3,0,0,0,0,0,3.903
+Spring 2023,SCM,3301,4,13467,SCM Fundamentals,Miller,Bradley D,154,135,36,7,1,0,1,3.29
+Spring 2023,COMM,4357,1,13468,Intercultural Communication,Vaughn,Ginger Koto,19,0,1,0,0,0,0,3.9
+Spring 2023,COSC,4353,2,13471,Software Design,Singh,Raj Kumar,105,13,1,0,0,0,0,3.855
+Spring 2023,MIS,3376,1,13472,Busn Appls Database Mgmt I,Dimoka,Angelika,13,14,5,2,0,0,1,3.04
+Spring 2023,MIS,3376,2,13473,Busn Appls Database Mgmt I,Kniffen,Richard Chad,10,16,12,5,3,0,1,2.543
+Spring 2023,SCM,7390,1,13474,Global Supply Chain Strategy,Smith,Gordon D,4,4,1,0,0,0,0,3.333
+Spring 2023,PHYS,1301,5,13475,College Physics I (lecture),McElhenny,Brian Patrick,24,33,31,4,7,0,20,2.626
+Spring 2023,FINA,4342,1,13476,Financial Eval Corp Reports,Disch,Chad Alan,12,21,2,2,0,0,0,3.109
+Spring 2023,FINA,4329,1,13477,Life Insurance and Annuities,Hong,James,19,27,1,0,0,0,2,3.446
+Spring 2023,FINA,4343,1,13478,Credit Analysis,Welch III,John Clifton,15,2,0,1,0,0,0,3.649
+Spring 2023,HDFS,2314,1,13479,Human Dev and Interventions,Rab,Saira,127,14,12,1,1,0,2,3.708
+Spring 2023,HDFS,3318,1,13480,Human Ecol of Adult Developmt,Schoger,Kimberly,32,1,3,0,3,0,1,3.462
+Spring 2023,HDFS,4318,2,13481,Parent-Child Relationships,Wang,Jennifer L,22,17,2,1,2,0,1,3.25
+Spring 2023,ENGL,1302,36,13482,First Year Writing II,Yates,Kaitlyn,11,6,2,1,3,0,2,2.884
+Spring 2023,ELED,4315,1,13483,Mathematics in Elem School II,Culpepper,Shea Mosley,22,2,1,0,0,0,0,3.8
+Spring 2023,ENGL,6323,1,13485,Fiction Workshop,Peynado,Brenda,8,0,0,0,0,0,0,4.0
+Spring 2023,COMM,2320,1,13487,Fundamentals Media Production,Crowe,Craig Warren,58,13,3,0,1,0,1,3.649
+Spring 2023,COMM,2322,1,13488,Television Production I,Crowe,Craig Warren,14,12,3,1,0,0,0,3.289
+Spring 2023,GERM,3381,2,13491,German Cinema,Frieden,Sandra M Gross,11,8,3,2,1,0,0,3.014
+Spring 2023,ENGI,1331,3,13493,Computing for Engineers,Claydon,Frank J,18,3,0,0,0,0,0,3.763
+Spring 2023,ECE,6111,3,13494,Graduate Research Seminar,Chen,Jiefu,0,0,0,0,0,1,0,
+Spring 2023,COMD,3371,1,13495,Speech Devel & Dis in Children,Cizek,Laura S,5,7,9,3,1,0,0,2.546
+Spring 2023,HDFS,2314,6,13503,Human Dev and Interventions,Dunsmore,Julie C,12,11,14,5,4,0,3,2.457
+Spring 2023,PETR,1111,1,13505,Intro to Petroleum Engineering,Hathon,Lori A,0,3,2,0,0,0,0,2.6
+Spring 2023,WGSS,2350,1,13508,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,0,1,0,1,0,1,3.786
+Spring 2023,WGSS,2350,3,13509,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,28,1,0,1,0,0,0,3.845
+Spring 2023,WGSS,2350,5,13510,Intro To Women's Studies,Martinez,Itzel Areli,19,6,1,1,2,0,1,3.356
+Spring 2023,WGSS,2350,6,13511,Intro To Women's Studies,Slatton,Brittany Chevon,15,7,3,0,1,0,3,3.372
+Spring 2023,PSYC,2319,2,13512,Intro to Social Psychology,Serrano Holden,Surizaday,72,2,2,0,0,0,4,3.899
+Spring 2023,BTEC,1322,30,13513,Introduction to Biotechnology,Hosseinzadeh,Hemen,1,1,1,1,0,0,0,2.583
+Spring 2023,BTEC,6100,30,13514,Seminar in Biotechnology,Balan,Venkatesh,3,2,0,0,0,0,0,3.666
+Spring 2023,LAW,5227,1,13515,Procedure of Patent Litigation,Dhanani,Ali N,6,7,0,0,0,0,0,3.385
+Spring 2023,LAW,5271,1,13516,Advanced Negotiation,Daic,Megan Ashley,2,4,0,0,0,0,0,3.333
+Spring 2023,LAW,5421,2,13517,Business Organizations,Ragazzo,Robert A,9,14,0,0,0,0,1,3.42
+Spring 2023,LAW,5603,1,13521,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,1,0,
+Spring 2023,LAW,5218,1,13522,Human Trafficking Law,Gallagher,Edward F,8,8,3,0,0,2,0,3.281
+Spring 2023,LAW,5600,1,13524,Judicial Externship I,Powers,William,0,0,0,0,0,1,0,
+Spring 2023,POLS,3310,2,13526,Intro to Political Theory,McDonald,John Terrence George,13,16,10,1,2,0,2,2.912
+Spring 2023,ACCT,2302,7,13527,Prin of Managerial Accounting,Newman,Michael Ray,14,7,0,0,0,0,1,3.682
+Spring 2023,POLS,3376,1,13528,Black Political Thought,LeVeaux,Christine,13,4,2,0,0,0,0,3.509
+Spring 2023,COMM,4303,4,13529,Communication Law and Ethics,Payne,Latosha Lewis Terrell,16,11,5,0,0,0,0,3.395
+Spring 2023,HDCS,4393,1,13531,Internship in RCS,Ezell,Shirley D,22,3,0,0,1,0,0,3.693
+Spring 2023,ACCT,7372,1,13532,Multijurisdictional Taxation,Evetts,Nancy Zalmanek,19,3,0,0,0,0,0,3.864
+Spring 2023,HIST,1302,52,13533,The U.S. Since 1877,Modaff,Abigail,20,3,0,0,0,0,1,3.827
+Spring 2023,ELET,2103,2,13535,Digital Systems Laboratory,Abdelhadi,Ahmed,12,4,3,0,0,0,0,3.387
+Spring 2023,SOCW,8425,1,13536,Statistics & Data Analysis II,Torres,Isabel,4,2,0,0,0,0,0,3.667
+Spring 2023,ELET,2105,2,13537,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,5,3,1,0,0,0,1,3.481
+Spring 2023,GHL,3361,1,13539,Hospitality Marketing,Shin,Min Jung,15,3,1,0,0,0,0,3.685
+Spring 2023,GHL,3348,1,13540,Principles of Hosp Revenue Mgt,Cheatham,Cathy A,40,18,4,0,3,0,1,3.385
+Spring 2023,GHL,6101,1,13541,Colloquium,Back,KiJoon,30,0,0,0,0,0,0,3.967
+Spring 2023,GHL,8304,1,13542,Qualitative Design in Hosp Adm,Legendre,Jungyoung Shin,3,0,0,0,0,0,0,4.0
+Spring 2023,GHL,3348,2,13543,Principles of Hosp Revenue Mgt,Kazemi Zarkouei,Mohammad Sadegh,7,4,4,2,3,0,10,2.55
+Spring 2023,BIOE,3340,1,13544,Quantitative Physiology,Roh,Jinsook,4,3,2,1,0,0,1,2.835
+Spring 2023,PSYC,7305,1,13548,Structural Equations,Mehta,Paras D,10,0,0,0,0,0,0,3.934
+Spring 2023,ANTH,7399,5,13550,Masters Thesis,Rasmussen,Susan J,0,0,0,0,0,1,0,
+Spring 2023,MAS,3343,1,13552,Latino Psychology,Pino,Diana,16,8,5,1,3,0,6,2.92
+Spring 2023,CNST,1361,1,13553,Construction Management I,Beadle,Dwight D,25,13,4,0,0,0,3,3.5
+Spring 2023,MECE,2334,1,13554,Thermodynamics,Love,Holley Carole,11,19,13,1,2,0,5,2.768
+Spring 2023,PHYS,6321,1,13556,Electrodynamics,Koerner,Lisa Whitehead,6,19,4,0,0,0,0,3.092
+Spring 2023,GEOL,4370,1,13557,Global Seismology,Chesnokov,Evgeni M,4,0,0,0,0,0,0,3.918
+Spring 2023,WGSS,2360,1,13558,Introduction to LGBT Studies,Pegoda,Andrew Joseph,7,11,5,0,0,0,6,3.116
+Spring 2023,WGSS,6301,1,13559,Feminist Theory & Methodology,Gregory,Elizabeth,6,0,0,0,0,0,0,4.0
+Spring 2023,ECON,2302,3,13561,Principles of Microeconomics,Blanchfield,Craig,25,0,0,0,0,0,0,3.974
+Spring 2023,CNST,3155,1,13562,Const Materials & Testing,Meyer,Joseph Ray,50,10,4,0,0,0,0,3.703
+Spring 2023,ENTR,7339,1,13566,Venture Fund,Rassin,Keith David,8,0,0,0,0,0,0,3.835
+Spring 2023,WGSS,2350,7,13567,Intro To Women's Studies,Norquist,Grete A,11,12,3,1,1,0,1,3.095
+Spring 2023,KIN,3301,1,13568,Design/Eval Phys Activity Prog,Gray,Jon Phillip,41,5,0,0,0,0,1,3.87
+Spring 2023,CNST,3301,1,13569,Constructn Equipment & Methods,Al-Nahhas,Amer Faisal,16,36,24,2,1,0,4,2.81
+Spring 2023,CNST,3331,1,13570,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,19,32,6,0,0,0,1,3.228
+Spring 2023,CNST,3355,1,13571,Strength of Construction Mtrls,Senouci,Ahmed,23,17,23,0,5,0,5,2.779
+Spring 2023,PETR,3372,1,13572,Petroleum Production Operation,Wong,George K,4,6,1,1,0,0,0,3.111
+Spring 2023,KIN,3306,4,13573,Physiology-Human Performance,Breslin,Whitney L,26,35,33,12,9,0,2,2.504
+Spring 2023,PHYS,1102,14,13575,College Physics II (lab),Wood,Lowell T,0,10,4,0,0,0,0,2.62
+Spring 2023,WGSS,3360,1,13576,Sexuality and Queer Theory,Backus,Margot Gayle,7,4,0,0,1,0,0,3.278
+Spring 2023,WGSS,2350,8,13577,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,24,3,2,0,1,0,0,3.611
+Spring 2023,WGSS,2350,4,13578,Intro To Women's Studies,Slatton,Brittany Chevon,17,3,3,0,5,0,2,2.941
+Spring 2023,BIOE,3140,1,13579,Quantitative Physiology Lab,Roh,Jinsook,10,4,2,0,0,0,0,3.5
+Spring 2023,MIS,7376,1,13580,Systems Analysis and Design,Johnson,Glynn L,31,3,0,0,0,0,1,3.834
+Spring 2023,ACCT,4380,1,13581,Contro & Sec Intern Fin Inform,Brant Jr,Robert Edward,2,4,1,0,0,0,0,3.143
+Spring 2023,CIVE,3434,3,13582,Fluid Mech and Hydraulic Engr,Momen,Mostafa,19,13,9,2,1,0,0,3.023
+Spring 2023,CIVE,4311,1,13584,Prof Practice in Civil Engr,Herman,Reagan,13,10,4,0,0,0,0,3.248
+Spring 2023,ATP,7196,1,13585,Clinical Experience VI,Knoblauch,Mark Alan,11,4,0,0,0,0,0,3.733
+Spring 2023,ATP,7321,1,13586,Behavioral Health in AT,Knoblauch,Mark Alan,15,0,0,0,0,0,0,4.0
+Spring 2023,ATP,7322,1,13587,Seminar in Athletic Training,Harrison,Layci,14,0,1,0,0,0,0,3.867
+Spring 2023,SPAN,2312,13,13588,Intermediate Spanish II,Serrano,Paloma A,7,7,6,0,3,0,0,2.609
+Spring 2023,SPAN,2312,14,13589,Intermediate Spanish II,Benalcazar Astudillo,Diana Salome,5,7,5,1,0,0,0,2.852
+Spring 2023,ACCT,4331,3,13590,Federal Income Tax-Individual,Small,Randolph Christopher,9,10,3,0,0,0,0,3.273
+Spring 2023,POLS,8999,14,13592,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,1,0,0,0,0,1,0,4.0
+Spring 2023,PETR,4312,1,13594,Petroleum Capstone Project II,Zargar,Zeinab,10,0,0,0,0,0,0,3.901
+Spring 2023,PETR,6312,1,13595,Well Log Eval of Petr Formatn,Hathon,Lori A,4,1,0,0,0,0,0,3.602
+Spring 2023,SPAC,6203,1,13597,Spacecraft/Habitat Design,Toups,Larry David,17,0,0,0,0,0,0,4.0
+Spring 2023,SPAC,6403,1,13598,Mission Planning and Analysis,Bannova,Olga,8,6,1,0,0,0,0,3.335
+Spring 2023,SPAC,6405,1,13599,Advanced Design and Analysis,Bannova,Olga,0,1,0,0,0,0,0,3.0
+Spring 2023,SPAC,7410,1,13600,Master's Project: Space Arch,Bell,Larry S,2,0,0,0,0,0,0,4.0
+Spring 2023,CNST,3185,2,13601,Construction Experience,Lyon,Eva Yaneth,22,4,2,0,0,0,0,3.691
+Spring 2023,CHEM,1111,2,13605,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,7,2,0,1,0,1,3.098
+Spring 2023,CHEM,1111,8,13606,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,3,0,0,0,3,3.111
+Spring 2023,MANA,4355,2,13609,Selection and Staffing,Bozeman,Dennis,19,12,4,0,0,0,1,3.504
+Spring 2023,CHEM,1112,60,13611,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,10,0,1,0,0,0,3.194
+Spring 2023,CHEM,1112,61,13612,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,10,2,0,1,0,2,2.644
+Spring 2023,CHEM,1112,62,13613,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,2,0,0,0,0,3.001
+Spring 2023,CHEM,1112,63,13614,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,3,3,0,0,0,2,3.239
+Spring 2023,ARCH,5500,3,13615,Architecture Design Studio IX,Louie,Jonathan Bung Chan,5,7,0,0,0,0,0,3.472
+Spring 2023,CHEM,1111,24,13617,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,1,1,0,0,2,3.045
+Spring 2023,CHEM,1111,25,13618,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,3,0,0,0,0,3.227
+Spring 2023,CHEM,1111,26,13619,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,2,0,0,0,5,3.104
+Spring 2023,CHEM,1111,29,13620,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,7,5,0,2,0,1,2.719
+Spring 2023,CHEM,1111,30,13621,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,2,1,0,0,1,2.977
+Spring 2023,CHEM,1111,31,13622,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,0,0,1,0,3,3.022
+Spring 2023,CHEM,1111,32,13623,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,7,1,0,1,0,1,2.733
+Spring 2023,CHEM,1111,33,13624,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,4,0,1,0,0,2.866
+Spring 2023,CHEM,1111,34,13625,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,9,2,2,2,0,4,2.451
+Spring 2023,CHEM,1111,37,13626,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,7,0,2,0,1,2.631
+Spring 2023,PSYC,2307,1,13628,Psychology of Adolescence,Martin,Rebecca B,54,9,5,1,0,0,1,3.638
+Spring 2023,MARK,4379,1,13632,Personal Branding,Vandaveer,Amy L,50,4,0,0,0,0,0,3.92
+Spring 2023,MATH,8698,11,13636,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,2,0,
+Spring 2023,MATH,8698,12,13638,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Spring 2023,PHOP,7399,8,13641,Masters Thesis,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6257,4,13642,Research Practicum B,Patel,Nimesh Bhikhu,2,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6267,4,13644,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6257,5,13645,Research Practicum B,Porter,Jason,0,1,0,0,0,0,0,3.0
+Spring 2023,PHOP,6198,29,13646,Spec Prob-Physio Optics,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,2330,1,13648,Writing Discipline English,Coleman,Quintin,15,3,0,0,0,0,1,3.778
+Spring 2023,COMD,7391,14,13651,Clinic in Speech Lang Disorder,Jacobson,Shannon,2,0,0,0,0,0,0,3.835
+Spring 2023,COMD,7391,13,13652,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,2,0,0,0,0,0,0,3.67
+Spring 2023,PHYS,4396,3,13653,Senior Research Project,Li,Liming,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8399,5,13656,Doctoral Dissertation,Gifford,Howard,0,0,0,0,0,1,0,
+Spring 2023,PETR,7399,3,13659,Masters Thesis,Myers,Michael Tolbert,1,0,0,0,0,1,0,3.67
+Spring 2023,PETR,7399,5,13661,Masters Thesis,Ehlig-Economides,Christine A,0,1,0,0,0,0,0,3.0
+Spring 2023,CUIN,8390,3,13667,Doctoral Thesis,Hausmann,Robert Carl,0,0,0,0,0,3,0,
+Spring 2023,PHOP,7399,9,13669,Masters Thesis,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,7399,11,13671,Masters Thesis,Burns,Alan R,0,0,0,0,0,0,0,
+Spring 2023,GHL,4343,2,13679,Financial Admin for Hosp.Ind.,Koh,Yoon,15,17,2,1,2,0,0,3.144
+Spring 2023,OPTO,7494,1,13680,General Clinic IIIb,Dempsey,Robert L,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8399,6,13685,Doctoral Dissertation,Larin,Kirill,0,0,0,0,0,1,0,
+Spring 2023,PCOL,7350,1,13687,Cellular Pharmacology I,Ruan,Ke-He,6,2,0,0,0,0,0,3.75
+Spring 2023,ENGL,7399,1,13688,Essay,Prufer,Kevin D,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8598,16,13690,Doctoral Research,May,Elebeoba E,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8298,15,13691,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Spring 2023,CHEE,3334,1,13692,Stat/Num Tchqs for Chem Engrs,Willson,Richard,14,9,7,1,0,0,1,3.087
+Spring 2023,BIOE,8398,17,13695,Doctoral Research,May,Elebeoba E,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8298,16,13696,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Spring 2023,PCEU,8998,2,13699,Doctoral Research,Liu,Xinli,2,0,0,0,0,0,0,4.0
+Spring 2023,FINA,4399,1,13701,Senior Honor Thesis,Rude,Dale,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8999,15,13702,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,3,0,
+Spring 2023,MECE,3336,3,13703,Mechanics II,Wang,Su Su,8,13,14,0,2,0,13,2.631
+Spring 2023,CHEE,8399,16,13704,Doctoral Dissertation,Varadarajan,Navin,4,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,6698,1,13705,Research,Berger,Jason,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8398,16,13706,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,3,0,
+Spring 2023,PETR,8398,3,13709,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,4,0,
+Spring 2023,ACCT,5378,1,13715,Control & Security of Fin Info,Brant Jr,Robert Edward,0,0,1,0,0,0,0,2.33
+Spring 2023,ELET,2300,3,13717,Introductn To C++ Programming,Lent,Marino Ricardo,15,24,10,9,8,0,10,2.494
+Spring 2023,MECT,3331,2,13719,Applied Thermodynamics,El Nahas,Medhat A,3,4,13,2,11,0,4,1.516
+Spring 2023,PSYC,8699,3,13722,Doctoral Dissertation,Ng,Vincent,0,0,0,0,0,1,0,
+Spring 2023,TEPM,6301,2,13726,Project Management Principles,Sherman,Dennis Louis,18,3,1,0,1,0,0,3.609
+Spring 2023,MATH,8698,13,13733,Doctoral Research,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Spring 2023,MATH,8698,14,13734,Doctoral Research,Mang,Andreas,0,0,0,0,0,4,0,
+Spring 2023,WGSS,4360,1,13740,Capstone Internship Course,Gregory,Elizabeth,11,0,0,0,0,0,0,4.0
+Spring 2023,PETR,8198,1,13741,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Spring 2023,PETR,8598,1,13742,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8398,17,13743,Doctoral Research,Vekilov,Peter,0,0,0,0,0,2,0,
+Spring 2023,PHAR,5681,5,13745,Infectious Diseases,Beyda,Nicholas D,1,1,0,0,0,0,0,3.5
+Spring 2023,MANA,4396,2,13747,Management Internship,Carlin,Barbara A,0,0,0,0,0,1,0,
+Spring 2023,ECON,3344,1,13748,History of Economic Doctrine,Gosselin,Richard John,4,4,1,0,0,0,5,3.223
+Spring 2023,MATH,2318,3,13749,Linear Algebra,Morgan,Jeffrey,13,16,11,5,2,0,10,2.688
+Spring 2023,MATH,2131,1,13750,Linear Alg Labs w/MATLAB,Vu,An Thuy,26,1,1,1,2,0,1,3.559
+Spring 2023,CUIN,8372,1,13751,Introduction to Qual Research,Thomas,Dustine J,7,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,6393,1,13752,Practicum,Klussmann,Duncan Foster,13,0,0,0,0,0,0,4.0
+Spring 2023,CLAS,3308,1,13753,Myths & Cult of the Greek Gods,Kidder,Kathleen,12,9,6,1,1,0,1,3.034
+Spring 2023,BCHS,4306,1,13754,Nucleic Acids,Bawa-Khalfe,Tasneem,8,8,1,0,1,0,1,3.296
+Spring 2023,BIOL,6240,1,13755,Molecular Genetics 1,Dauwalder,Brigitte,9,1,0,0,0,0,0,3.867
+Spring 2023,BIOL,6241,1,13756,Molecular Genetics 2,McKeon,Frank D,10,0,0,0,0,0,0,4.0
+Spring 2023,FINA,3332,6,13757,Prin of Financial Management,Suleymanov,Masim,74,73,47,22,2,0,1,2.907
+Spring 2023,MIS,3370,3,13758,Info Systems Development Tools,Knighton,William B,17,9,15,7,0,0,16,2.743
+Spring 2023,BIOL,2121,11,13759,Microbiology for Science Major,Knapp,Richard D,13,9,0,0,0,0,0,3.576
+Spring 2023,PSYC,2316,4,13760,Psychology of Personality,Westmoreland,Kirsten E,8,18,12,7,1,0,3,2.572
+Spring 2023,PSYC,2330,5,13761,Biological Psychology,Gehm,Kevan H,10,11,7,5,0,0,0,2.808
+Spring 2023,CUIN,4361,10,13762,Second Language Methodology,Latiolais,Cheryl S,13,0,0,0,0,0,1,4.0
+Spring 2023,COMM,3368,3,13763,Principles of Public Relations,Ashley,Laura B,17,12,1,0,0,0,0,3.522
+Spring 2023,COMM,3369,3,13764,Strategic Comm. Writing,Emery II,Philip M,22,3,0,0,0,0,0,3.906
+Spring 2023,COMM,4303,3,13765,Communication Law and Ethics,Dulin,Matthew D,14,38,2,4,0,0,2,3.035
+Spring 2023,COMM,4378,1,13766,Social Impact of Info Tech,Gonzalez,David De Jesus,59,0,0,0,0,0,1,4.0
+Spring 2023,PSYC,6332,1,13767,CDLNeuropsych: Assess/App I,Woods,Steven Paul,5,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,3377,1,13769,Oceanography,Maddocks,Rosalie F,2,6,5,5,3,0,3,1.968
+Spring 2023,PETR,4311,1,13770,Petroleum Capstone Project I,Zargar,Zeinab,3,0,0,0,0,0,0,3.67
+Spring 2023,PHYS,3316,1,13771,Quantum Mechanics,Ordonez,Carlos,6,3,1,0,2,0,0,2.834
+Spring 2023,ELED,4314,2,13772,Mathematics in Elem School I,Burris,Justin T,21,4,0,0,0,0,0,3.787
+Spring 2023,CUIN,4332,2,13773,Literacy Assess Rdg Writing,Reis,Nancy,18,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,3140,2,13774,Quantitative Physiology Lab,Roh,Jinsook,6,5,2,0,1,0,1,3.166
+Spring 2023,EDRS,8381,1,13775,Rsch Mthds in Educ,Johnson PhD,Detra DeVerne,3,1,0,0,1,0,0,2.934
+Spring 2023,BIOL,2321,2,13776,Microbiology for Science Major,Knapp,Richard D,47,57,62,38,20,0,27,2.324
+Spring 2023,ELED,3322,1,13777,Elem Reading Phonics Instructn,Alba,Celeste,4,1,0,0,0,0,0,3.734
+Spring 2023,HLT,3306,1,13796,Environmental Health,Behjat,Amirmohsen,40,23,15,3,5,0,7,2.943
+Spring 2023,HLT,4307,2,13797,Research and Eval in Health,Fedor Amador,Theresa Marie,24,9,2,1,1,0,1,3.352
+Spring 2023,SCM,4385,1,13798,Supply Chain Analytics,Murray,Michael J,4,4,5,0,0,0,3,2.847
+Spring 2023,COMM,3340,1,13799,Health Campaigns,Xiao,Zhiwen,20,5,2,0,0,0,0,3.654
+Spring 2023,COMM,3377,1,13800,Strategic PR Planning,Uhrick,Jan,16,3,0,0,0,0,0,3.859
+Spring 2023,ARED,3305,1,13801,Art in Elementary Schools,Allen,Andrea E,26,2,1,1,0,0,0,3.745
+Spring 2023,ELED,4310,2,13802,Reading/Language in Elementary,Black,Misty Paul,12,1,0,0,0,0,0,3.847
+Spring 2023,ENTR,3311,1,13803,Technology Entrepreneurship,Chatterji,Tanushree,9,2,1,1,1,0,0,3.167
+Spring 2023,MARK,4332,1,13807,Social Media Marketing,Zahn,William J,42,22,4,0,1,0,0,3.507
+Spring 2023,MARK,7332,1,13808,Social Media Marketing,Gavin,Daniel Yaakov,40,5,1,0,1,0,1,3.766
+Spring 2023,CUIN,3333,1,13809,Differentiating Diverse Learn,Dokes,Rosa Mack,40,0,0,0,0,0,0,3.967
+Spring 2023,CUIN,4315,5,13810,Assessment of Children,Katz,Denise Annette,15,1,0,0,0,0,0,3.917
+Spring 2023,CUIN,4375,2,13811,Classroom Management,Thompson,Alan M,9,5,0,0,0,0,0,3.572
+Spring 2023,ENGI,1100,2,13812,Introduction To Engineering,Metrovich,Brian,12,17,13,6,5,0,5,2.409
+Spring 2023,ENGI,1100,3,13814,Introduction To Engineering,Aksu,Gulin Tulunay,21,14,17,0,5,0,3,2.766
+Spring 2023,COSC,1336,2,13816,Computer Science & Program,Solorio Martinez,Thamar Ivette,44,21,15,13,8,0,14,2.74
+Spring 2023,COSC,1336,3,13817,Computer Science & Program,Hilford,Victoria,32,32,14,9,9,0,15,2.726
+Spring 2023,CHEE,2332,2,13819,Chem Engr Thermodyn I,Malamataris,Nikolaos,0,1,1,0,1,0,0,1.557
+Spring 2023,BIOE,4342,1,13820,Biomedical Signal Processing,Ince,Nuri Firat,2,1,0,0,0,0,0,3.667
+Spring 2023,BIOE,4349,1,13821,Biomedical Microdevices,Majd,Sheereen,2,4,0,0,0,0,0,3.278
+Spring 2023,BIOE,4150,1,13823,Genomic & Proteomic Lab,Akay,Yasemin M,9,1,0,0,0,0,0,3.9
+Spring 2023,BIOE,4350,1,13825,Genomic & Proteomic Engr,Wu,Tianfu,37,5,0,0,0,0,0,3.865
+Spring 2023,BIOE,4302,1,13826,Numerical Analysis for BME,Zhang,Yingchun,10,1,1,0,0,0,0,3.723
+Spring 2023,BIOE,6300,1,13827,Mathematical Methods in BME,Yazdi,Iman,24,18,1,0,2,0,1,3.356
+Spring 2023,HLT,2320,1,13828,Introduction to Public Health,Solari Williams,Kayce D,77,30,8,2,2,0,1,3.44
+Spring 2023,ENTR,7390,1,13829,Technology Entrepreneurship,Chatterji,Tanushree,11,0,0,0,0,0,0,3.91
+Spring 2023,MECE,4340,1,13830,Mechanical Engr Capstone I,Chang,Christiana,19,33,7,3,0,0,0,3.091
+Spring 2023,COSC,6373,1,13831,Computer Vision,Kakadiaris,Ioannis A,12,8,0,0,0,0,1,3.501
+Spring 2023,MANA,3335,5,13832,Intro Org Behavior and Mgmt,Currie,Daniel David,175,56,7,2,2,0,6,3.598
+Spring 2023,COSC,6323,1,13833,Statistical Method in Research,Pavlidis,Ioannis T,21,13,1,0,0,0,0,3.581
+Spring 2023,MANA,6A83,2,13834,Strategic Analysis,Wesley,Curtis,9,12,0,0,0,0,1,3.35
+Spring 2023,PETR,8399,1,13835,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Spring 2023,PETR,8399,3,13837,Doctoral Dissertation,Myers,Michael Tolbert,2,0,0,0,0,2,0,3.835
+Spring 2023,PETR,8399,4,13838,Doctoral Dissertation,Qin,Guan,1,0,0,0,0,0,0,4.0
+Spring 2023,PETR,8399,5,13839,Doctoral Dissertation,Ehlig-Economides,Christine A,0,0,0,0,0,2,0,
+Spring 2023,PETR,8399,7,13841,Doctoral Dissertation,Wong,George K,2,0,0,0,0,0,0,4.0
+Spring 2023,PETR,8399,8,13842,Doctoral Dissertation,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Spring 2023,PETR,8399,9,13843,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,2,0,
+Spring 2023,ENGL,3331,1,13844,Beg Creative Writing-Poetry,Belieu,Erin Colleen,11,3,0,0,0,0,1,3.833
+Spring 2023,PETR,8699,7,13851,Doctoral Dissertation,Wong,George K,0,0,0,0,0,1,0,
+Spring 2023,PETR,8699,9,13853,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,2,0,
+Spring 2023,PETR,8398,7,13854,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Spring 2023,PETR,8398,8,13855,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Spring 2023,PETR,8298,1,13857,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,2,0,
+Spring 2023,PETR,8999,1,13858,Doctoral Dissertation,Soliman,Mohamed Yousef,1,0,0,0,0,0,0,4.0
+Spring 2023,PETR,8999,2,13859,Doctoral Dissertation,Hathon,Lori A,0,0,0,0,0,1,0,
+Spring 2023,PETR,8298,3,13868,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,3,0,
+Spring 2023,PETR,8298,5,13870,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,3,0,
+Spring 2023,PETR,8298,7,13872,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Spring 2023,PETR,8298,8,13873,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Spring 2023,PETR,8298,9,13874,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,4,0,
+Spring 2023,COSC,1336,1,13875,Computer Science & Program,Huang,Shou-Hsuan Stephen,14,21,18,10,16,0,37,2.076
+Spring 2023,KIN,3306,4,13876,Physiology-Human Performance,Park,Yoonjung,10,21,9,2,2,0,4,2.803
+Spring 2023,PETR,8598,3,13887,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,5,0,
+Spring 2023,PETR,8598,5,13889,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Spring 2023,PETR,8598,8,13892,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Spring 2023,MANA,4336,1,13894,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,4,27,9,5,1,0,2,2.594
+Spring 2023,MANA,4348,1,13895,Global Leadership,Walker,William A,35,8,4,0,0,0,0,3.674
+Spring 2023,TECH,3365,3,13896,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,20,17,6,0,0,0,4,3.425
+Spring 2023,ECE,2202,1,13897,Circuit Analysis II,Shan,Xiaonan,10,17,13,4,4,0,4,2.535
+Spring 2023,PHLS,6352,1,13899,Assessmnt in Educ Psych,Lee,Jungeun,11,1,0,0,0,0,0,3.889
+Spring 2023,PHLS,7393,1,13900,Internship and Practicum,Margulis,Milena A,0,0,0,0,0,0,0,
+Spring 2023,PHLS,8300,1,13901,Advanced Educ/Psy Measurement,Fan,Weihua,15,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8305,1,13902,Supervisn in Counseling,Reyna,Ronda,8,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8334,1,13903,Research Counseling Psychology,Arbona,Consuelo,4,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8347,1,13904,Assessment Cog Abilities,Garcia,Amy Keiko,7,3,1,0,0,0,0,3.515
+Spring 2023,PHLS,8367,1,13905,Behavioral Consultation,Gonzalez,Jorge E,2,1,0,0,0,0,0,3.777
+Spring 2023,PHLS,8362,1,13906,Innov Acad Assmt & Invt: RTI,Margulis,Milena A,6,0,0,0,0,0,0,3.945
+Spring 2023,CUIN,1350,1,13907,Mathematics for Teachers 1,Burris,Justin T,19,11,1,0,0,0,0,3.538
+Spring 2023,SOCW,7325,3,13908,Assessment in SW Practice,Bhatt,Riya V,28,1,0,0,0,0,0,3.966
+Spring 2023,HRD,4352,1,13909,Facilitation Strategies,Hampton,Elaine Denae,35,4,0,0,0,0,0,3.872
+Spring 2023,HRD,4352,30,13910,Facilitation Strategies,Owens-Shepard,Toya,19,0,1,0,0,0,0,3.884
+Spring 2023,HRD,4396,30,13911,Internship in HRD,Polesello,Daiane,23,11,4,1,2,0,3,3.252
+Spring 2023,INDE,6333,1,13913,Probability Stat For Engineers,Feng,Qianmei,18,28,6,2,1,0,4,3.091
+Spring 2023,INDE,6372,1,13914,Advanced Linear Optimization,Peng PhD,Jiming Ouyang,7,4,5,0,1,0,0,2.941
+Spring 2023,DIGM,3152,31,13915,Graphic Comm Output Lab,Dawson,Michael John,7,0,0,0,0,0,0,4.0
+Spring 2023,DIGM,3152,32,13916,Graphic Comm Output Lab,Dawson,Michael John,4,1,0,0,1,0,1,3.167
+Spring 2023,DIGM,3152,33,13917,Graphic Comm Output Lab,Dawson,Michael John,6,0,0,0,0,0,1,4.0
+Spring 2023,DIGM,3350,30,13918,Graph Comm Prod Processes,Pegram,Norman,13,2,0,0,0,0,0,3.713
+Spring 2023,DIGM,3356,30,13919,ePublishing,Alters,Monika Joanna,22,18,7,0,0,0,3,3.214
+Spring 2023,DIGM,3374,30,13921,Video Production 2,Snyder,Philip Charles,16,11,1,0,0,0,1,3.477
+Spring 2023,DIGM,4375,30,13923,Package Design,De Vega,Jaime M,22,3,0,0,0,0,0,3.84
+Spring 2023,DIGM,4379,30,13925,Transmedia Marketing,Snyder,Karen Yvonne,38,50,12,4,2,0,3,3.123
+Spring 2023,CNST,4302,30,13928,Construction Law and Ethics,Escobar,C Mauricio,14,8,3,0,0,0,1,3.427
+Spring 2023,HDFS,4315,1,13929,Culture and Diversity,Rab,Saira,34,3,0,0,3,0,0,3.584
+Spring 2023,HLT,3325,2,13930,Medical Terminology,Bloom,Joel A,127,21,1,1,0,0,0,3.78
+Spring 2023,SOCW,8395,2,13931,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,0,0,
+Spring 2023,SOCW,8395,3,13932,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Spring 2023,CUIN,3347,1,13933,Reading in the Content Area,Morris,Alana,32,1,2,0,0,0,0,3.763
+Spring 2023,PEP,7393,1,13934,Internship & Practicum,Walsh,David W,2,1,0,0,0,0,0,3.667
+Spring 2023,POLS,3362,1,13935,Political Campaign Management,Rottinghaus,Brandon J,11,16,6,3,2,0,4,2.824
+Spring 2023,POLS,3356,1,13937,Intro-Constitutionl Law,Wall,Kenneth S,5,4,5,5,0,0,4,2.439
+Spring 2023,POLS,4391,1,13938,Internships in Intl Affairs,Sisman,Ozlem,5,0,0,0,0,0,1,4.0
+Spring 2023,MECE,6384,1,13939,Methods of Applied Math I,Chen,Yi-Chao,0,3,1,0,0,0,3,2.833
+Spring 2023,SCLT,4375,31,13940,Global Supply Chain,Velarde,Jose Manuel,25,7,2,0,0,0,3,3.686
+Spring 2023,SCLT,4387,30,13941,Financial Evaluation For SCM,Reyes,Jorge,21,16,6,0,2,0,1,3.163
+Spring 2023,SCLT,4389,31,13942,Practicum in Supply Chain,Henson,Alfred Bernard,27,2,0,0,0,0,0,3.863
+Spring 2023,SCLT,6314,2,13943,Measurement and Evaluation,Bian,Zheyong,34,5,0,0,1,0,1,3.816
+Spring 2023,ACCT,2301,4,13944,Prin of Financial Accounting,Sykes,Mary Reeves,28,24,8,6,0,0,2,3.196
+Spring 2023,FINA,6387,1,13945,Managerial Analysis,Basu,Swati,17,2,0,0,0,0,1,3.843
+Spring 2023,ACCT,6331,3,13946,Financial Accounting,Li,Bin,5,2,0,0,0,0,0,3.667
+Spring 2023,MATH,2318,6,13947,Linear Algebra,Perepelitsa,Mikhail Antolyevic,18,12,5,3,6,0,9,2.75
+Spring 2023,MATH,3321,2,13948,Engineering Mathematics,West,James David,6,14,14,7,26,0,10,1.493
+Spring 2023,MARK,4362,1,13954,Applied Buyer Behavior,Noriega,Jaime L,30,16,4,0,0,0,0,3.421
+Spring 2023,ELET,4345,1,13956,App of Fuel Cell Technology,Bose,Anima B,0,2,0,0,0,0,0,3.0
+Spring 2023,MANA,6A25,2,13957,Ethical Leadrshp & Crit Reason,Celly,Nikhil,33,0,0,0,0,0,1,3.96
+Spring 2023,BTEC,3302,30,13958,Molecular Genetics and Biotech,Lin,Yuheng,20,10,2,2,1,0,0,3.286
+Spring 2023,CORE,1101,2,13960,College Success,Peterson,Christal Helena,10,3,0,0,0,0,0,3.769
+Spring 2023,BIOL,3301,2,13961,Mendelian and Pop Genetics,Lekven,Arne,35,51,42,9,9,0,8,2.619
+Spring 2023,PHYS,1304,1,13962,Solar System,Li,Liming,103,55,7,3,1,0,1,3.4
+Spring 2023,LAW,5328,1,13963,Judicial Externship I,Powers,William,0,0,0,0,0,4,0,
+Spring 2023,LAW,5378,4,13964,Statutory Interpretation & Rea,Hester,Tracy,27,43,3,0,0,0,0,3.36
+Spring 2023,LAW,7328,1,13966,WRC: Writing Criminal Defense,Maselli,Jani,6,5,1,0,0,0,0,3.389
+Spring 2023,LAW,5375,1,13967,Admin Estates & Guardianship,Akers,Georgia Lee Hinkle,5,8,2,0,0,0,0,3.266
+Spring 2023,MUSA,6141,1,13968,Graduate Recital II,Dorough,Aralee,0,0,0,0,0,0,0,
+Spring 2023,MUSA,6204,1,13971,Conducting,Krager,Franz A,5,0,0,0,0,0,0,4.0
+Spring 2023,THEA,1111,1,13972,Production,Davis,Lauren E,17,0,0,0,0,0,0,3.961
+Spring 2023,THEA,1111,2,13973,Production,Whittenton,Laura Lynn,26,1,0,0,1,0,0,3.786
+Spring 2023,THEA,1112,1,13974,Production,Vlahos,Kalliope,12,1,0,0,0,0,0,3.948
+Spring 2023,THEA,1340,1,13975,Fundamentals of Acting,Fretwell,Patrick Sexton,12,2,1,0,0,0,3,3.667
+Spring 2023,LAW,5376,1,13976,Colloquium,Hoffman,Lonny,2,2,0,0,0,11,0,3.418
+Spring 2023,THEA,2321,1,13977,Acting IV,Pistorius,Allison Marie,7,4,1,0,0,0,0,3.39
+Spring 2023,THEA,2350,1,13978,Movement for the Actor II,Bronfenbrenner,Skye,9,2,0,0,0,0,0,3.848
+Spring 2023,THEA,2380,1,13979,Voice for the Actor II,Johnson,James B,10,2,0,0,0,0,0,3.778
+Spring 2023,THEA,2382,1,13980,Stage Management I,Bush,Rachel R,10,4,0,0,0,0,0,3.667
+Spring 2023,THEA,3321,1,13981,Acting VI,Wetzel,Molly Elizabeth,9,2,2,0,0,0,0,3.437
+Spring 2023,THEA,3332,1,13982,Directing I,Watt,Sophia M,4,4,0,0,0,0,0,3.541
+Spring 2023,THEA,3333,1,13983,Directing II,Watt,Sophia M,13,0,0,0,0,0,0,4.0
+Spring 2023,THEA,3336,1,13984,History of the Theatre II,Shimko,Robert B,17,7,0,1,0,0,0,3.587
+Spring 2023,THEA,3364,1,13985,Costume History,Gist,Victoria Nicolette,6,3,5,0,1,0,0,2.889
+Spring 2023,THEA,3371,1,13986,"Hist of Arch, Int & Decor Arts",Willson,Paige A,7,0,1,1,0,0,1,3.481
+Spring 2023,THEA,3372,1,13987,Digital Design Techniques,Vintu,Tatiana,4,0,0,0,1,0,0,3.134
+Spring 2023,THEA,3385,1,13988,Scenic Design,Vintu,Tatiana,5,0,0,0,0,0,0,4.0
+Spring 2023,THEA,3393,1,13989,Applied Stage Management,Bush,Rachel R,2,0,0,0,0,0,0,4.0
+Spring 2023,THEA,4283,1,13990,Seminar in Stage Management,Bush,Rachel R,7,0,0,0,0,0,0,4.0
+Spring 2023,THEA,4321,1,13991,Acting VIII,Pistorius,Allison Marie,8,0,1,0,0,0,0,3.741
+Spring 2023,THEA,4350,1,13992,Movement for the Actor IV,Bronfenbrenner,Skye,10,3,0,0,0,0,0,3.769
+Spring 2023,THEA,4352,1,13993,Senior Project:Capstone,Damour,Lisa Jane,3,0,0,0,0,0,0,4.0
+Spring 2023,THEA,4380,1,13994,Voice for the Actor IV,Johnson,James B,9,5,0,0,0,0,0,3.454
+Spring 2023,THEA,4390,1,13995,Acting Showcase: Capstone,Pistorius,Allison Marie,9,0,0,0,0,0,0,3.927
+Spring 2023,THEA,4600,1,13996,Adv Thea Education Internship,Minor,Blake,5,0,0,0,0,0,0,3.868
+Spring 2023,THEA,6294,1,13998,Design and Production Studio,Willson,Paige A,2,0,0,0,0,0,0,4.0
+Spring 2023,THEA,6294,3,13999,Design and Production Studio,Niederer,Barbara,0,0,0,0,0,0,0,
+Spring 2023,LAW,5354,1,14000,Environmental Law Practicum,Hester,Tracy,6,4,0,0,0,1,0,3.501
+Spring 2023,LAW,5361,1,14001,Financial Statement Analysis,Brennan,Daniel,7,6,0,0,0,0,0,3.386
+Spring 2023,LAW,5203,1,14003,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,8,0,
+Spring 2023,LAW,5206,1,14004,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,2,0,
+Spring 2023,THEA,4313,1,14005,Advanced Playwriting,Damour,Lisa Jane,2,0,0,0,0,0,0,4.0
+Spring 2023,LAW,5392,1,14006,Int Business Trans,Foteh,Samir Jabra,2,3,0,0,0,0,0,3.4
+Spring 2023,LAW,5228,1,14007,Judicial Externship I,Powers,William,0,0,0,0,0,5,0,
+Spring 2023,LAW,5229,1,14008,Judicial Externship II,Powers,William,0,0,0,0,0,1,0,
+Spring 2023,THEA,7141,1,14009,Grad Direct/Design Collaboratn,Rigdon,Kevin L,5,0,0,0,0,0,0,4.0
+Spring 2023,THEA,7212,1,14010,Graduate Movement II,Noble,Adam S,6,1,0,0,0,0,0,3.716
+Spring 2023,THEA,7222,1,14012,Graduate Voice II,Johnson,James B,7,0,0,0,0,0,0,3.953
+Spring 2023,THEA,7252,1,14014,Graduate Speech II,Wetzel,Molly Elizabeth,5,2,0,0,0,0,0,3.62
+Spring 2023,THEA,7302,1,14016,Graduate Acting II,Young,John M,0,8,0,0,0,0,0,3.165
+Spring 2023,THEA,7304,1,14017,Graduate Acting IV,Young,John M,2,3,0,0,0,0,0,3.334
+Spring 2023,THEA,7305,1,14018,Acting Creative Project,Noble,Adam S,6,1,0,0,0,0,0,3.716
+Spring 2023,THEA,7314,1,14019,Graduate Movement IV,Noble,Adam S,5,2,0,0,0,0,0,3.526
+Spring 2023,THEA,7324,1,14020,Graduate Voice/Speech IV,Wetzel,Molly Elizabeth,2,3,0,0,0,0,0,3.466
+Spring 2023,THEA,7355,1,14021,Design Portfolio,Rigdon,Kevin L,3,0,0,0,0,0,0,4.0
+Spring 2023,ARLD,6300,1,14022,Fndmntals & Planning for Arts,Fernando,Fleurette S,9,3,0,0,0,0,0,3.64
+Spring 2023,ARLD,6691,1,14023,Internship in Arts Organizatn,Luks Jacobs,Joel,5,0,0,0,0,0,0,4.0
+Spring 2023,LAW,6321,1,14024,Professional Responsibility,Schwartz,Richard Austin,10,11,3,0,0,0,0,3.264
+Spring 2023,LAW,5320,1,14025,Pretrial Procedure,Schwartz,Charles W,16,12,4,1,0,16,0,3.333
+Spring 2023,ARTH,3303,1,14026,After Theory,Rubinstein,Raphael,0,1,1,0,0,0,0,2.83
+Spring 2023,ARTH,4383,1,14027,Contemporary Painting,Barrera,Debra,23,8,4,0,2,0,0,3.289
+Spring 2023,ARTH,6303,1,14028,After Theory,Rubinstein,Raphael,4,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,6331,1,14029,Contemporary Painting,Barrera,Debra,3,0,0,0,0,0,0,4.0
+Spring 2023,ECE,3331,2,14030,Program Appl in Elec Comp Engr,Sheth,Bhavin R,2,0,3,2,2,0,1,1.741
+Spring 2023,ECE,3355,3,14031,Electronics,Litvinov,Dmitri,0,3,5,5,1,0,0,1.691
+Spring 2023,ECE,3441,1,14032,Digital Logic Design,Ramachandran,Deepa,26,1,2,0,1,0,0,3.645
+Spring 2023,ECE,3337,3,14035,Signals and Systems Analysis,Reddy,Rohith Krishna,0,4,3,0,0,0,0,2.383
+Spring 2023,MUSA,6410,1,14036,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8241,1,14039,Doctoral Recital II,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6100,1,14042,Chamber Music,Yon,Kirsten A,9,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1176,1,14043,Applied Jazz Percussion,Hubley,Robert L,7,1,0,0,0,0,1,3.628
+Spring 2023,MUSA,1300,1,14044,Applied Voice,Averyt,Zachary Benjamin,2,0,0,0,0,0,0,3.835
+Spring 2023,MUSA,1300,2,14045,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1300,4,14047,Applied Voice,Jones,Timothy J,1,1,0,0,0,0,0,3.335
+Spring 2023,MUSA,1300,5,14048,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1320,1,14049,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,1320,2,14050,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1322,1,14051,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1326,1,14052,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1330,1,14053,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1334,1,14055,Applied Clarinet,Griffin,Randall S,2,0,1,0,0,0,0,3.333
+Spring 2023,MUSA,1336,1,14056,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1338,1,14057,Saxophone,Witt,Woodrow W,2,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,1340,2,14058,Applied Trumpet,Vassallo,Jim Cates,6,0,0,0,0,0,0,3.945
+Spring 2023,MUSA,1344,1,14060,Applied Trombone,Kauk,Brian Keith,2,0,1,0,0,0,0,3.223
+Spring 2023,MUSA,1346,1,14061,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1348,1,14062,Applied Euphonium,Freeman,Phillip I,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1350,1,14063,Applied Percussion,Warren,Paul Alexander,2,4,0,0,0,0,0,3.388
+Spring 2023,MUSA,2202,1,14064,Applied Composition,Maroney,Marcus K,0,2,0,0,0,0,0,2.835
+Spring 2023,MUSA,2202,2,14065,Applied Composition,Smith,Robert Thomas,3,1,0,0,0,0,1,3.668
+Spring 2023,MUSA,2300,1,14066,Applied Voice,Clayton Vasquez,Cynthia L,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2300,3,14068,Applied Voice,Jones,Timothy J,4,0,0,0,0,0,0,3.918
+Spring 2023,MUSA,2300,6,14070,Applied Voice,Averyt,Zachary Benjamin,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2310,2,14072,Applied Piano,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2320,1,14073,Applied Violin,Lo,Mann-Wen,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2322,1,14074,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2330,1,14075,Applied Flute,Russell,Peggy,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2336,1,14077,Applied Bassoon,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2338,1,14078,Applied Saxophone,Witt,Woodrow W,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2344,1,14080,Applied Trombone,Kauk,Brian Keith,5,1,0,0,0,0,0,3.778
+Spring 2023,MUSA,2348,1,14081,Applied Euphonium,Freeman,Phillip I,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3400,1,14082,Applied Voice,Averyt,Zachary Benjamin,1,1,0,0,0,0,0,3.5
+Spring 2023,MUSA,3400,2,14083,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3400,3,14084,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,3.89
+Spring 2023,MUSA,3420,1,14086,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3420,2,14087,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3430,1,14089,Applied Flute,Dorough,Aralee,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3434,1,14090,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3436,1,14091,Applied Bassoon,Wagner,Elise L,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3438,1,14092,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3444,1,14093,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3446,1,14094,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3448,1,14095,Applied Euphonium,Freeman,Phillip I,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4400,1,14096,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4410,1,14099,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4420,2,14100,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,4430,2,14101,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4434,1,14102,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4438,1,14103,Applied Saxophone,Witt,Woodrow W,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4440,1,14104,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4442,1,14105,Applied French Horn,Johnson,Robert,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4444,1,14106,Applied Trombone,Kauk,Brian Keith,1,0,0,0,0,0,1,4.0
+Spring 2023,MUSA,4446,1,14107,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4448,1,14108,Applied Euphonium,Freeman,Phillip I,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4450,1,14109,Applied Percussion,Wilkins,Blake M,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6104,1,14110,New Music Ensemble,Smith,Robert Thomas,7,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6300,1,14111,Intro Res Method in Musicology,Caton,Kathryn L.,6,2,1,0,0,0,0,3.519
+Spring 2023,MUSI,6300,2,14112,Intro Res Method in Musicology,Dirst,Matthew C,2,1,0,0,1,0,1,2.668
+Spring 2023,MUSI,8300,1,14113,Doct Research Seminar,Lange,Barbara Rose,3,1,0,0,0,0,0,3.668
+Spring 2023,MUSI,8351,1,14114,Classic Rom.Perform. Practice,Bertagnolli,Paul A,1,5,0,0,0,0,0,3.112
+Spring 2023,MUED,3320,1,14115,Intro To Education in Music,McGinnis,Emily Jane,7,4,1,0,1,0,0,3.256
+Spring 2023,MUED,4305,1,14117,General Music/Elem & Sec Schls,Derges,Julie D,17,7,1,0,0,0,0,3.561
+Spring 2023,MUSI,1102,2,14119,Wind Ensemble,Bertman,David Garry,52,1,0,0,0,0,0,3.981
+Spring 2023,MUSI,1102,3,14120,Wind Ensemble,Bertman,David Garry,29,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,1103,1,14121,Cougar Brass,Kubos,Cameron Kade,41,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,1110,1,14122,Jazz Orchestra,Marmolejo,Noe J,24,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,1121,1,14126,Concert Chorus,Mueller,Jebediah Lee,25,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,1140,1,14127,Orchestra,Krager,Franz A,50,0,0,0,0,0,2,3.934
+Spring 2023,MUSI,1182,1,14129,Group Piano II,Van Kekerix,Todd Evan,10,3,1,0,0,0,0,3.36
+Spring 2023,MUSI,1182,2,14130,Group Piano II,Van Kekerix,Todd Evan,9,3,2,0,1,0,0,3.179
+Spring 2023,MUSI,1182,3,14131,Group Piano II,Van Kekerix,Todd Evan,8,5,1,0,0,0,0,3.359
+Spring 2023,MUSI,1116,1,14132,Aural Skills I,Estrada Valadez,Eric,16,7,1,0,1,0,3,3.401
+Spring 2023,MUSI,1117,1,14133,Aural Skills II,Lee,Ji Yeon,7,4,4,1,0,0,0,3.021
+Spring 2023,MUSI,1117,2,14134,Aural Skills II,Lee,Ji Yeon,5,11,3,0,1,0,0,2.934
+Spring 2023,MUSI,1117,3,14135,Aural Skills II,Lee,Ji Yeon,5,9,3,0,1,0,0,2.963
+Spring 2023,MUSI,1311,1,14136,Music Theory I,Estrada Valadez,Eric,15,5,3,0,1,0,3,3.43
+Spring 2023,MUSI,1312,1,14137,Music Theory II,Lee,Ji Yeon,9,2,5,0,1,0,0,3.059
+Spring 2023,MUSI,1312,2,14138,Music Theory II,Lee,Ji Yeon,14,4,1,0,0,0,0,3.632
+Spring 2023,MUSI,1312,3,14139,Music Theory II,Lee,Ji Yeon,7,10,1,0,0,0,0,3.333
+Spring 2023,MUSI,2182,1,14140,Group Piano IV,Van Kekerix,Todd Evan,5,5,3,0,1,0,0,2.834
+Spring 2023,MUSI,2182,3,14142,Group Piano IV,Van Kekerix,Todd Evan,3,6,3,0,2,0,0,2.619
+Spring 2023,MUSI,2182,4,14143,Group Piano IV,Van Kekerix,Todd Evan,5,8,2,0,1,0,0,2.897
+Spring 2023,MUSI,2117,1,14144,Aural Skills IV,Guez,Jonathan Charles,16,7,1,0,0,0,3,3.57
+Spring 2023,MUSI,2117,3,14146,Aural Skills IV,Guez,Jonathan Charles,8,7,1,0,2,0,1,3.056
+Spring 2023,MUSI,2117,4,14147,Aural Skills IV,Guez,Jonathan Charles,14,7,1,0,0,0,1,3.531
+Spring 2023,MUSI,2214,1,14148,Techniques of Music Since 1900,Guez,Jonathan Charles,14,10,1,2,0,0,1,3.309
+Spring 2023,MUSI,2214,3,14150,Techniques of Music Since 1900,Guez,Jonathan Charles,10,7,1,1,0,0,2,3.351
+Spring 2023,MUSI,2214,4,14151,Techniques of Music Since 1900,Guez,Jonathan Charles,13,6,1,0,0,0,0,3.534
+Spring 2023,MUSI,2302,1,14152,Listening to Jazz,Hubley,Robert L,18,32,20,7,9,0,7,2.473
+Spring 2023,MUSI,2362,1,14153,History of Music I,Dirst,Matthew C,10,16,22,2,4,0,8,2.408
+Spring 2023,MUSI,3216,1,14154,Analysis,Garza,Paul Victor,15,1,1,0,1,0,1,3.593
+Spring 2023,MUSI,1307,1,14155,Listening to Classical Music,Diehl,Alaina B,29,3,1,2,0,0,3,3.695
+Spring 2023,MUSI,1307,2,14156,Listening to Classical Music,Diehl,Alaina B,31,3,0,0,0,0,2,3.921
+Spring 2023,MUSI,3301,1,14157,Listening To World Music,Diehl,Alaina B,25,6,1,0,1,0,2,3.586
+Spring 2023,MUSI,3303,1,14158,Pop Music of Americas Sn 1840,Garza,Paul Victor,26,7,1,1,0,0,1,3.676
+Spring 2023,MUSI,3364,1,14159,History of Music III,Caton,Kathryn L.,22,22,8,1,0,0,1,3.127
+Spring 2023,MUSI,4120,1,14160,Percussion Ensemble,Wilkins,Blake M,7,0,0,0,0,0,1,4.0
+Spring 2023,MUSI,4120,2,14161,Percussion Ensemble,Warren,Paul Alexander,10,1,0,0,0,0,0,3.939
+Spring 2023,MUSI,6106,1,14162,Grad Large Ensemble,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6106,2,14163,Grad Large Ensemble,Marmolejo,Noe J,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6106,3,14164,Grad Large Ensemble,Krager,Franz A,25,0,0,0,0,0,0,3.921
+Spring 2023,MUSI,6112,1,14165,Chamber Music - Woodwind,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6114,1,14166,Chamber Music - Brass,Bertman,David Garry,6,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6330,1,14167,Adv Instrumental Conducting,Krager,Franz A,5,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,8106,2,14168,Doctoral Large Ensemble,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,8106,3,14169,Doctoral Large Ensemble,Krager,Franz A,14,0,0,0,0,0,0,3.906
+Spring 2023,MUSI,1102,1,14170,Wind Ensemble,Bertman,David Garry,46,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,3333,1,14171,Issues in Contemporary Design,Orto,Luisa,15,6,0,0,0,0,0,3.699
+Spring 2023,ARTH,6333,1,14172,Issues in Contemporary Design,Orto,Luisa,4,1,0,0,0,0,0,3.8
+Spring 2023,CUIN,4351,1,14173,Develop Proportional Reasoning,Gallagher,Melissa Ann,9,4,0,0,0,0,0,3.616
+Spring 2023,LAW,5199,2,14176,Special Problems,Vetter,Greg R,0,0,0,0,0,17,0,
+Spring 2023,LAW,5199,3,14177,Special Problems,Alderman,Richard M,0,0,0,0,0,4,0,
+Spring 2023,LAW,5299,2,14181,Special Problems,Vetter,Greg R,0,0,0,0,0,25,0,
+Spring 2023,LAW,5299,3,14182,Special Problems,Alderman,Richard M,0,0,0,0,0,2,0,
+Spring 2023,COMM,1307,4,14185,Media and Society,Lyn,Robyn,84,7,1,1,3,0,1,3.76
+Spring 2023,RELS,2360,1,14187,Introduction to Buddhism,Huynh,Trung,18,7,3,2,1,0,2,3.215
+Spring 2023,RELS,3355,1,14188,Yoga and Philosophy,Jones,Naamleela Free,12,3,1,0,4,0,4,2.95
+Spring 2023,HLT,4307,3,14189,Research and Eval in Health,Fedor Amador,Theresa Marie,18,13,2,1,2,0,1,3.213
+Spring 2023,WGSS,2360,2,14190,Introduction to LGBT Studies,Pegoda,Andrew Joseph,6,9,7,1,2,0,4,2.6
+Spring 2023,MECT,4345,1,14192,Applications of Fuel Cell,Bose,Anima B,10,19,5,0,0,0,2,3.118
+Spring 2023,NURS,3631,1,14193,Nur Process Symptom Mgmt,Quintana,Danielle,2,59,0,0,0,0,12,3.033
+Spring 2023,NURS,3633,1,14194,Clinical Nursing Practice I,Quintana,Danielle,56,5,0,0,0,0,12,3.918
+Spring 2023,NURS,3247,1,14195,Pharm for Collbrtv Nurs Prac,Anderson,Viia,6,56,0,2,0,0,7,3.031
+Spring 2023,EDUC,4322,1,14198,Student Teaching:Theater Elem,Chuter,Frank Philip,3,2,0,0,0,0,0,3.6
+Spring 2023,EDUC,4323,1,14199,Student Teaching: Theater Sec,Chuter,Frank Philip,3,2,0,0,0,0,0,3.6
+Spring 2023,TEPM,6391,1,14201,Project Management Seminar,Carden,Lila L,8,1,0,0,0,0,0,3.889
+Spring 2023,IDNS,1111,1,14202,Physics 1321 Workshop,Pattison,Donna,24,10,8,0,0,0,4,3.35
+Spring 2023,IDNS,1111,2,14203,Physics 1321 Workshop,Pattison,Donna,16,4,0,0,0,0,0,3.668
+Spring 2023,IDNS,1112,1,14204,Physics 1322 Workshop,Pattison,Donna,16,8,0,0,0,0,0,3.667
+Spring 2023,SCLT,3376,30,14206,Global Trade Intermediaries,Crockett,Brianne,16,6,2,0,1,0,0,3.321
+Spring 2023,MUSI,2188,1,14207,Keybd Skills & Collab Technqs,Hester,Timothy E,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,3216,2,14209,Analysis,Lee,Ji Yeon,7,0,0,0,0,0,1,4.0
+Spring 2023,MUSI,3303,2,14210,Pop Music of Americas Sn 1840,Garza,Paul Victor,26,1,5,1,1,0,1,3.49
+Spring 2023,MUSI,4102,1,14211,Acting for Opera,Edelson,Lawrence Michael,10,0,0,0,0,0,0,3.934
+Spring 2023,MUSI,4250,1,14212,Performance Pedagogy,Evans,Joseph,4,10,1,0,0,0,1,3.288
+Spring 2023,MUSI,6351,1,14213,Applied Music Pedagogy,Sonnenberg,Melanie,5,0,0,0,0,0,1,4.0
+Spring 2023,PSYC,3350,4,14218,Intro to Cognitive Psychology,Santacroce,Lindsay,30,28,10,4,10,0,2,2.772
+Spring 2023,ENTR,4110,2,14221,Entrepren Values & Leadership,Cook,David B,20,8,0,0,0,0,0,3.655
+Spring 2023,MUSA,1342,2,14222,Applied French Horn,Reed,Gavin Davis,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3440,1,14223,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Spring 2023,MSCI,1220,4,14224,Agile & Adaptive Leadership,Comiskey,Melissa C,5,0,0,0,0,0,1,3.736
+Spring 2023,HON,3399,2,14227,Senior Honors Thesis,Morrison,Iain P D,0,0,0,0,0,0,0,
+Spring 2023,HON,4399,2,14228,Senior Honors Thesis,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,
+Spring 2023,PSYC,2306,1,14229,Psychology of Human Sexuality,Keo-Meier,Colton Lawrence,26,29,8,6,6,0,4,2.831
+Spring 2023,PSYC,2317,6,14231,Intro to Psychology Statistics,Saiyed,Amna Shabbir,54,7,1,2,1,0,0,3.647
+Spring 2023,MUSA,3434,2,14234,Applied Clarinet,Griffin,Randall S,2,0,0,0,0,0,0,4.0
+Spring 2023,ENTR,4110,1,14236,Entrepren Values & Leadership,Cook,David B,21,8,1,0,0,0,0,3.645
+Spring 2023,MUSI,6261,1,14237,Intern in Piano Teaching II,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8699,2,14239,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,2,0,
+Spring 2023,PHLS,8999,1,14240,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,
+Spring 2023,CHEM,2123,18,14246,Organic Chemistry Lab I,Bean,Mary B,4,12,6,0,0,0,2,2.864
+Spring 2023,PSYC,4399,1,14248,Senior Honors Thesis,Reyes,Denise Lucia,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,3399,1,14249,Senior Honors Thesis,Miciak,Jeremy Richard,0,0,0,0,0,0,0,
+Spring 2023,THEA,4323,1,14250,Dramaturgy,Shimko,Robert B,3,1,0,0,0,0,1,3.668
+Spring 2023,THEA,6323,1,14251,Dramaturgy for 21st Century,Shimko,Robert B,13,2,0,0,0,0,0,3.889
+Spring 2023,ENGL,2315,1,14252,Literature and Film,English,Joshua,23,2,3,0,1,0,1,3.552
+Spring 2023,MUSA,1300,7,14253,Applied Voice,Ceres,Emily Margaret,2,0,0,0,0,0,0,3.835
+Spring 2023,ENGL,8699,3,14255,Doctoral Dissertation,Tejada,Roberto Jose,1,0,0,0,0,1,0,4.0
+Spring 2023,FINA,4380,1,14256,R E Fin & Investment,Picazo,Cindy Lee,13,16,6,0,0,0,0,3.209
+Spring 2023,ENGL,8699,4,14257,Doctoral Dissertation,Harris,Francine Julia,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8699,5,14258,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6399,1,14259,Masters Thesis,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,8999,2,14260,Dissertation,Robbins,Susan P,0,0,0,0,0,2,0,
+Spring 2023,HDCS,4369,2,14261,Entrepreneurship,Kellough,James David,33,10,2,1,2,0,2,3.41
+Spring 2023,MUSI,6101,1,14264,Opera Role Performance,Edelson,Lawrence Michael,18,0,0,0,1,0,0,3.789
+Spring 2023,ENGL,8699,6,14266,Doctoral Dissertation,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6604,7,14267,Architecture Design Studio IV,Martinez,Marcus E,8,1,0,0,0,0,0,3.816
+Spring 2023,PSYC,6398,1,14272,Independent Studies,Spitzmuller,Christiane,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6352,1,14273,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,3,0,
+Spring 2023,ENGL,8699,7,14274,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,1,0,
+Spring 2023,MUSA,4402,2,14275,Applied Composition,Maroney,Marcus K,3,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6393,3,14277,Clinical Research Practicum,Viana,Andres G,2,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8699,8,14278,Doctoral Dissertation,Parsons,Alexander M,0,0,0,0,0,1,0,
+Spring 2023,PHOP,7399,5,14279,Masters Thesis,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,7399,6,14280,Masters Thesis,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,1,14294,Spec Prob-Physio Optics,O'Brien,John,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6399,3,14305,Masters Thesis,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8699,9,14306,Doctoral Dissertation,Turchi,Peter D,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8999,16,14309,Doctoral Dissertation,Marinov,Nikolay,0,0,0,0,0,2,0,
+Spring 2023,HLT,3380,1,14311,Culture and Health,Fedor Amador,Theresa Marie,43,13,3,1,0,0,0,3.573
+Spring 2023,MATH,8398,22,14312,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8191,1,14317,Special Field Projects,Shockley,Gerald,11,0,0,0,1,0,0,3.667
+Spring 2023,CHEE,8399,17,14320,Doctoral Dissertation,Vekilov,Peter,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,4374,3,14323,Info Technology Project Mgmt,Scott,Carl P,34,7,0,0,0,0,0,3.757
+Spring 2023,CHEE,8399,18,14324,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,1351,2,14325,Intro to Geometric Reasoning,Hong,Yuqi,10,24,58,14,30,0,34,1.687
+Spring 2023,PSYC,6399,4,14326,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2023,PSYC,7390,1,14327,Clin Neuropsychology Practicum,Woods,Steven Paul,0,0,0,0,0,9,0,
+Spring 2023,PSYC,7399,3,14328,Masters Thesis,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,1303,1,14329,Fundamentals of Music,Ash,Stephen,16,6,2,1,0,0,0,3.44
+Spring 2023,MARK,4389,6,14332,Marketing Strategy & Planning,Muschalik,Monica Harper,15,11,1,1,0,0,1,3.37
+Spring 2023,PSYC,6398,2,14333,Independent Studies,Bick,Johanna R,0,0,0,0,0,2,0,
+Spring 2023,PSYC,6398,3,14334,Independent Studies,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6398,4,14338,Independent Studies,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6398,5,14341,Independent Studies,Yoshida,Hanako,0,0,0,0,0,2,0,
+Spring 2023,THEA,6294,4,14342,Design and Production Studio,Rigdon,Kevin L,3,0,0,0,0,0,0,4.0
+Spring 2023,TMTH,3360,1,14343,Applied Technical Statistics,Dick,Deanna L,3,8,11,6,5,0,3,1.799
+Spring 2023,INDS,4380,1,14344,Design Internship,Kimbrough,Mark S,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7392,1,14345,Psychology Practicum,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6352,2,14349,Directed Rsch in I/O Psyc,Ng,Vincent,0,0,0,0,0,4,0,
+Spring 2023,HIST,8388,2,14351,Dissertation Proposal,Takriti,Abdel Razzaq,2,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,7181,1,14353,Sem in Phrm Hlth Outcomes &Pol,Chen,Hua,15,1,0,0,0,0,0,3.938
+Spring 2023,PSYC,7399,4,14355,Masters Thesis,Leasure,Jennifer Leigh,1,0,0,0,0,2,0,4.0
+Spring 2023,MECE,3338,1,14359,Dynamic & Control of Mech Syst,Hammami,Farah,16,24,36,8,5,0,4,2.379
+Spring 2023,PSYC,6352,3,14360,Directed Rsch in I/O Psyc,Spitzmuller,Christiane,1,0,0,0,0,0,0,4.0
+Spring 2023,EGRP,1141,1,14362,Engineering Applications IV,Luna Singh,Jennifer Austin,0,0,0,0,0,17,2,
+Spring 2023,BIOE,8699,9,14363,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2023,POLS,8999,17,14365,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8399,4,14366,Doctoral Dissertation,Sharp,Carla,3,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,6399,10,14368,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8298,19,14371,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8298,20,14372,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,3,0,
+Spring 2023,BIOE,8398,19,14373,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8398,20,14374,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,3,0,
+Spring 2023,BIOE,8398,23,14377,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8598,19,14378,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,4,0,
+Spring 2023,BIOE,8598,20,14379,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8598,22,14381,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8399,8,14382,Doctoral Dissertation,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8399,9,14383,Doctoral Dissertation,Das,Mini,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8399,12,14386,Doctoral Dissertation,Al-Ubaidi,Muayyad,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8699,11,14388,Doctoral Dissertation,Majd,Sheereen,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8699,13,14390,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8699,14,14391,Doctoral Dissertation,Romero Ortega,Mario Ignacio,0,0,0,0,0,3,0,
+Spring 2023,BIOE,8699,15,14392,Doctoral Dissertation,Shevkoplyas,Sergey,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8699,16,14393,Doctoral Dissertation,Wu,Tianfu,1,0,0,0,0,2,0,4.0
+Spring 2023,BIOE,8699,20,14397,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,3350,1,14399,Am Lit To 1865,Snediker,Michael,10,9,6,0,0,0,0,3.147
+Spring 2023,ECE,5367,1,14400,Intro To Computer Arch & Dsgn,Baker,Abu M,68,11,1,0,0,0,0,3.825
+Spring 2023,BTEC,1322,1,14401,Introduction to Biotechnology,Hosseinzadeh,Hemen,11,18,9,9,3,0,3,2.427
+Spring 2023,BTEC,3320,30,14402,Intro to QA/QC in BTEC,Parikh,Tina,3,10,8,1,0,0,2,2.592
+Spring 2023,PHYS,4396,4,14403,Senior Research Project,Ratti,Claudia,1,0,0,0,0,0,0,4.0
+Spring 2023,PCEU,6498,5,14404,Special Problems,Tam,Vincent H,0,0,0,0,0,1,0,
+Spring 2023,PSYC,7399,6,14406,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,3,0,
+Spring 2023,BIOL,2102,21,14407,Anatomy & Physiology II (lab),Gill,Tejendra,7,12,2,2,0,0,1,3.058
+Spring 2023,BIOL,2102,22,14408,Anatomy & Physiology II (lab),Gill,Tejendra,5,11,5,2,0,0,0,2.883
+Spring 2023,PSYC,7399,7,14409,Masters Thesis,Derrick,Jaye L,0,0,0,0,0,1,0,
+Spring 2023,PSYC,2308,1,14412,Child Development,Yoshida,Hanako,28,23,6,2,6,0,3,3.0
+Spring 2023,CHEM,1312,4,14413,Fundamentals of Chemistry 2,Chen,Tai-Yen,90,67,52,20,23,0,30,2.696
+Spring 2023,MATH,8698,15,14414,Doctoral Research,Labate,Demetrio,0,0,0,0,0,9,0,
+Spring 2023,COMM,4384,1,14416,Strategic Comm Applications,Vardeman,Jennifer E,21,0,0,0,0,0,0,3.969
+Spring 2023,SPAN,2312,6,14419,Intermediate Spanish II,Martinez,Carlos David,5,13,4,0,0,0,0,3.045
+Spring 2023,COMD,2338,1,14420,Phonetics,Townsend,Alayna,18,11,1,0,0,0,0,3.6
+Spring 2023,PSYC,6398,6,14421,Independent Studies,Burling,Joseph Michael,0,4,0,0,0,0,0,2.67
+Spring 2023,PSYC,7399,8,14423,Masters Thesis,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,
+Spring 2023,PSYC,4399,3,14424,Senior Honors Thesis,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Spring 2023,HLT,1353,2,14425,Personal Health,Rafique,Kiran Sajid,85,19,5,1,5,0,3,3.502
+Spring 2023,ECON,8399,1,14427,Doctoral Dissertation,Yi,Kei-Mu,1,0,0,0,0,4,0,4.0
+Spring 2023,PSYC,6398,8,14430,Independent Studies,Hernandez,Arturo E,2,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8298,21,14431,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8399,7,14432,Doctoral Dissertation,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,6368,1,14435,Mechanical Design Proj,Sharma,Pradeep,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6398,9,14436,Independent Studies,Kosten,Therese A,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6398,11,14438,Independent Studies,Ng,Vincent,0,0,0,0,0,1,0,
+Spring 2023,MATH,8698,17,14445,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Spring 2023,MATH,8398,24,14446,Doctoral Research,Ru,Min,0,0,0,0,0,2,0,
+Spring 2023,PSYC,6398,12,14448,Independent Studies,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Spring 2023,ECON,3334,4,14451,Intermediate Macroeconomics,Jiu,Haibin Brett,10,27,3,2,5,0,3,2.703
+Spring 2023,LAW,5309,1,14453,Advanced Trial Advocacy,Draper,Genesis Elaine,2,4,0,0,0,7,0,3.333
+Spring 2023,LAW,5311,1,14454,Product Liability,Sanders,Joseph,6,13,0,0,0,12,0,3.403
+Spring 2023,LAW,7307,1,14455,WRS: Advanced Topics in IP,Janicke,Paul,3,5,0,0,0,0,0,3.375
+Spring 2023,ARCH,2501,13,14460,Architecture Design Studio IV,Lee,Seo Hee,3,2,1,0,0,0,2,3.223
+Spring 2023,ARCH,2501,17,14462,Architecture Design Studio IV,Sen,Ozan,14,1,1,0,0,0,0,3.792
+Spring 2023,ARCH,3501,3,14464,Architecture Design Studio VI,Truitt,William C,11,3,0,0,1,0,0,3.467
+Spring 2023,ARCH,6601,1,14466,Architecture Design Studio II,Peters,Patrick A,7,4,0,0,0,0,0,3.606
+Spring 2023,GEOL,1102,1,14468,Intro to Climate Change Lab,Wang,Yuxuan,4,1,2,0,1,0,0,2.875
+Spring 2023,BCHS,3304,4,14469,General Biochemistry I,Wang,Yuhong,103,38,8,0,0,0,1,3.7
+Spring 2023,BIOL,7124,1,14470,Cell Biology Seminar,Feng,Qin,0,0,0,0,0,8,0,
+Spring 2023,MATH,1314,1,14472,College Algebra,Caputo,Matthew G,33,30,56,17,25,0,35,2.125
+Spring 2023,MATH,3336,4,14473,Discrete Mathematics,Winkle,James J,52,50,32,16,0,0,10,2.92
+Spring 2023,MATH,3339,5,14474,Statistics for the Sciences,Wang,Wenshuang,137,53,18,10,4,0,12,3.359
+Spring 2023,PSYC,4344,4,14475,Cultural Psychology,Haddad,Sana,35,9,14,7,4,0,2,2.894
+Spring 2023,PSYC,4344,5,14476,Cultural Psychology,Brooks,Jasmin R,32,25,10,4,8,0,0,2.944
+Spring 2023,PSYC,2319,3,14478,Intro to Social Psychology,Shepherd,Justin M,33,6,0,0,1,0,0,3.734
+Spring 2023,PSYC,2317,3,14479,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,36,19,14,1,1,0,7,3.239
+Spring 2023,PSYC,2317,7,14480,Intro to Psychology Statistics,Alonso,Nicole,30,17,9,2,4,0,5,3.043
+Spring 2023,PSYC,3339,2,14485,Intro To Clinical Psychology,Szafranski,Derek D,65,9,4,2,0,0,0,3.663
+Spring 2023,PSYC,2330,3,14486,Biological Psychology,Leonard,Samuel J,40,30,8,1,1,0,0,3.416
+Spring 2023,PSYC,2330,6,14487,Biological Psychology,Bodet III,Jean Philippe,36,17,13,8,4,0,1,2.978
+Spring 2023,MATH,2413,1,14489,Calculus I,Constante,Beatrice,136,90,98,30,46,0,40,2.541
+Spring 2023,MATH,2413,11,14495,Calculus I,Perepelitsa,Irina,168,128,86,26,36,0,42,2.766
+Spring 2023,MATH,2413,41,14497,Calculus I,Douglas,Casey,68,66,72,26,66,0,98,2.103
+Spring 2023,MATH,2414,1,14499,Calculus II,May,Jennifer Ruhnow,81,52,55,27,25,0,35,2.528
+Spring 2023,MATH,2414,11,14504,Calculus II,Xhabli,Blerina,115,43,46,25,20,0,42,2.815
+Spring 2023,MATH,2414,21,14507,Calculus II,Xhabli,Blerina,151,66,35,13,14,0,18,3.168
+Spring 2023,MATH,2414,31,14513,Calculus II,West,James David,19,15,24,16,30,0,33,1.769
+Spring 2023,MATH,2415,21,14518,Calculus III,West,James David,16,18,20,11,19,0,24,1.992
+Spring 2023,MATH,2413,31,14521,Calculus I,Sosa,Moses,80,70,66,40,62,0,44,2.141
+Spring 2023,MATH,2413,61,14523,Calculus I,Perepelitsa,Irina,34,24,10,14,20,0,16,2.36
+Spring 2023,MATH,2414,61,14525,Calculus II,West,James David,7,5,5,1,9,0,9,2.012
+Spring 2023,PSYC,2319,4,14536,Intro to Social Psychology,Osika,Matylda Maria,15,35,9,2,4,0,2,2.811
+Spring 2023,PSYC,2305,8,14537,Intro to Methods in Psychology,Wang,Carol,33,13,6,2,2,0,4,3.256
+Spring 2023,PSYC,7307,1,14540,Applied PSYC Measurement,Steinberg,Lynne,4,1,0,0,0,0,0,3.602
+Spring 2023,PSYC,2301,6,14541,Introduction to Psychology,Maynard,Mark Eugene,21,14,12,0,1,0,1,3.18
+Spring 2023,WCL,3372,1,14542,Indian Film:Bollywood & Beyond,Tiwari,Bhavya,3,3,0,1,1,0,0,2.791
+Spring 2023,HON,3301,2,14544,Readings in Medicine & Society,Brown,Erika J,13,2,1,0,0,0,2,3.75
+Spring 2023,POLS,3309,1,14545,Democratization,Kennedy,Ryan P,25,13,5,0,0,0,2,3.381
+Spring 2023,POLS,3322,1,14546,Intro Latin-Am Politics,Aleman,Eduardo,16,17,3,0,1,0,0,3.244
+Spring 2023,PSYC,3350,5,14547,Intro to Cognitive Psychology,Yoshida,Hanako,17,18,5,10,0,0,1,2.853
+Spring 2023,INDS,7301,3,14549,Design Thesis II,Chow,George K,2,0,0,0,0,0,0,4.0
+Spring 2023,MANA,4347,1,14551,Ethics and Corp Soc Respon.,Salaiz,Ashley,39,13,3,3,2,0,0,3.362
+Spring 2023,MANA,4385,1,14552,Intro to Strategic Management,Tabesh,Pooya,30,10,1,2,0,0,2,3.589
+Spring 2023,CHEM,3333,1,14555,Inorganic Chemistry I,Zastrow,Melissa L,13,24,7,0,2,0,1,2.907
+Spring 2023,HDCS,1300,5,14556,Human Ecosystems & Tech Change,Ramirez,Stefanie Ann,26,4,3,3,6,0,5,2.921
+Spring 2023,BIOL,2121,12,14557,Microbiology for Science Major,Knapp,Richard D,7,5,3,0,0,0,1,3.311
+Spring 2023,BIOL,1107,45,14558,Biology for Science Majors II,Medrano,Ana I,15,0,2,1,0,0,0,3.593
+Spring 2023,BIOL,1107,46,14559,Biology for Science Majors II,Medrano,Ana I,13,5,2,2,0,0,0,3.228
+Spring 2023,BIOL,1107,47,14560,Biology for Science Majors II,Medrano,Ana I,14,5,0,2,1,0,1,3.318
+Spring 2023,BIOL,1107,48,14561,Biology for Science Majors II,Medrano,Ana I,8,7,3,1,2,0,2,2.81
+Spring 2023,CUIN,8690,1,14563,Doctoral Thesis,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Spring 2023,HDCS,4380,1,14564,Merchandising,Jacobs,Karen S,8,11,9,5,5,0,1,2.238
+Spring 2023,TEPM,6305,2,14567,Project Manager Tools,Sherman,Dennis Louis,10,0,0,0,0,0,0,3.967
+Spring 2023,POLS,3315,1,14568,International Organization,Sisman,Ozlem,5,20,8,1,5,0,5,2.428
+Spring 2023,FINA,4328,1,14569,Principles of Personal Finance,Coleman,Alfred G,25,11,12,2,3,0,0,2.994
+Spring 2023,PHLS,8322,2,14570,Intermed Stats in Psy/Educ Res,Wiesner,Margit F,11,4,0,0,0,0,0,3.667
+Spring 2023,FINA,6A35,1,14571,Managerial Finance,Povel,Paul,17,11,1,0,1,0,4,3.389
+Spring 2023,HRD,6301,1,14572,Leadership Development in HRD,Edwards,Malaika,13,4,0,1,0,0,0,3.629
+Spring 2023,ENTR,3310,5,14573,Entrepreneurship,Ortega,Carlos Alberto,152,19,16,2,4,0,4,3.579
+Spring 2023,ENTR,3312,5,14574,Corporate Entrepreneurship,Karonika,John R,28,14,2,1,0,0,2,3.423
+Spring 2023,MARK,4389,2,14575,Marketing Strategy & Planning,Lish,Alan D,29,8,2,0,0,0,0,3.625
+Spring 2023,MARK,4389,5,14576,Marketing Strategy & Planning,Suki,Yara D,16,13,2,0,1,0,0,3.323
+Spring 2023,COMM,3304,1,14579,Multicultural Health Comm,Xiao,Zhiwen,24,5,0,0,0,0,0,3.737
+Spring 2023,PHLS,8393,1,14580,Doctoral Practicum in Psy,Fein,Rachel,0,0,0,0,0,11,0,
+Spring 2023,PHLS,8393,2,14581,Doctoral Practicum in Psy,Smith,Nathan G,0,0,0,0,0,14,0,
+Spring 2023,PHLS,8393,3,14582,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,5,0,
+Spring 2023,SCLT,3381,31,14583,Industrial and Consumer Sales,Cassler,Daniel,31,2,0,0,0,0,0,3.919
+Spring 2023,COSC,2425,1,14584,Computer Org & Architecture,Long,Kevin B,46,13,9,0,5,0,2,3.297
+Spring 2023,COMM,4392,1,14586,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,25,0,
+Spring 2023,COSC,3380,2,14588,Database Systems,Ramamurthy,Uma,21,28,12,2,4,0,6,2.836
+Spring 2023,FINA,4381,1,14589,Essentials of Real Estate,Madison,Necitha,14,11,1,0,0,0,0,3.36
+Spring 2023,DIGM,1350,31,14591,Graphics for Digital Media,Beyl,Charles Eugene,17,8,5,0,0,0,2,3.378
+Spring 2023,DIGM,3353,34,14592,Visual Communications Tech,Dozier,Devin K,27,10,4,2,1,0,0,3.334
+Spring 2023,COMM,3360,4,14596,Principles of Strategic Comm,Thorp,Charles Arthur,28,1,0,0,1,0,1,3.734
+Spring 2023,SCLT,3389,30,14598,Transportation Law,Henson,Alfred Bernard,44,19,4,0,0,0,0,3.538
+Spring 2023,KIN,3309,4,14600,Biomechanics,Arellano,Christopher,17,60,21,0,0,0,2,2.946
+Spring 2023,COSC,2436,5,14602,Programming and Data Structure,Rizk,Nouhad J,24,17,17,4,10,0,36,2.56
+Spring 2023,COSC,1437,1,14604,Introduction to Programming,Biediger,Daniel Edward,72,15,8,1,4,0,23,3.474
+Spring 2023,POLS,3311,3,14605,Intro Compar Politics,Cantu,Francisco,5,2,5,3,2,0,6,2.275
+Spring 2023,COSC,1437,3,14607,Introduction to Programming,Chen,Guoning,42,16,10,5,14,0,29,2.725
+Spring 2023,CUIN,1350,2,14608,Mathematics for Teachers 1,Burris,Justin T,24,13,2,0,0,0,0,3.488
+Spring 2023,COSC,1437,5,14610,Introduction to Programming,Biediger,Daniel Edward,70,15,15,0,10,0,16,3.197
+Spring 2023,KIN,4360,1,14611,Adaptive Athletics Management,Cottingham,Michael,16,0,0,0,0,0,0,3.959
+Spring 2023,SOC,3355,2,14612,Sociology of India,Majumder,Sarasij,12,6,1,1,0,0,0,3.269
+Spring 2023,BIOE,2331,1,14614,Biomedical Processes,Shevkoplyas,Sergey,9,8,0,1,0,0,0,3.352
+Spring 2023,NUTR,4352,1,14615,Child and Adolescent Nutrition,Vollrath,Kirstin,24,27,14,4,0,0,2,2.933
+Spring 2023,HDFS,3317,2,14617,Prenatal and Infant Developmt,Fraser,Camille,24,9,6,1,0,0,0,3.293
+Spring 2023,TMTH,3360,6,14618,Applied Technical Statistics,Daniel,Patrick Nathanial,5,7,11,0,0,0,3,2.753
+Spring 2023,DIGM,3370,30,14620,Two Dimensional Animation,Snyder,Philip Charles,39,16,3,1,0,0,2,3.537
+Spring 2023,MECE,6334,1,14623,Convection Heat Transfr,Liu,Dong,1,3,0,0,1,0,0,2.468
+Spring 2023,ECE,6348,1,14624,Material Science of Thin Films,Wolfe,John C,39,2,0,0,0,0,0,3.951
+Spring 2023,MECE,6363,1,14626,Physical Metallurgy,Sun,Li,0,3,1,0,0,0,1,2.833
+Spring 2023,ELCS,6370,1,14628,Research for Educatnal Leaders,Horner,Glenda Sue,12,0,0,0,0,0,0,4.0
+Spring 2023,HLT,4309,1,14629,Health Disparities,Carmack,Chakema,20,2,0,0,1,0,1,3.739
+Spring 2023,MARK,4332,2,14630,Social Media Marketing,Zahn,William J,35,30,4,0,0,0,1,3.449
+Spring 2023,POLS,6381,1,14631,Quantitative Methods II,Basinger,Scott J,8,2,1,0,0,0,0,3.576
+Spring 2023,SOCW,7305,1,14632,Evaluation of SW Practice,Guzman,Paola E,14,2,0,0,0,0,0,3.875
+Spring 2023,SOCW,7305,2,14633,Evaluation of SW Practice,Guzman,Paola E,18,2,0,0,0,0,0,3.9
+Spring 2023,TEPM,6308,1,14634,Project Procurement Practices,Conover,Sharon Cecilia,5,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,4366,1,14635,Biomolecular Engr Fundamentals,Varadarajan,Navin,26,50,14,0,0,0,0,3.093
+Spring 2023,ELCS,8361,1,14638,Public & Community Relations,Freelon,Rhoda,5,0,0,1,0,0,0,3.445
+Spring 2023,ENTR,3312,6,14639,Corporate Entrepreneurship,Karonika,John R,23,14,3,0,3,0,5,3.164
+Spring 2023,ELCS,6320,1,14641,Instructional Supervision,Horner,Glenda Sue,13,0,0,0,0,0,0,3.949
+Spring 2023,ACCT,2301,5,14642,Prin of Financial Accounting,Goble,Samuel,33,55,22,16,9,0,16,2.728
+Spring 2023,INDE,2333,4,14644,Engineering Statistics I,Wiggins,Nathanial David,3,5,1,0,0,0,0,3.296
+Spring 2023,BTEC,6302,30,14645,Intro to Regulatory Affairs,Flavier,Albert B,4,0,1,0,0,0,0,3.666
+Spring 2023,BTEC,6303,30,14646,Protein Engineering Technology,Flavier,Albert B,2,2,2,0,0,0,1,3.0
+Spring 2023,GHL,1367,2,14647,Lodging Management,Kenyan,Erin Oeser,35,5,1,2,3,0,1,3.464
+Spring 2023,GHL,3358,2,14648,Hospitality Industry Law,Abbott,Jeanna L,28,10,2,4,2,0,4,3.247
+Spring 2023,GHL,3361,2,14649,Hospitality Marketing,Shin,Min Jung,34,7,4,1,0,0,3,3.58
+Spring 2023,PHAR,5646,1,14650,Medication Safety,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6380,1,14654,Business Analytics,Lee,Minwoo,25,3,0,0,1,0,0,3.747
+Spring 2023,MECT,3355,2,14655,Strength of Materials,Basaran,Burak,0,4,22,13,13,0,3,1.213
+Spring 2023,SOCW,7378,1,14656,Integrated Behav Healthcare,Eisenbaum,Stephanie,27,1,0,0,0,0,0,3.964
+Spring 2023,ENGL,1302,17,14658,First Year Writing II,Johnston,Leah Beth,16,0,0,2,0,0,1,3.703
+Spring 2023,PSYC,2307,2,14666,Psychology of Adolescence,Cifre,Anthony Ballachie,41,24,11,0,3,0,0,3.216
+Spring 2023,PSYC,2305,10,14673,Intro to Methods in Psychology,Wilson,Danielle,21,29,11,3,6,0,10,2.725
+Spring 2023,SPAN,1507,1,14675,Intns Elem Span Heritage Learn,Monarrez Martinez,Sendy Patricia,11,5,2,0,1,0,2,3.246
+Spring 2023,ARTH,3334,1,14677,History of Graphic Design,Orto,Luisa,15,15,2,1,0,0,2,3.313
+Spring 2023,ENGI,1331,4,14678,Computing for Engineers,Aksu,Gulin Tulunay,21,20,3,2,6,0,12,2.898
+Spring 2023,MATH,3330,3,14679,Abstract Algebra,O'Malley,Matthew J,2,3,3,1,1,0,1,2.499
+Spring 2023,MATH,3330,4,14680,Abstract Algebra,Heier,Gordon,5,5,0,0,1,0,1,3.272
+Spring 2023,CIS,3343,30,14681,Info Systems Analysis & Design,Faiyaz,Sajida,5,14,13,0,3,0,2,2.618
+Spring 2023,CIS,4339,2,14682,Enterprise Appls Development,Lindner,Peggy,56,17,4,3,3,0,4,3.434
+Spring 2023,CIS,3368,30,14684,Adv Info Systems Development,Dobretsberger,Otto,25,7,6,2,7,0,1,2.893
+Spring 2023,NURS,4322,1,14686,Policy &Ethics in Prof Nursing,Shani,Pinky,30,14,0,0,0,0,0,3.682
+Spring 2023,NURS,3230,1,14687,Nursing Professional Role I,Shani,Pinky,54,12,0,1,0,0,1,3.776
+Spring 2023,PHLS,8193,1,14690,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,3,0,
+Spring 2023,PHLS,8193,2,14691,Internship in Psychology,Allan,Blake A,0,0,0,0,0,8,0,
+Spring 2023,ENGI,2304,12,14693,Technical Communications,Contos,Ashlie Meghan,25,0,3,2,0,0,1,3.545
+Spring 2023,CHEM,8999,22,14695,Doctoral Dissertation,Do,Loi H,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7399,10,14698,Masters Thesis,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6350,1,14699,Applied Music Pedagogy,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Spring 2023,AAS,2320,6,14700,Intro To African American Stdy,Thompson,Kevin Bernard,29,4,0,0,1,0,0,3.755
+Spring 2023,MUSA,2300,7,14702,Applied Voice,Vasquez,Hector A,1,0,0,0,0,0,0,3.67
+Spring 2023,CNST,6320,1,14703,Cost Analysis and Bidding,Eldin,Neil N,27,0,1,0,0,0,0,3.929
+Spring 2023,MUSA,8320,2,14705,Doctoral Applied Music,Yon,Kirsten A,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,3,14706,Doctoral Applied Music,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,4,14707,Doctoral Applied Music,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Spring 2023,MECT,4276,1,14709,Senior Design Project II,Zhu,Weihang,30,13,2,0,0,0,0,3.608
+Spring 2023,RELS,3366,1,14711,Magic and Occult,Allen,Paul J,32,1,0,0,1,0,0,3.843
+Spring 2023,RELS,3370,1,14712,The Bible and Modern Science,Ott,Aaron Frederick,11,9,8,2,4,0,6,2.598
+Spring 2023,PHAR,4331,1,14714,Pharmaceutics II,Liu,Xinli,64,41,13,0,0,0,2,3.432
+Spring 2023,PHAR,4251,1,14715,Pharmacy Skills Program II,Wollen,Joshua T,77,31,2,0,0,0,2,3.682
+Spring 2023,MUSA,6340,1,14720,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6322,1,14721,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,6,14724,Doctoral Applied Music,Morgulis,Tali,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,7,14725,Doctoral Applied Music,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,9,14726,Doctoral Applied Music,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,11,14728,Doctoral Applied Music,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6393,4,14729,Clinical Research Practicum,Zvolensky,Michael J,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,8106,1,14731,Doctoral Large Ensemble,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7360,2,14732,International Finance,Susmel,Raul,5,1,0,0,0,0,0,3.888
+Spring 2023,LACP,2111,1,14733,Liberal Arts Career Planning,Espinosa,Adalia,0,0,0,0,0,25,2,
+Spring 2023,LACP,2111,2,14734,Liberal Arts Career Planning,Hayes,Olivia Kaye,0,0,0,0,0,15,0,
+Spring 2023,MATH,1332,5,14735,Contemporary Mathematics,Hafeez,Shahinda,19,24,25,8,15,0,19,2.133
+Spring 2023,PHAR,5695,2,14736,Geriatrics,Truong,Mabel,0,1,0,0,0,0,0,3.0
+Spring 2023,PHAR,5686,2,14737,Psychiatry,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,8999,23,14741,Doctoral Dissertation,Brgoch,Jakoah,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8318,1,14742,Issues in Urban Education,Hausmann,Robert Carl,6,2,0,0,0,0,0,3.709
+Spring 2023,KIN,4315,1,14744,Motor Learning and Control,Layne,Charles S,22,61,14,1,1,0,1,3.0
+Spring 2023,CNST,6320,2,14745,Cost Analysis and Bidding,Eldin,Neil N,32,0,0,0,0,0,0,4.0
+Spring 2023,CNST,6330,1,14747,Project Planning & Management,Eldin,Neil N,28,1,0,0,0,0,0,3.966
+Spring 2023,CNST,6330,2,14748,Project Planning & Management,Eldin,Neil N,23,0,0,1,2,0,0,3.577
+Spring 2023,MUSA,3424,1,14749,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLA,6213,1,14750,Workforce Competency,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4436,1,14751,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,3426,1,14755,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,8999,1,14756,Dissertation,Berger Cardoso,Jodi A,1,0,0,0,0,0,0,4.0
+Spring 2023,PETR,7399,12,14767,Masters Thesis,Dindoruk,Birol,0,0,0,0,0,1,0,
+Spring 2023,DIGM,3152,34,14773,Graphic Comm Output Lab,Dawson,Michael John,5,1,0,0,0,0,0,3.833
+Spring 2023,PETR,8298,11,14775,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Spring 2023,PETR,8298,12,14776,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,5,0,
+Spring 2023,PETR,8398,10,14778,Doctoral Research,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Spring 2023,PETR,8399,12,14784,Doctoral Dissertation,Dindoruk,Birol,0,0,0,0,0,2,0,
+Spring 2023,PETR,8598,10,14791,Doctoral Research,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Spring 2023,PETR,8598,11,14792,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Spring 2023,PETR,8598,12,14793,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Spring 2023,PETR,8598,13,14794,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Spring 2023,PETR,8699,10,14795,Doctoral Dissertation,Farouq-Ali,Syed,1,0,0,0,0,0,0,4.0
+Spring 2023,PETR,8699,11,14796,Doctoral Dissertation,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Spring 2023,OPTO,6124,1,14804,Perception,Stevenson,Scott Bailli,76,17,2,0,0,0,0,3.779
+Spring 2023,ENGL,7398,2,14807,Special Problems,Chatterjee,Sreya,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2310,3,14809,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,1302,9,14811,The U.S. Since 1877,Buzzanco,Robert,140,61,28,7,12,0,21,3.214
+Spring 2023,ARTH,7399,1,14814,Master's Thesis,Tejada,Roberto Jose,2,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,2332,1,14815,Mechanics of Solids,Mansour,Mohamad Y,4,17,6,3,0,0,1,2.678
+Spring 2023,PHOP,8299,1,14820,Doctoral Dissertation,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6157,7,14823,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,4,14829,Spec Prob-Physio Optics,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,7399,2,14835,Masters Thesis,Cheng,Han,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6352,4,14839,Directed Rsch in I/O Psyc,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8698,18,14841,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,2,0,
+Spring 2023,POLS,8999,19,14842,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,2,0,
+Spring 2023,DIGM,1350,32,14843,Graphics for Digital Media,De Vega,Jaime M,12,8,3,1,3,0,4,2.889
+Spring 2023,ARCH,3501,15,14846,Architecture Design Studio VI,Davis,Curtis M,3,4,8,0,0,0,0,2.601
+Spring 2023,MECT,4188,2,14848,Ethics in Engineering Tech,Bose,Anima B,15,13,2,0,1,0,2,3.301
+Spring 2023,PHOP,6257,9,14849,Research Practicum B,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,6,14851,Spec Prob-Physio Optics,Porter,Jason,2,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,7,14853,Spec Prob-Physio Optics,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6198,1,14860,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6336,1,14862,Directed Rsch in Social Psyc,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8999,21,14865,Doctoral Dissertation,Aleman,Eduardo,0,0,0,0,0,1,0,
+Spring 2023,HIST,8388,5,14870,Dissertation Proposal,Ramos,Raul,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6398,14,14871,Independent Studies,Leasure,Jennifer Leigh,1,0,0,0,0,2,0,4.0
+Spring 2023,EGRP,1151,1,14873,Engineering Applications VII,Luna Singh,Jennifer Austin,0,0,0,0,0,11,0,
+Spring 2023,ARTH,7399,2,14874,Master's Thesis,Harren,Natilee O,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8698,19,14876,Doctoral Research,Josic,Kresimir,0,0,0,0,0,1,0,
+Spring 2023,COMM,3360,3,14878,Principles of Strategic Comm,Smith,LaRahia M,14,3,0,3,0,0,0,3.301
+Spring 2023,PEP,8699,8,14882,Doctoral Dissertation,Ledoux,Tracey A,0,0,0,0,0,2,0,
+Spring 2023,COMD,7391,12,14883,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,15,14884,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,4198,1,14886,Independent Study,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,1111,38,14887,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,8,2,0,1,0,4,2.867
+Spring 2023,MUSA,4410,2,14888,Applied Piano,Morgulis,Tali,3,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,1102,15,14889,College Physics II (lab),Wood,Lowell T,1,13,6,0,0,0,3,2.684
+Spring 2023,BIOE,8298,22,14890,Doctoral Research,Wu,Tianfu,0,0,0,0,0,3,0,
+Spring 2023,PSYC,6398,15,14895,Independent Studies,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Spring 2023,PSYC,6365,1,14896,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,3,0,
+Spring 2023,BTEC,4300,30,14897,Principles of Bioinformatics,Balan,Venkatesh,9,8,4,0,0,0,1,3.238
+Spring 2023,HIST,1302,10,14898,The U.S. Since 1877,Buzzanco,Robert,157,54,19,8,12,0,15,3.286
+Spring 2023,PEP,8699,1,14899,Doctoral Dissertation,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Spring 2023,HON,4398,3,14902,Independent Study,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8242,3,14903,Doctoral Recital III,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6365,2,14905,Dir Rsch in Dev Cog Beh Neuro,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8698,22,14908,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Spring 2023,MUSA,2350,1,14910,Applied Percussion,Warren,Paul Alexander,2,1,0,0,0,0,0,3.667
+Spring 2023,MUSA,3450,1,14911,Applied Percussion,Wilkins,Blake M,2,0,0,0,0,0,1,3.835
+Spring 2023,PSYC,8399,8,14919,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,3,0,
+Spring 2023,MUSA,2326,1,14920,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8399,9,14921,Doctoral Dissertation,Viana,Andres G,0,0,0,0,0,2,0,
+Spring 2023,HRD,3351,30,14922,Instructional Design for HRD,Pereira-Leon,Maura Josefina,13,23,2,1,0,0,0,3.273
+Spring 2023,ECON,3332,4,14929,Intermediate Microeconomics,Paluszynski,Radoslaw,13,5,9,8,1,0,14,2.519
+Spring 2023,ECON,3320,1,14930,Intro to Econ Data Analysis,Zhivan,Natalia A,21,20,21,18,18,0,29,2.061
+Spring 2023,ECON,7335,1,14932,Applied Econometrics,Chin,Aimee,13,0,0,0,0,0,0,3.848
+Spring 2023,ECON,2302,2,14933,Principles of Microeconomics,Thorell,Troy E,29,31,18,6,4,0,5,2.837
+Spring 2023,ECON,3347,1,14934,Capital Market Economics,Jiu,Haibin Brett,14,18,4,4,1,0,0,2.992
+Spring 2023,MATH,4362,1,14935,Theory Diff Equ and Nonlnr Dyn,Torok,Andrei S,5,2,7,0,0,0,5,2.716
+Spring 2023,MATH,1324,2,14938,Finite Math with Applications,Caglar,Atife,94,76,86,38,68,0,60,2.263
+Spring 2023,CHEM,1305,2,14939,Foundations of Chemistry,Zaitsev,Vladimir G,5,13,19,18,23,0,24,1.491
+Spring 2023,CHEM,2325,3,14940,Organic Chemistry II,Comito,Robert Joseph,6,6,11,8,8,0,6,1.829
+Spring 2023,INDE,6399,4,14948,Masters Thesis,Lin PhD,Ying,1,0,0,0,0,0,0,4.0
+Spring 2023,CLAS,4305,1,14949,Fifth-Century Athens,Due Hackney,Casey L,17,0,1,0,1,0,1,3.667
+Spring 2023,INDE,8399,2,14951,Doctoral Dissertation,Lin PhD,Ying,2,0,0,0,0,0,0,4.0
+Spring 2023,INDE,8399,3,14952,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Spring 2023,LAW,6386,1,14954,Oil and Gas Tax,Wright,Denney L,2,2,0,0,0,3,0,3.583
+Spring 2023,LAW,6392,1,14955,Privacy and Data Protection,Guggenberger,Nikolas,16,22,0,1,0,0,0,3.359
+Spring 2023,LAW,6350,1,14956,Admiralty:P.I. & Death,Unger,John F,2,5,0,0,0,5,0,3.38
+Spring 2023,LAW,6226,1,14957,Advanced Oil & Gas Contracting,Borrego,Theodore R,1,3,0,0,0,0,0,3.333
+Spring 2023,SOCW,7301,1,14958,Confronting Oppression & Injus,Barthelemy,Juan,17,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7301,4,14959,Confronting Oppression & Injus,Young,Kyee Altranice,24,0,0,0,0,0,1,4.0
+Spring 2023,SOCW,7301,5,14960,Confronting Oppression & Injus,Mendoza,Yvonne Anette,20,2,0,0,0,0,0,3.909
+Spring 2023,LAW,6205,1,14961,Patent Prosecution,Cotrone,Carlo M,4,4,0,0,0,0,0,3.459
+Spring 2023,MATH,2312,5,14962,Precalculus,Perepelitsa,Irina,48,38,32,20,14,0,28,2.518
+Spring 2023,SPAN,1501,5,14963,Elementary Spanish I,Martinez,Carlos David,4,3,2,1,2,0,2,2.445
+Spring 2023,SPAN,1502,1,14965,Elementary Spanish II,Ruffino,Maythe,5,7,10,1,1,0,1,2.597
+Spring 2023,SPAN,2615,2,14967,Intsve Inter Span Heritg Lrnrs,Ruiz,Eugenia Maria,8,8,2,3,0,0,2,2.984
+Spring 2023,GEOL,1147,1,14968,Introductory Meteorology Lab,Jiang,Xun,6,4,1,0,2,0,1,2.898
+Spring 2023,GEOL,1303,1,14969,Physical Geology,Carlson,Brandee Nicole,23,22,10,3,6,0,2,2.771
+Spring 2023,GEOL,1303,3,14970,Physical Geology,Wu,Jonathan En Lin,45,67,62,16,12,0,9,2.571
+Spring 2023,GEOL,1370,1,14971,Natural Disasters,Hauptvogel,Daniel William,191,173,95,16,26,0,17,2.952
+Spring 2023,ENGI,1331,5,14972,Computing for Engineers,Aksu,Gulin Tulunay,36,17,5,1,1,0,6,3.461
+Spring 2023,ENGI,1100,1,14974,Introduction To Engineering,Kota,Venkata Krishna Tulasi,25,20,4,5,3,0,2,2.966
+Spring 2023,ENGI,1100,4,14975,Introduction To Engineering,Metrovich,Brian,3,18,20,2,8,0,8,2.092
+Spring 2023,CHEM,4330,1,14976,Polymer Chemistry,Harth,Eva M,21,3,1,2,3,0,3,3.189
+Spring 2023,PHAR,4200,1,14977,Immunology I,Knoll,Brian J,28,48,36,5,3,0,3,2.775
+Spring 2023,PHAR,4221,1,14978,Physiology II,Marwaha,Aditi,44,42,23,4,0,0,2,3.115
+Spring 2023,PHAR,4275,1,14979,FIMMRA,Cuny,Gregory D,28,48,36,5,1,0,3,2.822
+Spring 2023,PHAR,4160,1,14980,Fundamentals Comm Pharm Pract,Wallace,David A,91,18,1,0,0,0,2,3.818
+Spring 2023,PHAR,4265,1,14981,Patient Assessment,Asias-Dinh,Bernadette De Leon,36,65,9,0,0,0,2,3.245
+Spring 2023,PHAR,4340,1,14982,OTC & Self Care,Rosario,Natalie,49,47,13,2,0,0,2,3.288
+Spring 2023,INDI,3372,1,14983,Bollywood and Beyond,Tiwari,Bhavya,6,2,0,1,0,0,1,3.371
+Spring 2023,ELED,4314,1,14984,Mathematics in Elem School I,Burris,Justin T,22,1,0,0,0,0,0,3.87
+Spring 2023,CUIN,4332,3,14985,Literacy Assess Rdg Writing,Reis,Nancy,9,0,0,0,0,0,0,3.927
+Spring 2023,BIOL,2102,23,14987,Anatomy & Physiology II (lab),Gill,Tejendra,8,12,3,1,0,0,0,3.098
+Spring 2023,BIOL,2102,24,14988,Anatomy & Physiology II (lab),Gill,Tejendra,8,12,3,0,0,0,1,3.232
+Spring 2023,BIOL,2120,1,14989,Microbiology for Non-Science,Knapp,Richard D,14,3,6,0,0,0,0,3.333
+Spring 2023,BIOL,2120,2,14990,Microbiology for Non-Science,Knapp,Richard D,6,11,4,0,0,0,1,3.19
+Spring 2023,SPAN,3343,1,14991,Span for the Health Profession,Zubiate,Maria Laura,8,2,3,1,0,0,1,3.261
+Spring 2023,COMM,3317,1,14992,Multimedia Journalism,Baruch Blanco,Maria Felicitas,18,1,0,0,0,0,0,3.965
+Spring 2023,MIS,4477,3,14993,Network & Security Infrastruct,Khan,Hina F,21,9,1,0,0,0,0,3.56
+Spring 2023,COMM,3374,1,14996,Strategic Social Media,Uhrick,Jan,28,2,0,0,0,0,0,3.856
+Spring 2023,ENGL,2318,3,14997,Creation and Perform of Lit,Prufer,Kevin D,10,14,9,2,3,0,4,2.702
+Spring 2023,COMM,4303,5,14998,Communication Law and Ethics,Dulin,Matthew D,11,20,7,1,5,0,1,2.57
+Spring 2023,POLS,3313,2,14999,Intro Internatl Relatns,Chatagnier,John Tyson,10,13,6,0,0,0,3,3.115
+Spring 2023,POLS,3316,2,15000,Stats for Political Scientists,Konak Unal,Saadet,14,10,6,5,2,0,3,2.748
+Spring 2023,POLS,3326,1,15001,Gov-Pol the Middle East,Contractor,Cyrus Ali,4,8,0,0,2,0,2,2.834
+Spring 2023,POLS,3348,1,15002,"Left, Right, and Center",McDonald,John Terrence George,11,20,5,2,3,0,3,2.861
+Spring 2023,PSYC,2308,3,15003,Child Development,Merrill,Livia Christine,37,24,13,2,3,0,0,3.085
+Spring 2023,ENRG,4320,1,15004,Case Studies-Enrgy & Sustainbl,Hallmark,Terrell L,6,13,0,0,0,0,1,3.351
+Spring 2023,MANA,3335,6,15005,Intro Org Behavior and Mgmt,Carlin,Barbara A,23,50,11,2,0,0,0,3.116
+Spring 2023,MANA,4330,2,15006,Intro to Strategic HR Mgt,Reinoso,Gaston,9,6,1,0,1,0,0,3.333
+Spring 2023,MANA,4350,1,15007,International Management,Celly,Nikhil,55,2,0,0,0,0,3,3.936
+Spring 2023,COMM,4360,2,15008,Media Planning & Placement,Tinnel,Jason Wayne,1,12,6,1,0,0,0,2.7
+Spring 2023,CUIN,3312,2,15010,Educational Technology,Nguyen,Phuong Thi Mai,19,2,1,0,0,0,1,3.803
+Spring 2023,COMM,4371,1,15011,American Cinema: The Directors,Jowett,Garth Samuel,13,4,0,0,0,0,1,3.745
+Spring 2023,COMM,4381,1,15012,Digital Cinematography,Houk,Keith R,21,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2320,4,15014,Abnormal Psychology,Busch,Haley Conroy,32,5,3,0,0,0,0,3.709
+Spring 2023,BIOL,2302,2,15016,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,88,87,63,43,5,0,26,2.71
+Spring 2023,CUIN,4349,1,15017,Teaching Geometry and Algebra,Sundrani,Anita,4,11,4,0,0,0,0,2.983
+Spring 2023,COMM,2331,1,15019,Relational Communication,Hudson-Gillan,Gail,17,12,8,3,0,0,0,3.05
+Spring 2023,SOC,3313,3,15021,Criminology,Nelson,Steven M,23,20,12,2,1,0,2,3.041
+Spring 2023,SOC,3351,2,15022,Soc Class&Mobilty in Am,Lorence,Jon P,8,26,11,0,3,0,0,2.771
+Spring 2023,SOC,3390,1,15023,Sociology of Gender,Katz,Sheila,30,11,2,2,4,0,1,3.218
+Spring 2023,ELED,4311,1,15024,Science in Elementary School I,Bailer,Jill,17,4,2,0,0,0,0,3.595
+Spring 2023,ELED,4311,3,15025,Science in Elementary School I,Domjan,Heather N,23,2,0,0,0,0,0,3.894
+Spring 2023,ELED,4311,4,15026,Science in Elementary School I,Domjan,Heather N,22,0,0,0,0,0,0,3.97
+Spring 2023,CUIN,7300,1,15027,Play-Early Chldhood Edu,Uzzell,Keela Judece,4,1,0,0,0,0,0,3.668
+Spring 2023,SOC,6306,2,15028,Sem in Quant Methods,Savage,Scott Vandenburgh,7,2,0,0,0,0,0,3.741
+Spring 2023,FINA,4320,4,15029,Investment Management,Pederzoli,Paola,40,9,1,0,0,0,0,3.734
+Spring 2023,FINA,4320,5,15030,Investment Management,Gargano,Antonio,12,6,1,0,0,0,0,3.579
+Spring 2023,PETR,6351,1,15031,Intro to Petroleum Engineering,Farouq-Ali,Syed,3,0,0,0,0,0,0,4.0
+Spring 2023,PETR,6364,1,15032,Origin & Dev Oil & Gas Resvrs,Zargar,Zeinab,2,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6354,1,15035,Endocrinology,Warner,Margaret,7,1,0,0,0,0,0,3.875
+Spring 2023,SOCW,7305,3,15038,Evaluation of SW Practice,Miyawaki,Christina E,17,8,1,0,0,0,0,3.615
+Spring 2023,SOCW,7318,1,15039,Cognitive Behavioral Interven,Amtsberg,Donna K,29,1,0,0,0,0,0,3.967
+Spring 2023,SOCW,7318,2,15040,Cognitive Behavioral Interven,Amtsberg,Donna K,15,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7318,3,15041,Cognitive Behavioral Interven,Amtsberg,Donna K,26,3,0,0,0,0,0,3.897
+Spring 2023,SOCW,7318,4,15042,Cognitive Behavioral Interven,Cheung,Monit,21,4,0,0,0,0,0,3.84
+Spring 2023,SOCW,7318,5,15043,Cognitive Behavioral Interven,Cheung,Monit,17,2,0,0,0,0,0,3.895
+Spring 2023,COSC,4393,1,15045,Digital Image Processing,Mantini,Pranav,98,46,12,2,1,0,2,3.482
+Spring 2023,HRD,6303,1,15047,Assessment & Evaluation in Hrd,Shin,Daeun,11,2,0,0,0,0,1,3.795
+Spring 2023,HRD,6304,1,15048,Research in Human Resource Dev,Greer,Tomika,15,9,1,1,0,0,0,3.398
+Spring 2023,MARK,4363,1,15049,International Marketing,Beveridge,Ivana,37,0,0,0,0,0,0,3.955
+Spring 2023,MARK,3365,1,15050,Intro to Digital Marketing,Koch,Steven F,69,68,10,2,0,0,2,3.345
+Spring 2023,MARK,3365,2,15051,Intro to Digital Marketing,Koch,Steven F,51,72,19,3,4,0,1,3.074
+Spring 2023,HRD,6352,30,15054,Inst Design for Training Envir,Waight,Consuelo L,2,5,0,0,0,0,0,2.956
+Spring 2023,SCM,4330,3,15055,Bus Modeling and Dec Analysis,Chin,Wynne W,13,6,9,4,0,0,5,2.875
+Spring 2023,SOC,3400,4,15056,Intro To Social Statistics,Baumle,Amanda K,8,14,4,2,5,0,8,2.465
+Spring 2023,ENGL,4382,1,15059,Poetry Writing,Harris,Francine Julia,6,2,0,0,0,0,0,3.791
+Spring 2023,BIOE,2100,1,15062,Intro To Biomedical Engr,Akay,Yasemin M,8,1,0,0,0,0,2,3.926
+Spring 2023,BIOE,6309,1,15063,Neural Interfaces,Abidian,Mohammad Reza,2,0,0,0,0,0,0,3.67
+Spring 2023,BIOE,6307,1,15064,Cell Biology for BME,Al-Ubaidi,Muayyad,2,2,0,0,0,0,0,3.583
+Spring 2023,COSC,3360,3,15065,Operating Systems,Rincon Castro,Carlos Alberto,49,30,20,2,10,0,18,2.887
+Spring 2023,COSC,6380,1,15066,Digital Image Processing,Mantini,Pranav,17,8,0,0,0,0,0,3.706
+Spring 2023,FINA,7A10,1,15067,Valuation,Povel,Paul,5,5,0,0,0,0,0,3.533
+Spring 2023,PHLS,6370,1,15068,Intro To Cross-Cultural Cslng,McCoy,Leah,4,3,1,0,0,0,0,3.416
+Spring 2023,PHLS,6391,1,15069,Counseling Methods &Techniques,Whitaker,Rachael Gwin,6,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6352,2,15070,Assessmnt in Educ Psych,Lee,Jungeun,2,3,0,0,0,0,0,3.532
+Spring 2023,ENGL,3365,1,15071,Postcolonial Literature,Chatterjee,Sreya,20,8,0,0,0,0,1,3.75
+Spring 2023,ENGL,4366,1,15072,Intro To Folklore,Lindahl,Carl R,10,3,1,0,3,0,4,2.884
+Spring 2023,PSYC,2320,5,15073,Abnormal Psychology,Walker,Jesse Hilliard,5,34,26,8,6,0,1,2.275
+Spring 2023,PEP,8323,1,15074,Programming & Proposal Writing,Johnston,Craig Allen,5,3,1,0,0,0,0,3.444
+Spring 2023,ELCS,6370,2,15075,Research for Educatnal Leaders,Snodgrass Rangel,Virginia Walker,14,1,0,0,0,0,0,3.933
+Spring 2023,ELCS,8313,1,15076,Issues for Urban Education Adm,Lopez,Ruth Maria,6,0,0,0,1,0,0,3.429
+Spring 2023,ELCS,6320,2,15077,Instructional Supervision,Butcher,Keith,4,0,0,0,1,0,0,3.2
+Spring 2023,SPEC,4365,1,15078,Data-Based Indiv Instruct,Rigby-Wills,Hope,7,4,0,1,0,0,0,3.362
+Spring 2023,SPEC,6360,1,15079,Individuals with Disabilities,Rigby-Wills,Hope,8,0,0,0,0,0,0,3.959
+Spring 2023,SPEC,4362,1,15080,Behavior: EBD,Carp,Charlotte Lynn,9,7,0,0,1,0,0,3.334
+Spring 2023,SPEC,7392,1,15081,Assmt Intellectual Abilities,Cole,Jana Belinda,12,0,0,0,0,0,0,3.918
+Spring 2023,ELCS,8311,1,15082,Lab of Practice-Lit Revw Devel,Hawkins,Jacqueline McLean,7,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8311,2,15083,Lab of Practice-Lit Revw Devel,Santi,Kristi L,0,0,0,0,0,0,0,
+Spring 2023,ELCS,8345,1,15085,School-Based Budget & Law,Gillman-Rich,Lynn,9,0,0,0,0,0,0,4.0
+Spring 2023,SPEC,4364,1,15086,Ed Students Giifts and Talents,Govan,Kordney J,28,1,1,0,0,0,0,3.878
+Spring 2023,SPEC,6362,1,15087,Behavior:Evidence-Based,Carp,Charlotte Lynn,14,1,0,0,0,0,0,3.757
+Spring 2023,SPEC,6365,1,15088,Data-Based Indiv Instruct,Rigby-Wills,Hope,16,1,1,0,0,0,0,3.797
+Spring 2023,SPEC,7343,1,15089,Psych Processes of Reading,Santi,Kristi L,12,4,0,0,0,0,0,3.833
+Spring 2023,PETR,6111,1,15090,Petroleum Graduate Seminar,Qin,Guan,0,0,0,0,0,33,0,
+Spring 2023,CIS,3365,1,15091,Database Management,Hu,Renjie,6,62,14,0,0,0,0,2.886
+Spring 2023,CIS,3368,31,15092,Adv Info Systems Development,Dobretsberger,Otto,14,6,3,1,1,0,5,3.266
+Spring 2023,COMD,2339,1,15093,Language Development,Mills,Monique T,21,8,2,0,2,0,0,3.414
+Spring 2023,ENRG,3310,1,15094,Intro to Energy & Sustainblty,Miljanic,Ognjen S,15,21,6,0,0,0,0,3.222
+Spring 2023,HON,3306,1,15096,Health and Human Rights,Myrick,Keri D,25,0,1,1,0,0,0,3.79
+Spring 2023,MECE,3369,1,15097,Solid Mechanics,Kulkarni,Yashashree,6,30,31,1,8,0,3,2.277
+Spring 2023,ECE,6327,1,15098,Smart Grid Systems,Li,Xingpeng,11,5,1,0,0,0,0,3.549
+Spring 2023,ECE,6329,1,15099,Power System Protection,Phillips,Desiree Lyn,25,2,0,0,0,0,0,3.914
+Spring 2023,HLT,4317,1,15100,Found of Epi in Public Health,Drenner,Kelli Linn,21,35,15,5,5,0,6,2.741
+Spring 2023,PHLS,7377,1,15101,Child & Adol Psychopathology,Kahn,David Andrew,8,0,0,0,0,0,0,4.0
+Spring 2023,ECE,3436,1,15102,Microprocessor Systems,De La Rosa-Pohl,Diana,28,2,0,0,0,0,1,3.9
+Spring 2023,ECE,3436,3,15103,Microprocessor Systems,Le,Hung Quang,9,3,2,0,0,0,2,3.406
+Spring 2023,ECE,5180,1,15104,Power Electonics Laboratory,Phillips,Desiree Lyn,6,2,0,0,0,0,0,3.709
+Spring 2023,HDFS,3300,1,15105,Educational Psychology,Conston,Toya,92,17,6,2,3,0,0,3.595
+Spring 2023,HDFS,3300,2,15106,Educational Psychology,Conston,Toya,102,15,8,1,7,0,1,3.516
+Spring 2023,HDFS,3300,3,15107,Educational Psychology,Kamdar-Sharif,Amber,16,16,4,0,3,0,1,3.077
+Spring 2023,ECE,5380,1,15108,Pwr Electrncs & Electrc Drives,Huang,Hao,10,10,1,0,0,0,0,3.491
+Spring 2023,ECE,5436,1,15109,Adv Microprocessor Systems,Le,Hung Quang,37,3,0,0,0,0,1,3.826
+Spring 2023,ECE,6336,1,15111,RTOS and IoT,Le,Hung Quang,7,2,0,0,0,0,1,3.741
+Spring 2023,POLS,3311,2,15112,Intro Compar Politics,Kharmats,Polina G,13,1,0,1,0,0,0,3.711
+Spring 2023,ECE,6357,1,15114,Introduction to Cybersecurity,Pan,Miao,65,9,2,0,0,0,1,3.742
+Spring 2023,ECE,3337,1,15115,Signals and Systems Analysis,Reddy,Rohith Krishna,12,20,5,0,0,0,1,3.18
+Spring 2023,HDFS,3320,1,15116,Careers in HDFS,Jordan,Erica F,27,7,1,1,2,0,0,3.422
+Spring 2023,BZAN,4397,1,15117,Sel Topics in Bus Analytics,Wang,Cheng,1,0,1,0,0,0,0,3.165
+Spring 2023,PHLS,8307,1,15118,Health Disparities,Carmack,Chakema,3,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2308,4,15119,Child Development,Trent,Erika S,43,24,9,2,2,0,0,3.275
+Spring 2023,GHL,4353,2,15120,Leadership in Hospitality Ind,Barth,Stephen C,20,14,6,5,4,0,3,2.823
+Spring 2023,GHL,4361,1,15121,Marketing Strategies,Taylor,David C,27,6,0,1,3,0,1,3.468
+Spring 2023,COMD,3371,2,15123,Speech Devel & Dis in Children,Ermgodts,Katherine Natalie,24,16,3,1,0,0,1,3.439
+Spring 2023,MECT,1365,1,15124,Elements Materials & Processes,Wari,Ezra Tsegaye,11,44,15,2,4,0,3,2.741
+Spring 2023,ENGL,4311,1,15125,Language Socialization,Zentz,Lauren R,12,2,2,1,1,0,2,3.278
+Spring 2023,CNST,4331,2,15126,Construction Management II,Menendez,Daniel,6,10,1,0,0,0,0,3.333
+Spring 2023,BIOE,6306,1,15127,Adv Artificial Neural Networks,Francis,Joseph Thachil,3,2,2,0,0,0,0,3.143
+Spring 2023,LAW,5300,1,15128,Criminal Defense Clinic,Locascio,Erik Matthew,0,3,0,0,0,0,0,3.33
+Spring 2023,ARCH,3501,17,15130,Architecture Design Studio VI,Kacmar,Donna,3,7,4,0,0,0,0,2.858
+Spring 2023,IDNS,1101,2,15132,Physics 1301 Workshop,Pattison,Donna,9,5,2,2,0,0,2,3.13
+Spring 2023,FINA,4383,1,15133,R E Mkt Research & Valuation,Witte,Jerome,25,5,3,1,0,0,1,3.549
+Spring 2023,CUIN,6383,1,15134,Intro to Early Childhood Rsrch,Katz,Denise Annette,8,0,0,0,1,0,0,3.519
+Spring 2023,BZAN,6355,1,15136,Adv Programming-Big Data Anlyt,Ma,Xiao,37,0,0,0,0,0,0,4.0
+Spring 2023,RELS,3360,1,15137,Muslim-Christian Relations,Haq,Muhammad Nisarul,12,12,4,2,3,0,1,2.908
+Spring 2023,WGSS,3321,1,15140,Gender in Transnational Persp,Al-Sowayel,Dina,16,8,3,2,0,0,1,3.265
+Spring 2023,LAW,5355,1,15141,Oil and Gas,Mason,Jasper,19,20,0,0,0,0,0,3.479
+Spring 2023,MUSI,1181,1,15142,Group Piano I,Van Kekerix,Todd Evan,6,7,0,0,0,0,1,3.411
+Spring 2023,MUSA,1300,6,15143,Applied Voice,Vasquez,Hector A,6,0,0,0,0,0,0,3.835
+Spring 2023,MUSA,3400,4,15149,Applied Voice,Vasquez,Hector A,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,3400,6,15150,Applied Voice,Laine,Eric G,2,1,0,0,0,0,0,3.667
+Spring 2023,MUSA,3430,2,15152,Applied Flute,Russell,Peggy,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3440,2,15153,Applied Trumpet,Vassallo,Jim Cates,2,1,0,0,0,0,0,3.777
+Spring 2023,MUSA,3442,1,15154,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4402,1,15155,Applied Composition,Smith,Robert Thomas,1,1,0,0,0,0,1,3.5
+Spring 2023,MUSA,4420,1,15156,Applied Violin,Yon,Kirsten A,0,0,0,0,0,0,0,
+Spring 2023,MUSA,4424,1,15157,Applied Violoncello,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4426,1,15158,Applied Double Bass,Larson,Eric Amery,2,1,0,0,0,0,0,3.667
+Spring 2023,MUSA,6141,3,15159,Graduate Recital II,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,6334,1,15160,History of Graphic Design,Orto,Luisa,2,0,0,0,0,0,0,3.835
+Spring 2023,CIVE,4312,3,15161,Civil Engr Design Project,Keyvani,Ali,18,22,11,0,0,0,0,3.131
+Spring 2023,MARK,4389,8,15163,Marketing Strategy & Planning,Randazzo,Gary W,29,1,0,0,0,0,0,3.901
+Spring 2023,CHEM,4370,1,15165,Physical Chemistry I,Lubchenko,Vassiliy,4,13,6,0,0,0,0,2.856
+Spring 2023,ELCS,8399,3,15169,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,2,0,
+Spring 2023,ELCS,8699,3,15170,Doctoral Dissertation,Horn,Catherine Lynn,2,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8312,3,15171,Lab of Practice-Res Meth Devel,Butcher,Keith,2,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8312,4,15172,Lab of Practice-Res Meth Devel,Davis,Bradley,2,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8312,5,15173,Lab of Practice-Res Meth Devel,Freelon,Rhoda,0,0,0,0,0,5,0,
+Spring 2023,NUTR,6305,1,15179,Research Methods,Ledoux,Tracey A,8,7,1,0,1,0,0,3.138
+Spring 2023,NUTR,6306,1,15180,Stats for Healthcare Prof,Haubrick,Kevin,10,6,1,0,1,0,0,3.333
+Spring 2023,SOCW,6293,1,15181,Field Practicum I - Foundation,Gonzales,Shelley A,0,0,0,0,0,0,0,
+Spring 2023,SOCW,6294,1,15182,Field Practicum II,Gonzales,Shelley A,0,0,0,0,0,122,1,
+Spring 2023,CIVE,5388,1,15183,Hazardous Waste Processes,Rixey,William G,2,2,1,0,0,0,0,3.068
+Spring 2023,ENGL,3330,3,15185,Beg Creative Writing-Fiction,Boswell,Robert L,15,3,0,0,1,0,1,3.614
+Spring 2023,ELED,4310,3,15187,Reading/Language in Elementary,Black,Misty Paul,17,0,0,0,0,0,0,3.981
+Spring 2023,MARK,3337,1,15188,Professional Selling,Boehm-Miller,Elizabeth A,105,74,20,8,7,0,4,3.197
+Spring 2023,MARK,3337,2,15189,Professional Selling,Vandaveer,Amy L,144,78,13,3,1,0,10,3.466
+Spring 2023,MARK,3337,3,15190,Professional Selling,Suki,Yara D,155,69,15,2,4,0,3,3.476
+Spring 2023,MARK,3337,4,15191,Professional Selling,Vandaveer,Amy L,153,70,12,1,1,0,10,3.526
+Spring 2023,EDUC,3101,1,15192,Practicum for Preservice Tchrs,Thompson,Amber M,117,1,0,0,0,0,0,3.975
+Spring 2023,CUIN,1103,1,15193,Educator Dispositions,Culpepper,Shea Mosley,69,25,4,0,1,0,1,3.533
+Spring 2023,CUIN,3321,1,15194,Intro to Teaching Middle Grade,Pauloski,Gwendolyn Jordan,18,5,0,0,0,0,1,3.682
+Spring 2023,CUIN,3302,4,15195,Social Education,Thomas,Dustine J,32,3,0,0,0,0,0,3.914
+Spring 2023,ELED,4320,1,15196,Social Studies Ele Sch,Ford,Haley Michelle Grimland,30,2,1,0,0,0,0,3.889
+Spring 2023,ELED,4320,2,15197,Social Studies Ele Sch,Ford,Haley Michelle Grimland,37,0,0,0,0,0,0,3.982
+Spring 2023,ELED,4320,3,15198,Social Studies Ele Sch,Ford,Haley Michelle Grimland,8,1,0,0,0,0,0,3.926
+Spring 2023,ELED,4310,4,15199,Reading/Language in Elementary,Tyson,Eleanore S,30,5,0,0,0,0,0,3.829
+Spring 2023,POLS,3367,1,15201,Campaings and Elections,Cole,Jeffrey Bryan,15,5,5,0,0,0,0,3.387
+Spring 2023,MUSA,8320,12,15202,Doctoral Applied Music,Hester,Timothy E,5,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8240,9,15203,Doctoral Recital I,Yon,Kirsten A,0,0,0,0,0,0,0,
+Spring 2023,MATH,3331,3,15204,Differential Equations,Onofrei,Daniel T,9,2,4,2,3,0,6,2.518
+Spring 2023,NUTR,6307,1,15206,Community Nutrition Practice,Haubrick,Kevin,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6334,1,15207,Applied Clarinet,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6400,1,15208,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,4489,1,15210,Clinical Procedures,Ivey,Michelle L,24,1,1,0,0,0,1,3.834
+Spring 2023,CHEM,2123,9,15211,Organic Chemistry Lab I,Bean,Mary B,5,7,6,2,0,0,3,2.701
+Spring 2023,CHEM,2125,12,15212,Organic Chemistry Lab II,Bean,Mary B,10,6,3,1,0,0,1,3.118
+Spring 2023,ECE,3355,1,15217,Electronics,Ruchhoeft,Paul,14,12,11,4,0,0,0,2.854
+Spring 2023,MUSA,8241,5,15222,Doctoral Recital II,Evans,Joseph,1,0,0,0,0,0,0,3.67
+Spring 2023,HON,4399,3,15223,Senior Honors Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6365,3,15224,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,3,0,
+Spring 2023,FINA,4320,6,15225,Investment Management,Pederzoli,Paola,25,16,1,0,0,0,1,3.587
+Spring 2023,CUIN,8369,1,15226,Leadership in a Complex World,Hausmann,Robert Carl,9,0,0,0,0,0,0,4.0
+Spring 2023,INDE,8298,5,15229,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Spring 2023,INDE,8399,5,15233,Doctoral Dissertation,Feng,Qianmei,0,0,0,0,0,1,0,
+Spring 2023,PHOP,6767,1,15239,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Spring 2023,PHOP,6667,10,15249,Research Practicum A,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7320,1,15254,Empowerment,Rabo,Amber L,24,1,0,0,0,0,1,3.96
+Spring 2023,HDFS,1300,13,15256,Dev of Contemporary Families,Jordan,Erica F,39,5,3,1,1,0,0,3.572
+Spring 2023,MUSA,4424,2,15258,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6257,13,15260,Research Practicum B,Cheng,Han,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6257,14,15261,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Spring 2023,INDE,8699,5,15264,Doctoral Dissertation,Feng,Qianmei,1,0,0,0,0,0,0,4.0
+Spring 2023,HON,4399,4,15265,Senior Honors Thesis,Fujita,Masaya,1,0,0,0,0,0,0,4.0
+Spring 2023,ECON,2301,1,15266,Principles of Macroeconomics,Rocha Campos,Felipe,25,43,37,10,14,0,24,2.449
+Spring 2023,IEEM,6330,1,15267,Managing Engineering Functions,Kamrani,Ali K,12,7,0,0,0,0,0,3.579
+Spring 2023,INDS,4501,3,15271,Industrial Design Studio VIII,Wells,Adam C,7,7,0,0,0,0,0,3.476
+Spring 2023,MUSA,6420,1,15275,Applied Violin,Yon,Kirsten A,3,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,3302,3,15277,Social Education,Thomas,Dustine J,25,1,0,0,0,0,0,3.962
+Spring 2023,ELED,3320,4,15279,Survey Literature Child Adol,Ortiz,Elizabeth Carter,24,0,0,0,0,0,0,3.986
+Spring 2023,ELED,4311,2,15281,Science in Elementary School I,Domjan,Heather N,16,2,0,0,0,0,2,3.871
+Spring 2023,ACCT,5330,2,15282,Advanced Accounting,Ramaswamy,Vinita,1,1,0,0,0,0,0,3.5
+Spring 2023,PSYC,6365,4,15283,Dir Rsch in Dev Cog Beh Neuro,Kosten,Therese A,2,0,0,0,0,0,0,4.0
+Spring 2023,ECON,8399,7,15284,Doctoral Dissertation,Liu,Elaine Meichen,1,0,0,0,0,0,0,4.0
+Spring 2023,ECON,8399,8,15285,Doctoral Dissertation,Friedman,Willa H,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8999,8,15294,Doctoral Dissertation,Chu,Ching Wu,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8999,22,15308,Doctoral Dissertation,Morrison,Gregory C,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8999,24,15310,Doctoral Dissertation,Pinsky,Lawrence S,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8999,25,15311,Doctoral Dissertation,Ratti,Claudia,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8999,26,15312,Doctoral Dissertation,Ren,Zhifeng,2,0,0,0,0,0,0,4.0
+Spring 2023,HIST,1301,4,15321,The U.S. to 1877,McDonald,Eric John,77,109,42,11,19,0,12,2.786
+Spring 2023,PSYC,6336,4,15324,Directed Rsch in Social Psyc,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Spring 2023,SCLT,6320,2,15326,Procurement Strategies,Wang,Kailai,11,2,0,0,0,0,1,3.77
+Spring 2023,CUIN,8393,3,15328,Adv Internship & Prac,Alarcon,Jeannette Driscoll,1,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6498,8,15329,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Spring 2023,PCEU,8998,3,15330,Doctoral Research,Tam,Vincent H,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6398,2,15334,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Spring 2023,PCEU,8998,4,15335,Doctoral Research,Hu,Ming,0,0,0,0,0,1,0,
+Spring 2023,SPAN,8399,11,15344,Dissertation,Goodin-Mayeda,Carrie Elizabeth,1,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,8699,11,15345,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8399,10,15347,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6393,5,15348,Clinical Research Practicum,Walker,Rheeda L,3,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,3330,4,15349,Beg Creative Writing-Fiction,Fretwell,Leah M,15,2,2,0,0,0,0,3.632
+Spring 2023,ENGL,3331,2,15350,Beg Creative Writing-Poetry,English,Joshua,15,0,0,0,1,0,0,3.729
+Spring 2023,SOCW,8399,3,15351,Dissertation,Narendorf,Sarah C,0,0,0,0,0,1,0,
+Spring 2023,CUIN,8690,3,15352,Doctoral Thesis,Hausmann,Robert Carl,1,0,0,0,0,1,0,4.0
+Spring 2023,PHYS,1102,16,15353,College Physics II (lab),Wood,Lowell T,0,9,5,0,0,0,1,2.666
+Spring 2023,PHYS,1102,17,15354,College Physics II (lab),Wood,Lowell T,3,9,10,0,0,0,1,2.667
+Spring 2023,MUSA,8320,14,15355,Doctoral Applied Music,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6359,2,15357,Directed Rsch in Clinical Psyc,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4.0
+Spring 2023,WGSS,2350,9,15362,Intro To Women's Studies,Jagannathan PhD,Meera,15,11,1,0,1,0,2,3.369
+Spring 2023,MUSI,4104,1,15366,New Music Ensemble,Smith,Robert Thomas,4,0,0,0,0,0,0,4.0
+Spring 2023,HON,4399,5,15367,Senior Honors Thesis,Alward,Beau Andrew,1,0,0,0,0,0,0,4.0
+Spring 2023,HON,3399,4,15369,Senior Honors Thesis,Anderson Fletcher,Elizabeth,0,0,0,0,0,0,0,
+Spring 2023,FINA,4330,1,15371,Corporate Finance,Suleymanov,Masim,21,18,9,0,0,0,1,3.25
+Spring 2023,PHYS,1102,18,15372,College Physics II (lab),Wood,Lowell T,0,11,2,0,1,0,0,2.69
+Spring 2023,PHYS,1102,19,15373,College Physics II (lab),Wood,Lowell T,2,14,5,1,0,0,0,2.698
+Spring 2023,CIVE,6361,1,15374,Engineering Hydrology,Rifai,Hanadi S,6,3,0,1,0,0,0,3.367
+Spring 2023,MUSA,8320,15,15375,Doctoral Applied Music,Evans,Joseph,2,0,0,0,0,0,0,4.0
+Spring 2023,COMM,7399,1,15378,Masters Thesis,Camaj,Lindita,2,0,0,0,0,0,0,4.0
+Spring 2023,INDS,6329,1,15379,Comp Aided Industr Design I,Chow,George K,0,1,0,0,0,0,0,3.33
+Spring 2023,PSYC,6393,6,15380,Clinical Research Practicum,Vujanovic,Anka Anna,4,0,0,0,0,0,0,4.0
+Spring 2023,CNST,6308,1,15383,Data Analysis in Construc Mgmt,Gao,Lu,40,10,0,0,0,0,0,3.774
+Spring 2023,MUSA,8241,6,15387,Doctoral Recital II,Morgulis,Tali,2,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8393,5,15388,Adv Internship & Prac,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8399,13,15389,Doctoral Dissertation,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8598,23,15391,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8298,23,15392,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Spring 2023,MIS,4374,4,15399,Info Technology Project Mgmt,Knighton,William B,26,5,0,0,0,0,0,3.839
+Spring 2023,ARTH,7393,1,15402,Art History Internship,Koontz,Rex A,3,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6365,5,15404,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,4,0,0,0,0,0,0,4.0
+Spring 2023,NUTR,2332,4,15409,Intro To Human Nutrition,Hughes,Lindsay,63,27,5,1,2,0,2,3.473
+Spring 2023,NUTR,2332,5,15410,Intro To Human Nutrition,Hughes,Lindsay,58,25,7,4,1,0,5,3.365
+Spring 2023,ECON,4390,2,15413,Economics Internship,Thornton,Rebecca Achee,5,0,0,0,0,0,0,3.802
+Spring 2023,PSYC,6365,6,15414,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,4,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6365,7,15415,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Spring 2023,ECON,4390,3,15422,Economics Internship,Thornton,Rebecca Achee,3,1,0,0,0,0,0,3.668
+Spring 2023,PHLS,6391,2,15429,Counseling Methods &Techniques,Whitaker,Rachael Gwin,6,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6391,3,15430,Counseling Methods &Techniques,Whitaker,Rachael Gwin,7,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6323,1,15432,Psychopathology,Lukingbeal,Patrick Livingston,24,0,0,0,0,0,0,3.945
+Spring 2023,DIGM,3355,30,15434,Package Technology,De Vega,Jaime M,20,1,5,0,1,0,0,3.444
+Spring 2023,CHEM,1312,5,15438,Fundamentals of Chemistry 2,Carrasquillo M,Edwin,5,17,29,13,38,0,32,1.382
+Spring 2023,MATH,6359,1,15439,Appl. Stat. & Mult. Analysis,Poliak,Cathy Dawn,18,0,0,0,0,0,0,3.945
+Spring 2023,MATH,6373,1,15440,Deep Learning and Neural Nets,Azencott,Robert Guy,16,9,0,0,0,0,0,3.614
+Spring 2023,MATH,6315,30,15441,Masters Tutorial,Poliak,Cathy Dawn,3,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7345,1,15442,Psych Methods,Gallagher,Matthew Ward,5,2,0,0,0,0,0,3.809
+Spring 2023,POLS,3312,1,15443,"Arguments, Data, Politics",Karimov,Samad,8,11,7,2,4,0,7,2.542
+Spring 2023,POLS,3312,3,15444,"Arguments, Data, Politics",Raychaudhuri,Tanika,13,14,7,2,1,0,5,2.991
+Spring 2023,POLS,3345,1,15445,National Security Law,Abbott Jr,Kenneth Wayne,15,3,0,0,0,0,0,3.76
+Spring 2023,POLS,3355,1,15446,Judicial Process,Tiede,Lydia B,9,8,3,0,2,0,3,2.985
+Spring 2023,ARCH,6357,1,15447,Contemporary Theory,Kubo,Michael,21,5,0,0,0,0,0,3.782
+Spring 2023,POLS,3311,4,15448,Intro Compar Politics,Aleman,Eduardo,13,15,4,7,2,0,2,2.716
+Spring 2023,GERM,3350,1,15449,20Th C Thru German Culture,Kleinheider,Julia D,5,8,7,2,4,0,3,2.244
+Spring 2023,WCL,3366,2,15450,Latin American and Latino Film,Centeno,Daniel,9,10,3,1,1,0,0,3.0
+Spring 2023,CLAS,3381,1,15451,From Homer To Hollywood,Wright,David John,12,5,3,0,0,0,0,3.417
+Spring 2023,POLC,6315,1,15452,Pol Res II: Mult Analysis,Vallejo,Agustin,12,1,0,0,0,0,0,3.822
+Spring 2023,POLC,6317,1,15453,Public Policy Capstone,Buttorff,Gail J,22,0,0,0,0,0,0,3.91
+Spring 2023,POLC,6320,1,15454,Pol Analysis II: Pol Analysis,Pinto,Pablo M,8,4,0,0,0,0,0,3.529
+Spring 2023,POLC,6330,1,15455,Philosophy and Public Policy I,Luttrell,Johanna,16,1,1,0,1,0,0,3.579
+Spring 2023,POLC,6391,1,15456,Public Policy Internship,Bronk,Robert C,4,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6356,1,15457,Medical Ethics,Determeyer,Peggy Lee,20,0,0,0,0,0,0,3.984
+Spring 2023,POLS,4365,1,15458,National Defense Policy,Vardy,Ronald V,19,8,4,3,4,0,2,2.817
+Spring 2023,TLIM,3300,1,15459,Leadership & Innovation Fund,Evans,Gerald S,30,3,2,0,0,0,0,3.715
+Spring 2023,TLIM,3340,4,15462,Org Leadership & Supervision,Evans,Gerald S,278,24,2,1,0,0,2,3.843
+Spring 2023,TLIM,3345,30,15464,Human Resources in Technology,Evans,Ruth Ann,23,29,15,5,0,0,1,2.972
+Spring 2023,TLIM,3355,1,15465,Project Management Principles,Moore,George P,45,20,6,0,4,0,2,3.276
+Spring 2023,TLIM,3363,33,15466,Technical Communications,Piercy,Penelope Junker,21,8,6,2,2,0,1,3.086
+Spring 2023,TLIM,3363,34,15467,Technical Communications,Piercy,Penelope Junker,25,9,3,2,0,0,1,3.377
+Spring 2023,TLIM,3363,35,15468,Technical Communications,Tangeman,Anthony C,15,17,3,1,2,0,1,3.097
+Spring 2023,TLIM,3363,36,15469,Technical Communications,Piercy,Penelope Junker,16,15,3,1,1,0,4,3.231
+Spring 2023,TLIM,3363,30,15470,Technical Communications,Tangeman,Anthony C,16,16,5,0,2,0,1,3.179
+Spring 2023,TLIM,3363,32,15471,Technical Communications,Tangeman,Anthony C,13,16,7,3,1,0,1,2.999
+Spring 2023,TLIM,3365,30,15472,Team Leadership,Feriante,Chris,31,7,0,0,2,0,0,3.658
+Spring 2023,TLIM,4341,30,15473,Production & Service Operation,Cao,Shun,20,6,5,0,0,0,1,3.463
+Spring 2023,TLIM,4341,32,15474,Production & Service Operation,Cao,Shun,19,6,1,0,4,0,0,3.189
+Spring 2023,TLIM,4341,31,15475,Production & Service Operation,Chance,Michael Dean,12,18,1,0,1,0,0,3.229
+Spring 2023,TLIM,4341,2,15476,Production & Service Operation,Chance,Michael Dean,24,16,1,0,1,0,0,3.405
+Spring 2023,TLIM,4342,2,15478,Quality Improvement Methods,O'Kelley,Donna K,16,30,7,2,1,0,1,3.048
+Spring 2023,TLIM,4342,31,15479,Quality Improvement Methods,Chance,Michael Dean,30,21,4,0,1,0,1,3.375
+Spring 2023,TLIM,4342,30,15480,Quality Improvement Methods,Chance,Michael Dean,32,15,6,1,2,0,1,3.239
+Spring 2023,TLIM,4350,30,15481,Occup Safety & Envir Health,Freedkin,Aaron Samuel,24,10,4,0,1,0,0,3.36
+Spring 2023,TLIM,4371,31,15482,Leading Change in the Wrkplace,Burns,Maria,42,3,2,1,1,0,0,3.714
+Spring 2023,TLIM,4372,1,15484,Proposal and Project Writing,Thomas,Jamie M,5,9,4,1,4,0,1,2.377
+Spring 2023,TLIM,4390,30,15485,Current Issues Ldshp & Innov,Mehring,Brian George,12,15,5,0,2,0,0,3.039
+Spring 2023,INDE,4364,1,15486,Big Data and Analytics,Lin PhD,Ying,16,19,1,0,0,0,0,3.444
+Spring 2023,POLS,3385,1,15487,Introduction to Law,Jackson,Jerald W,16,16,12,0,0,0,1,3.016
+Spring 2023,PSYC,2317,5,15488,Intro to Psychology Statistics,Pierce,Jace D,18,10,7,1,2,0,2,3.088
+Spring 2023,PSYC,2305,12,15489,Intro to Methods in Psychology,Jewell,Rebecca D,7,30,20,5,6,0,12,2.383
+Spring 2023,LAW,6235,1,15491,Juvenile Representation,Cepeda Hendrickson,Grecia,1,0,0,0,0,3,0,4.0
+Spring 2023,BIOL,3301,50,15492,Mendelian and Pop Genetics,Farmer,Lisa M,6,3,2,0,0,0,0,3.394
+Spring 2023,BIOL,1307,51,15493,Biology for Science Majors II,Hanke,Marc H,5,5,0,0,0,0,0,3.5
+Spring 2023,POLS,3349,1,15494,American Political Thought,Koganzon,Rita,9,24,4,4,1,0,3,2.826
+Spring 2023,HON,3301,3,15495,Readings in Medicine & Society,Valier,Helen K,20,2,0,0,0,0,0,3.879
+Spring 2023,LAW,5345,1,15496,Real Estate Transactions,Crump,David L,10,9,1,0,0,4,0,3.384
+Spring 2023,HON,3304,1,15497,Material Cultures of Medicine,Lunstroth,John,19,5,0,0,0,0,0,3.805
+Spring 2023,HON,3302,1,15498,Readings in Public Health,Lunstroth,John,7,2,0,0,0,0,0,3.741
+Spring 2023,BIOE,4347,1,15499,Cell Biology for BME,Al-Ubaidi,Muayyad,3,8,3,0,0,0,0,3.071
+Spring 2023,BIOE,4313,1,15501,Intro to Neural Computation,Francis,Joseph Thachil,3,1,1,0,0,0,0,3.268
+Spring 2023,LAW,5357,1,15503,Evidence,Gomez,Alissa R,14,23,2,0,0,10,0,3.282
+Spring 2023,MANA,4310,2,15507,Behavioral Finance,Rude,Dale,3,1,0,0,1,0,1,3.0
+Spring 2023,MANA,3335,7,15508,Intro Org Behavior and Mgmt,Currie,Daniel David,164,59,14,1,5,0,5,3.492
+Spring 2023,MANA,4331,1,15509,Current Issues Human Res Mgmt,Walker,William A,18,4,0,1,0,0,2,3.71
+Spring 2023,MANA,3335,8,15510,Intro Org Behavior and Mgmt,Geraldi,Mark,16,43,17,1,0,0,1,2.961
+Spring 2023,MANA,6310,1,15512,Fundamentals of Business,Celly,Nikhil,12,0,0,0,0,0,0,3.973
+Spring 2023,MANA,7A49,1,15513,Managerial Decision Making,Carlin,Barbara A,12,9,3,1,0,0,0,3.201
+Spring 2023,INDS,2165,1,15515,Design Research Methods I,McEuen,Aaron Ross,15,3,2,0,0,0,0,3.535
+Spring 2023,MANA,7373,1,15516,Strat Mgt O & G Industry,Angelides,Christos O,23,2,0,0,0,0,1,3.788
+Spring 2023,MANA,7356,1,15519,Inclusive Leadership,Walker,William A,4,0,0,0,0,0,0,4.0
+Spring 2023,MANA,6A83,3,15520,Strategic Analysis,Wesley,Curtis,10,3,0,0,0,0,0,3.744
+Spring 2023,AAMS,2300,1,15524,Intro Asian American Studies,Nguyen,An,2,2,4,2,3,0,2,1.846
+Spring 2023,COMM,1303,3,15525,Writing for Communicators,Lyn,Robyn,31,4,0,1,5,0,5,3.35
+Spring 2023,ARCH,1210,1,15526,Introduction to Design Media,Kudless,Andrew Justin,63,30,12,1,7,0,4,3.227
+Spring 2023,SPEC,7394,1,15527,Diagnostician Practicum I,Hassett,Kristen Spring,0,0,0,0,0,5,0,
+Spring 2023,SPEC,7395,1,15528,Diagnostician Practicum II,Hassett,Kristen Spring,0,0,0,0,0,8,0,
+Spring 2023,ARCH,1501,20,15529,Arc/Int Arc Design Studio II,Murray,Cara,2,4,4,0,1,0,3,2.545
+Spring 2023,PHYS,6363,1,15532,Graduate Laboratory,Ren,Zhifeng,5,0,0,0,0,0,0,3.802
+Spring 2023,CNST,3185,3,15533,Construction Experience,Beadle,Dwight D,43,8,4,0,0,0,0,3.709
+Spring 2023,CNST,3265,2,15534,Construction Layout & Site Dvp,Lupher,Jacob John,23,16,6,0,1,0,0,3.268
+Spring 2023,INDS,3397,1,15535,Selected Topics,Kang,Chul Min,3,0,0,0,0,0,0,3.78
+Spring 2023,ELED,4315,4,15536,Mathematics in Elem School II,Cutler,Carrie Sybil,18,3,0,0,0,0,0,3.826
+Spring 2023,ACCT,7378,1,15538,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,19,7,0,0,0,0,0,3.743
+Spring 2023,ELET,4326,1,15539,Power Converter Circuits,Shireen,Wajiha,4,4,2,0,0,0,0,3.134
+Spring 2023,ELET,4126,1,15540,Power Converter Circuits Lab,Shireen,Wajiha,6,3,0,0,0,0,0,3.63
+Spring 2023,ACCT,2302,8,15541,Prin of Managerial Accounting,Seltz,Joe D,18,13,12,4,1,0,7,2.923
+Spring 2023,PSYC,3339,3,15544,Intro To Clinical Psychology,Smit,Tanya,64,11,1,0,2,0,2,3.735
+Spring 2023,SEDE,4311,1,15545,Teaching Social Studie Sec Sch,Brower,Samuel Richard,6,1,0,0,0,0,1,3.904
+Spring 2023,KIN,3304,2,15546,Human Structure & Phys Perform,LaVoy,Emily Claire-Pyle,16,12,15,2,0,0,4,2.875
+Spring 2023,KIN,3306,5,15547,Physiology-Human Performance,Hamilton,Marc,6,15,27,16,9,0,8,1.909
+Spring 2023,KIN,3309,1,15548,Biomechanics,Gorniak,Stacey,14,33,27,8,12,0,1,2.323
+Spring 2023,KIN,4310,2,15550,Measurement Tech Human Perf,Parikh,Pranav J,34,13,2,0,0,0,0,3.606
+Spring 2023,KIN,4370,1,15551,Exercise Testing,Markofski,Melissa,27,61,33,7,3,0,1,2.781
+Spring 2023,SPAN,4337,1,15558,Contempry Span-Amer Lit,Rivera Garza,Cristina,4,0,1,0,0,0,0,3.534
+Spring 2023,CLAS,3307,1,15559,Greek & Roman Myths of Heroes,Houlihan,James W,23,3,2,0,0,0,0,3.656
+Spring 2023,COMM,2326,1,15561,Intro to Sports Broadcasting,Trupiano,Jerome,19,0,1,0,0,0,0,3.9
+Spring 2023,COMM,2327,1,15562,Introduction to Screen Writing,Vaughan,Thomas Michael,16,7,4,0,0,0,0,3.432
+Spring 2023,HIST,1301,1,15563,The U.S. to 1877,Hopkins,Kelly Y,150,105,53,23,12,0,9,3.023
+Spring 2023,HIST,1302,51,15564,The U.S. Since 1877,Modaff,Abigail,23,0,0,0,0,0,2,3.957
+Spring 2023,COMM,2356,1,15565,Business & Professional Comm,Lee,Jaesub,132,62,16,7,16,0,17,3.206
+Spring 2023,NUTR,4353,1,15566,Cultural Comp for Nutr Prof,Yoon,Cynthia Yursun,44,10,4,1,0,0,0,3.56
+Spring 2023,NUTR,4351,1,15567,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,63,78,27,10,14,0,4,2.798
+Spring 2023,COMM,3326,3,15568,Graphics Applications,Economou-Clarke,Ann M,17,2,0,0,0,0,1,3.825
+Spring 2023,ELET,6331,1,15573,Fund of Medical Imaging,Zouridakis,George,4,1,0,0,0,0,0,3.8
+Spring 2023,RELS,2330,1,15574,Judaism,Weiss,Kenneth Scott,0,0,0,0,0,0,0,
+Spring 2023,EDUC,1301,1,15575,Intro to Teaching Profession,Larry,Frederick,20,0,0,0,0,0,0,4.0
+Spring 2023,NUTR,4201,1,15576,Dietetics as a Profession II,Honig,Caryn A,12,18,4,4,1,0,1,2.864
+Spring 2023,ECE,4113,1,15578,Energy Conversion Laboratory,Phillips,Desiree Lyn,25,3,0,0,0,0,0,3.905
+Spring 2023,ECE,4363,1,15579,Electromech Energy Conv,Phillips,Desiree Lyn,25,5,0,0,0,0,0,3.8
+Spring 2023,PHYS,1303,1,15580,Stars and Galaxies,Pinsky,Lawrence S,18,4,5,1,3,0,9,3.075
+Spring 2023,CUIN,4375,1,15581,Classroom Management,Auzenne-Curl,Chestin,20,1,2,0,0,0,0,3.768
+Spring 2023,CUIN,4375,3,15582,Classroom Management,Snead,Lauren Oropeza,25,0,0,0,0,0,0,3.96
+Spring 2023,SOCW,7318,6,15583,Cognitive Behavioral Interven,Parks,Steven Lee,22,5,0,0,0,0,0,3.815
+Spring 2023,ECE,6353,1,15584,Rf & Microwave Electronics,Chen,Jinghong,13,4,0,0,0,0,1,3.726
+Spring 2023,SOCW,7318,7,15585,Cognitive Behavioral Interven,Parks,Steven Lee,21,1,0,0,0,0,0,3.955
+Spring 2023,ENGL,3301,3,15586,Intro To Literary Studies,Singh,Kavita Ashana,9,5,3,1,0,0,1,3.277
+Spring 2023,ENGL,3304,1,15587,Chaucer,Stock,Lorraine K,2,9,6,0,0,0,8,2.823
+Spring 2023,ENGL,3317,1,15588,The British Novel Before 1832,Mazella,David S,13,4,0,0,3,0,5,3.184
+Spring 2023,ENGL,3322,1,15590,Contemporary Novel,Majumder,Auritro,13,11,0,2,2,0,1,3.154
+Spring 2023,ENGL,3340,1,15591,Advanced Composition,Garcia,Sylvia A,13,5,0,1,0,0,0,3.579
+Spring 2023,ENGL,4300,1,15592,Intro-Study of Language,Lee,Eunjeong,18,5,3,0,2,0,0,3.227
+Spring 2023,ACCT,3368,2,15593,Intermediate Accounting II,Wang,Yu,8,5,5,2,0,0,2,2.868
+Spring 2023,ACCT,3368,3,15594,Intermediate Accounting II,Wang,Yu,6,5,5,0,1,0,2,2.824
+Spring 2023,COSC,1336,4,15595,Computer Science & Program,Hilford,Victoria,17,42,24,9,4,0,13,2.621
+Spring 2023,BIOL,4374,2,15596,Cell Biology,Farmer,Lisa M,19,43,8,1,1,0,1,3.093
+Spring 2023,BCHS,4313,3,15597,Cell Biochemistry,Rea,Michael A,4,7,4,2,0,0,0,2.745
+Spring 2023,HLT,4310,2,15599,Program Planning for Hlt Prof,Behjat,Amirmohsen,8,14,5,0,0,0,0,3.099
+Spring 2023,KIN,4300,1,15600,Phys Activity Older Adults,Alastuey,Lisa L,36,31,19,8,2,0,3,2.903
+Spring 2023,HLT,1353,3,15601,Personal Health,Selzer,Lori Michele,71,32,9,4,1,0,3,3.394
+Spring 2023,LAW,6321,2,15602,Professional Responsibility,Duncan,Meredith J,23,33,4,0,0,0,0,3.399
+Spring 2023,CNST,6396,5,15606,Master's Project,Gao,Lu,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6350,1,15608,Biomedical Sciences Practicum,Scott,Sean-Patrick,25,1,0,0,0,0,0,3.962
+Spring 2023,ELCS,6304,1,15609,Law & Policy for School Leader,Klussmann,Duncan Foster,20,0,0,0,0,0,0,3.951
+Spring 2023,ELCS,6310,1,15610,Strategic Engagement,Bird,Shawn,16,0,0,0,0,0,0,4.0
+Spring 2023,HLT,3301,2,15611,Health Behavior Theories,Shamblin,Angel Ann,72,1,0,0,0,0,0,3.955
+Spring 2023,ELCS,6350,1,15612,School Leadership-Principalshp,Butcher,Keith,10,1,0,0,0,0,0,3.909
+Spring 2023,EDRS,8380,1,15613,Rsch Mthds in Educ,Hawkins,Jacqueline McLean,7,0,0,0,0,0,0,3.906
+Spring 2023,COSC,2306,1,15614,Data Programming,Shah,Shishir,22,7,3,3,3,0,17,3.053
+Spring 2023,COSC,2436,1,15615,Programming and Data Structure,Biediger,Daniel Edward,42,39,16,0,12,0,18,2.854
+Spring 2023,COSC,2436,3,15617,Programming and Data Structure,Rizk,Nouhad J,18,21,12,1,19,0,31,2.212
+Spring 2023,COSC,3320,2,15618,Algorithms and Data Structures,Pandurangan,Gopal,15,49,30,3,5,0,9,2.702
+Spring 2023,COSC,4337,1,15619,Data Science II,Vilalta,Ricardo,34,19,1,0,0,0,0,3.483
+Spring 2023,COSC,4364,1,15620,Numerical Methods,Johnsson,Lennart,7,25,14,1,2,0,11,2.701
+Spring 2023,HDCS,6300,30,15621,Quan. & Stat. Methods in HDCS,Greer,Tomika,5,3,0,0,0,0,0,3.625
+Spring 2023,HRD,3350,30,15623,Workforce Diversity and Global,Polesello,Daiane,9,3,0,2,1,0,1,3.155
+Spring 2023,HDCS,1300,6,15624,Human Ecosystems & Tech Change,Vercher,Michelle Taylor,29,14,3,2,0,0,1,3.341
+Spring 2023,HDCS,3304,1,15625,Visual Merchandising,Mudd,Blake Stevens,14,1,1,0,0,0,0,3.771
+Spring 2023,BIOL,4206,3,15626,Ecology & Evolution Laboratory,Cheek,Ann Oliver,13,6,3,1,0,0,1,3.362
+Spring 2023,GHL,1320,1,15627,Foodservice Management,Ding,Anni,43,20,3,1,2,0,1,3.421
+Spring 2023,WGSS,4350,2,15629,Issues in Feminist Research,Villarroel,Carolina A,4,0,0,0,0,0,1,4.0
+Spring 2023,GHL,3336,2,15631,Beverage Management,Jarvis,Nathan Alexander,9,14,10,2,2,0,0,2.738
+Spring 2023,GHL,2356,1,15632,Comm Strategies for Hospitalty,Pede,Michael Lawrence,21,1,1,1,0,0,0,3.75
+Spring 2023,GHL,3335,1,15633,Alcoholic Beverage Production,Corsi,Aaron James,20,4,0,0,0,0,0,3.82
+Spring 2023,GHL,3349,1,15634,Hosp Procurement & Purchasing,Jarvis,Nathan Alexander,18,15,4,2,6,0,3,2.822
+Spring 2023,GHL,3420,1,15635,Foodservice Operations,Ginapp,Kathrine,25,13,1,2,0,0,0,3.448
+Spring 2023,GHL,4350,1,15637,Strategy&Innovation Hosp Ind,Morosan,Cristian,13,6,5,1,4,0,1,2.816
+Spring 2023,GHL,4352,1,15638,Hosp Organizational Behavior,Maneethai,Dustin,8,9,3,0,2,0,1,2.955
+Spring 2023,GHL,2356,2,15639,Comm Strategies for Hospitalty,Barth,Stephen C,12,4,1,2,2,0,2,2.985
+Spring 2023,MATH,3349,1,15641,Inferential Statistics,Poliak,Cathy Dawn,4,4,3,0,0,0,1,3.091
+Spring 2023,SCLT,2362,33,15642,Intro To Logistics Technology,Cassler,Daniel,51,0,0,3,1,0,0,3.752
+Spring 2023,SCLT,3381,32,15643,Industrial and Consumer Sales,Cassler,Daniel,48,6,2,0,1,0,1,3.743
+Spring 2023,SCLT,2362,31,15645,Intro To Logistics Technology,Cassler,Daniel,50,1,0,6,2,0,1,3.554
+Spring 2023,GHL,6342,1,15646,Alcoholic Beverage Production,Corsi,Aaron James,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,7390,2,15650,Instructional Design,Dogan,Bulent,19,1,1,0,0,0,0,3.841
+Spring 2023,PHAR,5270,1,15651,Pcon & Hospital Pharmacy Mgmt,Sansgiry,Sujit Sharad,65,33,7,0,0,0,0,3.552
+Spring 2023,PHAR,5259,1,15652,Module Related Skills Lab II,Davis,Shantera Rayford,102,3,0,0,0,0,0,3.971
+Spring 2023,PHAR,5327,1,15653,Integrated Endocrine Module,Asias-Dinh,Bernadette De Leon,36,57,12,0,0,0,0,3.229
+Spring 2023,PHAR,5228,1,15654,Integrated Men & Women Health,Das,Joydip,29,53,23,0,0,0,0,3.057
+Spring 2023,PHAR,5329,1,15655,Integrated CV I Module,McConnell,Bradley K,40,50,15,0,0,0,0,3.238
+Spring 2023,PHAR,5330,1,15656,Integrated CV II Module,Boini,Krishna M,68,33,4,0,0,0,0,3.61
+Spring 2023,RELS,1301,3,15658,Intro To Religious Studies,Dawson,Cindy,14,3,6,3,4,0,0,2.59
+Spring 2023,ECE,3317,1,15659,Applied Electromagnetic Waves,Chen,Ji,8,14,12,2,0,0,0,2.769
+Spring 2023,LAW,5323,1,15661,Conflict of Laws,Ungureanu,Razvan C,4,5,0,0,0,0,0,3.334
+Spring 2023,PSYC,2307,3,15662,Psychology of Adolescence,Anderson,Jill Annette,11,20,10,2,4,0,4,2.688
+Spring 2023,MATH,4323,1,15666,Data Science and Stats Learn,Wang,Wenshuang,73,16,7,0,1,0,1,3.646
+Spring 2023,ELET,4351,1,15667,Biomedical Data Mining,Pollonini,Luca,30,6,2,0,0,0,0,3.598
+Spring 2023,INTB,3355,4,15668,Global Environment of Business,Miljanic,Andra Olivia,92,22,0,0,3,0,4,3.704
+Spring 2023,ACCT,2302,9,15669,Prin of Managerial Accounting,Weber,Catherine K,52,72,27,4,3,0,13,3.12
+Spring 2023,BZAN,6354,1,15670,DB Mgt Tools Bus Analytics,Grimes,George M,27,3,2,0,0,0,0,3.781
+Spring 2023,FINA,7323,1,15671,Applied Equity Fund Management,George,Thomas J,14,0,1,0,0,0,0,3.823
+Spring 2023,COMM,1303,1,15672,Writing for Communicators,Lyn,Robyn,80,7,5,1,2,0,4,3.712
+Spring 2023,IEEM,6335,1,15676,Engr Mgmt of Organizations,Chang PhD,Feng-Chang Roger,65,5,1,0,0,0,0,3.911
+Spring 2023,MIS,3376,3,15677,Busn Appls Database Mgmt I,Dimoka,Angelika,12,11,9,0,1,0,2,3.03
+Spring 2023,MIS,3376,4,15678,Busn Appls Database Mgmt I,Dimoka,Angelika,14,11,5,1,2,0,0,2.9
+Spring 2023,SPEC,8341,1,15679,Seminar in Learning Science,McCormick,Marina,5,4,0,0,0,0,0,3.519
+Spring 2023,ACCT,4335,1,15680,Financial Statement Auditing,Rousseau,Linette Marie,13,9,7,2,0,0,1,3.128
+Spring 2023,ACCT,4331,5,15681,Federal Income Tax-Individual,Small,Randolph Christopher,10,4,2,0,0,0,0,3.5
+Spring 2023,TLIM,3330,30,15682,Innovation Principles,Mehring,Brian George,7,7,6,2,2,0,5,2.653
+Spring 2023,ARLD,6340,1,15683,Law and the Arts,Payne,Brendettae,11,0,0,0,0,0,0,4.0
+Spring 2023,MUED,2320,1,15684,Computers for Musicians,Welch,Carl Chapman,7,2,3,1,0,0,0,3.052
+Spring 2023,MUED,2320,2,15685,Computers for Musicians,Welch,Carl Chapman,10,5,0,1,0,0,0,3.459
+Spring 2023,MUED,2342,3,15686,Music for Children,Riddle,Mary Colleen,12,7,1,0,0,0,1,3.6
+Spring 2023,MUED,2342,2,15687,Music for Children,Riddle,Mary Colleen,18,3,0,0,1,0,0,3.607
+Spring 2023,MUED,2342,5,15688,Music for Children,Bigwood,Cora Morgan,21,1,0,0,0,0,0,3.895
+Spring 2023,MUED,2342,4,15689,Music for Children,Bigwood,Cora Morgan,20,1,1,0,0,0,0,3.759
+Spring 2023,MUED,3100,1,15690,Woodwinds,Bell,Priscilla Garrett,9,6,0,0,0,0,0,3.512
+Spring 2023,MUED,3101,1,15691,Woodwinds,Bell,Priscilla Garrett,15,0,0,0,0,0,0,3.934
+Spring 2023,MUED,3103,1,15692,Brasses,Bell,Priscilla Garrett,10,6,0,0,0,0,0,3.625
+Spring 2023,TEPM,6302,1,15693,Leadership and Team Building,Hopkins,Ronald K,9,2,0,0,0,0,0,3.668
+Spring 2023,TEPM,6303,1,15694,Risk Assessment in Project Mgm,Gadison,Paulette D.,14,1,1,0,0,0,1,3.709
+Spring 2023,TEPM,6306,1,15696,Project Management Office,Rypien,David V,7,0,0,0,0,0,0,4.0
+Spring 2023,TEPM,6306,2,15697,Project Management Office,Rypien,David V,6,0,0,0,1,0,0,3.429
+Spring 2023,TEPM,6308,2,15698,Project Procurement Practices,Conover,Sharon Cecilia,7,0,0,0,0,0,0,3.953
+Spring 2023,TEPM,6391,2,15699,Project Management Seminar,Carden,Lila L,6,1,0,0,0,0,0,3.81
+Spring 2023,MUED,4221,1,15700,Choral Conducting II,Weber,Mary E,10,0,0,0,0,0,0,3.835
+Spring 2023,MUED,4231,1,15701,Instrumental Conducting II,Bertman,David Garry,15,1,0,0,0,0,0,3.938
+Spring 2023,MUED,4340,1,15702,Elem/Middle Schl Inst. Admin.,Meals,Cory Dewitt,18,3,2,0,1,0,0,3.569
+Spring 2023,FINA,4310,1,15703,Behavioral Finance,Rude,Dale,19,15,1,0,0,0,1,3.477
+Spring 2023,MUED,3108,1,15704,Piano for Choral Directors,Van Kekerix,Todd Evan,6,3,1,0,0,0,0,3.434
+Spring 2023,PHYS,1102,20,15706,College Physics II (lab),Wood,Lowell T,1,10,3,0,0,0,1,2.716
+Spring 2023,PHYS,1102,21,15707,College Physics II (lab),Wood,Lowell T,2,9,11,0,0,0,0,2.711
+Spring 2023,IRW,1300,2,15710,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,25,2,
+Spring 2023,THEA,4367,1,15711,Costume Cutting & Draping,Niederer,Barbara,3,1,0,0,0,0,0,3.585
+Spring 2023,THEA,6309,1,15712,CAD I for Theatre Design,Vlahos,Kalliope,2,0,0,0,0,0,0,3.67
+Spring 2023,ARCH,5500,19,15713,Architecture Design Studio IX,Roldan Caballero,Jose Manuel,5,6,1,0,0,0,1,3.113
+Spring 2023,TEPM,6304,1,15716,Quality Improvemnt in Proj Mgt,Kovach,Jamison,9,1,1,0,0,0,1,3.727
+Spring 2023,MUED,3107,1,15719,Basic Vocal Techniques,Mueller,Jebediah Lee,23,1,0,0,0,0,0,3.931
+Spring 2023,MUSI,6200,1,15721,Accompanying Seminar,Hester,Timothy E,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4410,3,15724,Applied Piano,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Spring 2023,THEA,6185,1,15725,Scenic Methods & Materials,Vlahos,Kalliope,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1340,1,15726,Applied Trumpet,Hughes,Mark Alan,4,0,0,0,0,0,0,4.0
+Spring 2023,MATH,6381,1,15727,Information Visualization,Shastri,Dvijesh J,13,6,1,0,0,0,0,3.485
+Spring 2023,MUSA,2342,2,15728,Applied French Horn,Reed,Gavin Davis,3,0,0,0,0,0,0,4.0
+Spring 2023,NURS,4312,1,15729,Ldership and Mgmt in Prof Nur,Phan,Huong Thi,18,5,0,0,0,0,0,3.783
+Spring 2023,TLIM,3350,30,15730,Emergency Management Principle,Freedkin,Aaron Samuel,25,12,2,2,2,0,0,3.203
+Spring 2023,MUSA,4400,5,15731,Applied Voice,Jones,Timothy J,0,0,0,0,0,0,0,
+Spring 2023,MUSI,6341,1,15733,Graduate Music Theory Review,Snyder,John L,3,0,0,0,0,0,2,3.78
+Spring 2023,ARCH,1360,1,15737,Architectural Sketching I,Williams,Celeste,21,7,0,0,0,0,1,3.668
+Spring 2023,NURS,6301,1,15738,Adv Rsrch Intgrtd Evdnce Prctc,Love,Mary Frances,4,1,0,0,0,0,2,3.8
+Spring 2023,NURS,6332,1,15739,Biostatistics,Love,Mary Frances,3,2,0,0,0,0,3,3.6
+Spring 2023,NURS,3312,1,15740,Fundamental Concepts of Care,Smith,Deborah Ann,6,38,0,1,0,0,0,3.089
+Spring 2023,NURS,3313,1,15741,Fundamental Clinical,Edwards-Maddox,Shermel Vinese,14,31,0,0,0,0,0,3.311
+Spring 2023,NURS,4211,1,15742,Mental Health Concepts of Care,Smith,Deborah Ann,13,31,0,0,0,0,0,3.295
+Spring 2023,NURS,4213,1,15743,Mental Health Clinical,Smith,Deborah Ann,44,0,0,0,0,0,0,4.0
+Spring 2023,NURS,3314,1,15744,Pharmacology,Kleinhans,Alicia Diane,4,38,0,2,0,0,0,3.0
+Spring 2023,ENTR,3312,7,15745,Corporate Entrepreneurship,Lish,Alan D,42,53,3,1,0,0,1,3.36
+Spring 2023,LAW,7308,1,15747,WRS: Scientific Evidence Law,Sanders,Joseph,6,5,0,0,0,0,0,3.395
+Spring 2023,CHEM,1111,36,15748,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,6,2,1,1,0,1,2.786
+Spring 2023,EDUC,4512,1,15750,Student Teaching - Elementary,Culpepper,Shea Mosley,116,7,2,0,0,0,0,3.872
+Spring 2023,EDUC,4511,1,15751,Student Teaching - Elementary,Thompson,Amber M,79,7,3,0,0,0,2,3.835
+Spring 2023,COSC,8398,101,15753,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,102,15754,Doctoral Research,Chen,Guoning,0,0,0,0,0,3,0,
+Spring 2023,COSC,8398,103,15755,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,106,15758,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,
+Spring 2023,COSC,8398,109,15761,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,112,15764,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,117,15769,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,118,15770,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,2,0,
+Spring 2023,COSC,8398,120,15772,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,124,15776,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,125,15777,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,126,15778,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,127,15779,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Spring 2023,COSC,8398,129,15781,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,2,0,
+Spring 2023,COSC,8398,130,15782,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Spring 2023,COSC,8698,101,15784,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Spring 2023,COSC,8698,102,15785,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Spring 2023,COSC,8698,107,15790,Doctoral Research,Eick,Christoph F,0,0,0,0,0,1,0,
+Spring 2023,COSC,8698,109,15792,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Spring 2023,COSC,8698,112,15795,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,2,0,
+Spring 2023,COSC,8698,113,15796,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Spring 2023,COSC,8698,114,15797,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Spring 2023,COSC,8698,119,15802,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,2,0,
+Spring 2023,COSC,8698,125,15808,Doctoral Research,Shi,Weidong,0,0,0,0,0,3,0,
+Spring 2023,COSC,8698,126,15809,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,2,0,
+Spring 2023,COSC,8698,127,15810,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Spring 2023,COSC,8698,128,15811,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Spring 2023,COSC,8698,130,15813,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,101,15815,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,106,15820,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,107,15821,Doctoral Research,Eick,Christoph F,0,0,0,0,0,2,0,
+Spring 2023,COSC,8998,109,15823,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,112,15826,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,117,15831,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,
+Spring 2023,COSC,8998,120,15834,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,122,15836,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,5,0,
+Spring 2023,COSC,8998,124,15838,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,126,15840,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,128,15842,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,129,15843,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Spring 2023,COSC,8998,130,15844,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Spring 2023,COSC,8998,131,15845,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Spring 2023,COSC,8399,106,15851,Doctoral Dissertation,Deng,Zhigang,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,8399,112,15857,Doctoral Dissertation,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Spring 2023,COSC,8399,113,15858,Doctoral Dissertation,Johnsson,Lennart,0,0,0,0,0,1,0,
+Spring 2023,COSC,8399,119,15864,Doctoral Dissertation,Ordonez,Carlos,0,0,0,0,0,1,0,
+Spring 2023,COSC,8399,126,15871,Doctoral Dissertation,Solorio Martinez,Thamar Ivette,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,8399,127,15872,Doctoral Dissertation,Subhlok,Jaspal,1,0,0,0,0,1,0,4.0
+Spring 2023,COSC,8399,128,15873,Doctoral Dissertation,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Spring 2023,COSC,8399,129,15874,Doctoral Dissertation,Verma,Rakesh M,0,0,0,0,0,1,0,
+Spring 2023,COSC,8699,101,15877,Doctoral Dissertation,Alipour,Mohammad Amin,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,8699,102,15878,Doctoral Dissertation,Chen,Guoning,0,0,0,0,0,0,0,
+Spring 2023,COSC,6398,101,15908,Special Problems,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Spring 2023,COSC,6398,106,15913,Special Problems,Deng,Zhigang,0,0,0,0,0,1,0,
+Spring 2023,COSC,6398,109,15916,Special Problems,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Spring 2023,COSC,6398,114,15921,Special Problems,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Spring 2023,COSC,6398,128,15935,Special Problems,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8298,25,15939,Doctoral Research,Das,Mini,0,0,0,0,0,3,0,
+Spring 2023,MECE,6374,1,15941,Nonlinear Control Syst Design,Grigoriadis,Karolos,8,8,5,0,0,0,0,3.174
+Spring 2023,GEOL,1102,4,15943,Intro to Climate Change Lab,Wang,Yuxuan,16,3,1,0,0,0,1,3.734
+Spring 2023,ARLD,3300,1,15944,Intro to Arts Administration,Kellner,Sara,15,6,0,0,1,0,0,3.485
+Spring 2023,MUSA,1334,2,15945,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Spring 2023,COMD,7392,5,15946,Adv Pract Sp & Lang Dis,Cadavid,Kelsey Lee,4,0,0,0,0,0,0,3.918
+Spring 2023,COMD,7392,6,15947,Adv Pract Sp & Lang Dis,Degge,Mary Chistine,3,1,0,0,0,0,0,3.668
+Spring 2023,COMD,7392,1,15948,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,3,1,0,0,0,0,0,3.668
+Spring 2023,GHL,6290,1,15951,Professional Paper I,Back,KiJoon,4,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,3462,1,15954,Unit Operations,Rimer,Jeffrey,23,29,9,1,0,0,0,3.172
+Spring 2023,PHOP,6157,12,15958,Research Practicum B,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,12,15960,Spec Prob-Physio Optics,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6757,2,15965,Research Practicum B,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6198,15,15966,Spec Prob-Physio Optics,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6157,14,15970,Research Practicum B,Ribelayga,Christophe Pierre,2,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6667,11,15971,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Spring 2023,PHOP,6467,2,15976,Research Practicuum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2023,HDFS,4315,3,15977,Culture and Diversity,Rab,Saira,22,7,1,0,4,0,0,3.245
+Spring 2023,ENGL,8699,1,15979,Doctoral Dissertation,Davies,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,1303,2,15981,Writing for Communicators,Lyn,Robyn,76,5,2,1,7,0,6,3.568
+Spring 2023,ARTH,7399,3,15984,Master's Thesis,Zalman,Sandra,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8677,2,15985,Reading for Comps Exams,Zarnow,Leandra Ruth,0,0,0,0,0,1,0,
+Spring 2023,MUSA,2340,1,15986,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6567,4,15987,Research Practicum A,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,4363,1,15989,Concrete Design,Belarbi,Abdeldjelil,15,15,24,6,2,0,0,2.485
+Spring 2023,PHAR,5683,3,15990,Cardiology,Wanat,Matthew A,2,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5681,4,15991,Infectious Diseases,Sofjan,Amelia Kartikasari,1,1,0,0,0,0,0,3.5
+Spring 2023,MUSA,4442,2,15992,Applied French Horn,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,6111,4,15993,Graduate Research Seminar,Li,Xingpeng,0,0,0,0,0,5,0,
+Spring 2023,PHOP,6567,5,15994,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6257,18,15997,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8698,1,15998,Graduate Research,Nelson,Antonya,0,0,0,0,0,2,0,
+Spring 2023,PHCA,8199,1,16001,Doctoral Dissertation Defense,Chen,Hua,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,4361,4,16002,Second Language Methodology,Li,Miao,34,4,1,0,0,0,0,3.812
+Spring 2023,NUTR,6312,1,16003,Capstone II,Haubrick,Kevin,3,1,0,0,0,0,0,3.668
+Spring 2023,NUTR,6311,1,16004,Capstone I,Haubrick,Kevin,2,1,0,0,0,0,0,3.667
+Spring 2023,HDFS,2314,8,16005,Human Dev and Interventions,Dunsmore,Julie C,44,17,8,2,3,0,5,3.257
+Spring 2023,INDS,3397,2,16008,Selected Topics,Vos,Gordon A,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8298,1,16009,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8298,3,16011,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2334,2,16013,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8399,2,16014,Doctoral Dissertation,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Spring 2023,AAS,2320,7,16015,Intro To African American Stdy,Lyons,Da' Vonte,28,7,1,0,0,0,0,3.723
+Spring 2023,BIOL,6309,1,16019,Mathematical Biology,Azevedo,Ricardo,3,0,0,0,0,0,1,4.0
+Spring 2023,PHCA,8298,5,16024,Doctoral Dissertation Research,Thornton,James D,2,0,0,0,0,0,0,4.0
+Spring 2023,EGRP,1150,2,16026,Engineering Applications VI,Luna Singh,Jennifer Austin,0,0,0,0,0,12,0,
+Spring 2023,ENGL,2330,2,16029,Writing Discipline English,Coleman,Quintin,11,6,3,0,0,0,0,3.4
+Spring 2023,MUSA,8243,2,16030,Doctoral Lecture Recital,Koozin,Timothy,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGI,1331,7,16036,Computing for Engineers,Luna Singh,Jennifer Austin,21,19,6,1,6,0,9,2.875
+Spring 2023,CUIN,8398,3,16037,Independent Study,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8999,4,16038,Doctoral Dissertation,Jacobs,Kris,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8320,8,16040,Doctoral Applied Music,Robinson,Daryl Allen,2,1,0,0,0,0,0,3.777
+Spring 2023,EGRP,1140,2,16045,Engineering Applications III,Luna Singh,Jennifer Austin,0,0,0,0,0,7,0,
+Spring 2023,CIS,3367,30,16046,Cloud Computing Architecture,Martinez,Jose C,15,25,12,0,2,0,0,2.981
+Spring 2023,EGRP,1142,1,16047,Engineering Applications V,Luna Singh,Jennifer Austin,0,0,0,0,0,10,0,
+Spring 2023,ECE,6307,1,16049,Nanomaterials and Solar Energy,Bao,Jiming,2,7,0,0,0,0,0,3.296
+Spring 2023,SPAN,8699,12,16054,Dissertation,Kanellos,Nicolas,0,0,0,0,0,2,0,
+Spring 2023,DIGM,1350,34,16055,Graphics for Digital Media,Johnson,Kelsey,9,14,2,2,0,0,5,3.123
+Spring 2023,CHEM,6498,10,16056,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8243,3,16058,Doctoral Lecture Recital,Hester,Timothy E,0,0,0,0,0,0,0,
+Spring 2023,MUSA,8243,4,16059,Doctoral Lecture Recital,Bertagnolli,Paul A,2,0,0,0,0,0,0,4.0
+Spring 2023,NUTR,6308,1,16061,Clinical Nutrition Practice I,Haubrick,Kevin,0,0,0,0,0,3,0,
+Spring 2023,COMM,3317,2,16062,Multimedia Journalism,Baruch Blanco,Maria Felicitas,20,0,0,0,0,0,0,3.967
+Spring 2023,HIST,6651,1,16063,Public History Internship,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,6380,1,16064,Public History Internship,Young,Nancy Beck,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4440,3,16065,Applied Trumpet,Vassallo,Jim Cates,2,1,0,0,0,0,0,3.667
+Spring 2023,PCOL,8298,1,16074,Doctoral Research,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2023,CHEM,1311,4,16076,Fundamentals of Chemistry,Teets,Thomas,18,49,56,28,35,0,28,1.958
+Spring 2023,HIST,8377,2,16077,Reading for Comps Exams,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6359,5,16078,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6498,2,16079,Special Problems,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6398,1,16080,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2023,PHLA,6100,1,16081,Leadership Seminar,Garey,Kevin W,14,0,0,0,0,0,0,4.0
+Spring 2023,PEP,8999,4,16082,Doctoral Dissertation,O'Connor,Daniel Patrick,0,0,0,0,0,1,0,
+Spring 2023,PHAR,5675,3,16085,Disease State Management,Gee,Jodie Sue,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4434,3,16088,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8399,15,16089,Doctoral Dissertation,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,1112,66,16090,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,10,2,0,0,0,3,3.045
+Spring 2023,MUSA,6140,1,16091,Graduate Recital I,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,7399,4,16094,Masters Thesis,Olson,Beth M,1,0,0,0,0,0,0,3.67
+Spring 2023,COSC,4370,1,16095,Interactive Computer Graphics,Deng,Zhigang,30,17,4,2,0,0,4,3.365
+Spring 2023,COSC,4331,1,16097,Real-Time Syst & Embedded Prog,Cheng,Albert M K,8,10,4,1,1,0,5,2.876
+Spring 2023,PCOL,8399,1,16103,Doctoral Dissertation,Bond,Richard A,0,0,0,0,0,1,0,
+Spring 2023,WGSS,2350,10,16106,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,22,3,0,0,2,0,3,3.568
+Spring 2023,HDCS,1300,7,16107,Human Ecosystems & Tech Change,Mudd,Blake Stevens,34,7,5,0,0,0,2,3.623
+Spring 2023,PSYC,6393,8,16108,Clinical Research Practicum,Medina PhD,Luis Daniel,0,0,0,0,0,1,0,
+Spring 2023,WGSS,2350,2,16115,Intro To Women's Studies,Pegoda,Andrew Joseph,6,6,9,3,4,0,2,2.262
+Spring 2023,BIOE,8298,8,16116,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Spring 2023,MUSA,3402,1,16117,Applied Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,3.67
+Spring 2023,SPAN,1502,7,16125,Elementary Spanish II,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,8,5,8,1,2,0,2,2.625
+Spring 2023,SPAN,2311,2,16127,Intermediate Spanish I,Gellon,Sofia,4,8,6,1,2,0,3,2.461
+Spring 2023,BZAN,6310,3,16128,Quant Analysis for Busn Dec,Wiley,Briceon C,15,16,8,0,0,0,1,3.163
+Spring 2023,MATH,8698,25,16130,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,2,0,
+Spring 2023,ARTH,4399,1,16131,Senior Honors Thesis,Zalman,Sandra,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8398,5,16132,Independent Study,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,7124,2,16137,Cell Biology Seminar,Dauwalder,Brigitte,0,0,0,0,0,6,0,
+Spring 2023,PCOL,8998,1,16139,Doctoral Research,Cuny,Gregory D,0,0,0,0,0,1,0,
+Spring 2023,SCLT,6396,1,16141,Internship in Logistics,Bian,Zheyong,1,0,0,0,0,0,0,4.0
+Spring 2023,HLT,4392,2,16142,Field Work in Community Health,Solari Williams,Kayce D,37,5,3,1,1,0,2,3.589
+Spring 2023,EGRP,1170,2,16144,Engineering Applications IX,Luna Singh,Jennifer Austin,0,0,0,0,0,7,0,
+Spring 2023,CUIN,8690,4,16155,Doctoral Thesis,McNeil,Sara G,0,0,0,0,0,1,0,
+Spring 2023,MUED,4340,2,16156,Elem/Middle Schl Inst. Admin.,Hansen,Erin Melissa,3,1,1,0,0,0,0,3.4
+Spring 2023,MUSI,8106,4,16157,Doctoral Large Ensemble,Weber,Mary E,3,0,0,0,0,0,0,4.0
+Spring 2023,LAAF,8300,1,16158,Study Abroad for Law Students,Gabriel,Derrick Earl,0,0,0,0,0,1,0,
+Spring 2023,HIST,4399,1,16163,Senior Honors Thesis,Hernandez,Jose A,0,0,1,0,0,0,0,2.0
+Spring 2023,CUIN,8699,5,16165,Doctoral Dissertation,Alarcon,Jeannette Driscoll,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6298,2,16166,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Spring 2023,MUSI,6100,2,16169,Chamber Music,Lo,Mann-Wen,6,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8699,3,16171,Doctoral Dissertation,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8243,8,16172,Doctoral Lecture Recital,Dirst,Matthew C,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8241,13,16174,Doctoral Recital II,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2023,NSS,4345,1,16176,Capstone - Nat. Sec. Studies,Vardy,Ronald V,1,3,2,1,2,0,1,1.963
+Spring 2023,POLS,1335,1,16177,World Politics,Sisman,Ozlem,4,13,12,6,3,0,6,2.219
+Spring 2023,POLS,3310,5,16178,Intro to Political Theory,Vassiliou,Constantine,9,11,15,4,0,0,3,2.573
+Spring 2023,POLS,3318,1,16179,Intro To Public Policy,Davis,Sharon M,6,9,5,1,2,0,2,2.753
+Spring 2023,POLS,3335,1,16180,Political Terrorism,Bagashka,Tanya G,5,4,2,1,1,0,2,2.694
+Spring 2023,SOCW,7305,4,16183,Evaluation of SW Practice,Rose,Alexis Lee,15,5,0,0,0,0,0,3.75
+Spring 2023,SOCW,7329,1,16184,SW Practice for Policy Change,Ortiz,Lillian Aguirre,19,4,0,0,0,0,0,3.826
+Spring 2023,SOCW,6305,1,16185,Social Work Research,Acquati,Chiara,20,3,0,0,0,0,0,3.87
+Spring 2023,SOCW,6305,2,16186,Social Work Research,Leung,Yuk-Hi Patrick,26,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,6305,3,16187,Social Work Research,Leung,Yuk-Hi Patrick,26,1,0,0,0,0,0,3.963
+Spring 2023,SOCW,7310,1,16188,Program Planning & Evaluation,Foster,Charday D,12,1,0,0,0,0,0,3.923
+Spring 2023,SOCW,6307,1,16189,Policy in the Soc Environment,Vogel,Alicia Nicole,27,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,6307,2,16190,Policy in the Soc Environment,Lucas,Virginia,23,1,0,0,0,0,0,3.958
+Spring 2023,SOCW,6307,3,16191,Policy in the Soc Environment,Powell,Torey Ian,23,2,0,0,0,0,0,3.92
+Spring 2023,ENGI,1331,8,16192,Computing for Engineers,Burleson,Daniel W,19,8,5,2,5,0,8,2.821
+Spring 2023,SOCW,7301,2,16193,Confronting Oppression & Injus,Shepherd,Donisha Shanice,25,0,0,0,0,0,0,4.0
+Spring 2023,CLAS,3345,1,16194,Myth&Performance in Greek Trag,Kidder,Kathleen,14,6,3,2,1,0,1,3.128
+Spring 2023,PHAR,5169,1,16202,Module Related Skills Lab IV,Surati,Dhara Divyang,82,23,0,0,0,0,0,3.781
+Spring 2023,PHAR,5367,1,16203,Integrated Heme/Onc Module,Trivedi PhD,Meghana,31,59,15,0,0,0,0,3.152
+Spring 2023,PHAR,5368,1,16204,Integrated Psychiatric Module,Tejada-Simon,Maria Victoria,23,64,18,0,0,0,0,3.048
+Spring 2023,PHAR,5269,1,16205,Complex Problems,Fernandez,Julianna M,48,45,12,0,0,0,0,3.343
+Spring 2023,PHAR,5266,1,16206,Pharmacy Law,Tolleson,Shane Russell,20,64,21,0,0,0,0,2.99
+Spring 2023,GHL,3440,1,16210,Hotel Operations,Cheatham,Cathy A,29,9,1,0,0,0,0,3.718
+Spring 2023,CHEM,2325,5,16212,Organic Chemistry II,Carrow,Bradley,7,5,0,0,0,0,1,3.501
+Spring 2023,ECON,3385,1,16214,Economics of Energy,Hirs,Edward A,36,7,0,0,0,0,6,3.753
+Spring 2023,ECON,3362,1,16215,Mathematics for Economics,Saboury,Piruz,12,10,5,1,4,0,6,2.719
+Spring 2023,SPAN,3374,1,16216,Span American Culture & Civ,Cuesta,Mabel,17,5,0,0,1,0,1,3.537
+Spring 2023,ECON,7331,1,16218,Econometrics I,Canen,Nathan Joseph,3,7,0,0,0,0,0,3.333
+Spring 2023,HON,4330,1,16220,Narratives in the Professions,Reynolds,Aaron E,24,0,0,0,0,0,0,3.959
+Spring 2023,WCL,2351,1,16221,World Cultures Thru Lit & Arts,Adkins,Alexander,21,3,0,0,1,0,1,3.641
+Spring 2023,HON,3350,1,16222,Principles of Data and Society,Kapral,Andrew J,7,2,0,0,0,0,1,3.704
+Spring 2023,HON,4350,1,16224,Data and Society in Practice,Kapral,Andrew J,7,2,1,0,0,0,0,3.567
+Spring 2023,COMD,1333,2,16225,Intro to Comm Sci & Disorders,Ross,Byron L,16,14,8,6,0,0,2,2.834
+Spring 2023,POLC,6342,1,16226,Pol Econ & Ethics of Market Pr,Granato,James S,2,3,0,0,0,0,0,3.466
+Spring 2023,ILAS,4350,1,16227,Interdisciplinary Problem Solv,Oliva,Luca,15,4,1,0,2,0,2,3.364
+Spring 2023,ARCH,1501,22,16228,Arc/Int Arc Design Studio II,Medina Vilela,Mario Andre,6,3,0,0,0,0,3,3.483
+Spring 2023,POLC,4342,2,16230,Pol Econ and Ethics of Market,Granato,James S,7,10,2,0,0,0,0,3.246
+Spring 2023,BIOL,4315,2,16234,Neuroscience,Ziburkus,Jokubas,60,23,11,0,0,0,6,3.532
+Spring 2023,BIOL,6315,1,16235,Neuroscience,Ziburkus,Jokubas,10,0,0,0,0,0,0,3.967
+Spring 2023,HON,3332,1,16236,Mapping Success,Rayder,Benjamin Taylor,9,1,0,0,0,0,0,3.9
+Spring 2023,HON,3132,1,16237,Mapping Success,Rayder,Benjamin Taylor,14,1,0,0,0,0,0,3.889
+Spring 2023,ARCH,5500,21,16238,Architecture Design Studio IX,Roldan Caballero,Jose Manuel,1,7,4,0,0,0,0,2.805
+Spring 2023,ARCH,5500,23,16240,Architecture Design Studio IX,Rogers,Susan,9,7,0,0,0,0,0,3.563
+Spring 2023,ARCH,5500,25,16242,Architecture Design Studio IX,Woodfill,Celeste Ponce,6,6,0,0,0,0,0,3.555
+Spring 2023,SPAN,2311,4,16244,Intermediate Spanish I,Pueyo Castan,Josefa,0,2,8,2,3,0,4,1.534
+Spring 2023,SPAN,2311,5,16245,Intermediate Spanish I,Pueyo Castan,Josefa,6,10,4,2,2,0,3,2.557
+Spring 2023,SPAN,1501,7,16246,Elementary Spanish I,Patterson,Haley F,4,8,8,0,1,0,3,2.73
+Spring 2023,SPAN,1501,9,16248,Elementary Spanish I,del Castillo Garza,Alejandro,11,7,3,0,1,0,0,3.137
+Spring 2023,SPAN,1501,15,16251,Elementary Spanish I,Torres-Calle,Maria Jose,7,9,3,0,4,0,1,2.681
+Spring 2023,SPAN,1501,19,16253,Elementary Spanish I,Martinez,Carlos David,7,10,4,0,2,0,1,2.841
+Spring 2023,MANA,6383,1,16255,Strategic Managment,Carlin,Barbara A,9,5,0,0,0,0,0,3.572
+Spring 2023,GEOL,4378,1,16256,Data Analyt and Mach Learning,Sun,Jiajia,5,3,0,0,1,0,0,3.222
+Spring 2023,INDE,6378,1,16257,Case Study in Applied Inde Erg,Irani,Shahrukh A,25,9,2,0,0,0,1,3.602
+Spring 2023,CHEM,6314,1,16258,Spectroscopy,Yang,Ding-Shyue,3,3,0,0,0,0,0,3.445
+Spring 2023,CHEM,7325,1,16259,Surface Science,Baldelli,Steve,1,2,0,0,0,0,0,3.553
+Spring 2023,INDS,6361,1,16260,Industrial Design Studio II,Feng,Jeff Feng,2,0,0,0,0,0,0,4.0
+Spring 2023,WCL,3376,2,16262,Photo & Visual Stories,Ramirez,Marie Theresa,3,0,0,0,0,0,0,3.89
+Spring 2023,WCL,2370,2,16263,Cultures of India,Tiwari,Bhavya,9,3,2,2,0,0,1,3.188
+Spring 2023,WCL,3366,3,16264,Latin American and Latino Film,Centeno,Daniel,11,8,5,0,2,0,1,2.886
+Spring 2023,INDS,1501,3,16266,Industrial Design Studio II,Jackson,Megan H,1,5,0,0,0,0,2,3.167
+Spring 2023,PETR,6320,1,16267,Enhanced Oil Recovery Proc I,Dindoruk,Birol,5,0,1,0,0,0,0,3.557
+Spring 2023,PETR,6326,1,16269,Applied Reservoir Simulation,Rietz,Dean C,4,3,1,0,0,0,0,3.375
+Spring 2023,HON,2341,1,16272,Classics of Modernity,Charara,Hayan S,11,0,0,0,0,0,0,3.88
+Spring 2023,HON,2341,2,16273,Classics of Modernity,Charara,Hayan S,6,6,0,0,0,0,0,3.555
+Spring 2023,MATH,4322,1,16274,Data Science and Machine Learn,Poliak,Cathy Dawn,80,15,2,1,0,0,0,3.759
+Spring 2023,GEOL,7341,1,16275,Geophysical Data Processing,Zhou,Hua-Wei,5,0,0,0,0,0,0,3.934
+Spring 2023,MATH,1300,1,16276,Fundamentals of Mathematics,Chang,James A,0,0,0,0,0,21,0,
+Spring 2023,MATH,1100,1,16277,Developmental Math,Chang,James A,0,0,0,0,0,48,16,
+Spring 2023,DIGM,3252,30,16278,Graphic Communication Output,Dawson,Michael John,5,12,11,1,0,0,0,2.679
+Spring 2023,DIGM,1376,30,16280,User Experience (UX)Principles,Rodwell,Elizabeth Ann,65,72,25,5,6,0,6,3.01
+Spring 2023,DIGM,2325,32,16281,Info Tech for Digital Media,Hargrove,Mark Stephen,58,55,13,1,9,0,8,3.106
+Spring 2023,GEOL,7301,2,16286,Capstone Project,Van Nieuwenhuise,Donald S,1,0,0,0,0,0,0,3.67
+Spring 2023,BCHS,4355,1,16287,Eukaryotic Gene Regulation,Schwartz,Robert J,23,2,0,0,0,0,0,3.828
+Spring 2023,PHYS,3305,1,16288,Introduction To Astrophysics,Renshaw,Andrew,17,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,4360,1,16289,Space and Atmospheric Physics,Bering,Edgar A,5,1,2,0,0,0,0,3.375
+Spring 2023,RELS,1301,4,16290,Intro To Religious Studies,Ullrey,Aaron Michael,20,11,5,1,3,0,7,3.174
+Spring 2023,HDCS,3300,3,16293,Org Decisions,Stewart,Quentin K,21,10,3,0,1,0,0,3.381
+Spring 2023,MATH,5385,1,16296,Statistics,Kwon,Junhyeon,6,6,0,0,1,0,1,3.231
+Spring 2023,ELCS,8399,4,16298,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8699,4,16301,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8331,1,16302,Finance in Higher Education,Messa,Emily Alice,20,1,0,0,0,0,0,3.874
+Spring 2023,MATH,3338,2,16303,Probability,Kao,Edward P,7,7,0,0,0,0,6,3.429
+Spring 2023,SCLT,3375,32,16306,Maritime Operations,Chopra,Anuj,15,14,4,0,0,0,0,3.293
+Spring 2023,SCLT,6314,3,16307,Measurement and Evaluation,Bian,Zheyong,34,4,0,0,0,0,0,3.877
+Spring 2023,SCLT,6320,3,16308,Procurement Strategies,Wang,Kailai,9,1,0,0,0,0,0,3.933
+Spring 2023,MATH,6359,2,16309,Appl. Stat. & Mult. Analysis,Poliak,Cathy Dawn,1,1,0,0,0,0,0,3.335
+Spring 2023,TLIM,3360,30,16311,Law & Ethics-Tech & Innovation,Feriante,Chris,57,24,11,4,5,0,0,3.234
+Spring 2023,PHLS,7393,3,16312,Internship and Practicum,Hassett,Kristen Spring,6,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8312,8,16314,Lab of Practice-Res Meth Devel,Lopez,Ruth Maria,1,0,0,0,0,0,0,4.0
+Spring 2023,SPEC,6390,1,16315,Supervised Exper in Spec Educ,Thompson,Amber M,0,0,0,0,0,0,1,
+Spring 2023,PSYC,4311,1,16316,Close Relationships,Derrick,Jaye L,32,10,2,0,0,0,0,3.637
+Spring 2023,FORE,6399,1,16318,Master's Thesis,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGI,1331,9,16319,Computing for Engineers,Kowal,Marsha Christine,27,12,7,6,5,0,7,2.837
+Spring 2023,ENGI,1331,10,16320,Computing for Engineers,Luna Singh,Jennifer Austin,8,0,2,0,1,0,1,3.243
+Spring 2023,ELET,4331,1,16321,Medical Imaging,Zouridakis,George,9,5,0,0,0,0,0,3.596
+Spring 2023,HRD,6302,2,16322,Design & Management E-Learning,Rainbolt,Hilary,3,0,0,0,0,0,1,3.67
+Spring 2023,HRD,6359,1,16323,Trends in Org Development,Kjerfve,Tania M,7,0,0,0,0,0,0,4.0
+Spring 2023,ELET,6351,1,16324,Biomedical Data Mining,Pollonini,Luca,8,1,0,0,0,0,0,3.816
+Spring 2023,ELET,6358,1,16325,Optical Brain Imaging,Pollonini,Luca,3,0,0,0,0,0,0,3.78
+Spring 2023,ELET,6354,1,16326,Biomedical Image Analysis,Merchant,Fatima Aziz,2,0,1,0,0,0,0,3.333
+Spring 2023,ELET,4354,1,16327,Biomedical Image Analysis,Merchant,Fatima Aziz,3,8,7,0,0,0,1,2.668
+Spring 2023,HRD,3310,2,16328,Talent Management,Edwards,Malaika,10,25,9,1,2,0,2,2.872
+Spring 2023,ARLD,6315,1,16330,PR & Marketing for Arts,Luks Jacobs,Joel,15,0,0,0,0,0,0,4.0
+Spring 2023,MECT,2354,30,16331,Introduction to Mechanics,Basaran,Burak,4,7,15,14,4,0,3,1.863
+Spring 2023,COSC,6386,1,16336,Prgrm Analys & Testing,Alipour,Mohammad Amin,8,0,1,0,0,0,0,3.778
+Spring 2023,HIST,1302,3,16337,The U.S. Since 1877,Amaral,Lindsay Nicole,73,23,10,5,14,0,8,3.091
+Spring 2023,PHAR,5662,2,16338,Academic Scholarship,Surati,Dhara Divyang,2,0,0,0,0,0,0,4.0
+Spring 2023,INDS,3265,1,16342,Design Research Methods II,Wells,Adam C,7,8,4,0,0,0,0,3.123
+Spring 2023,ENGL,3318,1,16343,The British Novel Since 1832,Chatterjee,Sreya,19,6,0,0,2,0,0,3.506
+Spring 2023,ENGL,3369,1,16345,Caribbean Literatures,Singh,Kavita Ashana,9,8,5,0,3,0,2,2.84
+Spring 2023,ENGL,4319,1,16346,English in Secondary Schools,Bachmann,Abbey M,23,1,0,0,0,0,0,3.903
+Spring 2023,ENGL,4378,1,16347,Women Writers,Stock,Lorraine K,4,2,3,0,0,0,0,2.964
+Spring 2023,ENGL,4394,1,16348,The Historical Novel,Zamora,Lois,3,3,0,1,4,0,2,1.85
+Spring 2023,CUIN,4304,1,16349,La/Read Meth in Span,Burgess,Miguel,14,0,0,0,0,0,0,4.0
+Spring 2023,MARK,4379,2,16350,Personal Branding,Muschalik,Monica Harper,19,3,0,0,0,0,0,3.879
+Spring 2023,TMTH,3360,2,16351,Applied Technical Statistics,Telles,John E,13,16,7,2,5,0,6,2.705
+Spring 2023,TEPM,6395,2,16353,Integration Project,Carden,Lila L,6,1,0,0,0,0,0,3.857
+Spring 2023,TLIM,3331,30,16354,Innovation Development,Crawley,David L,5,1,4,0,1,0,2,2.788
+Spring 2023,TLIM,3330,31,16356,Innovation Principles,Mehring,Brian George,8,7,10,2,3,0,0,2.456
+Spring 2023,CIS,6322,1,16358,Secure Enterprise Computing,Burke,Ross,62,6,0,0,0,0,0,3.897
+Spring 2023,MANA,6A32,4,16359,Organizational Behavior & Mgt,Krylova,Ksenia O,26,2,0,0,1,0,0,3.702
+Spring 2023,CIS,6326,1,16360,Critical Thinking in Info Sec,Conklin,William A,37,6,0,0,0,0,0,3.845
+Spring 2023,COSC,6384,1,16361,Real-Time Systems,Cheng,Albert M K,2,5,2,0,0,0,0,3.183
+Spring 2023,COSC,6372,1,16362,Computer Graphics,Deng,Zhigang,5,3,0,0,0,0,0,3.543
+Spring 2023,ARLD,6325,1,16363,Artist Career Development,Dallas,Marci R,3,1,2,1,0,0,0,2.763
+Spring 2023,MATH,1351,1,16364,Intro to Geometric Reasoning,Chang,James A,52,102,46,62,46,0,36,2.15
+Spring 2023,MATH,1342,2,16365,Elementary Statistical Methods,Weber,Thomas Christian,100,90,74,50,56,0,50,2.335
+Spring 2023,ELED,3322,5,16367,Elem Reading Phonics Instructn,Alba,Celeste,14,2,0,0,0,0,0,3.813
+Spring 2023,MANA,7356,2,16369,Inclusive Leadership,Fernandez,Alejandro,23,1,0,0,0,0,0,3.931
+Spring 2023,MANA,7334,1,16371,Learning Sys &Mgmt Development,Bozeman,Dennis,8,10,0,0,0,0,1,3.518
+Spring 2023,BUSI,2305,1,16373,Business Statistics,Patterson,Staci A,86,102,98,72,24,0,130,2.363
+Spring 2023,BUSI,2305,2,16374,Business Statistics,Patterson,Staci A,52,64,66,96,38,0,144,1.929
+Spring 2023,BUSI,2305,3,16375,Business Statistics,Wiley,Briceon C,126,124,94,66,12,0,88,2.668
+Spring 2023,GHL,2315,1,16376,Introduction to SPA Management,Doudna,Simone P,28,16,2,2,1,0,1,3.388
+Spring 2023,GHL,3353,1,16378,Hosp Metrics & Data Analytics,Lee,Minwoo,13,3,0,0,0,0,0,3.771
+Spring 2023,GHL,4360,1,16379,Hospitality Internship,Shepherd,Ashley,64,4,0,0,3,0,2,3.742
+Spring 2023,GHL,6324,1,16381,Hosp. Busn Strategies in Amer,Kim,Jaewook,19,0,0,0,0,0,0,4.0
+Spring 2023,GHL,7334,1,16382,Pricing & Revenue Mgmt in Hosp,Kazemi Zarkouei,Mohammad Sadegh,8,3,0,1,1,0,0,3.256
+Spring 2023,GHL,6340,1,16383,Behavior and Hosp. Lead. Strat,Guchait,Priyanko,15,3,1,0,0,0,0,3.754
+Spring 2023,MATH,3339,4,16384,Statistics for the Sciences,Niu,Yabo,33,16,16,2,4,0,7,2.982
+Spring 2023,ATP,6324,1,16385,Healthcare Administration,Knoblauch,Mark Alan,15,0,0,0,0,0,0,4.0
+Spring 2023,CNST,6307,1,16387,Stati and Optimiz Method in CM,Senouci,Ahmed,13,2,1,0,0,0,0,3.709
+Spring 2023,ETIM,6310,1,16390,Fundamentals of Innovation,Kovach,Jamison,5,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6317,1,16391,Innovative Hosp. Technologies,Lee,Minwoo,18,1,0,0,0,0,0,3.947
+Spring 2023,MANA,4346,2,16393,Leadership Development,Evans,Klavdia Markelova,47,8,3,0,0,0,0,3.719
+Spring 2023,MANA,4350,2,16394,International Management,Celly,Nikhil,55,3,1,0,1,0,0,3.85
+Spring 2023,MANA,4341,1,16395,Leading Organizational Change,Barrett,Beverly,47,9,1,0,0,0,1,3.772
+Spring 2023,MANA,4331,2,16396,Current Issues Human Res Mgmt,Walker,William A,5,3,1,1,0,0,0,3.101
+Spring 2023,MANA,4330,3,16397,Intro to Strategic HR Mgt,Sebastijanovic,Marina,21,32,5,0,0,0,2,3.264
+Spring 2023,MANA,4358,1,16398,Compensation and Benefits,Zamanipour,Tina,29,14,8,4,0,0,3,3.236
+Spring 2023,BUSI,2305,4,16399,Business Statistics,Wiley,Briceon C,18,22,6,0,0,0,2,3.218
+Spring 2023,BZAN,6350,1,16400,Quant Found for Busi Analytics,Wang,Cheng,21,2,0,0,0,0,0,3.913
+Spring 2023,BZAN,6353,1,16401,Res Design-Probs Busi Anlytcs,Aron,Ravi,5,18,0,0,0,0,0,3.275
+Spring 2023,BUSI,3300,1,16403,Intro to Personal Finance,Munchbach,Jim,46,5,1,1,0,0,0,3.786
+Spring 2023,BUSI,3300,2,16404,Intro to Personal Finance,Munchbach,Jim,37,8,2,1,3,0,3,3.399
+Spring 2023,BUSI,3300,3,16405,Intro to Personal Finance,Harvey,Danny,52,0,0,0,2,0,1,3.84
+Spring 2023,MIS,4378,3,16406,Admin of Computer-Based MIS,Skinner,Richard James,16,25,8,1,0,0,0,3.12
+Spring 2023,DIGM,4378,30,16407,Senior Project,Liao,Tony Chung-Li,18,12,1,0,0,0,1,3.41
+Spring 2023,HRD,3350,1,16409,Workforce Diversity and Global,Lopez,Johana,13,15,5,1,4,0,2,2.816
+Spring 2023,HRD,4344,30,16410,Designing E-Learning,Bennett,LaTasha,30,9,1,0,0,0,0,3.643
+Spring 2023,HRD,4350,30,16412,Org Dev & Consulting,Polesello,Daiane,5,3,3,1,1,0,0,2.693
+Spring 2023,BCIS,1305,1,16413,Business Computer Applications,Felvegi,Emese,195,86,39,12,6,0,11,3.339
+Spring 2023,BCIS,1305,2,16414,Business Computer Applications,Felvegi,Emese,152,101,49,16,7,0,17,3.149
+Spring 2023,BCIS,1305,3,16415,Business Computer Applications,Felvegi,Emese,25,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6160,2,16416,Gen Sem Visual Sciences,Della Santina,Luca,22,0,0,0,0,0,0,3.985
+Spring 2023,PHOP,7241,2,16417,Pathophysiology of the Eye,Harrison,Wendy W,1,1,0,0,0,0,0,3.665
+Spring 2023,PHOP,7242,2,16418,Visual Neuroscience,Das,Vallabh E,4,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,7243,2,16419,Optics and the Eye,Porter,Jason,3,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6371,3,16420,Experimental Design in VS,Burns,Alan R,9,1,0,0,0,0,1,3.834
+Spring 2023,FINA,4353,2,16422,Practicum Pers Finan Planning,Lopez,John C,8,4,5,0,0,0,0,3.293
+Spring 2023,FINA,4382,1,16423,Developing R E Project,Williams,Junious E,14,3,2,0,1,0,1,3.434
+Spring 2023,SCM,7335,1,16424,Logistics Management,Robinson Jr,Powell Ersell,14,15,0,0,0,0,2,3.437
+Spring 2023,SCM,7385,1,16425,Supply Chain Corp Projects,Smith,Gordon D,8,4,0,0,0,0,0,3.777
+Spring 2023,FINA,7383,1,16427,R E MKT Analysis & Valuation,Rando,Scott,8,0,0,0,0,0,0,4.0
+Spring 2023,FINA,4323,1,16428,Investment & Mutual Fund Mgt,Kumar,Praveen,40,14,1,0,0,0,0,3.721
+Spring 2023,BUSI,3302,1,16429,Connecting Bauer to Business,Belinne,Jamie King,312,72,22,8,5,0,4,3.618
+Spring 2023,BUSI,3302,2,16430,Connecting Bauer to Business,Belinne,Jamie King,202,73,29,15,6,0,8,3.385
+Spring 2023,BUSI,4350,1,16431,Business Law and Ethics,Currie,Daniel David,215,38,10,3,5,0,4,3.641
+Spring 2023,BUSI,4350,2,16432,Business Law and Ethics,Currie,Daniel David,198,57,14,5,1,0,0,3.591
+Spring 2023,BUSI,4350,3,16433,Business Law and Ethics,Williams,John M,120,103,26,8,5,0,4,3.21
+Spring 2023,BUSI,4350,4,16434,Business Law and Ethics,Williams,John M,75,31,7,1,2,0,1,3.48
+Spring 2023,BUSI,4350,5,16435,Business Law and Ethics,Williams,John M,43,26,4,1,1,0,0,3.352
+Spring 2023,PHYS,1301,3,16438,College Physics I (lecture),Portillo Vazquez,Israel,8,12,20,8,5,0,13,2.214
+Spring 2023,PHYS,1301,6,16439,College Physics I (lecture),Chu,Wei-Kan,13,30,12,5,0,0,19,2.85
+Spring 2023,MANA,4353,2,16440,Mgmt Training and Career Devel,Belinne,Jamie King,16,2,0,0,1,0,0,3.684
+Spring 2023,KIN,1304,8,16445,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,225,27,24,6,7,0,4,3.612
+Spring 2023,KIN,1304,9,16446,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,224,33,12,10,11,0,5,3.572
+Spring 2023,KIN,1304,10,16447,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,126,31,12,7,12,0,6,3.372
+Spring 2023,MANA,3335,9,16458,Intro Org Behavior and Mgmt,Currie,Daniel David,117,46,4,2,1,0,3,3.565
+Spring 2023,BUSI,1301,1,16463,Business Principles,Thompson,Joseph Lee,108,2,1,0,0,0,3,3.961
+Spring 2023,BUSI,1301,2,16464,Business Principles,Thompson,Joseph Lee,217,10,6,1,10,0,2,3.732
+Spring 2023,COMM,2311,5,16465,Writing for Print and Digital,Crixell,Charles A,6,15,3,2,2,0,1,2.762
+Spring 2023,COMM,2311,9,16466,Writing for Print and Digital,Butler,Bryan C,7,11,2,0,0,0,0,3.283
+Spring 2023,BUSI,1301,3,16468,Business Principles,Thompson,Joseph Lee,20,0,0,0,0,0,0,3.951
+Spring 2023,PSYC,7338,1,16469,CDLNeuropsych: Assess/App II,Cirino,Paul,3,1,0,0,0,0,0,3.668
+Spring 2023,KIN,4315,2,16470,Motor Learning and Control,Park,Seoung Hoon,28,6,0,2,1,0,1,3.523
+Spring 2023,COMM,2311,11,16472,Writing for Print and Digital,Radcliffe Andre,Jennifer,12,7,3,0,0,0,3,3.244
+Spring 2023,COMM,2311,13,16474,Writing for Print and Digital,Radcliffe Andre,Jennifer,14,11,0,0,1,0,1,3.283
+Spring 2023,MARK,4380,1,16476,Digital Selling,Habel,Johannes,23,6,0,0,0,0,0,3.793
+Spring 2023,CUIN,7314,1,16478,Sociocul & Policies in Bil Ed,Cole,Mikel Walker,8,3,0,0,0,0,0,3.607
+Spring 2023,MANA,4355,3,16480,Selection and Staffing,Van Egdom,Drake Alexander,26,7,4,0,2,0,0,3.444
+Spring 2023,COMM,3301,1,16481,Doctor-Patient Interaction,Yamasaki,Jill S,50,7,3,0,0,0,0,3.761
+Spring 2023,COMM,3311,2,16482,Editing Print & Digital Media,Crixell,Charles A,9,5,4,0,0,0,0,3.259
+Spring 2023,COMM,3311,3,16483,Editing Print & Digital Media,Crixell,Charles A,9,8,4,0,0,0,0,3.254
+Spring 2023,COMM,3315,2,16484,News and Social Media,Trigg,Katishia Leonna,18,3,2,0,0,0,0,3.653
+Spring 2023,CHEE,5379,1,16485,Safety and Reliability,Smith,Christopher Michael,1,1,0,0,0,0,0,3.335
+Spring 2023,COMM,3318,1,16486,Multimedia Storytelling,Uhrick,Jan,18,3,0,0,0,0,0,3.826
+Spring 2023,CHEE,6379,1,16487,Safety and Reliability,Smith,Christopher Michael,9,3,0,0,0,0,0,3.75
+Spring 2023,CHEM,1305,3,16488,Foundations of Chemistry,St Hill,Lydia Ruth,5,23,13,5,17,0,9,1.889
+Spring 2023,BIOE,4150,3,16489,Genomic & Proteomic Lab,Akay,Yasemin M,12,1,0,0,0,0,0,3.872
+Spring 2023,BIOE,4150,4,16490,Genomic & Proteomic Lab,Akay,Yasemin M,12,0,0,0,0,0,0,3.945
+Spring 2023,MECT,4331,1,16491,Heat Transfer Applications,Al-Jamal,Helmi,4,9,12,7,2,0,1,2.128
+Spring 2023,BIOE,3340,2,16492,Quantitative Physiology,Roh,Jinsook,3,7,3,0,0,0,0,2.949
+Spring 2023,CUIN,4375,10,16495,Classroom Management,Mateer,Ramona Caravella,9,6,0,0,0,0,0,3.578
+Spring 2023,EDUC,4315,2,16496,Student Teaching Sec,Evans,Paige K,35,0,0,0,0,0,1,3.962
+Spring 2023,PHYS,3112,1,16500,Modern Optics Laboratory,Forrest,Rebecca L,11,6,0,1,0,0,0,3.463
+Spring 2023,PHYS,3313,1,16501,Advanced Laboratory I,Timmins,Anthony Robert,6,1,1,1,0,0,0,3.223
+Spring 2023,ECON,6395,1,16504,Wkshp Res Method II,Prokopovych,Pavlo,0,0,0,0,0,0,0,
+Spring 2023,SOC,3301,1,16508,Intro to Sociological Research,Hwang,Hyunseok,10,24,4,0,1,0,0,3.043
+Spring 2023,COMM,3328,1,16509,Intro to Sports Production,Freedman,Michael,15,8,5,1,0,0,0,3.299
+Spring 2023,BUSI,4335,1,16510,Brainstorming to Bankrolling,Khumawala,Saleha B,5,1,1,0,0,0,2,3.43
+Spring 2023,THEA,2373,1,16511,Costume Technology,Niederer,Barbara,5,7,3,0,1,0,0,2.896
+Spring 2023,BUSI,1301,5,16513,Business Principles,Carvalho,Diogo,164,49,14,6,7,0,6,3.419
+Spring 2023,BUSI,1301,6,16514,Business Principles,Carvalho,Diogo,142,42,20,4,20,0,9,3.196
+Spring 2023,PHLS,6312,1,16515,Crisis Counseling,Lee,Jungeun,24,1,0,0,0,0,0,3.92
+Spring 2023,PHLS,6312,2,16516,Crisis Counseling,Lee,Jungeun,16,1,0,0,0,0,0,3.864
+Spring 2023,INTB,3355,5,16517,Global Environment of Business,Miljanic,Andra Olivia,116,93,20,8,4,0,8,3.247
+Spring 2023,INTB,3355,7,16518,Global Environment of Business,Farah,Elena,34,9,2,1,2,0,2,3.459
+Spring 2023,COMM,3368,4,16519,Principles of Public Relations,Ni,Lan,11,9,7,0,2,0,2,2.942
+Spring 2023,BIOE,4348,1,16520,Tissue Engineering,Horton,Renita Elillian,2,1,0,0,1,0,0,2.75
+Spring 2023,COMM,3369,4,16522,Strategic Comm. Writing,Belton,Stephanie,17,2,1,0,0,0,0,3.817
+Spring 2023,COMM,3376,1,16523,Media Effects,Archer,Allison Michelle Nam,18,11,0,1,1,0,1,3.313
+Spring 2023,ENGL,2306,3,16525,Intro To Poetry,Bradley,Jari,16,0,0,0,4,0,2,3.2
+Spring 2023,ENGL,2315,2,16526,Literature and Film,Christopherson,Alissa N,16,3,4,0,0,0,0,3.464
+Spring 2023,CIS,3365,3,16529,Database Management,Wu,Xuqing,12,26,28,0,0,0,4,2.778
+Spring 2023,ENGL,1301,14,16531,First Year Writing I,Valcin,Mariot,5,8,2,4,3,0,3,2.289
+Spring 2023,ENGL,1301,21,16533,First Year Writing I,Pan,Weijia,13,4,0,1,4,0,3,2.865
+Spring 2023,ENGL,1301,28,16534,First Year Writing I,Brooks,Stuart,12,2,0,1,3,0,1,3.074
+Spring 2023,ENGL,1301,29,16535,First Year Writing I,Jones,Baylea,11,3,1,0,4,0,0,2.773
+Spring 2023,ENGL,1301,30,16536,First Year Writing I,Jones,Baylea,7,3,1,2,5,0,1,2.223
+Spring 2023,ENGL,1301,32,16538,First Year Writing I,Brooks,Stuart,11,4,1,0,3,0,1,3.018
+Spring 2023,ENGL,1301,34,16540,First Year Writing I,Hiers,Maria,10,3,3,3,0,0,0,2.983
+Spring 2023,ENGL,1301,36,16542,First Year Writing I,Repass,Scott,6,6,2,2,2,0,1,2.685
+Spring 2023,ENGL,1301,38,16544,First Year Writing I,Repass,Scott,10,3,2,1,0,0,2,3.313
+Spring 2023,ENGL,1301,39,16545,First Year Writing I,Hiers,Maria,11,2,3,1,1,0,1,3.203
+Spring 2023,ENGL,1301,40,16546,First Year Writing I,Bronson,Brittany Leigh,5,6,4,0,0,0,4,2.957
+Spring 2023,ENGL,1301,44,16550,First Year Writing I,Rolater,Sara C,4,5,2,1,6,0,1,1.963
+Spring 2023,ENGL,1301,46,16552,First Year Writing I,Backus,Margot Gayle,5,9,1,0,2,0,1,2.844
+Spring 2023,ENGL,1302,19,16554,First Year Writing II,O'Bryan,Ann Patricia,14,3,1,0,1,0,0,3.544
+Spring 2023,ENGL,1302,20,16555,First Year Writing II,Fletcher,Larry L,2,3,7,2,3,0,1,1.902
+Spring 2023,ENGL,1302,21,16556,First Year Writing II,O'Bryan,Ann Patricia,13,2,1,1,1,0,1,3.371
+Spring 2023,ENGL,1302,22,16557,First Year Writing II,Lee,Eunjeong,5,7,2,1,2,0,2,2.686
+Spring 2023,ENGL,1302,34,16558,First Year Writing II,Yates,Kaitlyn,11,9,1,0,3,0,1,2.973
+Spring 2023,ENGL,1302,38,16560,First Year Writing II,Dykes,Justin,9,7,2,1,3,0,3,2.788
+Spring 2023,ENGL,1302,39,16561,First Year Writing II,Dykes,Justin,9,7,6,1,0,0,0,3.015
+Spring 2023,ENGL,1302,40,16562,First Year Writing II,Dykes,Justin,7,10,4,0,1,0,2,2.94
+Spring 2023,ENGL,1302,41,16563,First Year Writing II,Cowan,Joshua Jared,7,5,1,2,5,0,4,2.301
+Spring 2023,ENGL,1302,43,16565,First Year Writing II,Chatham,Donna Marie,6,6,3,0,7,0,2,2.107
+Spring 2023,ENGL,1302,44,16566,First Year Writing II,Rolater,Sara C,10,6,5,1,1,0,2,2.842
+Spring 2023,ENGL,1302,45,16567,First Year Writing II,Chatham,Donna Marie,10,5,2,1,5,0,1,2.537
+Spring 2023,ENGL,1302,47,16569,First Year Writing II,Chatham,Donna Marie,8,2,2,1,10,0,2,1.769
+Spring 2023,ENGL,1302,49,16570,First Year Writing II,Rolater,Sara C,10,3,3,3,2,0,4,2.746
+Spring 2023,ENGL,1302,50,16571,First Year Writing II,Krajniak,Matthew J,2,13,5,1,2,0,2,2.608
+Spring 2023,ENGL,1302,51,16572,First Year Writing II,Long,Steven A.,4,10,3,0,2,0,0,2.737
+Spring 2023,ENGL,1302,52,16573,First Year Writing II,Presswood,Phillip Hilliard,15,2,0,0,2,0,1,3.474
+Spring 2023,ENGL,1302,53,16574,First Year Writing II,Guajardo,Paul,8,6,2,0,1,0,1,3.157
+Spring 2023,ENGL,1302,54,16575,First Year Writing II,Shepley,Nathan,5,11,2,1,0,0,0,3.087
+Spring 2023,ENGL,1302,56,16577,First Year Writing II,Rajkumar,Nidhi,12,6,3,1,1,0,2,3.117
+Spring 2023,ENGL,1302,61,16580,First Year Writing II,Anderson,Claire F,21,2,1,0,0,0,1,3.806
+Spring 2023,CHEM,1112,5,16581,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,12,0,0,0,0,1,3.214
+Spring 2023,COMM,2328,3,16582,Broadcast Writing Basics,Trigg,Katishia Leonna,5,9,3,0,0,0,3,3.098
+Spring 2023,CNST,4220,1,16584,Comp CM & Emerging Practices,Coble,Lana Kay,29,5,1,0,0,0,1,3.753
+Spring 2023,IDNS,1141,1,16585,Chemistry I SEP Workshop,Pattison,Donna,9,10,4,4,0,0,7,2.816
+Spring 2023,IDNS,1130,1,16586,Precalculus SEP Workshop,Pattison,Donna,16,12,14,6,2,0,6,2.693
+Spring 2023,IDNS,1141,2,16587,Chemistry I SEP Workshop,Pattison,Donna,11,11,3,3,0,0,1,3.071
+Spring 2023,IDNS,1141,3,16588,Chemistry I SEP Workshop,Pattison,Donna,4,12,5,2,2,0,6,2.52
+Spring 2023,IDNS,1131,1,16589,Calculus I SEP Workshop,Pattison,Donna,14,4,4,4,0,0,4,3.128
+Spring 2023,IDNS,1131,2,16590,Calculus I SEP Workshop,Pattison,Donna,16,6,8,0,0,0,2,3.179
+Spring 2023,IDNS,1142,1,16591,Chemistry II SEP Workshop,Pattison,Donna,8,1,2,0,0,0,1,3.545
+Spring 2023,IDNS,1132,1,16592,Calculus II SEP Workshop,Pattison,Donna,18,2,4,0,2,0,0,3.257
+Spring 2023,IDNS,1142,2,16593,Chemistry II SEP Workshop,Pattison,Donna,9,6,2,3,1,0,2,2.905
+Spring 2023,IDNS,1132,2,16594,Calculus II SEP Workshop,Pattison,Donna,18,6,8,0,0,0,4,3.354
+Spring 2023,IDNS,1142,3,16595,Chemistry II SEP Workshop,Pattison,Donna,11,2,2,2,0,0,2,3.314
+Spring 2023,IDNS,1132,3,16596,Calculus II SEP Workshop,Pattison,Donna,16,2,6,4,0,0,4,3.071
+Spring 2023,COMM,1307,5,16597,Media and Society,Ashley,Laura B,30,33,18,6,10,0,2,2.687
+Spring 2023,IDNS,1142,4,16598,Chemistry II SEP Workshop,Pattison,Donna,20,5,6,1,0,0,3,3.354
+Spring 2023,IDNS,1142,5,16599,Chemistry II SEP Workshop,Pattison,Donna,15,11,2,0,0,0,1,3.476
+Spring 2023,IDNS,2133,1,16600,Calculus III SEP Workshop,Pattison,Donna,8,1,1,0,0,0,0,3.667
+Spring 2023,COMM,3353,3,16601,Information & Comm Tech I,Liu,Youmei,18,5,1,0,0,0,4,3.708
+Spring 2023,IDNS,1142,6,16602,Chemistry II SEP Workshop,Pattison,Donna,22,6,3,3,0,0,1,3.421
+Spring 2023,COMM,3360,5,16603,Principles of Strategic Comm,Choi,Ho Joon,19,1,0,1,2,0,2,3.421
+Spring 2023,IDNS,3121,1,16604,Engineering Math SEP Workshop,Pattison,Donna,10,6,1,0,0,0,1,3.452
+Spring 2023,COMM,4365,2,16605,Digital PR and Advertising,Choi,Ho Joon,12,8,2,0,1,0,2,3.304
+Spring 2023,IDNS,3131,1,16606,Organic Chem I SEP Workshop,Pattison,Donna,30,8,18,12,0,0,4,2.814
+Spring 2023,IDNS,3131,2,16607,Organic Chem I SEP Workshop,Pattison,Donna,26,4,18,4,2,0,6,2.877
+Spring 2023,IDNS,3131,3,16608,Organic Chem I SEP Workshop,Pattison,Donna,46,16,6,4,0,0,0,3.463
+Spring 2023,IDNS,3131,4,16609,Organic Chem I SEP Workshop,Pattison,Donna,12,16,10,6,10,0,16,2.223
+Spring 2023,IDNS,3132,1,16610,Organic Chem II SEP Workshop,Pattison,Donna,22,14,0,2,0,0,2,3.404
+Spring 2023,IDNS,3132,2,16611,Organic Chem II SEP Workshop,Pattison,Donna,26,14,4,2,0,0,2,3.42
+Spring 2023,IDNS,3132,3,16612,Organic Chem II SEP Workshop,Pattison,Donna,38,12,2,4,0,0,4,3.465
+Spring 2023,IDNS,3132,4,16613,Organic Chem II SEP Workshop,Pattison,Donna,34,8,0,0,2,0,0,3.636
+Spring 2023,IDNS,3132,5,16614,Organic Chem II SEP Workshop,Pattison,Donna,36,14,10,4,4,0,0,3.098
+Spring 2023,IDNS,3132,6,16615,Organic Chem II SEP Workshop,Pattison,Donna,60,8,4,0,0,0,4,3.741
+Spring 2023,IDNS,3132,7,16616,Organic Chem II SEP Workshop,Pattison,Donna,40,14,8,4,0,0,2,3.394
+Spring 2023,IDNS,1131,3,16617,Calculus I SEP Workshop,Pattison,Donna,26,6,8,10,4,0,2,2.814
+Spring 2023,IDNS,1132,4,16618,Calculus II SEP Workshop,Pattison,Donna,40,8,8,0,0,0,2,3.583
+Spring 2023,AAS,2330,2,16619,Black Liberation Theology,Johnson,Alexander Emmitt Maurice,7,12,1,4,5,0,0,2.368
+Spring 2023,GENB,6A50,1,16620,Business Communications,Pineda,Dalia Rivera,14,2,1,0,0,0,1,3.687
+Spring 2023,ENTR,3342,1,16621,Women in Entrepreneurship,McCormick,Kelly,18,7,4,0,0,0,1,3.46
+Spring 2023,ENTR,7342,1,16622,Women in Entrepreneurship,McCormick,Kelly,6,1,0,0,1,0,1,3.375
+Spring 2023,ELET,6396,1,16623,Master's Project,Zouridakis,George,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,1112,51,16624,Fundamentals of Chm Lab,Zaitsev,Vladimir G,0,9,0,0,0,0,0,3.11
+Spring 2023,CHEE,6323,1,16626,Fund of Tissue Engineering,Horton,Renita Elillian,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6323,2,16630,Psychopathology,Lukingbeal,Patrick Livingston,15,0,0,0,0,0,0,3.956
+Spring 2023,HLT,3301,4,16633,Health Behavior Theories,Drenner,Kelli Linn,26,27,1,0,2,0,3,3.304
+Spring 2023,HLT,4303,1,16634,The Obesity Epidemic,Olvera,Norma E,33,18,5,2,1,0,1,3.339
+Spring 2023,CIS,4375,5,16635,Project Management & Practice,Martinez,Jose C,3,26,15,0,0,0,0,2.682
+Spring 2023,CIS,4375,6,16636,Project Management & Practice,Martinez,Jose C,7,28,10,2,0,0,0,2.837
+Spring 2023,BTEC,3200,31,16637,Biotech Research Methods,Hosseinzadeh,Hemen,8,10,3,0,1,0,1,3.076
+Spring 2023,BUSI,4350,11,16639,Business Law and Ethics,Krylova,Ksenia O,14,10,0,0,0,0,0,3.528
+Spring 2023,MARK,4380,2,16640,Digital Selling,Habel,Johannes,24,4,0,0,0,0,0,3.834
+Spring 2023,ECE,7373,1,16641,Adv Topics in Comp Arch,Fu,Xin,44,30,5,1,0,0,0,3.463
+Spring 2023,NURS,4318,1,16642,High Acuity Concepts of Care,Edwards-Maddox,Shermel Vinese,2,17,0,0,0,0,4,3.105
+Spring 2023,NURS,4419,1,16643,High Acuity Clinical,Edwards-Maddox,Shermel Vinese,15,4,0,0,0,0,4,3.789
+Spring 2023,NURS,4219,1,16644,Pediatric Concepts of Care,Anderson,Viia,2,21,0,0,0,0,0,3.087
+Spring 2023,NURS,4221,1,16645,Pediatric Clinical,Anderson,Viia,22,1,0,0,0,0,0,3.957
+Spring 2023,CNST,1330,2,16646,Graphics I,Lyon,Eva Yaneth,7,6,3,0,2,0,2,2.944
+Spring 2023,BUSI,3300,4,16647,Intro to Personal Finance,Harvey,Danny,49,2,0,0,2,0,2,3.799
+Spring 2023,FINA,4328,2,16648,Principles of Personal Finance,Coleman,Alfred G,18,4,5,3,3,0,0,2.889
+Spring 2023,PHOP,7276,3,16650,MATLAB Programming,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,2302,10,16654,Prin of Managerial Accounting,Weber,Catherine K,25,28,11,2,2,0,1,3.122
+Spring 2023,HIST,4366,1,16655,Latin Amer Hist Thru the Novel,Zamora,Lois,2,1,4,1,2,0,3,1.901
+Spring 2023,ACCT,6331,4,16656,Financial Accounting,Li,Bin,8,4,0,0,0,0,0,3.584
+Spring 2023,MARK,6361,2,16658,Marketing Administration,Koch,Steven F,11,1,0,0,0,0,0,3.917
+Spring 2023,HLT,3304,1,16659,Child and Adolescent Health,Farmer,Jennifer,74,10,4,0,2,0,0,3.689
+Spring 2023,ELET,4105,1,16660,Senior Design Lab in EPET,Shi,Jian,18,2,0,0,0,0,0,3.867
+Spring 2023,ELET,4103,1,16661,Power Transmission Lab,Shireen,Wajiha,12,2,0,0,0,0,0,3.857
+Spring 2023,ENGL,2318,2,16662,Creation and Perform of Lit,Prufer,Kevin D,13,13,5,2,4,0,3,2.73
+Spring 2023,HIST,1301,6,16664,The U.S. to 1877,Goldberg,Mark A,144,66,25,8,12,0,11,3.258
+Spring 2023,HIST,1302,5,16665,The U.S. Since 1877,Amaral,Lindsay Nicole,52,33,20,7,15,0,5,2.759
+Spring 2023,HIST,1302,6,16666,The U.S. Since 1877,Rector,Josiah John,172,36,20,6,17,0,13,3.328
+Spring 2023,TLIM,3330,3,16669,Innovation Principles,Crawley,David L,16,4,9,0,0,0,2,3.093
+Spring 2023,TLIM,3371,30,16670,Budgeting and Financial Princ,Burns,Maria,42,1,1,0,0,0,1,3.932
+Spring 2023,LAW,5222,1,16674,Intro to the Law of Mexico,Pinto-Leon,Ignacio,1,3,0,0,0,0,0,3.415
+Spring 2023,FINA,4330,4,16676,Corporate Finance,Allena,Rohit,1,9,0,0,0,0,0,3.1
+Spring 2023,HLT,4320,2,16678,Admin of Health Services,Markowitz,Eliz,21,8,2,0,1,0,0,3.459
+Spring 2023,MUED,3104,1,16679,Strings,Hansen,Erin Melissa,2,6,5,1,1,0,1,2.379
+Spring 2023,LAW,5402,1,16681,Entrpr Community Dev Clinic I,Heard,Christopher D,1,6,0,0,0,0,0,3.379
+Spring 2023,MUED,4231,2,16682,Instrumental Conducting II,Bertman,David Garry,7,0,0,0,1,0,0,3.459
+Spring 2023,PHCA,7320,1,16684,Health Care Systems & Policy,Thornton,James D,2,4,0,0,0,0,0,3.333
+Spring 2023,PHCA,7307,1,16685,Methods & Research Design,Essien,Ekere James,4,2,0,0,0,0,0,3.612
+Spring 2023,SCM,7A01,1,16686,Project Management,Tibodeau,Dale,3,2,0,0,0,0,0,3.534
+Spring 2023,MUSI,1122,1,16687,Concert Chorale,Weber,Mary E,39,4,1,0,0,0,0,3.864
+Spring 2023,MUSI,1121,2,16696,Concert Chorus,Mueller,Jebediah Lee,16,2,0,0,0,0,0,3.907
+Spring 2023,MUSI,6350,2,16697,Applied Music Pedagogy,Van Kekerix,Todd Evan,6,0,0,0,0,0,0,4.0
+Spring 2023,LAW,6240,1,16698,Death Penalty Clinic,Dow,David R,0,1,0,0,0,2,0,3.33
+Spring 2023,LAW,6213,1,16699,Innocence Investigations,Dow,David R,1,2,0,0,0,0,0,3.443
+Spring 2023,HIST,2368,1,16700,Intro to African Studies,Chery,Tshepo Morongwa,5,6,2,2,2,0,1,2.549
+Spring 2023,LAW,6234,1,16701,Juvenile Representation II,Cepeda Hendrickson,Grecia,0,0,0,0,0,1,0,
+Spring 2023,LAW,5382,1,16706,Administrative Law,Kumar,Sapna,15,13,2,1,0,12,0,3.334
+Spring 2023,MUSA,1310,2,16709,Applied Piano,Morgulis,Tali,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1310,3,16710,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1324,2,16711,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2324,2,16716,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2340,2,16718,Applied Trumpet,Vassallo,Jim Cates,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2346,1,16720,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2350,2,16721,Applied Percussion,Wilkins,Blake M,2,0,0,0,0,0,0,3.835
+Spring 2023,MUSA,3402,2,16722,Applied Composition,Maroney,Marcus K,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3410,3,16723,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3424,2,16724,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3442,2,16725,Applied French Horn,Reed,Gavin Davis,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4400,6,16726,Applied Voice,Vasquez,Hector A,1,1,0,0,0,0,0,3.665
+Spring 2023,HLT,4307,4,16730,Research and Eval in Health,Dao,Tam K,20,3,1,0,0,0,0,3.792
+Spring 2023,ARTH,4388,1,16732,Methods of Art History,Nevitt Jr,Hugh R,12,0,0,0,0,0,2,4.0
+Spring 2023,PHAR,5218,1,16733,Critical Care Therapeutics,Wanat,Matthew A,79,11,1,0,0,0,0,3.857
+Spring 2023,PHAR,5208,1,16734,Infect Disease Pharmacotherapy,Sofjan,Amelia Kartikasari,17,6,0,0,0,0,0,3.739
+Spring 2023,MUSA,6141,4,16736,Graduate Recital II,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,AAMS,2300,2,16737,Intro Asian American Studies,Nguyen,An,2,3,2,1,3,0,2,1.97
+Spring 2023,MUSA,8320,16,16738,Doctoral Applied Music,Dorough,Aralee,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,18,16740,Doctoral Applied Music,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Spring 2023,LAW,6369,1,16742,Legal Analysis and Writing,Stein,Katherine Ann,0,0,0,0,0,8,0,
+Spring 2023,FINA,4352,2,16745,Fin Planning for Professionals,Lopez,John C,4,6,3,0,0,0,0,3.102
+Spring 2023,FINA,4325,2,16746,Retirement and Estate Planning,Lopez,John C,0,3,6,4,2,0,0,1.821
+Spring 2023,ARCH,3501,19,16747,Architecture Design Studio VI,Story,Jon Kevin,5,7,0,0,1,0,0,3.027
+Spring 2023,FINA,7A33,1,16749,Mergers & Acquisitions I,Yerramilli,Vijay,17,10,0,1,0,0,0,3.571
+Spring 2023,FINA,7A34,1,16750,Mergers & Acquisitions II,Yerramilli,Vijay,14,4,0,0,0,0,0,3.686
+Spring 2023,ARCH,5500,27,16751,Architecture Design Studio IX,Louie,Jonathan Bung Chan,9,4,0,0,0,0,0,3.591
+Spring 2023,ARCH,5500,29,16753,Architecture Design Studio IX,Smith,Joshua S,7,7,1,0,0,0,0,3.444
+Spring 2023,INDS,2355,2,16756,Design History I,Williams,Celeste,25,0,0,0,0,0,0,3.881
+Spring 2023,COMM,4355,1,16757,Organizational Comm,Liu,Wenlin,22,8,0,0,0,0,0,3.645
+Spring 2023,COMD,3383,4,16758,Language Disorders in Children,Schaff,Carrie Allyson,32,8,0,0,0,0,0,3.792
+Spring 2023,HIST,3308,1,16759,The American West,Ramos,Raul,33,0,0,1,0,0,0,3.863
+Spring 2023,CIS,3365,4,16760,Database Management,Detillier,Bret James,4,34,28,0,0,0,4,2.636
+Spring 2023,PUBL,6313,1,16761,Fundamentals Policy Analysis,Zhu,Ling,15,2,0,0,0,0,0,3.824
+Spring 2023,CUIN,3111,4,16764,Educational Tech Elem Teachers,Tran,Hien Thi,33,0,0,0,0,0,0,3.99
+Spring 2023,ELCS,6370,3,16765,Research for Educatnal Leaders,Stewart,Cedric Benjamin,13,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7A50,1,16766,Derivatives I,Rabinovitch,Ramon,9,4,1,1,1,0,2,3.167
+Spring 2023,FINA,7A51,1,16767,Derivatives II,Rabinovitch,Ramon,5,4,0,0,0,0,0,3.592
+Spring 2023,MANA,7354,1,16769,Cultrl Issues in Global Mgt,Sebastijanovic,Marina,6,0,0,0,0,0,0,3.835
+Spring 2023,MUSI,6106,4,16770,Grad Large Ensemble,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Spring 2023,MANA,4333,1,16771,Current Issues in Mgmt,Walker,William A,35,4,0,0,0,0,2,3.914
+Spring 2023,ENGI,1331,11,16774,Computing for Engineers,Kota,Venkata Krishna Tulasi,12,6,2,0,1,0,0,3.286
+Spring 2023,MATH,2312,2,16775,Precalculus,Namakforoosh,Navid,54,40,30,22,38,0,52,2.239
+Spring 2023,LAW,6364,1,16781,Contract Drafting,Toedt III,Dell Charles,5,7,0,0,0,4,0,3.389
+Spring 2023,LAW,6364,2,16782,Contract Drafting,Toedt III,Dell Charles,3,11,0,0,0,1,0,3.309
+Spring 2023,SOCW,7309,1,16784,Contemporary Issues in MH,Battle,Jennifer Alene,17,0,0,0,0,0,0,4.0
+Spring 2023,WGSS,2360,5,16785,Introduction to LGBT Studies,Boffone,Trevor James,24,3,1,0,0,0,1,3.81
+Spring 2023,PHCA,6297,3,16788,Selected Topics,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2023,LAW,6369,2,16789,Legal Analysis and Writing,Perez,Nicholas Alejandro,0,0,0,0,0,8,0,
+Spring 2023,LAW,6369,5,16790,Legal Analysis and Writing,Nieuwveld,Lisa Bench,0,0,0,0,0,8,0,
+Spring 2023,LAW,6369,6,16791,Legal Analysis and Writing,Cohen,Lisa Elaine,0,0,0,0,0,8,0,
+Spring 2023,LAW,6369,7,16792,Legal Analysis and Writing,Horsey,Kandice Lorissa,0,0,0,0,0,7,1,
+Spring 2023,MSCI,4320,1,16794,Company Grade Leadership,Comiskey,Melissa C,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,6A31,2,16796,Analyzing Financial Statements,Woods,James D,9,5,0,2,0,0,2,3.23
+Spring 2023,HRD,3310,3,16797,Talent Management,Shakir,Khalimah,8,1,0,1,3,0,1,2.769
+Spring 2023,ENGL,1301,4,16799,First Year Writing I,Coleman,Quintin,8,2,1,0,5,0,5,2.397
+Spring 2023,ENGL,1301,48,16800,First Year Writing I,Sutton,Anthony Villavelez,11,3,1,0,1,0,1,3.499
+Spring 2023,PHLS,7393,4,16801,Internship and Practicum,Margulis,Milena A,2,0,0,0,0,0,0,4.0
+Spring 2023,WGSS,2350,11,16805,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,27,2,0,0,1,0,0,3.767
+Spring 2023,WGSS,2350,12,16806,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,24,1,2,0,1,0,1,3.679
+Spring 2023,WGSS,2350,13,16807,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,2,0,1,0,0,1,3.805
+Spring 2023,ENGL,1302,62,16808,First Year Writing II,Stewart-Steele,Heather Marie,13,6,3,0,3,0,0,3.0
+Spring 2023,ENGL,1302,63,16809,First Year Writing II,Stewart-Steele,Heather Marie,12,6,0,0,3,0,3,3.017
+Spring 2023,ENGL,1302,64,16810,First Year Writing II,Stewart-Steele,Heather Marie,8,6,2,2,1,0,4,2.861
+Spring 2023,ENGL,1302,65,16811,First Year Writing II,Stewart-Steele,Heather Marie,5,11,3,2,0,0,3,2.873
+Spring 2023,ENGL,1302,66,16812,First Year Writing II,Garcia,Serena Mari,14,6,3,0,1,0,1,3.196
+Spring 2023,ENGL,1302,68,16813,First Year Writing II,Garcia,Serena Mari,15,5,0,2,0,0,3,3.365
+Spring 2023,ENGL,1302,69,16814,First Year Writing II,Garcia,Serena Mari,14,6,2,0,1,0,2,3.248
+Spring 2023,ENGL,1302,74,16816,First Year Writing II,Kozma,Andrew,17,6,0,0,0,0,2,3.653
+Spring 2023,ENGL,2305,6,16818,Intro To Fiction,Penzien,Eugene Norman,9,5,0,0,5,0,2,2.702
+Spring 2023,ENGL,2305,7,16819,Intro To Fiction,Alcorn III,Charles William,17,8,0,0,4,0,0,3.138
+Spring 2023,CIVE,4381,2,16820,Adv Geomatics & Geosensing,Lee,Hyongki,10,20,6,0,0,0,1,3.12
+Spring 2023,NUTR,3330,1,16821,Mgmt in Food & Nutr Systems,Haubrick,Kevin,4,7,1,0,0,0,1,3.223
+Spring 2023,ELCS,8399,5,16822,Doctoral Dissertation,Zou,Yali,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,3441,3,16823,Digital Logic Design,Sheth,Bhavin R,34,13,1,1,2,0,2,3.464
+Spring 2023,HLT,4310,3,16828,Program Planning for Hlt Prof,Bennett,Kristin C,16,10,5,2,5,0,2,2.72
+Spring 2023,WGSS,2350,14,16831,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,25,1,1,0,0,0,1,3.852
+Spring 2023,WGSS,2350,15,16832,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,1,1,1,2,0,0,3.489
+Spring 2023,SOCW,7301,3,16835,Confronting Oppression & Injus,Barthelemy,Juan,24,2,0,0,0,0,1,3.923
+Spring 2023,BIOL,3224,4,16836,Human Physiology Laboratory,Gill,Tejendra,32,16,0,0,0,0,0,3.55
+Spring 2023,MUSA,6324,1,16837,Applied Violoncello,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6324,2,16838,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,4150,5,16841,Genomic & Proteomic Lab,Akay,Yasemin M,7,0,0,0,0,0,0,3.811
+Spring 2023,CIS,3355,30,16843,Integrated Information Systems,Peddoju,Suresh Kumar,30,34,8,0,6,0,0,3.001
+Spring 2023,MUSA,3432,1,16845,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Spring 2023,PCEU,7181,1,16853,Pharmaceutics Seminar,McConnell,Bradley K,0,0,0,0,0,10,0,
+Spring 2023,PCOL,7181,1,16854,Pharmacology Seminar,McConnell,Bradley K,0,0,0,0,0,16,0,
+Spring 2023,GHL,3445,1,16856,Global Wine Immersion,Taylor,David C,10,2,0,0,0,0,0,3.751
+Spring 2023,PHLS,8699,3,16858,Doctoral Dissertation,de Dios,Marcel A,1,0,0,0,0,0,0,4.0
+Spring 2023,BUSI,4396,1,16860,Business Internship,Hopkins,Troy D,0,0,0,0,0,34,0,
+Spring 2023,BUSI,4396,2,16861,Business Internship,Hopkins,Troy D,0,0,0,0,0,6,0,
+Spring 2023,MECE,8298,33,16862,Doctoral Research,Chen,Zheng,0,0,0,0,0,3,0,
+Spring 2023,MECE,8398,30,16863,Doctoral Research,Chen,Zheng,0,0,0,0,0,2,0,
+Spring 2023,COSC,4353,3,16868,Software Design,Subramaniam,Venkat,20,2,1,0,0,0,1,3.754
+Spring 2023,COSC,6353,3,16869,Software Design,Subramaniam,Venkat,5,0,0,0,0,0,1,4.0
+Spring 2023,PETR,3363,1,16876,Fluid Mechanics for PETR Engr,Sakhaee Pour,Ahmad,3,1,0,0,0,0,0,3.75
+Spring 2023,MANA,4356,2,16883,Managing Diversity,Fernandez,Alejandro,54,4,1,0,0,0,0,3.893
+Spring 2023,MUSI,8399,1,16884,Doctoral Document,Maroney,Marcus K,0,0,0,0,0,1,0,
+Spring 2023,MECE,8699,26,16890,Doctoral Dissertation,Joshi,Shailendra Pramod,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8398,31,16891,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,1,0,
+Spring 2023,FINA,7A33,2,16894,Mergers & Acquisitions I,Yerramilli,Vijay,9,2,0,0,0,0,0,3.788
+Spring 2023,COMM,2327,2,16895,Introduction to Screen Writing,Vaughan,Thomas Michael,20,4,2,0,0,0,0,3.591
+Spring 2023,ARCH,1198,1,16896,Special Problems,Phan,Trang Anh Thuc,16,0,2,0,0,0,0,3.778
+Spring 2023,MUSI,6198,15,16898,Research,Yon,Kirsten A,6,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4298,1,16899,Special Problems in Pedagogy,Cho,Eunghee,3,4,0,0,0,0,0,3.381
+Spring 2023,BIOL,8698,3,16910,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2023,MUSI,8296,2,16916,Doctoral Essay,Bertagnolli,Paul A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,16,16917,Research,Brooks,Wayne A,3,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8199,2,16922,Dissertation,Gonzalez,Jorge E,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8399,4,16933,Doctoral Dissertation,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8699,4,16939,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,4,0,
+Spring 2023,MECE,8298,35,16941,Doctoral Research,Cescon,Marzia,0,0,0,0,0,3,0,
+Spring 2023,PHLS,8699,5,16944,Doctoral Dissertation,Smith,Nathan G,1,0,0,0,0,1,0,4.0
+Spring 2023,SCLT,4380,31,16945,Quality Systems,Hu,Minxiang,41,13,4,0,3,0,0,3.362
+Spring 2023,KIN,3305,7,16947,Sport Sociology,Ogunrinde,Joyce,4,18,11,7,6,0,2,2.152
+Spring 2023,BUSI,1301,7,16961,Business Principles,Carvalho,Diogo,40,26,9,7,16,0,8,2.62
+Spring 2023,MECE,8399,28,16962,Doctoral Dissertation,Agrawal,Ashutosh,1,0,0,0,0,0,0,4.0
+Spring 2023,MARK,8999,2,16967,Doctoral Dissertation,Tirunillai,Seshadri N,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8698,26,16969,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Spring 2023,MUSI,6198,18,16972,Research,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,19,16973,Research,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4198,6,16975,Special Problems in Repertoire,Kitai,Anthony T,4,0,0,0,0,0,0,3.835
+Spring 2023,MUSI,4198,7,16976,Special Problems in Repertoire,Larson,Eric Amery,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4198,3,16978,Special Problems in Repertoire,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,8398,28,16979,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6498,3,17001,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6498,4,17002,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8698,2,17010,Graduate Research,Tejada,Roberto Jose,0,0,0,0,0,2,0,
+Spring 2023,BIOL,8999,5,17013,Doctoral Dissertation,Liu,Yu,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8999,6,17014,Doctoral Dissertation,Peng,Weiyi,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8999,7,17015,Doctoral Dissertation,Meisel,Richard P,0,0,0,0,0,1,0,
+Spring 2023,MARK,8999,4,17028,Doctoral Dissertation,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,2330,3,17031,Writing Discipline English,Pegoda,Andrew Joseph,2,9,2,0,2,0,5,2.578
+Spring 2023,MECE,8399,29,17035,Doctoral Dissertation,Liu,Dong,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,6399,20,17036,Masters Thesis,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Spring 2023,ENGL,2315,3,17038,Literature and Film,Kennedy,Daniel Peter,14,7,3,0,2,0,2,3.065
+Spring 2023,MUSA,8240,3,17062,Doctoral Recital I,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8240,5,17064,Doctoral Recital I,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8240,6,17065,Doctoral Recital I,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,37,17067,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Spring 2023,MECE,8699,27,17068,Doctoral Dissertation,Yang,Di,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,38,17073,Doctoral Research,Yang,Di,0,0,0,0,0,2,0,
+Spring 2023,HIST,1301,7,17075,The U.S. to 1877,McDonald,Eric John,88,95,42,8,21,0,14,2.848
+Spring 2023,BUSI,2305,5,17079,Business Statistics,Patterson,Staci A,6,20,4,4,6,0,26,2.318
+Spring 2023,COMM,1303,4,17080,Writing for Communicators,Lyn,Robyn,14,7,3,1,1,0,2,3.218
+Spring 2023,BIOL,6398,3,17090,Special Problems,Nunez,Martin A,0,0,0,0,0,2,0,
+Spring 2023,BIOL,6398,4,17091,Special Problems,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6398,5,17092,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6398,6,17093,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6398,7,17094,Special Problems,Khan,Abdul Latif,0,0,0,0,0,1,0,
+Spring 2023,PSYC,7398,1,17096,Statistics in PSYC Practicum,Francis,David J,0,0,0,0,0,3,0,
+Spring 2023,BUSI,4396,3,17100,Business Internship,Newman,Michael Ray,0,0,0,0,0,27,1,
+Spring 2023,INDE,4337,1,17108,Human Factors & Ergonomics,Schulze,Lawrence John Henry,5,25,2,0,0,0,0,3.083
+Spring 2023,MATH,8399,3,17110,Doctoral Dissertation,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Spring 2023,MUSI,7399,1,17114,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,1,0,
+Spring 2023,CUIN,3347,3,17124,Reading in the Content Area,Morris,Alana,33,3,0,0,0,0,0,3.853
+Spring 2023,MUSI,6198,5,17126,Research in Chamber Music,Cho,Eunghee,5,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,40,17129,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Spring 2023,MECE,8699,29,17130,Doctoral Dissertation,Song,Gangbing,0,0,0,0,0,0,0,
+Spring 2023,ENGL,2330,4,17132,Writing Discipline English,Coleman,Quintin,12,2,1,2,1,0,2,3.186
+Spring 2023,BIOL,6298,2,17136,Special Problems,Chung,Sanghyuk,0,0,0,0,0,2,0,
+Spring 2023,BIOL,6298,4,17139,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6298,5,17140,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6298,6,17141,Special Problems,Rea,Michael A,0,0,0,0,0,2,0,
+Spring 2023,PSYC,7398,2,17156,Statistics in PSYC Practicum,Gallagher,Matthew Ward,3,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,6111,1,17159,Graduate Seminar,Kalliontzis,Dimitrios,0,0,0,0,0,24,0,
+Spring 2023,PCOL,6498,1,17161,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6398,3,17162,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2023,SOC,7399,3,17165,Masters Thesis,Lee,Shayne,0,0,0,0,0,0,0,
+Spring 2023,PSYC,6365,8,17167,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,1,0,0,0,0,2,0,4.0
+Spring 2023,SOC,4399,1,17168,Senior Honors Thesis,Anderson,Kathryn,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,3370,4,17191,Info Systems Development Tools,Knighton,William B,18,17,12,4,1,0,12,2.904
+Spring 2023,BIOL,6498,5,17192,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6598,7,17193,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Spring 2023,MECE,8298,41,17196,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Spring 2023,MECE,8298,42,17197,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,3,0,
+Spring 2023,MECE,8398,40,17198,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Spring 2023,MECE,8398,39,17199,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Spring 2023,MECE,8399,32,17203,Doctoral Dissertation,Sun,Li,2,0,0,0,0,1,0,4.0
+Spring 2023,MECE,8399,33,17204,Doctoral Dissertation,Ghasemi,Hadi,1,0,0,0,0,0,0,4.0
+Spring 2023,POLC,6311,1,17205,Leader and Prof Development,Witt,Lawrence A,18,0,0,0,0,0,1,3.945
+Spring 2023,MECE,8399,34,17206,Doctoral Dissertation,Baxevanis,Theocharis,1,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,2312,2,17213,Intermediate Spanish II,Reyes Ferrufino,Diana Eufemia,11,8,4,0,2,0,0,2.961
+Spring 2023,ENGI,8111,1,17218,FFP,Sharma,Pradeep,0,0,0,0,0,16,0,
+Spring 2023,BIOL,6498,6,17221,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Spring 2023,MUSI,8296,6,17223,Doctoral Essay,Snyder,John L,0,0,0,0,0,0,0,
+Spring 2023,CHEM,2125,18,17230,Organic Chemistry Lab II,Bean,Mary B,4,6,3,0,0,0,0,3.001
+Spring 2023,BCHS,6598,4,17239,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6598,6,17241,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2023,ECON,7390,4,17243,Research & Readings - Economic,Paluszynski,Radoslaw,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6422,1,17250,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,6,17251,Research in Chamber Music,Yon,Kirsten A,3,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6398,4,17252,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Spring 2023,ENGI,2304,8,17253,Technical Communications,Contos,Ashlie Meghan,11,4,6,1,2,0,2,2.916
+Spring 2023,PHLS,8199,4,17254,Dissertation,de Dios,Marcel A,0,0,0,0,0,1,0,
+Spring 2023,CIS,2348,2,17255,Info Systems Appl Development,Ratner,Edward,29,16,12,3,7,0,7,2.821
+Spring 2023,CIS,2336,31,17261,Internet Application Developmt,Faiyaz,Sajida,30,26,15,0,1,0,6,3.268
+Spring 2023,MECE,7399,25,17265,Masters Thesis,Grigoriadis,Karolos,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8598,48,17266,Doctoral Research,Franchek,Matthew,0,0,0,0,0,1,0,
+Spring 2023,MECE,8598,49,17267,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,3,0,
+Spring 2023,MECE,8398,42,17268,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,1,0,
+Spring 2023,MECE,8399,37,17271,Doctoral Dissertation,Selvamanickam,Venkat,0,0,0,0,0,2,0,
+Spring 2023,MECE,8398,43,17272,Doctoral Research,Franchek,Matthew,0,0,0,0,0,3,0,
+Spring 2023,BIOL,6598,8,17273,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6598,9,17274,Special Problems,Warner,Margaret,0,0,0,0,0,1,0,
+Spring 2023,ACCT,8999,3,17281,Doctoral Dissertation,Larson,Chad R,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8199,5,17285,Dissertation,Arbona,Consuelo,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8399,42,17288,Doctoral Dissertation,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Spring 2023,TLIM,4342,32,17301,Quality Improvement Methods,O'Kelley,Donna K,25,24,11,4,2,0,0,2.945
+Spring 2023,CUIN,8399,5,17302,Doctoral Dissertation,Chung,Sheng Kuan,0,0,0,0,0,1,0,
+Spring 2023,CUIN,8399,6,17303,Doctoral Dissertation,Wong,Sissy S,1,0,0,0,0,1,0,4.0
+Spring 2023,WGSS,2360,6,17304,Introduction to LGBT Studies,Stone,Lauren Michelle,21,6,2,0,1,0,0,3.511
+Spring 2023,MECE,8298,44,17305,Doctoral Research,Franchek,Matthew,0,0,0,0,0,7,0,
+Spring 2023,MECE,8699,33,17306,Doctoral Dissertation,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,46,17313,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,5,0,
+Spring 2023,MUSI,4330,1,17315,Adv Instrumental Conducting,Krager,Franz A,3,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,47,17319,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Spring 2023,WGSS,2350,16,17320,Intro To Women's Studies,Slatton,Brittany Chevon,14,3,3,2,6,0,1,2.584
+Spring 2023,MUSA,6304,4,17327,Conducting,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6304,3,17328,Conducting,Krager,Franz A,3,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8298,7,17332,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8199,3,17333,Doctoral Dissertation Defense,Sansgiry,Sujit Sharad,0,0,0,0,0,1,0,
+Spring 2023,MUSI,8296,5,17341,Doctoral Essay,Koozin,Timothy,1,0,0,0,0,1,0,4.0
+Spring 2023,CHEE,8598,19,17345,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,2,0,
+Spring 2023,BCHS,3399,1,17346,Senior Honors Thesis,Widger,William R,0,0,0,0,0,0,0,
+Spring 2023,MECE,8398,45,17348,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8398,24,17355,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,0,0,
+Spring 2023,THEA,6326,1,17369,Alley Thea Dramaturgy Prac II,Shimko,Robert B,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,7399,26,17374,Masters Thesis,Grigoriadis,Karolos,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,6399,23,17375,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6359,8,17376,Directed Rsch in Clinical Psyc,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8699,9,17379,Doctoral Dissertation,Margulis,Milena A,1,0,0,0,0,3,0,4.0
+Spring 2023,CUIN,8390,4,17380,Doctoral Thesis,McNeil,Sara G,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,48,17382,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,
+Spring 2023,CUIN,8699,2,17389,Doctoral Dissertation,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,49,17390,Doctoral Research,Liu,Dong,0,0,0,0,0,2,0,
+Spring 2023,PETR,6312,2,17391,Well Log Eval of Petr Formatn,Hathon,Lori A,5,7,0,0,0,0,1,3.334
+Spring 2023,PETR,6320,2,17392,Enhanced Oil Recovery Proc I,Dindoruk,Birol,2,1,0,0,1,0,1,2.75
+Spring 2023,MUSI,4198,31,17401,Research in Chamber Music,Cho,Eunghee,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4198,32,17402,Research in Chamber Music,Suits,Brian J,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4198,34,17404,Research in Chamber Music,Lo,Mann-Wen,7,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,7,17408,Research in Chamber Music,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,8,17409,Research in Chamber Music,Morgulis,Tali,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,9,17410,Research in Chamber Music,Suits,Brian J,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSI,6198,10,17411,Research in Chamber Music,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2301,8,17415,Introduction to Psychology,Orr,Michael F,15,37,16,2,7,0,2,2.727
+Spring 2023,PSYC,2319,5,17416,Intro to Social Psychology,Thompson,Jennifer L,64,10,5,0,0,0,1,3.713
+Spring 2023,PSYC,2305,24,17417,Intro to Methods in Psychology,Anderson,Jill Annette,23,18,5,3,3,0,0,3.058
+Spring 2023,BCHS,3304,5,17427,General Biochemistry I,Sen,Mehmet,17,38,15,0,3,0,11,2.882
+Spring 2023,MECE,8399,41,17430,Doctoral Dissertation,Joshi,Shailendra Pramod,2,0,0,0,0,0,0,3.67
+Spring 2023,SOC,3300,2,17439,Intro to Sociological Theory,Grigorian,Stella,21,9,5,2,0,0,2,3.306
+Spring 2023,SOC,3380,2,17440,Intro/Soc Health Care,Monserud,Maria Aleksandrovna,42,5,2,0,0,0,0,3.803
+Spring 2023,HISP,2374,2,17445,Spanish American Culture & Civ,Ruisanchez Serra,Jose Ramon,15,3,2,2,2,0,3,3.084
+Spring 2023,SPAN,1502,3,17447,Elementary Spanish II,Abend Van Dalen,Raquel Andreina de la Trinidad,6,10,4,1,1,0,0,2.894
+Spring 2023,SPAN,3373,1,17449,Spanish Culture & Civilization,Solino,Maria Elena,12,4,1,0,3,0,2,3.067
+Spring 2023,SPAN,2307,2,17450,Span for Heritage Learners I,Ferrer,Tatiana Ines,15,7,0,3,0,0,0,3.373
+Spring 2023,ITAL,1502,5,17452,Elementary Italian II,Ercolani,Monica,11,2,0,0,0,0,0,3.745
+Spring 2023,WCL,2352,3,17459,World Cinema,Centeno,Daniel,5,14,1,3,0,0,0,2.884
+Spring 2023,WCL,4352,1,17460,Frames of Modernity II,Carrera,Alessandro,8,3,1,0,0,0,3,3.556
+Spring 2023,WCL,6352,1,17461,Postmodernity & Globalization,Carrera,Alessandro,1,0,0,0,0,0,0,4.0
+Spring 2023,CLAS,3374,1,17464,Women in the Ancient World,Houlihan,James W,23,2,0,0,0,0,2,3.92
+Spring 2023,WCL,3355,1,17467,Goddesses,Tamber-Rosenau,Caryn M,19,4,3,1,1,0,0,3.358
+Spring 2023,ARED,2310,1,17468,Intro Critical Visual Culture,Chung,Sheng Kuan,16,2,1,1,3,0,1,3.073
+Spring 2023,PHLS,8328,1,17474,HLM in Psyc & Educ Research,Fan,Weihua,8,0,0,0,0,0,0,3.959
+Spring 2023,HDFS,4397,1,17476,Selected Topics in Hdfs,Master,Allison,3,1,0,0,0,0,0,3.833
+Spring 2023,EDRS,8381,2,17479,Rsch Mthds in Educ,Johnson PhD,Detra DeVerne,5,1,0,0,0,0,0,3.833
+Spring 2023,ELCS,8313,2,17480,Issues for Urban Education Adm,Lopez,Ruth Maria,6,0,0,0,0,0,0,3.945
+Spring 2023,ELCS,8312,11,17492,Lab of Practice-Res Meth Devel,Snodgrass Rangel,Virginia Walker,4,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,6310,2,17493,Strategic Engagement,Brosnahan,Carla,13,1,0,0,0,0,0,3.929
+Spring 2023,ELCS,6304,2,17495,Law & Policy for School Leader,Klussmann,Duncan Foster,18,0,0,0,0,0,0,4.0
+Spring 2023,DIGM,4378,31,17498,Senior Project,Alters,Monika Joanna,14,1,0,0,0,0,0,3.955
+Spring 2023,DIGM,1300,30,17500,Introduction to Digital Media,Liao,Pamara F,41,26,15,1,8,0,2,3.029
+Spring 2023,BIOL,4356,1,17501,Genomics,Lin,Chin-Yo,9,4,3,0,0,0,1,3.396
+Spring 2023,BIOL,1309,1,17504,Biol for Non-Science Majors II,Ibrahim,Abdalla Zanouny,25,33,13,2,3,0,4,2.965
+Spring 2023,BIOL,1309,2,17505,Biol for Non-Science Majors II,Farmer,Lisa M,44,48,28,17,12,0,5,2.604
+Spring 2023,ELCS,6342,1,17508,Critical Issues in Higher Educ,McKinney,Lonnie Lyle,14,3,0,0,0,0,0,3.824
+Spring 2023,EDUC,2301,1,17511,Intro to Special Populations,Rigby-Wills,Hope,41,13,5,1,1,0,1,3.449
+Spring 2023,EDUC,2301,2,17512,Intro to Special Populations,Christensen,Caroline,25,20,9,4,3,0,1,2.978
+Spring 2023,EDUC,2301,3,17513,Intro to Special Populations,McKee,Shannon,45,16,2,2,2,0,1,3.429
+Spring 2023,EDUC,2301,4,17514,Intro to Special Populations,Christensen,Caroline,26,17,9,0,5,0,3,3.012
+Spring 2023,SPEC,2350,1,17515,RBT Training,Carp,Charlotte Lynn,7,1,1,1,2,0,0,2.806
+Spring 2023,SPEC,6367,1,17516,Special Education for Leaders,McCormick,Marina,2,1,0,0,0,0,0,3.667
+Spring 2023,ECON,7344,1,17520,Macroeconomic Theory II,Sorensen,Bent E,4,5,0,0,0,0,0,3.444
+Spring 2023,ENGR,2301,1,17521,Mechanics I,Krakowiak,Konrad,5,15,9,8,4,0,3,2.22
+Spring 2023,ENGR,2301,2,17522,Mechanics I,Hoskere,Vedhus,9,6,16,2,7,0,3,2.085
+Spring 2023,ECON,3351,1,17528,The Economics of Development,Liu,Elaine Meichen,5,23,5,4,1,0,1,2.702
+Spring 2023,BCHS,4314,1,17532,Lipids and Carbohydrates,Yeo,Hye-Jeong,15,21,5,0,0,0,0,3.204
+Spring 2023,BIOL,6301,1,17533,Conservation Biology,Crawford,Kerri M,3,0,0,0,0,0,0,4.0
+Spring 2023,PHIL,1334,1,17534,Minds and Machines,Weisberg,Joshua,13,51,25,6,16,0,6,2.277
+Spring 2023,CHIN,1502,1,17535,Elementary Chinese II,Zhang,Jing,15,1,2,1,1,0,0,3.384
+Spring 2023,CHIN,1502,3,17537,Elementary Chinese II,Zhang,Jing,14,4,4,0,0,0,0,3.38
+Spring 2023,CHIN,2312,1,17539,Intermediate Chinese II,Zhang,Jing,14,2,3,3,1,0,0,3.044
+Spring 2023,CHIN,3302,1,17540,Advanced Mandarin Chinese II,Li,Melody Yunzi,8,0,1,0,0,0,0,3.631
+Spring 2023,SPCH,1318,1,17541,Interpersonal Communication,Uhrick,Jan,25,3,0,1,0,0,0,3.77
+Spring 2023,LATI,1302,2,17543,Elementary Latin II,Behr,Francesca D,6,1,1,0,1,0,0,3.149
+Spring 2023,LATI,2312,1,17544,Intermediate Latin II,Armstrong,Richard H,7,7,0,0,0,0,0,3.5
+Spring 2023,SOCI,1301,2,17547,Introduction To Sociology,Dorsey,Patricia Lynne,14,10,13,2,5,0,4,2.583
+Spring 2023,CHIN,1502,5,17548,Elementary Chinese II,McArthur,Charles M,4,3,0,0,0,0,0,3.571
+Spring 2023,CHIN,4302,1,17550,Integrated Chinese,Wen,Xiaohong Sharon,3,0,0,0,0,0,0,3.89
+Spring 2023,SOCI,1301,10,17551,Introduction To Sociology,Dorsey,Patricia Lynne,7,16,4,5,6,0,2,2.29
+Spring 2023,GOVT,2306,9,17552,US and Texas Const/Politics,Littlepage,Kelley G,12,27,27,3,12,0,10,2.309
+Spring 2023,CUIN,8398,13,17555,Independent Study,Hausmann,Robert Carl,3,0,0,0,0,0,0,4.0
+Spring 2023,SGNL,2302,1,17556,Intermediate Sign Language II,Gietz,Merrilee Ruth,0,13,6,1,0,0,0,2.633
+Spring 2023,SGNL,2302,2,17557,Intermediate Sign Language II,Gietz,Merrilee Ruth,2,9,2,0,0,0,0,2.949
+Spring 2023,SOCI,1301,14,17558,Introduction To Sociology,Adams,Jennifer Lauren,42,7,1,3,1,0,2,3.556
+Spring 2023,GOVT,2306,1,17559,US and Texas Const/Politics,Colby,Cory G,25,48,35,12,24,0,6,2.246
+Spring 2023,SGNL,1301,1,17560,Elementary Sign Language I,Brittain,Terrell,1,6,10,1,0,0,2,2.334
+Spring 2023,COMM,7399,11,17561,Masters Thesis,Huang,Yan,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCI,1301,11,17562,Introduction To Sociology,Dorsey,Patricia Lynne,21,17,13,3,2,0,3,2.887
+Spring 2023,SOCI,1301,12,17563,Introduction To Sociology,Dorsey,Patricia Lynne,21,15,9,0,4,0,0,2.933
+Spring 2023,GOVT,2305,5,17564,"US Govt: Congress,Pres & Crts",Casellas,Jason,72,157,9,0,3,0,6,3.195
+Spring 2023,GOVT,2306,10,17565,US and Texas Const/Politics,Marcinek,Elizabeth Nicole Simas,68,84,70,8,11,0,6,2.782
+Spring 2023,SGNL,1302,5,17567,Elementary Sign Language II,Hill,Sharon Grigsby,2,9,5,0,0,0,2,2.792
+Spring 2023,GOVT,2306,50,17568,US and Texas Const/Politics,Belco,Michelle Helene,20,4,0,1,1,0,0,3.564
+Spring 2023,SGNL,2302,3,17570,Intermediate Sign Language II,Brittain,Terrell,10,1,0,0,0,0,0,3.759
+Spring 2023,CHIN,3360,2,17573,A Look Into Modern China,McArthur,Charles M,7,6,4,1,1,0,3,2.877
+Spring 2023,SOCI,1301,8,17574,Introduction To Sociology,Nelson,Steven M,19,10,5,2,5,0,5,2.854
+Spring 2023,SOCI,1301,13,17575,Introduction To Sociology,Adams,Jennifer Lauren,44,7,1,1,1,0,1,3.679
+Spring 2023,DANC,1246,1,17576,Modern Dance I Part II,Beasant III,John J,11,1,0,0,0,0,0,3.917
+Spring 2023,DANC,1301,1,17577,Dance Improvisation,Scates,Leslie Ann,18,0,0,0,0,0,0,3.963
+Spring 2023,DANC,2303,1,17578,Introduction to Dance,Bobet,Jacqueline A,62,20,8,2,18,0,4,2.904
+Spring 2023,DANC,3302,1,17579,Int. Technique and Theory,Jackson,Tracie,9,4,1,0,0,0,1,3.666
+Spring 2023,DANC,3311,1,17580,Dance History II,Estrada,Maria Gabriela,6,6,0,0,1,0,0,3.307
+Spring 2023,DANC,4110,1,17581,Dance Ensemble,Beasant III,John J,13,0,0,0,0,0,0,4.0
+Spring 2023,DANC,4302,1,17582,Advanced Technique and Theory,Gibson,Elijah,5,3,1,1,0,0,0,3.101
+Spring 2023,DANC,4308,1,17583,Teaching Dance Skills,Chapman,Teresa Lynn,5,3,4,0,0,0,0,3.083
+Spring 2023,DRAM,1310,1,17584,Introduction to Theatre,Egging,Jon Leo,59,12,1,4,5,0,10,3.404
+Spring 2023,DRAM,1310,12,17585,Introduction to Theatre,Egging,Jon Leo,30,10,1,2,3,0,3,3.312
+Spring 2023,DRAM,1310,3,17586,Introduction to Theatre,Ostrow,Stuart,17,1,1,0,0,0,0,3.842
+Spring 2023,DRAM,1310,4,17587,Introduction to Theatre,Hinkel,Heidi Anne,24,15,5,2,4,0,1,3.034
+Spring 2023,DRAM,1310,7,17588,Introduction to Theatre,Hinkel,Heidi Anne,46,2,1,0,2,0,1,3.713
+Spring 2023,DRAM,1352,1,17589,Acting II,Ferrarone,Jessica,12,1,0,0,0,0,0,3.796
+Spring 2023,DRAM,1341,1,17590,Make up for Actors,Gardecki,Samantha Lauren,9,4,0,0,0,0,0,3.54
+Spring 2023,DRAM,1330,1,17592,Scenic Technology,Ramos,Emili,3,3,1,0,0,0,0,3.333
+Spring 2023,DRAM,2331,1,17594,Lighting and Sound Technology,Giannelli,Christina Rose,4,3,1,0,0,0,0,3.334
+Spring 2023,DANC,2306,1,17596,Dance Composition II,Lockett,KeyAira,10,0,0,0,0,0,1,3.868
+Spring 2023,ARTS,1303,1,17597,Art Hist I(Prehistoric 14th C),Koontz,Rex A,71,26,15,2,14,0,2,3.029
+Spring 2023,ARTS,1316,3,17599,Fundamentals of Drawing,Meza,Edgar,18,0,0,0,0,0,1,4.0
+Spring 2023,ARTS,1316,2,17600,Fundamentals of Drawing,Aguirre,Isela,20,0,0,0,0,0,0,3.918
+Spring 2023,ARTS,1316,6,17601,Fundamentals of Drawing,Meza,Edgar,18,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,1316,5,17602,Fundamentals of Drawing,Alderson,Saran,19,0,0,0,0,0,1,4.0
+Spring 2023,ARTS,1316,4,17603,Fundamentals of Drawing,Griffin,Alvin Garrett,12,4,0,0,0,0,2,3.688
+Spring 2023,ARTS,2316,4,17604,Fundamentals of Painting,Kidd,Julia A,13,4,0,0,0,0,2,3.726
+Spring 2023,ARTS,2316,1,17605,Fundamentals of Painting,Stephan,Hollie,10,5,2,1,0,0,2,3.37
+Spring 2023,ARTS,2333,1,17606,Fundamentals of Printmaking,Christlieb,Lauren Nicole,14,0,0,0,0,0,1,4.0
+Spring 2023,ARTS,1311,1,17607,Fundamentals of Graphic Design,Williams,Celeste,14,6,1,0,0,0,2,3.588
+Spring 2023,ARTS,1311,2,17608,Fundamentals of Graphic Design,Williams,Celeste,7,10,1,0,0,0,2,3.333
+Spring 2023,ARTS,2326,1,17609,Fundamentals of Sculpture,Martinez,Catherine Ruth,10,1,0,0,0,0,1,3.819
+Spring 2023,ARTS,2326,2,17610,Fundamentals of Sculpture,De Leon,Laura,12,0,0,1,0,0,1,3.642
+Spring 2023,ARTS,2356,2,17611,Fundamentals of Photo/DM,Krouba,Blya Ange Ernestine,8,6,0,0,0,0,3,3.477
+Spring 2023,ARTS,1372,1,17612,Fundamentals of Video Art,Majithia,Maria Jacinta,14,3,0,0,0,0,0,3.785
+Spring 2023,ARTS,2348,2,17613,Digital Tools,Sawhney,Ashita,9,3,2,1,0,0,0,3.245
+Spring 2023,ARTS,1383,1,17614,Introduction to New Media,Reed,John G,9,0,2,0,4,0,2,2.491
+Spring 2023,ARTS,2311,1,17615,"Color, Materials and Methods",Bootwala,Jennifer Elizabeth,15,5,1,1,0,0,0,3.425
+Spring 2023,ARTS,2311,2,17616,"Color, Materials and Methods",Williams,Celeste,17,6,2,0,0,0,0,3.508
+Spring 2023,ARTS,3304,1,17617,Intermediate Painting,Willis,William H,18,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3309,1,17618,Jr Painting Major,Ledvina,Cody,14,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3310,1,17619,Jr Painting Major,Parazette,Aaron,14,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3311,1,17620,Jr Painting Major,Parazette,Aaron,14,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3313,1,17621,Silkscreen,Masterson,Patrick D,10,3,0,0,0,0,0,3.769
+Spring 2023,ARTS,3313,2,17622,Silkscreen,Masterson,Patrick D,10,2,1,0,0,0,0,3.692
+Spring 2023,ARTS,3316,1,17623,Relief Printmaking,Gates,Elizabeth Ann,14,0,0,0,0,0,1,4.0
+Spring 2023,ARTS,3330,1,17624,Intermediate Graphic Design,Jamaluddin,Mohd Ikhram,7,8,2,1,0,0,2,3.02
+Spring 2023,ARTS,3331,1,17625,Graphic Design Software,Sawhney,Ashita,17,2,0,0,0,0,0,3.738
+Spring 2023,ARTS,3334,2,17626,Introduction to Typography,Gamble,Travis Hunter,13,10,0,0,0,0,1,3.537
+Spring 2023,ARTS,3335,1,17627,Junior Graphic Design Major,Hagmann,Sibylle,13,8,1,0,0,0,0,3.62
+Spring 2023,ARTS,3336,1,17628,Junior Graphic Design Major,Unikel,Joshua,19,3,0,0,0,0,0,3.864
+Spring 2023,ARTS,3337,1,17629,Junior Graphic Design Major,Stipeche,Cynthia,12,10,0,0,0,0,0,3.62
+Spring 2023,ARTS,3361,1,17630,Wood and Metal Fabrication,Giampietro,Francis A,15,0,0,0,0,0,0,3.956
+Spring 2023,ARTS,3365,1,17631,Jr Sculpture Major,Kittelson,Paul A,5,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3366,1,17632,Jr Sculpture Major,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3367,1,17633,Jr Sculpture Major,Kittelson,Paul A,5,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3372,1,17634,Intermediate Video Art,Hillerbrand,Stephan C,4,4,1,0,1,0,0,2.835
+Spring 2023,ARTS,3374,1,17635,Computer Imaging,Shon,Jean Young,13,5,0,0,0,0,0,3.631
+Spring 2023,ARTS,3375,1,17636,Jr Photo/Digital Media Major,Castillo,James Phillip,14,3,1,0,0,0,0,3.649
+Spring 2023,ARTS,3376,1,17637,Jr Photo/Digital Media Major,Ramirez,Stephanie Concepcion,13,5,0,0,0,0,0,3.667
+Spring 2023,ARTS,3377,1,17638,Jr Photo/Digital Media Major,Molina,Lorena Guadalupe,11,4,3,0,0,0,0,3.444
+Spring 2023,ARTS,4300,1,17639,Senior Painting Major I,Hecker,Rachel G,8,0,1,0,0,0,0,3.778
+Spring 2023,ARTS,4301,1,17640,Senior Painting Major I,Hecker,Rachel G,8,0,1,0,0,0,0,3.778
+Spring 2023,ARTS,4302,1,17641,Senior Painting Major I,Frankfort,Dana M,8,0,1,0,0,0,0,3.741
+Spring 2023,ARTS,4303,1,17642,Senior Painting Major II,Hecker,Rachel G,9,0,0,1,0,0,0,3.7
+Spring 2023,ARTS,4304,1,17643,Senior Painting Major II,Hecker,Rachel G,9,0,0,1,0,0,0,3.7
+Spring 2023,ARTS,4305,1,17644,Senior Painting Major II,Frankfort,Dana M,9,0,0,1,0,0,0,3.7
+Spring 2023,ARTS,4334,1,17645,Senior Graphic Design Major II,Beckett,Cheryl A,13,8,2,1,0,0,0,3.334
+Spring 2023,ARTS,4335,1,17646,Senior Graphic Design Major II,Suryadi,Adry,17,7,0,0,0,0,0,3.681
+Spring 2023,ARTS,4360,1,17647,Senior Sculpture Major I,Kittelson,Paul A,5,0,0,0,0,0,0,3.934
+Spring 2023,ARTS,4361,1,17648,Senior Sculpture Major I,Conrad,Jillian,5,0,0,0,0,0,0,3.934
+Spring 2023,ARTS,4362,1,17649,Senior Sculpture Major I,Kittelson,Paul A,5,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,4363,1,17650,Senior Sculpture Major II,Kittelson,Paul A,3,1,0,0,0,0,0,3.75
+Spring 2023,ARTS,4364,1,17651,Senior Sculpture Major II,Conrad,Jillian,3,1,0,0,0,0,0,3.75
+Spring 2023,ARTS,4365,1,17652,Senior Sculpture Major II,Kittelson,Paul A,3,1,0,0,0,0,0,3.668
+Spring 2023,ARTS,4373,1,17653,Sr Photo/Digital Media Maj II,Ramirez,Stephanie Concepcion,12,0,0,1,0,0,0,3.744
+Spring 2023,ARTS,4374,1,17654,Sr Photo/Digital Media Maj II,Molina,Lorena Guadalupe,7,3,3,0,0,0,0,3.257
+Spring 2023,ARTS,4375,1,17655,Sr Photo/Digital Media Maj II,Politzer,David,8,3,1,1,0,0,0,3.359
+Spring 2023,ARTS,6300,1,17656,Drawing Studio,Hecker,Rachel G,14,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,6330,1,17657,Graphic Design Studio,Beckett,Cheryl A,3,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,6360,1,17658,Sculpture Studio,Hawk,Ryan,8,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,6370,1,17659,Photography Studio,Molina,Lorena Guadalupe,4,1,0,0,0,0,0,3.734
+Spring 2023,ARTS,6385,1,17660,IPEF Studio,Reed,John G,5,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,7310,1,17661,Printmaking Studio,Masterson,Patrick D,2,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,7310,2,17662,Printmaking Studio,Masterson,Patrick D,2,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,1316,1,17663,Fundamentals of Drawing,Reeves,Cory,11,5,1,0,1,0,3,3.371
+Spring 2023,GOVT,2305,50,17664,"US Govt: Congress,Pres & Crts",Belco,Michelle Helene,26,1,0,0,0,0,0,3.951
+Spring 2023,GOVT,2306,19,17665,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,16,20,9,0,0,0,3,3.163
+Spring 2023,GOVT,2306,53,17666,US and Texas Const/Politics,Leland,Alison W,16,6,1,0,0,0,1,3.48
+Spring 2023,ARTS,6308,1,17667,Graduate Critique,Rubinstein,Raphael,10,0,0,0,0,0,0,3.934
+Spring 2023,DANC,2303,2,17668,Introduction to Dance,Bobet,Jacqueline A,54,36,10,4,8,0,6,3.089
+Spring 2023,CHIN,3360,3,17669,A Look Into Modern China,McArthur,Charles M,5,6,1,0,3,0,1,2.645
+Spring 2023,GOVT,2306,12,17670,US and Texas Const/Politics,McDonald,John Terrence George,86,86,49,11,11,0,5,2.897
+Spring 2023,GOVT,2305,8,17671,"US Govt: Congress,Pres & Crts",Zhou,Hui,23,45,34,10,18,0,8,2.328
+Spring 2023,SGNL,1302,3,17672,Elementary Sign Language II,Warmack,Chris Kiskinis,6,13,2,0,0,0,1,3.143
+Spring 2023,SGNL,2301,2,17673,Intermediate Sign Language I,Warmack,Chris Kiskinis,2,11,7,2,1,0,0,2.464
+Spring 2023,SGNL,1301,2,17674,Elementary Sign Language I,Brittain,Terrell,5,6,3,3,1,0,2,2.556
+Spring 2023,GOVT,2305,21,17675,"US Govt: Congress,Pres & Crts",Davis,Sharon M,24,6,5,2,2,0,7,3.256
+Spring 2023,DRAM,1310,2,17676,Introduction to Theatre,Ostrow,Stuart,13,1,1,0,0,0,1,3.822
+Spring 2023,ARTS,3331,2,17679,Graphic Design Software,Hamouda,Salma Mohamed Ashraf Moussad Mohamed,9,2,1,0,0,0,0,3.612
+Spring 2023,ARTS,4333,1,17680,Senior Graphic Design Major II,Hagmann,Sibylle,20,4,0,0,0,0,0,3.833
+Spring 2023,DRAM,1310,6,17683,Introduction to Theatre,Hinkel,Heidi Anne,314,69,32,9,10,0,12,3.471
+Spring 2023,DRAM,1310,8,17684,Introduction to Theatre,Hinkel,Heidi Anne,43,5,2,0,1,0,1,3.726
+Spring 2023,DRAM,1310,9,17685,Introduction to Theatre,Young,Courtney Leigh,43,6,1,0,0,0,2,3.847
+Spring 2023,ARTS,2356,1,17687,Fundamentals of Photo/DM,Hillerbrand,Stephan C,8,4,2,1,1,0,3,3.042
+Spring 2023,ARTS,1372,2,17688,Fundamentals of Video Art,Majithia,Maria Jacinta,11,7,0,0,0,0,0,3.574
+Spring 2023,ARTS,3374,2,17689,Computer Imaging,Butler,Rontaye Micquan,14,2,1,0,0,0,0,3.609
+Spring 2023,ARTS,2316,2,17690,Fundamentals of Painting,Willis,William H,17,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3301,1,17691,Life Drawing,Barrera,Debra,21,0,0,0,0,0,0,3.953
+Spring 2023,ARTS,4398,2,17692,Independent Study,Hecker,Rachel G,4,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,2326,3,17693,Fundamentals of Sculpture,Long,Randi Rochelle,12,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,2333,2,17694,Fundamentals of Printmaking,Christlieb,Lauren Nicole,13,1,1,0,0,0,0,3.8
+Spring 2023,ARTS,2356,4,17695,Fundamentals of Photo/DM,Ranjbarcheshmehsorkhi,Mandana,16,0,0,0,1,0,1,3.59
+Spring 2023,ARTS,3304,3,17696,Intermediate Painting,Stern,Lindsey Rose,18,2,0,0,0,0,0,3.917
+Spring 2023,ARTS,2348,1,17698,Digital Tools,Sawhney,Ashita,14,0,0,0,0,0,0,3.929
+Spring 2023,CHIN,3354,1,17701,Chinese Culture and Language,Wang,Wei,0,5,4,3,1,0,1,2.127
+Spring 2023,GOVT,2306,8,17702,US and Texas Const/Politics,Jefferies,Kevin E,63,43,19,3,13,0,2,2.977
+Spring 2023,SOCI,1301,5,17703,Introduction To Sociology,Nelson,Steven M,14,14,6,5,6,0,3,2.497
+Spring 2023,ARTS,3330,2,17705,Intermediate Graphic Design,Unikel,Joshua,9,8,4,0,0,0,3,3.301
+Spring 2023,ARTS,3334,1,17706,Introduction to Typography,Hagmann,Sibylle,7,14,3,0,0,0,0,3.139
+Spring 2023,DANC,3314,1,17709,Technology in Dance,Beasant III,John J,6,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,3371,1,17710,Photo-Dig Media Portfolio Dev,Shon,Jean Young,4,7,0,1,0,0,0,3.249
+Spring 2023,SGNL,1301,3,17712,Elementary Sign Language I,Brittain,Robyn Michelle,0,4,5,2,1,0,8,1.973
+Spring 2023,DRAM,1310,10,17714,Introduction to Theatre,Young,Courtney Leigh,41,7,3,0,0,0,1,3.713
+Spring 2023,DRAM,1310,11,17715,Introduction to Theatre,Young,Courtney Leigh,43,7,1,1,0,0,0,3.738
+Spring 2023,ARTS,4398,1,17716,Independent Study,Parazette,Aaron,9,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,2356,3,17717,Fundamentals of Photo/DM,Duron-Larson,Angela Marie,13,1,1,0,2,0,1,3.314
+Spring 2023,ARTS,3304,2,17719,Intermediate Painting,Litos,Joshua David,19,0,1,0,0,0,0,3.801
+Spring 2023,ARTS,1311,4,17720,Fundamentals of Graphic Design,Lopez,Jonathan Christopher,5,8,3,0,2,0,1,2.778
+Spring 2023,CUIN,8398,2,17721,Independent Study,Alarcon,Jeannette Driscoll,1,0,0,0,0,0,0,4.0
+Spring 2023,DRAM,1310,13,17722,Introduction to Theatre,Egging,Jon Leo,31,5,0,1,7,0,7,3.129
+Spring 2023,GOVT,2306,6,17724,US and Texas Const/Politics,Jefferies,Kevin E,103,44,21,7,22,0,8,2.993
+Spring 2023,CHIN,3350,1,17725,Chinese Culture Through Films,McArthur,Charles M,14,8,3,0,1,0,3,3.32
+Spring 2023,CHIN,3304,1,17726,Business Chinese,Zhang,Xincui,6,0,0,0,0,0,0,3.945
+Spring 2023,GOVT,2306,55,17727,US and Texas Const/Politics,Leland,Alison W,13,12,0,0,0,0,0,3.546
+Spring 2023,BIOL,4374,50,17729,Cell Biology,Sharp,Rita Evelyn,12,12,0,0,1,0,1,3.347
+Spring 2023,BCHS,4313,50,17730,Cell Biochemistry,Sharp,Rita Evelyn,3,3,0,0,0,0,0,3.445
+Spring 2023,DRAM,1352,2,17731,Acting II,Ferrarone,Jessica,3,1,0,0,0,0,0,3.75
+Spring 2023,ARTS,6305,1,17732,Painting Studio,Frankfort,Dana M,9,0,0,0,0,0,0,4.0
+Spring 2023,DANC,4331,1,17733,PR and Marketing - Arts,Valle,Toni Leago,3,1,1,0,0,0,0,3.268
+Spring 2023,ARTS,1304,1,17734,Art Hist II(15th C to Present),Lee,Kyoung Yong,24,73,38,12,13,0,12,2.492
+Spring 2023,ARTS,2326,5,17735,Fundamentals of Sculpture,Patzke,Katie,11,0,1,0,0,0,0,3.806
+Spring 2023,ARTS,3374,3,17736,Computer Imaging,Gaona,Veronica,17,0,0,0,0,0,0,3.961
+Spring 2023,COMM,7399,6,17737,Masters Thesis,Liu,Wenlin,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,6399,7,17738,Masters Thesis,Camaj,Lindita,1,0,0,0,0,0,0,4.0
+Spring 2023,GOVT,2306,5,17740,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,67,86,67,20,2,0,6,2.784
+Spring 2023,CHIN,6364,1,17742,Issues in Chinese Lang & Cult,Wang,Wei,0,1,0,0,0,0,0,3.33
+Spring 2023,CHIN,3343,1,17743,Chinese Popular Culture,Li,Melody Yunzi,19,7,0,0,0,0,1,3.667
+Spring 2023,GOVT,2306,56,17745,US and Texas Const/Politics,LeVeaux,Christine,14,10,1,0,0,0,0,3.348
+Spring 2023,BIOL,1307,52,17747,Biology for Science Majors II,Sharp,Rita Evelyn,17,13,1,0,0,0,1,3.569
+Spring 2023,ARTS,3360,1,17751,Intermediate Sculpture,Kittelson,Paul A,10,9,1,0,0,0,0,3.516
+Spring 2023,DANC,2309,1,17752,Dance Production II,Valle,Toni Leago,9,3,0,0,0,0,0,3.778
+Spring 2023,PHLA,7299,1,17753,Masters Thesis,Wanat,Matthew A,0,0,0,0,0,1,0,
+Spring 2023,PHLA,7299,2,17754,Masters Thesis,Tolleson,Shane Russell,0,0,0,0,0,1,0,
+Spring 2023,PHLA,7299,3,17755,Masters Thesis,Wallace,David A,0,0,0,0,0,1,0,
+Spring 2023,PHLA,7299,4,17756,Masters Thesis,Varkey,Divya A,0,0,0,0,0,3,0,
+Spring 2023,PHLA,7299,7,17757,Masters Thesis,Garey,Kevin W,0,0,0,0,0,1,0,
+Spring 2023,ARTS,2326,4,17758,Fundamentals of Sculpture,Vega,Zulma C.,10,0,0,0,0,0,1,4.0
+Spring 2023,BCHS,6198,2,17764,Special Problems,Widger,William R,0,0,0,0,0,4,0,
+Spring 2023,LATI,1302,1,17765,Elementary Latin II,Kidder,Kathleen,3,4,1,1,1,0,0,2.7
+Spring 2023,BIOE,6306,2,17767,Adv Artificial Neural Networks,Francis,Joseph Thachil,14,5,0,0,0,0,2,3.702
+Spring 2023,BIOE,4313,2,17768,Intro to Neural Computation,Francis,Joseph Thachil,7,3,1,1,0,0,1,3.416
+Spring 2023,GEOL,1102,5,17769,Intro to Climate Change Lab,Wang,Yuxuan,12,5,2,0,0,0,1,3.561
+Spring 2023,GEOL,1102,6,17770,Intro to Climate Change Lab,Wang,Yuxuan,7,4,0,1,0,0,0,3.472
+Spring 2023,GEOL,1102,7,17771,Intro to Climate Change Lab,Wang,Yuxuan,20,1,2,0,0,0,0,3.754
+Spring 2023,POLS,3311,5,17773,Intro Compar Politics,Vardy,Ronald V,31,4,0,0,1,0,1,3.769
+Spring 2023,CUIN,8352,1,17775,Tech Apps for Ed Leaders,McNeil,Sara G,8,0,0,0,0,0,0,3.959
+Spring 2023,MATH,2318,4,17778,Linear Algebra,Mang,Andreas,26,18,6,0,3,0,6,3.183
+Spring 2023,MATH,2318,5,17779,Linear Algebra,Morgan,Jeffrey,28,24,11,4,8,0,11,2.791
+Spring 2023,MATH,3321,5,17782,Engineering Mathematics,Ryan,John M,43,44,60,14,23,0,13,2.4
+Spring 2023,MATH,3333,2,17784,Intermediate Analysis,Ji,Shanyu,7,4,4,0,2,0,0,2.843
+Spring 2023,PHYS,3214,1,17785,Advanced Laboratory II,Freelon,Byron Kendall,6,3,3,0,0,0,0,3.058
+Spring 2023,MATH,3363,3,17787,Introduction To Pde,Fitzgibbon,William E,5,6,5,0,0,0,1,2.959
+Spring 2023,MATH,3363,5,17788,Introduction To Pde,Mamonov,Alexander V,6,10,7,6,3,0,7,2.313
+Spring 2023,CUIN,2300,1,17789,Introduction to STEM Teaching,Manuel,Mariam A,18,0,0,0,0,0,0,4.0
+Spring 2023,INDE,2331,1,17793,Computer Applications for IE,Wiggins,Nathanial David,1,3,0,0,0,0,0,3.085
+Spring 2023,MATH,4315,1,17794,Graph Theory with Applications,Josic,Kresimir,7,15,6,0,3,0,4,2.699
+Spring 2023,CHEE,6383,1,17803,Adv Unit Operations,Kaushik,Krishna R,2,1,0,0,0,0,0,3.667
+Spring 2023,MATH,1314,4,17805,College Algebra,Hafeez,Shahinda,9,15,27,8,21,0,10,1.713
+Spring 2023,BIOL,6368,1,17806,Ecology,Pennings,Steven C,2,0,0,0,0,0,0,3.835
+Spring 2023,CNST,2351,2,17807,Construction Estimating I,Liggin,Gregory G,11,33,10,2,2,0,3,2.845
+Spring 2023,CNST,3205,2,17808,Construction Safety Management,Hart,Lee J,18,3,0,0,0,0,0,3.857
+Spring 2023,CNST,3331,2,17809,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,11,17,12,2,3,0,6,2.689
+Spring 2023,CNST,3351,2,17810,Construction Estimating II,Siddiqui,Muhammad Ali,9,9,2,1,1,0,0,3.091
+Spring 2023,CIS,3320,3,17811,Information Visualization,Ratner,Edward,38,64,19,3,8,0,4,2.862
+Spring 2023,CIS,3355,31,17812,Integrated Information Systems,Peddoju,Suresh Kumar,36,54,14,2,4,0,4,3.049
+Spring 2023,HRD,6359,30,17813,Trends in Org Development,Egan,Toby,7,0,0,0,0,0,0,3.953
+Spring 2023,GEOL,1147,3,17814,Introductory Meteorology Lab,Jiang,Xun,9,4,3,3,0,0,1,3.0
+Spring 2023,GEOL,1303,2,17815,Physical Geology,Khan,Shuhab D,15,36,18,3,8,0,5,2.633
+Spring 2023,FINA,4330,5,17816,Corporate Finance,Allena,Rohit,13,14,1,0,0,0,0,3.275
+Spring 2023,BIOL,1307,53,17817,Biology for Science Majors II,Hanke,Marc H,10,9,6,2,0,0,3,3.061
+Spring 2023,ARCH,7601,5,17818,Architecture Design Studio VI,Froehlich,Dietmar,6,3,0,0,0,0,0,3.63
+Spring 2023,MATH,2131,2,17823,Linear Alg Labs w/MATLAB,Goligerdian,Arash,12,4,0,0,3,0,2,3.193
+Spring 2023,CUIN,4303,2,17825,Sec Language Acq,Elshafie,Marwa,7,1,1,0,0,0,0,3.63
+Spring 2023,CUIN,4361,3,17826,Second Language Methodology,Leon,Maredil Josefina,18,8,5,0,0,0,1,3.334
+Spring 2023,LAW,6239,1,17830,Admiralty Envirmnt'l Insurance,Engerrand,Kenneth G,1,4,0,0,0,6,0,3.398
+Spring 2023,CUIN,3111,1,17832,Educational Tech Elem Teachers,Tran,Hien Thi,18,1,0,1,0,0,0,3.8
+Spring 2023,GHL,4350,2,17833,Strategy&Innovation Hosp Ind,Johnson,Tucker A,31,11,3,2,2,0,1,3.354
+Spring 2023,GHL,4352,2,17834,Hosp Organizational Behavior,Jarvis,Nathan Alexander,27,11,5,5,2,0,0,3.061
+Spring 2023,GHL,3372,1,17837,Convention and Meeting Mgmt,Kenyan,Erin Oeser,32,6,4,1,4,0,0,3.312
+Spring 2023,GHL,3384,1,17838,Gourmet Night Managment,Haskell,Rebecca Erin,12,0,0,0,0,0,0,4.0
+Spring 2023,GHL,4326,1,17839,Catering Management,Ginapp,Kathrine,1,3,1,0,2,0,1,2.237
+Spring 2023,GHL,4372,1,17841,Global Hosp Leadership: Asia,Back,KiJoon,3,2,0,0,0,0,0,3.732
+Spring 2023,GHL,4384,1,17842,Gourmet Night Management II,Haskell,Rebecca Erin,6,0,0,0,0,0,0,4.0
+Spring 2023,GHL,4462,1,17843,Practical Project Mgmt in Hosp,Park,Hyekyung,9,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6364,2,17845,Hosp. Managerial Accounting,Johnson,Tucker A,7,1,0,1,0,0,0,3.519
+Spring 2023,GHL,6343,1,17846,Beverage Management,Jarvis,Nathan Alexander,10,0,2,0,1,0,0,3.308
+Spring 2023,GHL,6351,1,17847,Lodging Operations Mgmt,Johnson,Tucker A,9,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6352,1,17849,Hospitality Market Analysis,McCaslin,Glynn Randle,19,0,0,0,0,0,0,4.0
+Spring 2023,GHL,7353,1,17850,Services Management in Hosp.,Boger Jr,Carl A,17,0,0,0,0,0,0,4.0
+Spring 2023,GHL,7369,1,17852,Hospitality Financial Assets,Koh,Yoon,4,4,0,0,1,0,0,3.258
+Spring 2023,GHL,7366,1,17854,Hosp. Management Strategies,Kim,Jaewook,22,0,0,0,1,0,0,3.826
+Spring 2023,GHL,7369,2,17855,Hospitality Financial Assets,Koh,Yoon,8,3,1,0,0,0,0,3.583
+Spring 2023,GHL,7353,2,17856,Services Management in Hosp.,Boger Jr,Carl A,11,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,1507,3,17857,Intns Elem Span Heritage Learn,Fairclough,Marta A,9,5,7,0,1,0,1,2.91
+Spring 2023,GHL,6368,1,17863,Career Capstone Project,Kim,Jaewook,1,0,0,0,0,0,0,4.0
+Spring 2023,SEDE,7340,2,17864,Reading in Middle and Secondar,Russell IV,Glen Curtis,6,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,7361,1,17865,Seminar: Literacy Leadership,Hale,Margaret Ann,26,1,0,0,1,0,0,3.821
+Spring 2023,CUIN,7325,1,17866,Dev & Publ Literacy Material,Bird,Shawn,10,0,0,0,1,0,0,3.636
+Spring 2023,LAW,5279,1,17872,Texas Consumer Law,Alderman,Richard M,3,4,0,0,0,10,1,3.381
+Spring 2023,LAW,5339,2,17873,Trusts and Wills,Reed,Hilary S,13,16,0,0,0,18,0,3.357
+Spring 2023,LAW,5342,1,17874,Prof Writing Strategies,Simmons,Laurel Ellis Parker,6,5,1,0,0,0,0,3.389
+Spring 2023,LAW,5312,1,17875,First Amendment,Salib,Peter,18,24,0,0,0,6,2,3.405
+Spring 2023,LAW,6316,1,17876,Energy Law & Policy,Wiseman,Hannah J,20,16,2,0,0,22,0,3.448
+Spring 2023,LAW,5326,1,17878,Criminal Procedure,Braley,Timothy Shawn,20,28,1,0,0,11,0,3.314
+Spring 2023,LAW,5326,2,17880,Criminal Procedure,Kwok,David Y,16,20,1,0,0,8,0,3.379
+Spring 2023,LAW,5308,1,17884,Federal Courts,Kumar,Sapna,19,12,3,1,0,15,0,3.362
+Spring 2023,LAW,5333,1,17885,Health Transactions,Mantel,Jessica,3,3,0,0,0,0,0,3.5
+Spring 2023,LAW,5209,1,17886,Legal Spanish-Spanish Speakers,Romero Jr,Reynaldo,4,7,1,0,0,2,1,3.278
+Spring 2023,SOCW,7371,1,17889,Trauma & SW,Parks,Steven Lee,26,0,0,0,0,0,0,4.0
+Spring 2023,TEPM,6304,2,17890,Quality Improvemnt in Proj Mgt,Kovach,Jamison,3,1,0,1,0,0,2,3.2
+Spring 2023,CUIN,7367,1,17896,Sci Instruc in Middle Grade II,Wong,Sissy S,19,1,0,0,0,0,0,3.884
+Spring 2023,BIOE,4309,2,17897,Neural Technology Interfaces,Abidian,Mohammad Reza,17,4,0,0,0,0,0,3.794
+Spring 2023,BIOE,6309,2,17898,Neural Interfaces,Abidian,Mohammad Reza,11,3,0,0,0,0,0,3.739
+Spring 2023,CUIN,4326,1,17899,Teach Science in Grades 4-8 II,Varnado,Jakarda Wiltz,8,0,0,0,0,0,0,3.959
+Spring 2023,CUIN,3312,1,17902,Educational Technology,Hebert,Waneta Suzanne,12,8,0,1,0,0,0,3.46
+Spring 2023,BIOE,6320,1,17903,Tissue Engineering,Horton,Renita Elillian,1,3,0,0,0,0,0,3.168
+Spring 2023,CHEM,6330,1,17912,Advanced Polymer Chemistry,Harth,Eva M,8,4,0,0,1,0,1,3.435
+Spring 2023,CUIN,6360,1,17914,Prin - Curric Develpmnt,Alarcon,Jeannette Driscoll,5,1,0,0,1,0,0,3.191
+Spring 2023,MANA,4336,2,17921,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,1,13,4,0,0,0,0,2.943
+Spring 2023,MANA,4337,1,17922,Stress and Work,Sebastijanovic,Marina,39,13,5,1,0,0,2,3.506
+Spring 2023,MANA,4347,2,17925,Ethics and Corp Soc Respon.,Salaiz,Ashley,25,10,2,0,1,0,0,3.483
+Spring 2023,MANA,4353,3,17927,Mgmt Training and Career Devel,Bozeman,Dennis,44,14,1,0,0,0,1,3.762
+Spring 2023,HDCS,2301,2,17928,Consumer Science,Stewart,Juliana Floriene,26,15,3,2,4,0,3,3.16
+Spring 2023,HDCS,3303,2,17929,Retailing and Consumer Science,Rifai,Rana Ihsan,31,12,3,1,1,0,2,3.438
+Spring 2023,HDCS,3304,2,17930,Visual Merchandising,Stewart,Barbara L,12,13,15,3,6,0,1,2.409
+Spring 2023,HDCS,4303,2,17931,Merchandising Systems,Gatterson,Beverly,26,13,4,3,3,0,1,3.055
+Spring 2023,MANA,4385,2,17932,Intro to Strategic Management,Chiu,Shih-chi,15,7,4,1,1,0,0,3.144
+Spring 2023,MANA,7312,1,17933,Fundtls of Healthcare Business,Kroger,Edward John,13,0,0,0,0,0,0,4.0
+Spring 2023,MANA,7351,1,17934,Mgt of  Global Organizations,Keller,Robert T,18,2,0,0,0,0,0,3.785
+Spring 2023,MANA,7355,1,17935,Staffing & Talent Management,Bozeman,Dennis,15,7,0,0,0,0,0,3.712
+Spring 2023,MANA,7358,1,17936,Compensation & Benefits,Werner,Steve,10,5,0,0,0,0,0,3.601
+Spring 2023,MANA,7380,1,17937,People Analytics,Abbott,Jeanna L,11,1,0,0,0,0,0,3.779
+Spring 2023,MANA,7382,1,17938,Strateg Leadership-Healthcare,Kroger,Edward John,7,0,0,0,0,0,0,4.0
+Spring 2023,MANA,8345,1,17940,Research Methodologies,Werner,Steve,3,0,1,0,0,0,0,3.418
+Spring 2023,MANA,6A83,4,17941,Strategic Analysis,Wesley,Curtis,8,2,0,0,0,0,1,3.866
+Spring 2023,ACCT,2301,6,17943,Prin of Financial Accounting,Goble,Samuel,40,57,25,8,4,0,14,2.972
+Spring 2023,MIS,6341,1,17945,Information Systems,Silva,Leiser O,12,0,0,0,0,0,0,3.945
+Spring 2023,ACCT,2302,11,17947,Prin of Managerial Accounting,Parthasarathy,Kiran M,80,36,22,5,1,0,3,3.345
+Spring 2023,ACCT,3367,1,17948,Intermediate Accounting I,Zhu,Steven Xuanrui,3,12,12,3,2,0,1,2.323
+Spring 2023,ACCT,3367,2,17949,Intermediate Accounting I,Kuruvilla,Mohan,0,0,0,0,3,0,2,0.0
+Spring 2023,ACCT,3367,3,17950,Intermediate Accounting I,Deng,Tianyi,16,9,6,5,0,0,2,3.064
+Spring 2023,FINA,7A34,2,17956,Mergers & Acquisitions II,Yerramilli,Vijay,5,2,0,0,0,0,0,3.667
+Spring 2023,MATH,1100,2,17957,Developmental Math,Chang,James A,0,0,0,0,0,19,8,
+Spring 2023,MATH,1100,3,17958,Developmental Math,Chang,James A,0,0,0,0,0,13,1,
+Spring 2023,MATH,1100,4,17959,Developmental Math,Chang,James A,0,0,0,0,0,4,0,
+Spring 2023,BZAN,6310,4,17960,Quant Analysis for Busn Dec,Wiley,Briceon C,14,18,3,0,1,0,2,3.213
+Spring 2023,BZAN,6351,2,17961,Basic Prog for Busi Analytics,Wang,Cheng,33,2,0,0,0,0,1,3.896
+Spring 2023,LAW,5201,1,17962,Intellectual Property Survey,Robinson,Erick Scott,2,9,0,0,0,0,0,3.272
+Spring 2023,CIS,3351,30,17963,Intrusion Detect & Incid Resp,Nsoh,Jovita T,18,6,2,1,3,0,7,3.123
+Spring 2023,ACCT,3371,1,17964,Accounting Information Systems,Miles,Carolyn A,14,15,6,1,2,0,2,2.983
+Spring 2023,ACCT,3371,2,17965,Accounting Information Systems,Seijas,Nuria S,29,31,5,0,1,0,0,3.333
+Spring 2023,ACCT,3371,4,17967,Accounting Information Systems,Seijas,Nuria S,23,19,7,0,1,0,7,3.214
+Spring 2023,ACCT,3377,1,17968,Cost Accounting,Serrato,Darlene Marie  Bohac,13,20,13,3,0,0,9,2.898
+Spring 2023,SOCW,7339,1,17969,Prof. Grant Writing for SW,Stagg,Helen Ruth,22,2,0,0,0,0,0,3.917
+Spring 2023,SOCW,7367,3,17970,Social Policy Analysis,Borja,Sharon G,21,7,0,0,0,0,0,3.75
+Spring 2023,SOCW,7367,4,17971,Social Policy Analysis,Mohr,Gabriella A,25,4,0,0,0,0,0,3.862
+Spring 2023,ACCT,3377,3,17973,Cost Accounting,Serrato,Darlene Marie  Bohac,32,24,12,3,1,0,3,3.153
+Spring 2023,HRD,4350,1,17974,Org Dev & Consulting,Clancy,James Patrick,23,8,4,0,1,0,0,3.389
+Spring 2023,SOCW,7367,5,17975,Social Policy Analysis,Ochoa,Ashley Marissa,25,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6313,1,17978,Prof Orientation & Adv Ethics,Hurt,Kara Marie,18,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6313,2,17979,Prof Orientation & Adv Ethics,Hurt,Kara Marie,13,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,4332,1,17980,Corporate Taxation,Fernandez,Ramon,3,4,1,0,0,0,0,3.333
+Spring 2023,ACCT,4332,2,17981,Corporate Taxation,Chen,Xi,2,2,1,0,0,0,0,3.2
+Spring 2023,ACCT,4332,3,17982,Corporate Taxation,Chen,Xi,0,3,0,0,0,0,0,3.0
+Spring 2023,ACCT,4335,2,17984,Financial Statement Auditing,Rousseau,Linette Marie,5,8,6,1,0,0,0,2.883
+Spring 2023,PHLS,6315,1,17985,Career Counseling,Whitaker,Rachael Gwin,21,0,0,0,0,0,0,3.984
+Spring 2023,PHLS,6315,2,17986,Career Counseling,Whitaker,Rachael Gwin,19,0,0,0,1,0,0,3.8
+Spring 2023,ACCT,4375,1,17988,Internal Audit Entity Environ,Brant Jr,Robert Edward,11,15,3,0,0,0,2,3.39
+Spring 2023,ACCT,5332,1,17989,Corporate Taxation,Fernandez,Ramon,0,2,0,0,0,0,0,3.0
+Spring 2023,ACCT,7375,3,17990,Corporate Taxation,Fernandez,Ramon,1,2,2,0,0,0,0,2.932
+Spring 2023,ACCT,5332,2,17991,Corporate Taxation,Chen,Xi,0,3,2,0,0,0,0,2.6
+Spring 2023,ACCT,7375,4,17992,Corporate Taxation,Chen,Xi,4,3,0,0,0,0,0,3.524
+Spring 2023,ACCT,7375,1,17994,Corporate Taxation,Chen,Xi,3,3,1,0,0,0,0,3.38
+Spring 2023,ACCT,5335,1,17997,Financial Statement Auditing,Rousseau,Linette Marie,4,4,5,0,0,0,1,2.948
+Spring 2023,ACCT,5371,1,18001,Accounting Information Systems,Seijas,Nuria S,2,8,0,0,0,0,0,3.134
+Spring 2023,ACCT,5371,2,18002,Accounting Information Systems,Seijas,Nuria S,0,1,0,0,0,0,0,3.0
+Spring 2023,ACCT,5375,2,18003,Internl Audit-Entity Ctrl Env,Brant Jr,Robert Edward,1,2,1,0,0,0,0,3.083
+Spring 2023,ACCT,5376,2,18004,Adv Fin Statement Auditing,Seltz,Joe D,0,0,1,0,0,0,0,2.0
+Spring 2023,ACCT,7370,2,18005,Adv Fin Statement Auditing,Seltz,Joe D,3,5,1,0,0,0,1,3.296
+Spring 2023,ACCT,5377,2,18006,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,0,5,0,0,0,0,1,3.264
+Spring 2023,MATH,3339,6,18007,Statistics for the Sciences,Papadakis,Emanuel Ioannis,5,5,3,4,2,0,13,2.455
+Spring 2023,SOCW,7312,1,18008,Suicide Assessment & Treatment,Gearing,Robin Edward,27,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,7373,1,18009,Appl Data Analytics in Acct I,Miles,Carolyn A,9,1,0,0,0,0,1,3.867
+Spring 2023,ENGL,2361,3,18010,Western World Lit II--Honors,Cooper,Carol B,5,0,0,0,0,0,0,3.802
+Spring 2023,ENGL,2361,4,18011,Western World Lit II--Honors,Cooper,Carol B,2,3,0,0,0,0,0,3.334
+Spring 2023,ENGL,2361,5,18012,Western World Lit II--Honors,Cremins,Robert Paul,1,0,0,0,0,0,0,3.67
+Spring 2023,ENGL,2361,6,18013,Western World Lit II--Honors,Cremins,Robert Paul,5,1,0,0,0,0,0,3.613
+Spring 2023,ENGL,2361,7,18014,Western World Lit II--Honors,Garner,Richard A,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,2361,8,18015,Western World Lit II--Honors,Lyke,Larry,0,2,0,0,0,0,0,2.67
+Spring 2023,ENGL,2361,9,18016,Western World Lit II--Honors,Morrison,Iain P D,3,2,1,0,0,0,0,3.333
+Spring 2023,ENGL,2361,10,18017,Western World Lit II--Honors,Morrison,Iain P D,0,2,1,0,0,0,0,2.667
+Spring 2023,ENGL,2361,11,18018,Western World Lit II--Honors,Rayneard,Max James Anthony,2,3,0,0,0,0,0,3.334
+Spring 2023,ENGL,2361,12,18019,Western World Lit II--Honors,Rayneard,Max James Anthony,2,2,0,0,0,0,0,3.335
+Spring 2023,ENGL,2361,13,18020,Western World Lit II--Honors,Vollrath,Lesli A,2,1,1,0,0,0,0,3.333
+Spring 2023,ENGL,2361,14,18021,Western World Lit II--Honors,Vollrath,Lesli A,1,3,0,0,0,0,0,3.25
+Spring 2023,ENGL,2361,21,18024,Western World Lit II--Honors,Bland,Laura Elizabeth,4,1,0,0,0,0,0,3.734
+Spring 2023,ENGL,2361,22,18025,Western World Lit II--Honors,Bland,Laura Elizabeth,4,1,0,0,0,0,0,3.8
+Spring 2023,ENGL,2361,23,18026,Western World Lit II--Honors,Barnes,Michael,3,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,2361,24,18027,Western World Lit II--Honors,Barnes,Michael,3,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,2361,25,18028,Western World Lit II--Honors,Church,Jeffrey,5,1,0,0,0,0,1,3.668
+Spring 2023,ENGL,2361,26,18029,Western World Lit II--Honors,Gish,Dustin,2,2,0,0,0,0,0,3.335
+Spring 2023,ENGL,2361,28,18030,Western World Lit II--Honors,Mikics,David,3,1,0,0,0,0,0,3.503
+Spring 2023,ENGL,2361,29,18031,Western World Lit II--Honors,Rainbow,David,2,0,0,0,1,0,1,2.557
+Spring 2023,ENGL,2361,30,18032,Western World Lit II--Honors,Rainbow,David,0,1,0,0,0,0,0,3.0
+Spring 2023,ENGL,2361,31,18033,Western World Lit II--Honors,Rainbow,Jesse J,1,3,0,0,0,0,0,3.415
+Spring 2023,ENGL,2361,32,18034,Western World Lit II--Honors,Rainbow,Jesse J,1,3,2,0,0,0,0,2.888
+Spring 2023,ENGL,2361,33,18035,Western World Lit II--Honors,Sisman,Cengiz,2,0,0,0,0,0,0,3.835
+Spring 2023,ENGL,2361,34,18036,Western World Lit II--Honors,Sisman,Cengiz,1,1,0,0,0,0,0,3.665
+Spring 2023,ENGL,2361,35,18037,Western World Lit II--Honors,Trninic,Marina,2,2,0,0,0,0,0,3.335
+Spring 2023,ENGL,2361,36,18038,Western World Lit II--Honors,Trninic,Marina,6,0,0,1,0,0,0,3.43
+Spring 2023,ENGL,2361,27,18041,Western World Lit II--Honors,Gish,Dustin,1,2,0,0,0,0,0,3.333
+Spring 2023,ACCT,7362,2,18042,Tax Research,Meade,Janet,4,7,0,0,0,0,1,3.364
+Spring 2023,INTB,3361,1,18044,Global Engagement and Research,Miljanic,Andra Olivia,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,4349,2,18046,Biomedical Microdevices,Majd,Sheereen,17,10,0,0,0,0,0,3.581
+Spring 2023,BIOE,6349,2,18047,Biomedical Microdevices,Majd,Sheereen,9,4,0,0,0,0,0,3.642
+Spring 2023,FINA,4336,1,18052,Consulting-Small Business Need,Bailey-Rihawi,Esther Elizabeth,5,0,0,0,0,0,0,4.0
+Spring 2023,HON,2341,3,18054,Classics of Modernity,Cooper,Carol B,7,3,0,0,2,0,0,3.083
+Spring 2023,HON,2341,4,18055,Classics of Modernity,Cooper,Carol B,5,4,1,0,1,0,0,3.031
+Spring 2023,HON,2341,5,18056,Classics of Modernity,Cremins,Robert Paul,12,4,0,0,1,0,0,3.471
+Spring 2023,HON,2341,6,18057,Classics of Modernity,Cremins,Robert Paul,6,4,0,0,1,0,0,3.273
+Spring 2023,HON,2341,7,18058,Classics of Modernity,Garner,Richard A,14,1,1,0,0,0,0,3.73
+Spring 2023,HON,2341,8,18059,Classics of Modernity,Lyke,Larry,8,7,0,0,0,0,0,3.467
+Spring 2023,HON,2341,9,18060,Classics of Modernity,Morrison,Iain P D,5,4,0,0,0,0,0,3.592
+Spring 2023,HON,2341,10,18061,Classics of Modernity,Morrison,Iain P D,6,1,1,0,0,0,1,3.501
+Spring 2023,HON,2341,11,18062,Classics of Modernity,Rayneard,Max James Anthony,10,2,0,0,0,0,0,3.723
+Spring 2023,HON,2341,12,18063,Classics of Modernity,Rayneard,Max James Anthony,8,5,0,0,0,0,0,3.565
+Spring 2023,HON,2341,13,18064,Classics of Modernity,Vollrath,Lesli A,4,8,0,0,0,0,1,3.471
+Spring 2023,HON,2341,14,18065,Classics of Modernity,Vollrath,Lesli A,9,4,0,0,0,0,0,3.667
+Spring 2023,HON,2341,21,18068,Classics of Modernity,Bland,Laura Elizabeth,9,4,0,0,0,0,2,3.642
+Spring 2023,HON,2341,22,18069,Classics of Modernity,Bland,Laura Elizabeth,5,7,0,0,0,0,0,3.499
+Spring 2023,HON,2341,23,18070,Classics of Modernity,Barnes,Michael,14,0,0,0,0,0,0,3.976
+Spring 2023,HON,2341,24,18071,Classics of Modernity,Barnes,Michael,12,1,0,0,0,0,0,3.847
+Spring 2023,HON,2341,25,18072,Classics of Modernity,Church,Jeffrey,8,0,0,0,0,0,0,3.753
+Spring 2023,HON,2341,26,18073,Classics of Modernity,Gish,Dustin,6,4,0,0,1,0,0,3.213
+Spring 2023,HON,2341,27,18074,Classics of Modernity,Gish,Dustin,2,2,1,0,0,0,0,3.266
+Spring 2023,HON,2341,28,18075,Classics of Modernity,Mikics,David,8,5,0,0,0,0,0,3.514
+Spring 2023,HON,2341,29,18076,Classics of Modernity,Rainbow,David,8,3,1,0,1,0,0,3.181
+Spring 2023,HON,2341,30,18077,Classics of Modernity,Rainbow,David,12,3,0,0,1,0,0,3.459
+Spring 2023,HON,2341,31,18078,Classics of Modernity,Rainbow,Jesse J,5,8,0,0,0,0,0,3.385
+Spring 2023,HON,2341,32,18079,Classics of Modernity,Rainbow,Jesse J,5,3,0,0,0,0,0,3.584
+Spring 2023,HON,2341,33,18080,Classics of Modernity,Sisman,Cengiz,10,5,0,0,0,0,0,3.667
+Spring 2023,HON,2341,34,18081,Classics of Modernity,Sisman,Cengiz,13,2,0,0,0,0,0,3.801
+Spring 2023,HON,2341,35,18082,Classics of Modernity,Trninic,Marina,9,4,0,0,0,0,0,3.642
+Spring 2023,HON,2341,36,18083,Classics of Modernity,Trninic,Marina,8,2,0,0,0,0,0,3.701
+Spring 2023,GENB,7304,4,18087,Bus Ethics for Accountants,Spartalis,Emmanuel Michael,8,1,0,0,0,0,0,3.779
+Spring 2023,FINA,4335,1,18089,Brainstorming to Bankrolling,Khumawala,Saleha B,10,3,0,0,0,0,3,3.744
+Spring 2023,GENB,5335,1,18090,Brainstorming to Bankrolling,Khumawala,Saleha B,1,0,0,0,0,0,0,4.0
+Spring 2023,GENB,5303,2,18091,Prof Acct Communication,Newman,Michael Ray,2,1,0,0,0,0,0,3.667
+Spring 2023,GENB,7303,4,18092,Prof Accounting Communication,Newman,Michael Ray,6,1,0,0,0,0,0,3.904
+Spring 2023,PHLA,7A20,1,18098,Leadership Transitions,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Spring 2023,PHLA,6240,1,18099,Regulatory Compliance,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Spring 2023,PHLA,6250,1,18100,Research Methodology,Garey,Kevin W,6,1,0,0,0,0,0,3.857
+Spring 2023,MARK,7A75,1,18101,Marketing Strategy,Lish,Alan D,16,4,1,1,0,0,0,3.516
+Spring 2023,COMM,1302,2,18102,Intro To Comm Theory,Lee,Jaesub,8,7,8,0,0,0,4,2.9
+Spring 2023,COMM,1307,6,18103,Media and Society,Olson,Beth M,14,39,22,11,12,0,3,2.337
+Spring 2023,MARK,6A61,3,18104,Marketing Administration,Lish,Alan D,8,13,4,0,1,0,0,3.0
+Spring 2023,COMM,1307,7,18105,Media and Society,Washington,Germaine Monteil,22,0,3,0,0,0,4,3.615
+Spring 2023,MARK,4389,7,18106,Marketing Strategy & Planning,Herman,Carl,9,5,0,0,0,0,0,3.572
+Spring 2023,ENRG,3311,1,18110,Fundamentals of Sustainability,Dieterich,Michael,7,8,0,0,1,0,2,3.188
+Spring 2023,HON,4355,1,18111,Engaged Data,Konstantinidis,Ioannis,2,1,0,0,0,0,0,3.667
+Spring 2023,POLC,3314,1,18112,Leadership and Public Policy,Witt,Lawrence A,20,3,3,1,0,0,2,3.556
+Spring 2023,COMD,3383,5,18114,Language Disorders in Children,Ivey,Michelle L,14,9,4,1,0,0,1,3.286
+Spring 2023,ARCH,5593,15,18119,Thesis Project,Beneytez-Duran,Rafael,11,2,0,0,0,0,0,3.821
+Spring 2023,ENGL,3327,1,18121,Masterpieces of British Lit I,Mazella,David S,14,7,0,0,3,0,3,3.222
+Spring 2023,ENGL,4322,1,18124,Grammar & Usage,Lagana,Karen E,27,1,0,0,0,0,0,3.964
+Spring 2023,ENGL,4341,1,18125,Queer Theory,Backus,Margot Gayle,7,2,1,0,2,0,1,2.945
+Spring 2023,SCM,7350,1,18127,Strategic Supply Management,Wayhan,Victor Brian,20,4,0,0,0,0,0,3.806
+Spring 2023,SCM,7330,2,18129,Demand and Supply Integration,Sahin,Funda,20,16,5,0,0,0,1,3.342
+Spring 2023,SCM,7320,1,18130,Supply Chain Analytics,Murray,Michael J,8,13,3,0,0,0,2,3.25
+Spring 2023,SCM,6A01,2,18131,SCM Concepts,Hossain,Md Mahbub,31,7,1,0,1,0,1,3.7
+Spring 2023,SCM,7A01,2,18133,Project Management,Tibodeau,Dale,12,3,1,0,0,0,0,3.626
+Spring 2023,ENGL,4383,1,18134,Poetic Forms,Serpas,Martha R,4,3,0,1,1,0,0,2.889
+Spring 2023,CHEE,8298,20,18136,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Spring 2023,ENGL,4392,1,18137,Practicum: TEAL,Nelms,Jodi Lynn,6,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8398,19,18138,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8398,20,18139,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Spring 2023,ARTS,2346,1,18140,Fundamentals of Ceramics,Oloshove,Angel,11,1,0,0,0,0,3,3.807
+Spring 2023,ARTS,2346,2,18141,Fundamentals of Ceramics,Oloshove,Angel,11,3,0,0,0,0,1,3.786
+Spring 2023,ARTS,2346,3,18142,Fundamentals of Ceramics,Mayer,Anna W,13,1,0,0,0,0,1,3.834
+Spring 2023,CHEE,8598,20,18145,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8399,19,18146,Doctoral Dissertation,Mountziaris,Triantafillos John,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,3374,2,18149,Strategic Social Media,Williams,Alexandria Simone,19,8,1,1,0,0,1,3.518
+Spring 2023,CHEE,6383,2,18153,Adv Unit Operations,Kaushik,Krishna R,2,2,0,0,0,0,0,3.5
+Spring 2023,CHEE,6379,2,18154,Safety and Reliability,Smith,Christopher Michael,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,3334,1,18155,Adv Multi & Vector Calculus,Jaramillo,Gabriela T,5,2,1,1,1,0,2,2.867
+Spring 2023,GEOL,6381,1,18159,Petroleum Geology,Van Nieuwenhuise,Donald S,3,5,0,0,0,0,0,3.416
+Spring 2023,COMD,4333,2,18164,Neuroscience for COMD,Dial,Heather Raye,23,7,3,2,0,0,0,3.495
+Spring 2023,COMD,6230,3,18165,Autism Spectrum Disorder,Ross,Byron L,22,8,0,0,0,0,0,3.733
+Spring 2023,COMM,4370,2,18166,Social Aspects of Film,Jowett,Garth Samuel,9,2,0,0,0,0,0,3.848
+Spring 2023,ENGI,2304,9,18167,Technical Communications,Wilson,Chad A,12,9,4,0,0,0,1,3.254
+Spring 2023,COMM,4378,3,18168,Social Impact of Info Tech,Ashley,Laura B,28,3,1,0,0,0,1,3.823
+Spring 2023,ACCT,3367,4,18169,Intermediate Accounting I,Kilic,Emre,21,33,9,1,0,0,5,3.203
+Spring 2023,ACCT,3367,5,18170,Intermediate Accounting I,Kilic,Emre,22,19,19,4,1,0,4,2.902
+Spring 2023,COMM,3372,1,18172,Gender and Media,Olson,Beth M,15,15,8,1,1,0,0,3.042
+Spring 2023,COMD,2339,2,18179,Language Development,Schaff,Carrie Allyson,25,4,3,0,2,0,1,3.441
+Spring 2023,MECT,4350,30,18185,Principles of Mechatronics,Fan,Zheng,17,7,0,0,0,0,0,3.681
+Spring 2023,MECT,3330,30,18187,Advanced Engineering Graphics,Hussain,Muhammad Muzamil,20,8,2,0,0,0,0,3.611
+Spring 2023,SOC,3390,2,18190,Sociology of Gender,Adams,Jennifer Lauren,24,12,1,1,3,0,1,3.26
+Spring 2023,MECT,4364,30,18191,Smart Manuf Systems Design,Hadi,Mahmoud,6,6,0,0,0,0,0,3.473
+Spring 2023,SOC,3327,2,18194,Racial and Ethnic Relations,Davis,Mary A,22,5,2,2,1,0,3,3.365
+Spring 2023,PHCA,7330,1,18195,Advanced Pharmacoeconomics,Chen,Hua,5,1,0,0,0,0,0,3.833
+Spring 2023,KIN,3301,2,18197,Design/Eval Phys Activity Prog,Graham,Marilynn Hadassah,45,12,4,0,2,0,1,3.54
+Spring 2023,POLS,3314,1,18201,Intro To Public Admin,Koelling,Peter,7,9,2,0,0,0,3,3.186
+Spring 2023,SOCI,1301,1,18203,Introduction To Sociology,Cooper,Chelsey Wells,26,12,3,1,4,0,1,3.124
+Spring 2023,SOCI,1301,4,18205,Introduction To Sociology,Davis,Mary A,24,5,10,3,6,0,1,2.778
+Spring 2023,SOC,3349,1,18207,Sociology of Culture,Adams,Jennifer Lauren,34,11,3,1,2,0,0,3.399
+Spring 2023,SOC,3326,1,18208,Immigration in US Society,Adams,Jennifer Lauren,28,10,2,2,7,0,0,2.946
+Spring 2023,BUSI,3302,3,18210,Connecting Bauer to Business,Belinne,Jamie King,308,74,30,8,4,0,6,3.59
+Spring 2023,GOVT,2305,14,18214,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,45,55,35,4,3,0,3,2.937
+Spring 2023,GOVT,2305,1,18216,"US Govt: Congress,Pres & Crts",Cole,Jeffrey Bryan,59,81,55,17,28,0,7,2.535
+Spring 2023,GOVT,2305,18,18217,"US Govt: Congress,Pres & Crts",Rottinghaus,Brandon J,65,21,9,0,4,0,1,3.348
+Spring 2023,GOVT,2305,19,18218,"US Govt: Congress,Pres & Crts",Shor,Boris,12,26,27,9,6,0,15,2.268
+Spring 2023,GOVT,2305,20,18219,"US Govt: Congress,Pres & Crts",Konak Unal,Saadet,15,48,25,5,0,0,5,2.792
+Spring 2023,GOVT,2305,15,18220,"US Govt: Congress,Pres & Crts",Davis,Sharon M,37,53,39,30,36,0,29,2.096
+Spring 2023,GOVT,2306,16,18223,US and Texas Const/Politics,Sisman,Ozlem,61,20,7,3,5,0,2,3.292
+Spring 2023,GOVT,2306,17,18224,US and Texas Const/Politics,McDonald,John Terrence George,54,32,8,1,0,0,3,3.439
+Spring 2023,MATH,2413,21,18226,Calculus I,Almus,Melahat,144,50,64,16,44,0,20,2.696
+Spring 2023,KIN,4330,1,18246,Child and Adolescent Obesity,Breslin,Whitney L,10,19,4,2,2,0,1,2.829
+Spring 2023,ENGI,1100,5,18248,Introduction To Engineering,Kota,Venkata Krishna Tulasi,3,1,0,2,0,0,0,2.668
+Spring 2023,ENGI,1100,6,18249,Introduction To Engineering,Kota,Venkata Krishna Tulasi,5,9,4,1,4,0,0,2.377
+Spring 2023,ENGL,8388,1,18262,Topics in Literary Translation,Aboul-Ela,Hosam,5,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8393,1,18263,Research Colloquium-Doctoral,Wong,Karen Y,5,0,0,0,0,0,0,4.0
+Spring 2023,KIN,4370,2,18264,Exercise Testing,Thomas,Shernice Avionne,6,9,7,1,0,0,0,2.87
+Spring 2023,TLIM,3330,32,18271,Innovation Principles,Feriante,Chris,7,16,4,0,1,0,3,3.153
+Spring 2023,AAS,3349,1,18272,AFAM Political Legal Studies,Putman,Eronn A,12,5,3,0,0,0,0,3.318
+Spring 2023,MUSI,4100,2,18275,Chamber Music,Bertman,David Garry,6,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4100,3,18276,Chamber Music,Bertman,David Garry,52,0,0,0,0,0,0,4.0
+Spring 2023,PETR,3310,1,18277,Petroleum Production Economics,Qin,Guan,12,6,0,0,0,0,0,3.667
+Spring 2023,LAW,6369,3,18278,Legal Analysis and Writing,Hastings,Madison Alexandra Nicole,0,0,0,0,0,8,0,
+Spring 2023,PETR,6111,2,18280,Petroleum Graduate Seminar,Qin,Guan,0,0,0,0,0,1,0,
+Spring 2023,PETR,6302,2,18281,Reservoir Engineering II,Thakur,Ganesh Chandra,4,2,0,0,0,0,0,3.722
+Spring 2023,PETR,6351,2,18283,Intro to Petroleum Engineering,Farouq-Ali,Syed,2,0,0,0,0,0,0,3.835
+Spring 2023,PETR,6364,2,18284,Origin & Dev Oil & Gas Resvrs,Zargar,Zeinab,2,1,0,0,0,0,0,3.557
+Spring 2023,MUED,3102,1,18291,Brasses,Bell,Priscilla Garrett,10,5,1,0,0,0,0,3.563
+Spring 2023,MUED,7305,1,18292,Contemp Methods in Music Educ,Hansen,Erin Melissa,1,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,6315,1,18294,Sem-Ethnographic Anlys,Ghazali,Marwa,6,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4315,1,18295,Human Motivation,Knee,Clifford R,13,1,0,0,0,0,0,3.905
+Spring 2023,ARTH,7381,1,18296,Grad. Art History Methods II,Koontz,Rex A,6,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,2301,8,18300,Prin of Financial Accounting,Sykes,Mary Reeves,33,22,8,2,2,0,3,3.303
+Spring 2023,ACCT,2301,9,18301,Prin of Financial Accounting,Goble,Samuel,26,43,27,10,3,0,18,2.819
+Spring 2023,ACCT,3366,6,18302,Financial Reporting Frameworks,Parthasarathy,Kiran M,27,10,11,2,1,0,8,3.164
+Spring 2023,KIN,4303,1,18304,The Obesity Epidemic,Alastuey,Lisa L,26,22,8,3,8,0,2,2.762
+Spring 2023,GENB,5304,5,18305,Business Ethics for Accountant,Brant Jr,Robert Edward,6,6,0,0,0,0,0,3.61
+Spring 2023,GENB,7304,5,18306,Bus Ethics for Accountants,Brant Jr,Robert Edward,7,6,1,0,0,0,0,3.499
+Spring 2023,CIVE,6338,1,18308,Advanced Steel Design,Mercan,Bulent,7,3,1,0,0,0,0,3.455
+Spring 2023,CIVE,6391,1,18312,Envrn Engr Microbiology,Fiorenza,Stephanie,6,0,1,0,0,0,0,3.667
+Spring 2023,CIVE,6399,1,18313,Master's Thesis,Mo,Larry Yi-Lung,1,0,0,0,0,1,0,4.0
+Spring 2023,ARTS,3300,1,18316,Advanced Drawing,Barrera,Debra,23,2,0,0,0,0,0,3.854
+Spring 2023,ARTS,3300,2,18317,Advanced Drawing,Safaitakhtehfooladi,Farima,18,0,0,0,1,0,1,3.772
+Spring 2023,COSC,3337,1,18318,Data Science I,Rizk,Nouhad J,12,39,45,8,7,0,5,2.337
+Spring 2023,COSC,4348,1,18319,Intro Game Art and Animation,Yun,Changhoon,93,10,2,0,0,0,3,3.854
+Spring 2023,COSC,6348,1,18321,Intro Game Art and Animation,Yun,Changhoon,11,0,0,0,0,0,0,4.0
+Spring 2023,COSC,6374,1,18322,Parallel Computations,Wu,Panruo,10,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2305,19,18324,Intro to Methods in Psychology,Wu,Dongjie,29,25,12,3,6,0,6,2.871
+Spring 2023,PSYC,2305,21,18326,Intro to Methods in Psychology,Shen,Shutian,32,22,10,1,9,0,8,2.856
+Spring 2023,PSYC,2305,26,18329,Intro to Methods in Psychology,Weinstein,Andrew Philip,18,9,6,4,1,0,2,3.0
+Spring 2023,NUTR,4345,1,18336,The Obesity Epidemic,Alastuey,Lisa L,42,21,9,1,0,0,1,3.379
+Spring 2023,HIST,2327,1,18339,Chicano History to 1910,Ramos,Raul,22,4,2,0,2,0,3,3.401
+Spring 2023,HIST,3311,1,18344,Civil War and Reconstruction,Deyle,Steven H,10,15,5,1,0,0,3,3.086
+Spring 2023,HIST,3325,1,18345,Mex Amer Civil Right in 20th C,San Miguel Jr,Guadalupe,13,4,2,0,0,0,3,3.544
+Spring 2023,HIST,3328,1,18346,"Colonial America, 1492-1776",Clavin,Matthew J,7,7,3,1,1,0,2,2.93
+Spring 2023,ARTS,3312,1,18348,Intaglio,Alderson,Saran,14,1,0,0,0,0,0,3.933
+Spring 2023,HIST,3370,1,18352,20Th Cen Revlutn Latin America,Cedillo,Adela Cedillo,9,15,3,0,1,0,1,3.095
+Spring 2023,BIOE,3341,2,18353,Biothermodynamics,Larin,Kirill,17,2,1,0,0,0,0,3.767
+Spring 2023,HIST,4340,1,18357,Philosophies of History,Hernandez,Jose A,10,2,0,0,0,0,1,3.778
+Spring 2023,PSYC,2330,7,18363,Biological Psychology,Kennedy,Caitlin Grace,61,12,5,0,1,0,1,3.633
+Spring 2023,MUSI,6300,3,18364,Intro Res Method in Musicology,Caton,Kathryn L.,5,2,0,0,0,0,0,3.62
+Spring 2023,OPTO,8696,1,18365,General Clinic IV,Dempsey,Robert L,0,0,0,0,0,28,0,
+Spring 2023,OPTO,8338,1,18366,Recent Developments/Round,Dempsey,Robert L,13,15,1,0,0,0,0,3.323
+Spring 2023,OPTO,8384,1,18370,Practice Management II,Davis,Mark K,24,5,0,0,0,0,0,3.657
+Spring 2023,NURS,6309,1,18373,Adv Leadership & Mgmt,Brohard,Cheryl L,3,1,0,0,0,0,0,3.75
+Spring 2023,NURS,6330,1,18374,Adv Diagnostic Physicl Examntn,Ecby,Chanique,2,2,0,0,0,0,0,3.5
+Spring 2023,MUSA,6143,3,18384,Graduate Recital IV,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,1302,12,18385,First Year Writing II,Coleman,Quintin,9,1,2,2,3,0,2,2.647
+Spring 2023,ENGL,1302,25,18386,First Year Writing II,Downey,Carlton M,14,4,0,0,1,0,0,3.579
+Spring 2023,ENGL,1302,67,18387,First Year Writing II,Garcia,Serena Mari,15,3,2,4,1,0,0,2.988
+Spring 2023,ENGL,1302,70,18388,First Year Writing II,Downey,Carlton M,17,2,0,0,3,0,2,3.319
+Spring 2023,ENGL,1302,71,18389,First Year Writing II,Downey,Carlton M,22,0,1,0,1,0,1,3.736
+Spring 2023,ENGL,1302,72,18390,First Year Writing II,Kozma,Andrew,10,8,2,0,1,0,2,3.27
+Spring 2023,ENGL,1302,73,18391,First Year Writing II,Kozma,Andrew,15,3,2,1,1,0,3,3.334
+Spring 2023,ENGL,1302,78,18392,First Year Writing II,Julian,Jennifer La'Vonne,20,5,0,0,0,0,0,3.734
+Spring 2023,ENGL,1302,79,18393,First Year Writing II,Arayilakath Mohammed,Ibrahim Badshah,17,3,1,0,1,0,2,3.501
+Spring 2023,ENGL,1302,80,18394,First Year Writing II,Presswood,Phillip Hilliard,23,1,1,0,0,0,1,3.88
+Spring 2023,ENGL,1302,82,18395,First Year Writing II,Presswood,Phillip Hilliard,23,2,0,0,0,0,0,3.946
+Spring 2023,ENGL,1302,83,18396,First Year Writing II,Rolater,Sara C,14,4,1,2,2,0,2,3.044
+Spring 2023,ENGL,1302,84,18397,First Year Writing II,Campese,Kathleen Ann,10,6,2,0,1,0,5,3.176
+Spring 2023,ENGL,1302,85,18398,First Year Writing II,Campese,Kathleen Ann,16,3,2,0,1,0,3,3.395
+Spring 2023,ENGL,1302,87,18399,First Year Writing II,Horton,Lara,7,4,1,0,2,0,0,2.882
+Spring 2023,ENGL,1302,89,18400,First Year Writing II,Braniger,Leslie,2,5,3,0,3,0,0,2.205
+Spring 2023,ENGL,1302,90,18401,First Year Writing II,Edens,Jenifer,2,9,1,2,1,0,0,2.622
+Spring 2023,ENGL,1302,92,18402,First Year Writing II,Moore,Kelly L,7,6,2,0,0,0,0,3.355
+Spring 2023,ENGL,1302,93,18403,First Year Writing II,Moore,Kelly L,5,8,3,0,0,0,0,2.939
+Spring 2023,ENGL,1302,94,18404,First Year Writing II,Horton,Lara,5,7,3,0,0,0,0,3.111
+Spring 2023,ENGL,1302,95,18405,First Year Writing II,Horton,Lara,4,6,6,0,0,0,0,2.834
+Spring 2023,ENGL,1302,96,18406,First Year Writing II,Bass,Kasey Dawn,6,7,2,0,4,0,0,2.475
+Spring 2023,ENGL,1302,97,18407,First Year Writing II,Bass,Kasey Dawn,7,3,2,0,3,0,0,2.777
+Spring 2023,ENGL,1302,110,18408,First Year Writing II,Braniger,Leslie,5,11,3,1,1,0,4,2.747
+Spring 2023,ENGL,1302,111,18409,First Year Writing II,Worley,Sharon J,9,7,5,2,3,0,0,2.565
+Spring 2023,ENGL,1302,112,18410,First Year Writing II,Butler,Paul G,10,6,0,0,1,0,2,3.334
+Spring 2023,ENGL,1302,113,18411,First Year Writing II,Khalil,Rand Omar,14,4,0,0,0,0,1,3.741
+Spring 2023,ENGL,1302,114,18412,First Year Writing II,Worley,Sharon J,7,11,1,1,4,0,1,2.584
+Spring 2023,ENGL,1302,115,18413,First Year Writing II,Khalil,Rand Omar,13,5,1,0,0,0,0,3.579
+Spring 2023,ENGL,1302,116,18414,First Year Writing II,Seelen,William,15,3,0,0,0,0,1,3.852
+Spring 2023,ENGL,1302,117,18415,First Year Writing II,Cooper-Edwards,Jacquelyn,11,1,4,3,0,0,0,2.931
+Spring 2023,ENGL,1302,118,18416,First Year Writing II,Long,Steven A.,15,1,3,0,0,0,0,3.632
+Spring 2023,ENGL,1302,119,18417,First Year Writing II,Seelen,William,10,4,2,1,0,0,1,3.353
+Spring 2023,ENGL,1302,120,18418,First Year Writing II,Coleman,Quintin,10,3,1,2,2,0,1,2.908
+Spring 2023,ENGL,1302,121,18419,First Year Writing II,Sicinski,Michael J,11,5,0,0,1,0,2,3.315
+Spring 2023,ENGL,1302,122,18420,First Year Writing II,Niaz,Zarlasht,8,5,0,2,0,0,4,3.135
+Spring 2023,ENGL,1302,123,18421,First Year Writing II,Johnston,Leah Beth,16,1,0,2,0,0,0,3.597
+Spring 2023,ENGL,1302,100,18423,First Year Writing II,Presswood,Phillip Hilliard,18,0,0,0,0,0,1,3.963
+Spring 2023,ENGL,1302,101,18424,First Year Writing II,Wingard,Jennifer L,22,1,1,0,0,0,1,3.861
+Spring 2023,ENGL,1302,102,18425,First Year Writing II,Long,Steven A.,6,4,4,1,2,0,1,2.647
+Spring 2023,ENGL,1302,103,18426,First Year Writing II,Wingard,Jennifer L,21,3,1,0,0,0,0,3.774
+Spring 2023,ENGL,1302,104,18427,First Year Writing II,Penzien,Eugene Norman,12,2,1,0,3,0,1,3.019
+Spring 2023,ENGL,1302,105,18428,First Year Writing II,Spencer,Jaxson Matthew,15,1,2,0,1,0,0,3.509
+Spring 2023,ENGL,1302,106,18429,First Year Writing II,Spencer,Jaxson Matthew,13,2,1,0,3,0,0,3.141
+Spring 2023,ENGL,1302,107,18430,First Year Writing II,Long,Steven A.,6,7,3,1,1,0,1,2.889
+Spring 2023,ENGL,1302,108,18431,First Year Writing II,Denton,Amy,10,4,1,2,2,0,0,2.93
+Spring 2023,ENGL,1302,109,18432,First Year Writing II,Johnston,Leah Beth,17,0,0,0,1,0,0,3.759
+Spring 2023,ARTS,3370,1,18437,Traditional Photography,Duron-Larson,Angela Marie,14,2,1,0,0,0,0,3.765
+Spring 2023,POLC,3313,1,18438,Contemporary Poli Phil Policy,Munawar,Sarah,5,9,1,0,0,0,4,3.201
+Spring 2023,LAW,6369,4,18440,Legal Analysis and Writing,Fazal,Fermeen,0,0,0,0,0,6,0,
+Spring 2023,LAW,5342,2,18441,Prof Writing Strategies,Davila,Ernest,5,4,1,0,0,0,0,3.4
+Spring 2023,BIOE,5317,2,18442,Intro to Biomedical Imaging,Gifford,Howard,0,1,0,0,0,0,0,3.33
+Spring 2023,BIOE,6346,2,18443,Advanced Medical Imaging,Gifford,Howard,6,2,0,0,0,0,0,3.626
+Spring 2023,TLIM,4335,30,18444,Communicating Innovation,Crawley,David L,1,1,2,0,0,0,0,2.998
+Spring 2023,TLIM,4340,30,18445,Commercializing Innovation,Crawley,David L,2,3,2,0,1,0,1,2.666
+Spring 2023,ENGL,7398,3,18446,Special Problems,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Spring 2023,DANC,2202,1,18447,Sophomore Technique,Chapman,Teresa Lynn,5,2,0,0,0,0,0,3.714
+Spring 2023,ENGL,4385,1,18449,Fiction Forms,Taurino,Giuseppe,13,2,1,3,0,0,0,3.316
+Spring 2023,MUSI,1120,1,18451,University Chorus,DeSpain,Kaitlin Elizabeth,3,1,0,0,0,0,2,3.75
+Spring 2023,ARTS,3383,1,18452,Digital Fabrication,Sawhney,Ashita,10,3,0,1,0,0,1,3.548
+Spring 2023,MUSI,1220,1,18453,Class Piano I,Van Kekerix,Todd Evan,9,5,1,0,0,0,1,3.577
+Spring 2023,MUSI,1220,2,18454,Class Piano I,Van Kekerix,Todd Evan,6,1,0,1,0,0,2,3.5
+Spring 2023,THEA,2100,1,18455,Theatre Education Internship,Cooper,Charles G,3,0,0,0,0,0,0,3.89
+Spring 2023,ENGI,4198,4,18461,Independent Study,Claydon,Frank J,0,0,0,0,0,14,0,
+Spring 2023,COMD,8392,1,18462,COMD Advanced Research Methods,Castilla-Earls,Anny,7,0,0,0,0,0,0,4.0
+Spring 2023,HLT,2320,3,18463,Introduction to Public Health,Proctor,Robin Ann,91,14,7,2,2,0,2,3.567
+Spring 2023,HLT,3380,2,18464,Culture and Health,Fedor Amador,Theresa Marie,47,7,3,3,0,0,0,3.606
+Spring 2023,HLT,3381,3,18465,Hlt Promotn & Disease Preventn,Proctor,Robin Ann,75,2,1,0,0,0,0,3.898
+Spring 2023,BUSI,4305,1,18467,Business Ethics for Accountant,Spartalis,Emmanuel Michael,6,5,0,0,0,0,0,3.545
+Spring 2023,HLT,4392,3,18468,Field Work in Community Health,Solari Williams,Kayce D,33,8,1,1,0,0,0,3.698
+Spring 2023,BUSI,4305,2,18469,Business Ethics for Accountant,Brant Jr,Robert Edward,3,5,0,0,0,0,0,3.458
+Spring 2023,PHED,1306,1,18470,Emergency Care & First Aid,Monreal,Daniel Joseph,28,3,1,1,0,0,1,3.758
+Spring 2023,PHED,1306,2,18471,Emergency Care & First Aid,Brown,Korey J,32,2,1,0,0,0,0,3.886
+Spring 2023,ECE,3331,3,18472,Program Appl in Elec Comp Engr,Sheth,Bhavin R,3,1,3,2,1,0,1,2.3
+Spring 2023,WGSS,2360,7,18473,Introduction to LGBT Studies,Stone,Lauren Michelle,19,5,2,2,1,0,0,3.299
+Spring 2023,ECE,3366,1,18474,Intro To Digital Signal Proc,Sheth,Bhavin R,10,8,7,2,0,0,3,2.89
+Spring 2023,GHL,6372,1,18475,Global Hosp: Asian Community,Back,KiJoon,10,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,3331,2,18477,Psychology of Gender,Moundas,Sean Eric,27,26,4,3,0,0,3,3.36
+Spring 2023,ECE,5357,1,18478,Intro to Cybersecurity,Pan,Miao,30,7,1,0,0,0,0,3.659
+Spring 2023,ECE,6112,1,18479,Department Colloquium,Nguyen,Hien V,0,0,0,0,0,16,0,
+Spring 2023,LAW,5120,1,18481,Texas Legal Research,Dykes,Christopher,9,10,0,0,0,0,0,3.404
+Spring 2023,ECE,6318,1,18484,Converters & Applications,Krishnamoorthy,Harish Sarma,5,0,0,0,0,0,0,3.802
+Spring 2023,ECE,6341,1,18485,Adv Electromag Waves,Chen,Jiefu,9,2,0,0,0,0,0,3.668
+Spring 2023,ECE,6343,1,18486,Renewable Energy,Rajashekara,Kaushik,14,13,0,0,0,0,4,3.543
+Spring 2023,ECE,6381,1,18487,Sparse Rep for Signl Processng,Prasad,Saurabh,6,1,0,0,0,0,0,3.716
+Spring 2023,PSYC,2317,8,18492,Intro to Psychology Statistics,Zamanipour,Tina,39,12,9,3,0,0,2,3.381
+Spring 2023,MUSA,6436,1,18493,Applied Bassoon,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,7373,2,18494,Bus Appls Database Mgt Sys I,Grimes,George M,24,3,5,0,1,0,1,3.485
+Spring 2023,ECE,2202,5,18496,Circuit Analysis II,Ramachandran,Deepa,8,7,3,2,0,0,0,2.951
+Spring 2023,ECE,2202,6,18497,Circuit Analysis II,Ramachandran,Deepa,11,14,6,2,1,0,2,2.883
+Spring 2023,ANTH,7399,7,18498,Masters Thesis,Sen,Debarati,0,0,0,0,0,1,0,
+Spring 2023,PSYC,7399,14,18504,Masters Thesis,Alfano,Candice A,2,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,2,18505,Doctoral Dissertation,Shepley,Nathan,0,0,0,0,0,1,0,
+Spring 2023,PEP,6322,1,18506,Sport Media & Public Relations,Walsh,David W,4,3,0,0,0,0,1,3.524
+Spring 2023,ENGL,1301,50,18507,First Year Writing I,Zachow,Alix V,8,4,2,0,3,0,2,2.726
+Spring 2023,ENGL,1302,124,18509,First Year Writing II,Box,Anthony Joseph,12,9,2,0,1,0,1,3.305
+Spring 2023,ENGL,1302,125,18510,First Year Writing II,Denton,Amy,12,5,2,0,0,0,0,3.405
+Spring 2023,ENGL,1302,126,18511,First Year Writing II,Johnston,Leah Beth,13,0,1,1,3,0,0,3.074
+Spring 2023,MECT,6396,1,18513,Master's Project,Zhu,Weihang,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,1302,128,18514,First Year Writing II,Niaz,Zarlasht,6,7,0,1,4,0,1,2.574
+Spring 2023,ENGL,1302,129,18515,First Year Writing II,Box,Anthony Joseph,10,5,2,0,0,0,1,3.529
+Spring 2023,ENGL,8399,3,18516,Doctoral Dissertation,Kastely,James L,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8399,4,18517,Doctoral Dissertation,Mazella,David S,0,0,0,0,0,2,0,
+Spring 2023,CUIN,7398,1,18518,Independent Study,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7360,1,18521,Intl SW:A Comparative Approach,Gearing,Robin Edward,22,0,0,0,0,0,0,4.0
+Spring 2023,HDCS,3376,3,18523,Resources in Technology Entrep,Palmer,Kristin B,6,18,8,3,4,0,2,2.411
+Spring 2023,ENGL,8399,5,18524,Doctoral Dissertation,Butler,Paul G,1,0,0,0,0,4,0,4.0
+Spring 2023,MUSI,4379,1,18525,History of Jazz II,Marmolejo,Noe J,6,0,0,0,0,0,0,4.0
+Spring 2023,BZAN,6353,2,18526,Res Design-Probs Busi Anlytcs,Aron,Ravi,2,6,0,0,0,0,0,3.333
+Spring 2023,MATH,3321,6,18527,Engineering Mathematics,West,James David,2,8,12,7,7,0,0,1.704
+Spring 2023,MUSI,6120,1,18529,Percussion Ensemble,Wilkins,Blake M,4,0,0,0,0,0,0,4.0
+Spring 2023,SGNL,1301,5,18531,Elementary Sign Language I,Brittain,Terrell,3,11,3,0,1,0,1,2.76
+Spring 2023,ENGL,8399,6,18533,Doctoral Dissertation,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2023,MUED,3106,1,18534,Percussion,Warren,Paul Alexander,9,4,3,0,0,0,1,3.375
+Spring 2023,IART,2300,1,18535,The Arts in Houston,Mitchell,Josephine Margaret,12,7,2,0,0,0,0,3.523
+Spring 2023,ENGL,8399,7,18536,Doctoral Dissertation,Harris,Francine Julia,1,0,0,0,0,0,0,4.0
+Spring 2023,MARK,7347,1,18538,Sales Analytics,Habel,Johannes,7,0,0,0,0,0,0,4.0
+Spring 2023,POLS,3313,5,18541,Intro Internatl Relatns,Bagashka,Tanya G,10,9,3,5,2,0,2,2.667
+Spring 2023,THEA,7399,1,18543,Masters Thesis,Coen,Elizabeth Manya,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1276,1,18546,Applied Jazz Percussion,Hubley,Robert L,1,0,0,0,0,0,0,3.67
+Spring 2023,PCOL,6498,5,18547,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8399,8,18548,Doctoral Dissertation,Boswell,Robert L,0,0,0,0,0,1,0,
+Spring 2023,CHEE,6360,1,18549,Biomolecular Engr Fundamentals,Orman,Mehmet,18,3,0,0,0,0,1,3.747
+Spring 2023,ENGL,8399,9,18550,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6344,1,18559,Applied Trombone,Kauk,Brian Keith,1,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,5301,1,18560,Financial and Managerial Acct,Kuruvilla,Mohan,3,1,1,0,1,0,5,2.833
+Spring 2023,INDE,2333,3,18562,Engineering Statistics I,Wiggins,Nathanial David,25,6,7,1,4,0,1,3.055
+Spring 2023,INDE,2331,2,18564,Computer Applications for IE,Wiggins,Nathanial David,6,4,0,0,0,0,0,3.468
+Spring 2023,THEA,3322,1,18565,Musical Theatre for Actors,Wetzel,Molly Elizabeth,7,2,0,0,0,0,0,3.778
+Spring 2023,ENGL,7699,2,18572,Thesis,Prufer,Kevin D,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,2334,2,18574,Thermodynamics,Love,Holley Carole,5,2,0,0,1,0,0,3.209
+Spring 2023,COSC,2425,3,18575,Computer Org & Architecture,Long,Kevin B,45,16,10,0,2,0,2,3.352
+Spring 2023,COSC,2425,5,18577,Computer Org & Architecture,Mantini,Pranav,82,27,15,2,6,0,7,3.296
+Spring 2023,CUIN,4332,1,18581,Literacy Assess Rdg Writing,Reis,Nancy,32,2,0,0,0,0,0,3.941
+Spring 2023,CIS,3347,32,18583,IS Infrastructure and Networks,Martinez,Jose C,26,18,6,1,1,0,2,3.288
+Spring 2023,INDS,4180,2,18588,Design Internship,McEuen,Aaron Ross,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,10,18590,Doctoral Dissertation,Prufer,Kevin D,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,11,18591,Doctoral Dissertation,Parsons,Alexander M,0,0,0,0,0,1,0,
+Spring 2023,COSC,6308,1,18592,Computer Architecture,Long,Kevin B,3,0,0,0,0,0,0,4.0
+Spring 2023,INDS,3370,1,18593,Advanced Design Systems,Feng,Jeff Feng,4,1,0,0,0,0,0,3.866
+Spring 2023,COMD,4198,2,18595,Independent Study,Mills,Monique T,1,0,0,0,0,0,0,4.0
+Spring 2023,AAS,2320,8,18599,Intro To African American Stdy,Boyce,Stephanie,38,0,0,0,0,0,2,4.0
+Spring 2023,PSYC,7399,15,18602,Masters Thesis,Reyes,Denise Lucia,0,0,0,0,0,2,0,
+Spring 2023,ENGL,7399,2,18603,Essay,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Spring 2023,SPEC,6355,1,18607,Creat & Prod Thinking for G/T,Carp,Charlotte Lynn,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8699,10,18608,Doctoral Dissertation,Mazella,David S,0,0,0,0,0,1,0,
+Spring 2023,ENGL,7699,3,18610,Thesis,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7399,3,18611,Essay,Divakaruni,Chitra B,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,12,18615,Doctoral Dissertation,Stock,Lorraine K,0,0,0,0,0,1,0,
+Spring 2023,INDS,2160,2,18617,Materials and Manufac Methods,Wells,Adam C,5,15,3,0,0,0,0,3.116
+Spring 2023,INDS,6197,4,18618,Selected Topics,Wells,Adam C,1,0,0,0,0,0,1,4.0
+Spring 2023,ENGL,8699,11,18619,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8699,12,18620,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8399,13,18625,Doctoral Dissertation,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,6381,2,18626,Information Visualization,Shastri,Dvijesh J,0,1,0,0,0,0,0,3.33
+Spring 2023,ENGL,8399,14,18628,Doctoral Dissertation,Gonzalez,Maria C,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6298,3,18629,Special Problems,Wu,Mingfu,0,0,0,0,0,0,0,
+Spring 2023,ENGL,8399,15,18630,Doctoral Dissertation,Voskuil,Lynn M,0,0,0,0,0,1,0,
+Spring 2023,THEA,2344,1,18631,American Drama,Coen,Elizabeth Manya,13,12,3,0,1,0,0,3.241
+Spring 2023,ENGL,7398,4,18634,Special Problems,Flynn,Nicholas,2,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,4337,2,18637,Transportation Engineering,Joskowicz,Isaac,30,14,1,0,0,0,0,3.644
+Spring 2023,NUTR,2332,7,18640,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,29,14,4,1,0,0,1,3.459
+Spring 2023,ENGL,7399,4,18641,Essay,Voskuil,Lynn M,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,16,18650,Doctoral Dissertation,Turchi,Peter D,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8199,7,18660,Doctoral Dissertation,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6167,6,18664,Research Practicum A,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6326,1,18665,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6399,12,18668,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,2,0,
+Spring 2023,PSYC,7399,16,18669,Masters Thesis,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,6338,2,18672,Advanced Steel Design,Mercan,Bulent,5,3,1,0,0,0,0,3.371
+Spring 2023,CIVE,6350,4,18673,Advanced Mechs of Matls,Nakshatrala,Kalyana,2,3,1,0,0,0,2,3.167
+Spring 2023,CIVE,6361,2,18674,Engineering Hydrology,Rifai,Hanadi S,2,5,1,0,0,0,0,3.166
+Spring 2023,CIVE,6391,3,18676,Envrn Engr Microbiology,Fiorenza,Stephanie,2,2,0,0,0,0,0,3.418
+Spring 2023,CIVE,6388,2,18683,Hazardous Waste Proceses,Rixey,William G,2,0,0,0,0,0,1,3.835
+Spring 2023,CHEE,3321,3,18684,Analytical Methods Chem Engr,Grabow,Lars C,0,0,0,0,0,0,1,
+Spring 2023,CHEE,3333,2,18685,Chem Engr Thermodyn II,Zerze,Gul,0,0,0,1,0,0,0,1.0
+Spring 2023,PHOP,7399,13,18691,Masters Thesis,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,3363,2,18693,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,1,0,0,0,0,0,0,3.67
+Spring 2023,PHCA,8199,4,18699,Doctoral Dissertation Defense,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7699,6,18701,Thesis,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7399,17,18704,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,1,0,
+Spring 2023,ACCT,3367,6,18705,Intermediate Accounting I,Gamble,George O,2,2,1,0,0,0,0,3.266
+Spring 2023,PSYC,6399,13,18710,Masters Thesis,Ng,Vincent,0,0,0,0,0,1,0,
+Spring 2023,ENGL,1302,130,18711,First Year Writing II,Downey,Carlton M,21,0,0,0,2,0,1,3.652
+Spring 2023,PHLS,8699,11,18712,Doctoral Dissertation,Master,Allison,1,0,0,0,0,0,0,4.0
+Spring 2023,BZAN,7320,3,18714,Bus Modeling For Comp Adv,Hess,James D,15,2,0,0,0,0,0,3.863
+Spring 2023,PSYC,2307,4,18715,Psychology of Adolescence,Anderson,Jill Annette,12,22,11,2,2,0,3,2.816
+Spring 2023,THEA,6399,1,18716,Masters Thesis,Coen,Elizabeth Manya,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7358,1,18724,Programming in R - Fina Appls,Li,Yu,26,1,0,0,0,0,0,3.877
+Spring 2023,PHLS,8199,6,18727,Dissertation,Margulis,Milena A,1,0,0,0,0,1,0,4.0
+Spring 2023,HLT,4310,4,18731,Program Planning for Hlt Prof,Bennett,Kristin C,30,6,4,0,0,0,0,3.609
+Spring 2023,ACCT,2302,12,18732,Prin of Managerial Accounting,Seltz,Joe D,41,34,19,2,3,0,1,3.134
+Spring 2023,ECE,6327,2,18734,Smart Grid Systems,Li,Xingpeng,7,5,0,0,0,0,3,3.528
+Spring 2023,SOCW,8999,3,18735,Dissertation,Leung,Yuk-Hi Patrick,3,0,0,0,0,0,0,4.0
+Spring 2023,COSC,6306,3,18737,Data Structures,Rizk,Nouhad J,0,1,0,0,0,0,0,3.33
+Spring 2023,PHLS,8699,12,18742,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Spring 2023,HIST,8688,1,18743,Dissertation Proposal,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2023,HIST,8688,2,18749,Dissertation Proposal,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8399,17,18764,Doctoral Dissertation,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,8399,1,18791,Dissertation I in Hosp. Admin,Boger Jr,Carl A,0,0,0,0,0,1,0,
+Spring 2023,CIVE,2332,2,18793,Mechanics of Solids,Safa,Mahdi,2,3,0,0,0,0,0,3.4
+Spring 2023,HIST,8677,3,18818,Reading for Comps Exams,Yuksel,Emire Cihan,2,0,0,0,0,0,0,3.835
+Spring 2023,CIVE,8498,3,18821,Doctoral Research,Lee,Hyongki,0,0,0,0,0,4,0,
+Spring 2023,BIOE,8598,26,18822,Doctoral Research,Pollonini,Luca,0,0,0,0,0,2,0,
+Spring 2023,ARTS,3384,1,18825,Sound Art,Cone,Marcus Andrew,11,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,4331,4,18826,Federal Income Tax-Individual,Meade,Janet,3,4,16,13,1,0,5,1.838
+Spring 2023,HIST,8677,4,18833,Reading for Comps Exams,Chakrabarti,Pratik,1,0,0,0,0,0,0,4.0
+Spring 2023,BZAN,6354,2,18846,DB Mgt Tools Bus Analytics,Grimes,George M,23,7,0,0,0,0,0,3.767
+Spring 2023,MIS,7375,1,18850,Transaction Processing Systems,Messinger,Jacob Nelson,16,5,0,0,0,0,0,3.699
+Spring 2023,ENTR,7335,1,18852,Entreprnl Profit & Cash Mgt,Becker,Charles D,9,2,3,0,0,0,0,3.381
+Spring 2023,ENTR,7337,1,18853,Entrepreneur Cap & Legal Forms,Wilbur,Stephen,8,4,3,0,0,0,1,3.245
+Spring 2023,COSC,7399,129,18854,Masters Thesis,Verma,Rakesh M,0,0,0,0,0,1,0,
+Spring 2023,MATH,8698,27,18856,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8298,7,18857,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Spring 2023,HON,4398,4,18859,Independent Study,Cremins,Robert Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,INDE,6333,2,18860,Probability Stat For Engineers,Chung,Christopher,3,17,10,2,1,0,1,2.576
+Spring 2023,MUSA,6450,1,18866,Applied Percussion,Wilkins,Blake M,2,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,7124,3,18867,Cell Biology Seminar,Lekven,Arne,0,0,0,0,0,12,0,
+Spring 2023,BCHS,6298,3,18874,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6298,4,18887,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8220,2,18890,Doctoral Applied Music,Wilkins,Blake M,2,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,7399,1,18891,Master's Thesis,Milillo,Pietro,1,0,0,0,0,1,0,4.0
+Spring 2023,SOC,7399,1,18892,Masters Thesis,Savage,Scott Vandenburgh,1,0,0,0,0,0,0,4.0
+Spring 2023,SOC,6399,1,18895,Masters Thesis,Karner,Tracy Xavia,0,0,0,0,0,0,0,
+Spring 2023,SOC,7399,4,18897,Masters Thesis,Anderson,Kathryn,2,0,0,0,0,0,0,4.0
+Spring 2023,SOC,7396,1,18898,Internship in Sociology,Anderson,Kathryn,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8399,13,18902,Doctoral Dissertation,Zhang,Yingchun,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGI,2304,13,18905,Technical Communications,Wilson,Chad A,19,2,0,1,0,0,2,3.758
+Spring 2023,ENGI,2304,10,18919,Technical Communications,Salvo,Deborah C,11,1,0,0,0,0,0,3.807
+Spring 2023,BIOE,8598,27,18921,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2023,PSYC,7399,21,18925,Masters Thesis,Fetterman,Adam Kent,0,0,0,0,0,3,0,
+Spring 2023,MECE,3336,4,18930,Mechanics II,Metrovich,Brian,5,3,2,1,1,0,0,2.888
+Spring 2023,CIVE,8398,8,18932,Doctoral Research,Zhang,Ruda,0,0,0,0,0,1,0,
+Spring 2023,ARTS,2316,3,18935,Fundamentals of Painting,Foutz,Madelyn Mairie,10,8,1,0,0,0,1,3.508
+Spring 2023,PEP,8699,2,18936,Doctoral Dissertation,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Spring 2023,PHIL,1301,5,18940,Intro To Philosophy,Haaga,Curtis W,48,26,5,4,2,0,4,3.302
+Spring 2023,MATH,8698,28,18942,Doctoral Research,Cappanera,Loic,0,0,0,0,0,2,0,
+Spring 2023,BIOE,8399,14,18945,Doctoral Dissertation,Ince,Nuri Firat,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8498,4,18948,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8699,1,18955,Doctoral Dissertation,Li,Hongyi,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8240,10,18957,Doctoral Recital I,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Spring 2023,PCEU,8998,4,18963,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6398,5,18964,Special Problems,Statsyuk,Alexander V,2,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6298,5,18966,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2023,PHCA,8199,6,18967,Doctoral Dissertation Defense,Aparasu,Rajender R,0,0,0,0,0,0,0,
+Spring 2023,CIVE,8298,11,18970,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8498,8,18971,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Spring 2023,POLS,8399,3,18977,Doctoral Dissertation,Clark,Jennifer H,0,0,0,0,0,1,0,
+Spring 2023,POLS,8999,26,18987,Doctoral Dissertation,Cantu,Francisco,0,0,0,0,0,1,0,
+Spring 2023,SOCW,8399,5,18994,Dissertation,Sampson,McClain,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,4304,1,18999,Varieties of English,Duran,Chatwara,12,15,2,1,0,0,0,3.278
+Spring 2023,FINA,7A20,3,19001,Capital Markets,Wu,Guojun,9,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,6297,4,19012,Selected Topics,Varkey,Divya A,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,2305,36,19016,Intro to Methods in Psychology,Anderson,Jill Annette,27,12,5,0,0,0,1,3.425
+Spring 2023,HIST,8377,4,19024,Reading for Comps Exams,Klieman,Kairn,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8388,3,19025,Dissertation Proposal,Mizelle Jr,Richard M,0,0,0,0,0,1,0,
+Spring 2023,SCM,4362,2,19026,Demand and Supply Integration,Li,Meng,21,29,16,0,0,0,0,3.031
+Spring 2023,GENB,6398,1,19027,Research,Ma,Xiao,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,6381,2,19029,Sparse Rep for Signl Processng,Prasad,Saurabh,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,3399,1,19031,Senior Honors Thesis,Gao,Li,0,0,0,0,0,0,0,
+Spring 2023,MUSA,6304,6,19032,Conducting,Weber,Mary E,0,0,0,0,0,0,0,
+Spring 2023,PSYC,2317,9,19033,Intro to Psychology Statistics,Steinberg,Lynne,3,4,8,2,8,0,17,1.68
+Spring 2023,PSYC,2319,6,19034,Intro to Social Psychology,Snead,Alexandra L,39,23,6,0,1,0,1,3.397
+Spring 2023,SOCI,1301,15,19038,Introduction To Sociology,Cooper,Chelsey Wells,35,10,2,1,2,0,3,3.48
+Spring 2023,SOCI,1301,16,19039,Introduction To Sociology,Colbert,Sharla Stettnisch,32,12,2,2,4,0,2,3.25
+Spring 2023,MARK,6398,2,19040,Research,Herman,Carl,7,0,0,0,0,0,0,3.906
+Spring 2023,COMM,1303,5,19044,Writing for Communicators,Graham,Catherine Burch,10,6,1,1,0,0,1,3.352
+Spring 2023,SPAN,2312,4,19050,Intermediate Spanish II,Reyes Ferrufino,Diana Eufemia,6,10,8,1,0,0,0,2.761
+Spring 2023,ECE,8699,10,19052,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8298,9,19055,Doctoral Research,Larin,Kirill,0,0,0,0,0,4,0,
+Spring 2023,GHL,6326,1,19057,Catering Management,Ginapp,Kathrine,0,2,1,0,0,0,0,2.997
+Spring 2023,HDFS,4318,3,19060,Parent-Child Relationships,Frankel,Leslie Ann,13,15,5,4,2,0,2,2.787
+Spring 2023,HDFS,1300,15,19061,Dev of Contemporary Families,Jordan,Erica F,25,16,3,0,1,0,0,3.386
+Spring 2023,HDFS,2314,10,19064,Human Dev and Interventions,Schoger,Kimberly,47,7,1,0,0,0,0,3.818
+Spring 2023,MECE,8298,51,19068,Doctoral Research,Zhao,Bo,0,0,0,0,0,2,0,
+Spring 2023,MECE,8298,52,19069,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,2,0,
+Spring 2023,MECE,8298,53,19070,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Spring 2023,MECE,7399,29,19075,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,
+Spring 2023,PEP,8699,3,19078,Doctoral Dissertation,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8298,7,19081,Doctoral Research,Li,Hongyi,0,0,0,0,0,6,0,
+Spring 2023,COSC,7362,1,19082,Advanced Machine Learning,Vilalta,Ricardo,21,3,3,0,0,0,0,3.508
+Spring 2023,MUSA,6140,2,19083,Graduate Recital I,Brooks,Wayne A,0,0,0,0,0,0,0,
+Spring 2023,PSYC,7399,23,19084,Masters Thesis,Neighbors,Clayton T,1,0,0,0,0,1,0,4.0
+Spring 2023,ECE,8699,11,19088,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,0,0,
+Spring 2023,CIVE,8298,8,19091,Doctoral Research,Momen,Mostafa,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8498,5,19092,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Spring 2023,ECE,2100,5,19093,Circuit Analysis Laboratory,Leigh,Kevin Benny,9,14,1,0,0,0,1,3.278
+Spring 2023,ECE,8699,12,19098,Doctoral Dissertation,Le,Hung Quang,0,0,0,0,0,1,0,
+Spring 2023,ECE,8699,13,19107,Doctoral Dissertation,Chen,Jiefu,1,0,0,0,0,0,0,4.0
+Spring 2023,ELET,4103,2,19111,Power Transmission Lab,Shireen,Wajiha,9,2,0,0,0,0,0,3.758
+Spring 2023,HDCS,1300,8,19113,Human Ecosystems & Tech Change,Mudd,Blake Stevens,40,4,2,0,1,0,2,3.738
+Spring 2023,MECT,3318,31,19114,Fluid Mechanics Applications,Jafri,Syed M,1,4,13,0,0,0,1,2.132
+Spring 2023,MIS,8999,1,19116,Doctoral Dissertation in MIS,Silva,Leiser O,0,0,0,0,0,1,0,
+Spring 2023,MIS,8999,2,19118,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8320,42,19119,Doctoral Applied Music,Mueller,Jebediah Lee,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8241,7,19121,Doctoral Recital II,Hester,Timothy E,1,0,0,0,0,0,0,3.67
+Spring 2023,SPAN,1502,13,19124,Elementary Spanish II,Cicerchia,Jose,12,7,3,1,2,0,1,2.987
+Spring 2023,CIVE,8398,10,19129,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Spring 2023,COSC,6323,2,19134,Statistical Method in Research,Pavlidis,Ioannis T,10,3,2,2,0,0,1,3.255
+Spring 2023,BIOE,8398,26,19140,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2023,MECE,8298,55,19143,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Spring 2023,BIOE,6398,5,19144,Research,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8498,6,19146,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,4,0,
+Spring 2023,POLS,6359,1,19151,Bibliographic Essay,Basinger,Scott J,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,3441,5,19153,Digital Logic Design,Ramachandran,Deepa,19,3,1,0,0,0,0,3.697
+Spring 2023,CIVE,8398,11,19160,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2023,COMM,1303,6,19161,Writing for Communicators,Lyn,Robyn,26,4,5,1,6,0,6,3.04
+Spring 2023,CIVE,8498,7,19163,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Spring 2023,MIS,8999,3,19165,Doctoral Dissertation in MIS,Chin,Wynne W,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,6398,21,19168,Independent Studies,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7392,3,19169,Psychology Practicum,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6393,11,19170,Clinical Research Practicum,Woods,Steven Paul,0,0,0,0,0,3,0,
+Spring 2023,INDS,6298,1,19171,Independent Study,Kang,Chul Min,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8398,12,19172,Doctoral Research,Momen,Mostafa,0,0,0,0,0,3,0,
+Spring 2023,PSYC,7392,4,19176,Psychology Practicum,Knee,Clifford R,2,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8699,15,19183,Doctoral Dissertation,Han,Zhu,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8598,21,19187,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Spring 2023,MIS,8999,4,19188,Doctoral Dissertation in MIS,Aron,Ravi,0,0,0,0,0,1,0,
+Spring 2023,MECE,7399,30,19195,Masters Thesis,Liu,Dong,0,0,0,0,0,0,0,
+Spring 2023,ECE,6298,1,19196,Research,Chen,Ji,0,0,0,0,0,2,0,
+Spring 2023,MECE,8399,43,19199,Doctoral Dissertation,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8398,51,19204,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Spring 2023,HON,4399,12,19206,Senior Honors Thesis,Rhoden,Brenda,6,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8320,43,19216,Doctoral Applied Music,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8240,14,19218,Doctoral Recital I,Hughes,Mark Alan,0,0,0,0,0,0,0,
+Spring 2023,FINA,8398,3,19219,Special Problems,Liu,Zesong,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8699,38,19227,Doctoral Dissertation,Cescon,Marzia,0,0,0,0,0,1,0,
+Spring 2023,MECE,8699,39,19240,Doctoral Dissertation,Liu,Dong,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8399,46,19241,Doctoral Dissertation,Ardebili,Haleh,2,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,8396,1,19247,Research Practicum,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,4302,2,19248,Numerical Analysis for BME,Zhang,Yingchun,16,0,1,1,1,0,0,3.509
+Spring 2023,HON,4398,6,19253,Independent Study,Modaff,Abigail,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,7392,5,19255,Psychology Practicum,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,4398,2,19258,Independent Study,Cross,Renee D,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,4396,2,19282,Finance Internship,Kumar,Praveen,0,0,0,0,0,4,0,
+Spring 2023,INDS,2298,1,19285,Independent Study,Wells,Adam C,0,1,0,0,0,0,0,3.0
+Spring 2023,ARCH,3198,6,19291,Independent Study,Phan,Trang Anh Thuc,8,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3398,2,19292,Independent Study,Phan,Trang Anh Thuc,7,0,0,0,0,0,0,4.0
+Spring 2023,ECON,2301,4,19322,Principles of Macroeconomics,Hadah,Hussain,31,26,43,11,19,0,24,2.27
+Spring 2023,ECON,2301,5,19323,Principles of Macroeconomics,Oni,Mehedi Hasan,27,26,22,5,0,0,8,2.921
+Spring 2023,ECON,2302,7,19324,Principles of Microeconomics,Biju,Nabila Rahman,36,52,35,15,11,0,10,2.542
+Spring 2023,ECON,2302,8,19325,Principles of Microeconomics,Liu,Jia,40,50,36,14,6,0,8,2.676
+Spring 2023,ECON,3371,2,19326,Economics of Money & Banking,Dasari,Babu,27,16,3,1,0,0,0,3.384
+Spring 2023,ECON,6351,1,19327,Economic Forecasting,Boul,Ruxandra,8,1,0,0,0,0,1,3.852
+Spring 2023,ECON,6353,1,19328,Capital Market Economics,Jiu,Haibin Brett,5,3,0,0,0,0,0,3.625
+Spring 2023,ECON,4389,2,19331,Tops-Contemporary Economics II,Saboury,Piruz,9,7,1,0,0,0,0,3.432
+Spring 2023,ECON,3357,1,19333,Data Mgmt with Econ Appl,Peru Durayalage,Dhanushka Arunasiri,20,10,4,0,3,0,2,3.118
+Spring 2023,ECON,4374,1,19335,Behavioral Economics,Friedman,Willa H,11,15,7,0,2,0,5,2.933
+Spring 2023,ECON,4373,1,19336,Economics of Financial Crises,Paluszynski,Radoslaw,9,3,2,1,1,0,15,3.125
+Spring 2023,ECON,4395,1,19337,Topics - Applied Econometrics,Boul,Ruxandra,10,5,2,0,1,0,3,3.259
+Spring 2023,ECON,4385,1,19338,Monetary Policy,Papell,David H,10,3,3,1,0,0,0,3.216
+Spring 2023,ECON,4378,1,19339,Chinese Economy,Liu,Elaine Meichen,3,11,2,0,0,0,0,2.959
+Spring 2023,ECON,8344,1,19340,Macroecon Theory III,Sorensen,Bent E,8,0,0,0,0,0,0,4.0
+Spring 2023,ECON,7395,1,19341,Selected Topics,Rubinstein,Yona Zvi,8,0,0,0,0,0,0,4.0
+Spring 2023,ECON,7376,1,19342,Industrial Organization,Szabo,Andrea,4,2,0,0,0,0,0,3.722
+Spring 2023,ECON,7346,1,19343,Quantitative Macroeconomics,Paluszynski,Radoslaw,4,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,1340,1,19362,Earth Systems,Lytwyn,Jennifer N,7,10,5,5,2,0,2,2.426
+Spring 2023,GEOL,1345,1,19363,Introduction to Oceanography,Sager,William W,90,64,35,14,10,0,4,2.953
+Spring 2023,PHYS,1302,4,19364,College Physics II (lecture),Curran,Seamus A,51,46,44,32,13,0,10,2.484
+Spring 2023,PHYS,2325,3,19365,University Physics I (lecture),Forrest,Rebecca L,8,6,6,0,0,0,1,3.166
+Spring 2023,PHYS,2325,5,19367,University Physics I (lecture),Weglein,Arthur B,15,23,11,1,6,0,12,2.602
+Spring 2023,GEOL,6382,1,19369,Plate Tectonics,Sager,William W,3,7,1,0,0,0,0,3.062
+Spring 2023,PHYS,4397,1,19372,Selected Topics-Physics,Gunaratne,Gemunu,3,3,0,0,0,0,0,3.555
+Spring 2023,PHYS,6350,1,19373,Computational Physics,Vovchenko,Volodymyr,4,11,0,0,0,0,0,3.333
+Spring 2023,PHYS,7338,1,19375,Solid State Physics II,Ting,Chin Sen,6,0,0,0,0,0,0,3.725
+Spring 2023,PHYS,3309,1,19377,Intermediate Mechanics,Meier,Mark Albert,6,4,1,0,2,0,0,2.847
+Spring 2023,CUIN,8342,1,19378,Social Justice and Equity,Brower,Samuel Richard,13,0,0,0,0,0,0,4.0
+Spring 2023,ARED,2310,3,19381,Intro Critical Visual Culture,Lee,Jhih-yin Diane,16,4,0,0,0,0,0,3.734
+Spring 2023,ARED,2310,2,19382,Intro Critical Visual Culture,Lee,Jhih-yin Diane,16,3,1,2,0,0,0,3.365
+Spring 2023,CLAS,3381,2,19397,From Homer To Hollywood,Due Hackney,Casey L,22,3,1,0,0,0,3,3.782
+Spring 2023,CLAS,3307,2,19398,Greek & Roman Myths of Heroes,Houlihan,James W,20,5,2,0,0,0,1,3.642
+Spring 2023,CLAS,3375,1,19399,"Roman, Jew, and Christian",Armstrong,Richard H,18,3,0,0,0,0,1,3.873
+Spring 2023,CLAS,3380,1,19400,Epic Masculinity,Wright,David John,16,2,0,0,0,0,0,3.871
+Spring 2023,GREK,2302,1,19401,Intermediate Greek II,Kidder,Kathleen,4,1,0,0,0,0,0,3.8
+Spring 2023,JWST,2372,1,19403,The Bible & Modern Pop Culture,Tamber-Rosenau,Caryn M,6,2,1,0,0,0,0,3.409
+Spring 2023,JWST,3380,1,19405,American Jewish Culture,Weiss,Kenneth Scott,5,2,2,1,3,0,2,2.359
+Spring 2023,WCL,3380,1,19406,American Jewish Culture,Weiss,Kenneth Scott,5,5,2,1,1,0,1,2.834
+Spring 2023,SPAN,2311,7,19414,Intermediate Spanish I,Morales Utria,Yordanis,6,5,4,1,0,0,0,3.021
+Spring 2023,SPAN,2312,1,19416,Intermediate Spanish II,Benalcazar Astudillo,Diana Salome,7,3,3,1,1,0,1,2.933
+Spring 2023,ARAB,3313,1,19418,Qur'an as Literature,El-Badawi,Emran,4,7,1,2,4,0,5,2.241
+Spring 2023,MCL,1502,1,19419,Beginning Language II,Back,Eunkyung Lee,8,2,2,1,1,0,2,2.93
+Spring 2023,MCL,1502,3,19421,Beginning Language II,Back,Eunkyung Lee,8,4,2,0,0,0,2,3.381
+Spring 2023,WCL,3397,1,19423,Selected Topics in WCL,Back,Eunkyung Lee,5,4,3,1,1,0,2,2.739
+Spring 2023,JAPN,1502,1,19424,Elementary Japanese II,LIU,JING,12,6,0,0,0,0,2,3.575
+Spring 2023,JAPN,1502,3,19426,Elementary Japanese II,LIU,JING,20,4,0,0,0,0,1,3.847
+Spring 2023,COMM,6363,1,19436,"Media, Global & Social Change",Harlow,Summer D,9,3,1,0,1,0,0,3.286
+Spring 2023,INDI,3397,1,19437,Topics in India Studies,Majumder,Sarasij,4,2,2,0,1,0,1,2.816
+Spring 2023,COMM,6375,1,19438,Intercultural and Global PR,Ni,Lan,18,4,0,0,0,0,0,3.743
+Spring 2023,INDI,3397,2,19439,Topics in India Studies,Majumder,Sarasij,1,1,0,0,0,0,0,3.5
+Spring 2023,FREN,3334,1,19441,Gastronomy in French History,Giacchetti,Claudine A,5,1,4,0,0,0,2,3.199
+Spring 2023,FREN,4315,1,19443,Advanced Translation,Green,Viola V,3,3,2,0,1,0,1,2.814
+Spring 2023,FREN,6315,1,19444,Advanced Translation,Green,Viola V,1,0,0,0,0,0,0,4.0
+Spring 2023,GERM,4373,1,19448,German Cultural History I,Glass,Hildegard,3,0,1,0,0,0,0,3.418
+Spring 2023,GERM,6393,1,19449,Reading German/Non-Majors II,Bandmann,Tanya,3,0,0,0,0,0,0,4.0
+Spring 2023,WCL,4356,1,19453,World Film and Film Theory,Carrera,Alessandro,15,5,0,0,0,0,0,3.717
+Spring 2023,WCL,6356,1,19454,World Film and Film Theory,Carrera,Alessandro,2,0,0,0,0,0,0,3.835
+Spring 2023,CUIN,3350,4,19457,Knowing/Learning Science-Math,McAlister,Leah Yvette,7,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,4350,2,19458,Multiple Teaching Strategies,Latiolais,Cheryl S,4,0,1,0,1,0,0,2.945
+Spring 2023,CUIN,3351,1,19459,Class Interact Science-Math,Manuel,Mariam A,13,0,0,1,0,0,0,3.786
+Spring 2023,CNST,6399,4,19463,Thesis,Din,Zia Ud,1,0,0,0,0,0,0,4.0
+Spring 2023,CNST,6308,2,19468,Data Analysis in Construc Mgmt,Gao,Lu,115,33,0,0,0,0,0,3.739
+Spring 2023,CNST,6397,1,19470,Sel Tops-Construction Managemt,Gao,Lu,15,2,0,0,0,0,0,3.902
+Spring 2023,CNST,6397,2,19472,Sel Tops-Construction Managemt,Gao,Lu,3,0,0,0,0,0,0,4.0
+Spring 2023,WCL,4396,1,19475,Selected Topics in WCL,Zaretsky,Robert D,1,0,0,0,1,0,0,2.0
+Spring 2023,COMM,6336,1,19479,Comm in Healthcare Contexts,Yamasaki,Jill S,14,2,0,0,1,0,0,3.589
+Spring 2023,ARCH,7601,7,19484,Architecture Design Studio VI,Fonseca,Sofia Y,5,3,0,0,0,0,1,3.46
+Spring 2023,WCL,3397,2,19486,Selected Topics in WCL,LIU,JING,7,1,0,0,0,0,1,3.916
+Spring 2023,ARCH,2501,25,19529,Architecture Design Studio IV,Olwi,Asmaa,4,4,1,0,0,0,0,3.223
+Spring 2023,ARCH,5508,1,19535,Design Studio Hist Struc/Sites,Race,Bruce Alan,15,5,4,0,0,0,0,3.445
+Spring 2023,ARCH,5508,3,19537,Design Studio Hist Struc/Sites,Zweig,Peter J,4,3,3,0,0,0,1,3.133
+Spring 2023,ARCH,5508,5,19539,Design Studio Hist Struc/Sites,Brune,Geoffrey,5,10,0,0,0,0,0,3.421
+Spring 2023,SPEC,7391,1,19553,Collab Consulting & Coaching,Hassett,Kristen Spring,1,0,0,0,0,0,0,4.0
+Spring 2023,MANA,8380,1,19554,Sem in Strategic Management,Chiu,Shih-chi,3,2,0,0,0,0,0,3.534
+Spring 2023,MANA,3335,10,19555,Intro Org Behavior and Mgmt,Miljanic,Andra Olivia,16,9,4,1,0,0,0,3.344
+Spring 2023,GEOL,4383,1,19556,Reservoir Geophysics,Stewart,Robert R,1,3,0,0,0,0,0,3.25
+Spring 2023,GEOL,6387,1,19558,Reservoir Geophysics,Stewart,Robert R,2,0,2,0,0,0,0,2.918
+Spring 2023,GEOL,1102,8,19559,Intro to Climate Change Lab,Wang,Yuxuan,15,3,0,0,0,0,1,3.833
+Spring 2023,GEOL,1147,4,19560,Introductory Meteorology Lab,Jiang,Xun,16,3,1,2,0,0,0,3.395
+Spring 2023,ELCS,6320,3,19568,Instructional Supervision,Butcher,Keith,15,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8356,1,19569,Program Policy Evaluation,Davis,Bradley,8,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8361,2,19570,Public & Community Relations,Freelon,Rhoda,9,1,0,0,0,0,0,3.867
+Spring 2023,ELCS,8312,13,19573,Lab of Practice-Res Meth Devel,Shockley,Gerald,1,0,0,0,0,0,0,3.67
+Spring 2023,WCL,3397,3,19574,Selected Topics in WCL,Behr,Francesca D,4,0,0,0,0,0,1,3.918
+Spring 2023,ITAL,3309,1,19575,Women Writers & Filmmakers,Behr,Francesca D,5,1,0,1,1,0,0,2.959
+Spring 2023,ELCS,8395,1,19576,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,5,0,
+Spring 2023,ELCS,8395,2,19577,Doctoral Thesis,Davis,Bradley,2,0,0,0,0,8,0,4.0
+Spring 2023,ELCS,8395,3,19578,Doctoral Thesis,Freelon,Rhoda,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8395,4,19579,Doctoral Thesis,Johnson PhD,Detra DeVerne,1,0,0,0,0,3,0,4.0
+Spring 2023,ELCS,8395,5,19580,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,0,0,
+Spring 2023,ELCS,8395,6,19581,Doctoral Thesis,Lopez,Ruth Maria,0,0,0,0,0,0,0,
+Spring 2023,ELCS,8395,7,19582,Doctoral Thesis,Peters-Hawkins,April,1,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8395,8,19583,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,2,0,0,0,0,4,0,4.0
+Spring 2023,ELCS,8395,9,19584,Doctoral Thesis,Shockley,Gerald,0,0,0,0,0,1,0,
+Spring 2023,WCL,3397,4,19585,Selected Topics in WCL,Zaretsky,Robert D,1,0,0,0,0,0,1,3.67
+Spring 2023,MANA,7338,1,19586,Org Power Politics & Culture,Abbott,Jeanna L,33,1,0,0,0,0,1,3.961
+Spring 2023,MANA,7339,3,19588,Leadership Development,Atwater,Leanne E,23,4,2,0,1,0,0,3.6
+Spring 2023,GEOL,1303,4,19590,Physical Geology,Murphy,Michael,80,48,13,2,5,0,1,3.302
+Spring 2023,GEOL,1303,5,19591,Physical Geology,Fu,Qi,9,17,19,9,4,0,3,2.288
+Spring 2023,ANTH,2301,2,19597,Intro to Physical Anthropology,McElvaney,Katherine Anne,21,11,2,1,1,0,0,3.334
+Spring 2023,MANA,7357,1,19604,Fund of Diversity Equity & Inc,Baldwin,Cheryl,11,2,1,3,0,0,0,3.138
+Spring 2023,ANTH,4363,1,19605,"Race, Racialization & Culture",De Genova,Nicholas Paul,16,3,0,0,0,0,0,3.721
+Spring 2023,ANTH,6363,1,19607,"Race, Racialization",De Genova,Nicholas Paul,2,1,0,0,0,0,0,3.667
+Spring 2023,GEOL,3145,2,19615,Strctrl Geology Lab,Murphy,Michael,5,2,4,0,1,0,0,2.806
+Spring 2023,ANTH,3338,1,19619,Peoples of Africa,Hannaford,Dinah Rebecca,23,4,0,0,1,0,0,3.644
+Spring 2023,ANTH,3342,1,19624,Food and Culture,Azua,Anneleise,22,6,0,1,0,0,0,3.599
+Spring 2023,ANTH,3316,1,19629,Society and Culture of India,Majumder,Sarasij,12,3,0,3,0,0,0,3.278
+Spring 2023,ANTH,3396,1,19632,Selected Tops in Cultural Anth,Picozza,Fiorenza,18,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,4394,1,19637,Selected Topics in Ant,Rasmussen,Susan J,6,3,1,0,0,0,2,3.401
+Spring 2023,ANTH,4394,2,19640,Selected Topics in Ant,Picozza,Fiorenza,18,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,4377,1,19642,Arch of African Diaspora,Brown,Kenneth L,11,4,6,0,1,0,0,3.061
+Spring 2023,ANTH,4351,1,19644,Human Osteology,Bytheway,Joan A,3,5,2,1,3,0,7,2.262
+Spring 2023,ANTH,4338,1,19645,Visual Anthropology,Ramirez,Marie Theresa,11,4,0,0,0,0,0,3.799
+Spring 2023,ANTH,4394,3,19646,Selected Topics in Ant,Ghazali,Marwa,7,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,6342,1,19647,Food and Culture,Azua,Anneleise,2,1,1,0,0,0,0,3.25
+Spring 2023,ANTH,6317,1,19648,Anthropology and Gender,Rasmussen,Susan J,4,0,0,0,0,0,0,3.918
+Spring 2023,ANTH,6399,2,19651,Masters Thesis,Brown,Kenneth L,0,0,0,0,0,2,0,
+Spring 2023,ANTH,6399,7,19656,Masters Thesis,Sen,Debarati,0,0,0,0,0,1,0,
+Spring 2023,ANTH,6395,2,19667,Selected Topics in Ant,Hannaford,Dinah Rebecca,3,0,0,0,0,0,0,4.0
+Spring 2023,RELS,2350,2,19680,Introduction to Islam,Haq,Muhammad Nisarul,22,13,2,0,1,0,2,3.343
+Spring 2023,RELS,2340,1,19682,Introduction to Hinduism,Ullrey,Aaron Michael,19,13,2,3,2,0,8,3.171
+Spring 2023,RELS,2372,1,19683,Bible and Modern Pop Culture,Tamber-Rosenau,Caryn M,11,3,4,0,2,0,0,3.067
+Spring 2023,RELS,3337,1,19684,Theologies from the Margins,Pegoda,Andrew Joseph,5,2,4,0,4,0,5,2.267
+Spring 2023,RELS,3396,1,19685,Sel Topics Religious Studies,Allen,Paul J,20,3,0,0,1,0,1,3.736
+Spring 2023,RELS,3396,2,19686,Sel Topics Religious Studies,Clark,Laura B,7,0,0,0,2,0,2,2.928
+Spring 2023,RELS,3396,3,19687,Sel Topics Religious Studies,Tierney,Robert Barkley,0,1,1,1,0,0,1,2.0
+Spring 2023,BCHS,6297,1,19693,Sel Tops Biochem & Biophys Sci,Schwartz,Robert J,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6397,1,19695,Sel Top-Biochm&Bphs Sci,Gunaratne,Preethi H,6,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,4397,1,19714,Topics-Biochem & Biophys Sci,Gunaratne,Preethi H,12,4,0,0,0,0,0,3.771
+Spring 2023,BCHS,4397,2,19715,Topics-Biochem & Biophys Sci,Liu,Yu,9,6,0,0,0,0,0,3.666
+Spring 2023,CUIN,6342,1,19716,Teaching Prob & Stats 6-12 Grd,Weiland,Travis,9,3,0,0,0,0,0,3.695
+Spring 2023,CUIN,7335,1,19717,Teach Math to Multilinguals,Gallagher,Melissa Ann,16,0,0,0,1,0,0,3.726
+Spring 2023,BIOL,4301,1,19727,Conservation Biology,Crawford,Kerri M,21,3,2,1,1,0,1,3.441
+Spring 2023,ELCS,8695,1,19736,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8695,2,19737,Doctoral Thesis,Davis,Bradley,2,0,0,0,0,2,0,4.0
+Spring 2023,ELCS,8695,5,19740,Doctoral Thesis,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8695,6,19741,Doctoral Thesis,Lopez,Ruth Maria,1,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8695,7,19742,Doctoral Thesis,Peters-Hawkins,April,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8695,8,19743,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,2340,1,19768,Cosmic Narratives,Wood,Barry Albert,11,3,1,0,1,0,2,3.314
+Spring 2023,MANA,7397,3,19782,Selected Topics in Management,Witt,Lawrence A,14,0,0,0,0,0,0,4.0
+Spring 2023,GENB,7397,1,19788,Selected Topics,Wilbur,Stephen,11,3,0,0,0,0,0,3.715
+Spring 2023,MANA,6383,2,19806,Strategic Managment,Carlin,Barbara A,8,1,0,0,0,0,0,3.779
+Spring 2023,ACCT,7397,1,19813,Selected Topics in Accounting,Crawford,Steven,6,1,0,0,0,0,0,3.857
+Spring 2023,ACCT,7397,2,19816,Selected Topics in Accounting,Lu,Tong,12,0,0,0,0,0,0,4.0
+Spring 2023,FINA,6335,1,19826,Managerial Finance,Wu,Guojun,7,0,0,0,0,0,0,4.0
+Spring 2023,GENB,7397,2,19827,Selected Topics,Webb,James R,9,0,0,0,0,0,0,3.89
+Spring 2023,ECON,4376,1,19838,Industrial Organization,Szabo,Andrea,5,4,4,0,1,0,2,2.881
+Spring 2023,SOC,3300,1,19839,Intro to Sociological Theory,Grigorian,Stella,8,1,1,0,0,0,4,3.601
+Spring 2023,SOC,3312,1,19840,Sociology of Deviance,Gallo,Joseph Ralph,37,6,2,2,1,0,1,3.583
+Spring 2023,SOC,3314,1,19841,Juvenille Delinquency,Gallo,Joseph Ralph,32,11,1,1,1,0,2,3.565
+Spring 2023,SOC,3316,2,19842,Sociology of Sport,Haltom,Trenton Matthews,21,7,13,3,4,0,1,2.805
+Spring 2023,SOC,3343,2,19843,Social Movements,Brailey,Carla,24,7,3,1,7,0,7,2.945
+Spring 2023,SOC,3344,2,19844,Sociology of Aging,Davis,Mary A,20,15,6,3,1,0,3,3.074
+Spring 2023,SOC,3330,1,19845,Intro-Social Psych,Savage,Scott Vandenburgh,14,18,11,4,0,0,0,2.823
+Spring 2023,SOC,3341,1,19846,Organizations,Hwang,Hyunseok,18,14,5,0,4,0,0,2.984
+Spring 2023,SOC,3342,1,19847,Sociology of Work,Lorence,Jon P,8,16,11,0,1,0,1,2.852
+Spring 2023,SOC,3370,1,19849,Popular Music and Society,Lee,Shayne,28,13,3,0,3,0,2,3.284
+Spring 2023,SOC,3373,1,19850,Comparative Family Structures,Monserud,Maria Aleksandrovna,26,10,5,1,2,0,4,3.265
+Spring 2023,SOC,3382,1,19851,Sociology of Drug Use & Recove,Colbert,Sharla Stettnisch,19,10,5,1,5,0,6,2.958
+Spring 2023,SOC,3397,1,19852,Sel-Topics in Sociology,Langa,Neema Michael,4,0,1,0,0,0,0,3.666
+Spring 2023,SOC,6321,1,19853,Sem in Sociology of Culture,Lee,Shayne,18,0,0,0,1,0,0,3.789
+Spring 2023,SOC,6397,1,19854,Selected Topics in Sociology,Nelson,Steven M,12,0,0,1,0,0,0,3.769
+Spring 2023,ILAS,2360,1,19855,Cosmic Narratives,Wood,Barry Albert,9,5,1,0,0,0,0,3.533
+Spring 2023,ENGL,3306,1,19856,Shakespeare-Major Works,Mikics,David,2,10,3,0,0,0,3,2.845
+Spring 2023,ENGL,3316,1,19858,Lit of Victorian Age,Guajardo,Paul,4,7,0,0,0,0,2,3.334
+Spring 2023,ENGL,3350,2,19859,Am Lit To 1865,Berger,Jason,20,2,6,0,0,0,2,3.5
+Spring 2023,ENGL,3361,1,19860,Mexican American Lit,Ellis,Amanda,22,3,1,0,0,0,2,3.732
+Spring 2023,ENGL,3367,1,19861,Gay and Lesbian Literature,Gonzalez,Maria C,18,7,0,0,0,0,2,3.588
+Spring 2023,ENGL,6323,2,19862,Fiction Workshop,Nelson,Antonya,9,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,3379,1,19864,African Literature,Aboul-Ela,Hosam,8,9,0,0,1,0,1,3.278
+Spring 2023,ENGL,4387,1,19872,SR Writing Proj CW: Fiction,Boswell,Robert L,18,1,0,0,0,0,0,3.947
+Spring 2023,ENGL,4396,1,19873,SR Experience Seminar Topics,Davies,Daniel,16,3,0,0,0,0,0,3.755
+Spring 2023,ENGL,6316,1,19875,American Folklore,Lindahl,Carl R,6,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,6322,1,19876,Poetry Workshop,Serpas,Martha R,9,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,6324,1,19877,Non-Fiction Prose Workshop,Flynn,Nicholas,10,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7325,1,19878,The British Empire,Lecourt,Sebastian Joseph,10,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7381,1,19880,Narrative and Narrative Theory,Mikics,David,10,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7396,1,19881,Topics in Language & Literatre,Kastely,James L,7,1,0,0,0,0,0,3.916
+Spring 2023,ENGL,7396,2,19882,Topics in Language & Literatre,Stock,Lorraine K,2,0,0,0,0,0,0,3.835
+Spring 2023,ENGL,7396,3,19883,Topics in Language & Literatre,Zentz,Lauren R,7,0,0,0,1,0,0,3.5
+Spring 2023,ENGL,8323,1,19884,Master Workshop: Narrative,Nelson,Antonya,5,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8376,1,19885,19th-C American Poetry,Snediker,Michael,12,0,0,0,0,0,0,3.918
+Spring 2023,ENGL,8394,1,19887,Sel Topics-Compar Lit,Zamora,Lois,3,1,0,0,0,0,0,3.75
+Spring 2023,ENGL,8395,1,19888,Sel Topics in Rhet and Comp,Shepley,Nathan,2,1,0,0,0,0,0,3.777
+Spring 2023,CUIN,8375,1,19889,Theory/Pract of Educ Prgm Eval,Ford,Haley Michelle Grimland,28,0,1,0,0,0,0,3.942
+Spring 2023,ELCS,8325,1,19890,Instnl Leadercurri&Prof Devlop,Hutchison,Laveria F,20,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8310,1,19891,Laboratory of Practice,Hutchison,Laveria F,9,0,0,0,0,0,0,4.0
+Spring 2023,ELED,4312,1,19893,Science in the Elem School II,Thompson,Amber M,23,1,1,0,0,0,0,3.854
+Spring 2023,ELED,4312,2,19894,Science in the Elem School II,Khalidi,Rana,24,2,0,0,0,0,0,3.834
+Spring 2023,ELED,4312,3,19895,Science in the Elem School II,Khalidi,Rana,22,3,1,0,0,0,0,3.757
+Spring 2023,ELED,4312,4,19896,Science in the Elem School II,Bailer,Jill,22,4,0,0,0,0,0,3.833
+Spring 2023,ELED,4312,5,19897,Science in the Elem School II,Rodriguez,Alberto J,13,5,3,0,0,0,0,3.382
+Spring 2023,CHEM,1322,1,19898,Honors Fund of Chem 2,Hoffman,David M,5,15,6,0,0,0,1,2.962
+Spring 2023,SPAN,4313,1,19901,Advanced Eng/Span Translation,Arboleda,Paola,7,2,1,0,0,0,0,3.435
+Spring 2023,SPAN,4365,1,19902,Contrastive Structures,Gutierrez,Manuel J,8,10,4,1,0,0,2,3.116
+Spring 2023,SOCI,1301,7,19903,Introduction To Sociology,Cooper,Chelsey Wells,32,6,3,2,2,0,1,3.349
+Spring 2023,CHEM,4373,2,19904,Survey of Physical Chemistry,Xu,Shoujun,27,22,19,7,3,0,2,2.753
+Spring 2023,CHEM,6353,1,19908,Physical Organic Chem,Miljanic,Ognjen S,5,4,0,0,0,0,0,3.372
+Spring 2023,TLIM,4378,31,19922,Senior Project,Burns,Maria,27,2,0,0,1,0,0,3.767
+Spring 2023,BIOL,4323,1,19940,Immunology,Peng,Weiyi,29,7,0,0,0,0,1,3.769
+Spring 2023,ENGI,1331,2,19957,Computing for Engineers,Kowal,Marsha Christine,21,1,0,0,0,0,0,3.895
+Spring 2023,SCLT,6397,31,19960,Selected Topics,Wang,Kailai,3,0,0,0,0,0,0,4.0
+Spring 2023,SCLT,6397,32,19964,Selected Topics,Wang,Kailai,10,0,0,0,0,0,0,3.934
+Spring 2023,ENGI,1331,1,19969,Computing for Engineers,Kowal,Marsha Christine,10,3,1,0,0,0,0,3.666
+Spring 2023,CUIN,4341,1,19999,Teaching Math Problem Solving,Mitchell,Morgan Love,11,0,0,0,0,0,0,3.94
+Spring 2023,CIS,6397,4,20032,Selected Topics,Zhang,Yunpeng,120,1,2,0,0,0,0,3.916
+Spring 2023,MANA,7397,2,20065,Selected Topics in Management,Ruggs,Enrica N,6,0,0,0,0,0,0,3.945
+Spring 2023,CIS,3337,1,20070,Secure Application Design,Nsoh,Jovita T,29,24,0,1,4,0,4,3.247
+Spring 2023,ARCH,2501,27,20095,Architecture Design Studio IV,Hueppe,Robin V,8,8,0,0,0,0,0,3.418
+Spring 2023,DIGM,4397,32,20125,Selected Tops in Digital Media,Liao,Pamara F,26,7,7,0,2,0,0,3.239
+Spring 2023,DIGM,4378,32,20129,Senior Project,Alters,Monika Joanna,23,11,1,0,0,0,1,3.6
+Spring 2023,DIGM,4378,33,20130,Senior Project,Rodwell,Elizabeth Ann,23,5,3,0,0,0,1,3.571
+Spring 2023,ENTR,3310,6,20163,Entrepreneurship,Boles,James Read,12,3,1,0,0,0,1,3.564
+Spring 2023,BIOL,4350,1,20178,Biology of Animal Signaling,Wiernasz,Diane C,5,9,1,2,0,0,2,3.058
+Spring 2023,PUBL,6343,1,20192,GIS for Urban Applications,Yuasa,Toshiyuki,2,1,0,0,0,0,1,3.447
+Spring 2023,ENTR,4330,2,20215,Entrepreneurial Costs/Budgets,Becker,Charles D,9,4,6,2,2,0,2,2.624
+Spring 2023,ELED,4311,11,20216,Science in Elementary School I,Shelton,Laura,2,0,0,0,0,0,0,3.835
+Spring 2023,ENTR,4340,1,20217,Entrepreneurial Capital,Wilbur,Stephen,4,6,7,1,0,0,0,2.686
+Spring 2023,ELED,4312,11,20220,Science in the Elem School II,Shelton,Laura,1,0,0,0,0,0,0,4.0
+Spring 2023,ELED,4314,11,20232,Mathematics in Elem School I,Shelton,Laura,2,0,0,0,0,0,0,4.0
+Spring 2023,GENB,7390,1,20233,Books an MBA Should Read,Galvani,Paul,8,1,0,0,0,0,0,3.852
+Spring 2023,MARK,3338,1,20234,Intro to Marketing Analytics,Wang,Yu,55,68,9,10,2,0,2,3.123
+Spring 2023,MARK,3338,2,20235,Intro to Marketing Analytics,Wang,Yu,22,48,10,7,8,0,11,2.702
+Spring 2023,MARK,4397,1,20263,Selected Topics in Mkt,Pogge,Joe M,16,11,5,0,0,0,0,3.303
+Spring 2023,CUIN,8329,1,20272,Academic Publishing/ Presentin,Gist,Conra D,7,0,0,0,0,0,0,3.906
+Spring 2023,ENGL,3331,3,20273,Beg Creative Writing-Poetry,Priest,Joy M,17,0,0,0,1,0,0,3.778
+Spring 2023,MARK,7379,1,20280,Sales Leadership,Herman,Carl,14,7,0,0,0,0,0,3.651
+Spring 2023,MARK,7399,1,20281,MS Marketing Prof Project,Koch,Steven F,13,1,0,0,0,0,0,3.858
+Spring 2023,MARK,7399,2,20282,MS Marketing Prof Project,Koch,Steven F,2,1,0,0,0,0,0,3.667
+Spring 2023,FINA,3332,5,20283,Prin of Financial Management,Suleymanov,Masim,76,81,39,11,5,0,8,2.991
+Spring 2023,MATH,4364,2,20284,Intro to Numerical Analysis,Cappanera,Loic,10,17,7,1,0,0,0,2.925
+Spring 2023,MATH,3336,5,20285,Discrete Mathematics,Xhabli,Blerina,38,40,64,12,16,0,14,2.404
+Spring 2023,MATH,1324,3,20286,Finite Math with Applications,Caglar,Atife,82,64,82,56,66,0,44,2.082
+Spring 2023,MATH,2318,2,20287,Linear Algebra,Sanders,Richard,15,15,10,5,7,0,7,2.513
+Spring 2023,ELET,6312,1,20304,Network Management,Lent,Marino Ricardo,3,0,0,0,0,0,0,3.78
+Spring 2023,ELET,6318,1,20309,Analysis of Data Networks,Yuan,Xiaojing,2,0,0,0,0,0,0,3.67
+Spring 2023,MATH,6397,1,20344,Selected Topics in Math,Labate,Demetrio,13,4,0,0,0,0,0,3.668
+Spring 2023,CUIN,7318,1,20367,Curr Issues Learning & Design,Dogan,Bulent,20,2,0,0,1,0,0,3.71
+Spring 2023,CUIN,7323,1,20372,Instructional Tech & Society,Gronseth,Susie L B,11,3,0,0,1,0,0,3.599
+Spring 2023,CUIN,7350,1,20374,Integrating Tech in Curriculum,Nguyen,Phuong Thi Mai,28,1,0,0,1,0,2,3.767
+Spring 2023,IDNS,1130,2,20387,Precalculus SEP Workshop,Pattison,Donna,18,0,6,0,0,0,2,3.445
+Spring 2023,BCHS,4397,3,20388,Topics-Biochem & Biophys Sci,Graur,Dan,1,0,0,0,0,0,0,3.67
+Spring 2023,MATH,7326,1,20389,Dynamical Systems,Ott,William R,18,0,0,0,0,0,0,3.963
+Spring 2023,BIOL,4397,1,20391,Selected Topics in Biology,Graur,Dan,10,8,3,1,0,0,2,3.092
+Spring 2023,MATH,6397,2,20393,Selected Topics in Math,Mang,Andreas,16,1,0,0,0,0,0,3.825
+Spring 2023,MATH,6397,3,20396,Selected Topics in Math,Blecher,David P,8,2,0,0,0,0,0,3.701
+Spring 2023,MATH,4335,1,20411,Partial Diff  Equations I,Jaramillo,Gabriela T,3,3,7,2,0,0,0,2.445
+Spring 2023,IDNS,2197,1,20416,Top-Natrl Sci & Mth,Pattison,Donna,14,2,6,1,0,0,2,3.218
+Spring 2023,IDNS,2197,2,20417,Top-Natrl Sci & Mth,Pattison,Donna,12,5,3,1,1,0,4,3.122
+Spring 2023,IDNS,2197,3,20418,Top-Natrl Sci & Mth,Pattison,Donna,5,2,3,0,0,0,5,3.134
+Spring 2023,INDS,6350,1,20420,Design Studies,McEuen,Aaron Ross,2,0,0,0,0,0,1,4.0
+Spring 2023,HON,3374,1,20421,Hist & Pol of the Hebrew Bible,Rainbow,Jesse J,13,3,0,0,0,0,2,3.73
+Spring 2023,ENRG,4397,1,20429,Sel Topics-Enrgy & Sustainblty,Vollrath,Lesli A,4,1,0,0,0,0,0,3.8
+Spring 2023,HON,3397,1,20434,Honors Selected Topics,Gish,Dustin,0,1,0,0,0,0,1,3.0
+Spring 2023,HIST,4361,1,20435,20th Century Genocides,Guenther,Irene V,20,1,0,0,0,0,1,3.89
+Spring 2023,HON,3397,2,20447,Honors Selected Topics,Trninic,Marina,20,1,0,0,0,0,4,3.827
+Spring 2023,HON,3397,3,20448,Honors Selected Topics,Rayneard,Max James Anthony,6,2,0,0,1,0,0,3.297
+Spring 2023,SPAN,3341,1,20449,Language of Business and Trade,Zubiate,Maria Laura,5,0,1,1,1,0,0,2.751
+Spring 2023,HON,3397,4,20451,Honors Selected Topics,Rainbow,David,8,0,0,0,0,0,2,3.918
+Spring 2023,HON,3397,5,20452,Honors Selected Topics,Bland,Laura Elizabeth,24,0,0,0,0,0,1,4.0
+Spring 2023,ENRG,3312,1,20454,Politics of Energy & the Env.,Williamson,Jonathan Lyle,8,5,0,0,0,0,0,3.539
+Spring 2023,BIOL,3397,1,20462,Selected Topics in Biology,Sharp,Rita Evelyn,23,1,1,0,0,0,0,3.854
+Spring 2023,HON,3397,6,20465,Honors Selected Topics,Price,Daniel M,19,4,1,0,0,0,1,3.695
+Spring 2023,POLS,3353,1,20466,Policy & Administration,Belco,Michelle Helene,16,3,1,1,0,0,1,3.65
+Spring 2023,BIOL,4302,1,20471,Galapago! Rsch Lrng Abroad,Hanke,Marc H,23,0,0,0,0,0,2,4.0
+Spring 2023,HON,3377,1,20476,Amer Legal History: Civil War,Erwing,Douglas A,8,0,0,0,0,0,1,3.918
+Spring 2023,POLS,3361,1,20485,Politics and Literature,Hallmark,Terrell L,9,0,0,0,0,0,0,3.89
+Spring 2023,GEOL,6385,1,20489,Seismic Imaging Fundamentals,Zheng,Yingcai,4,2,0,0,0,0,0,3.667
+Spring 2023,GEOL,6397,1,20500,Selected Topics in Geology,Castagna,John P,16,1,0,0,0,0,0,3.844
+Spring 2023,GEOL,6397,2,20504,Selected Topics in Geology,Wellner,Julia S,12,1,0,0,0,0,0,3.872
+Spring 2023,GEOL,6343,1,20507,Organic Geochemistry,Fu,Qi,5,1,0,0,0,0,0,3.833
+Spring 2023,PETR,5397,1,20528,Selected Topics,Ehlig-Economides,Christine A,2,0,0,0,0,0,0,3.67
+Spring 2023,PETR,5356,1,20530,Completion and Stimulation,Soliman,Mohamed Yousef,7,0,0,0,0,0,0,3.811
+Spring 2023,PETR,6336,1,20532,Petroleum Energy Markets,Hollo,Reuven,5,1,0,0,0,0,0,3.668
+Spring 2023,ENGL,1301,54,20538,First Year Writing I,Ivanov,Katerina,7,5,2,0,4,0,1,2.574
+Spring 2023,MATH,4370,1,20540,Mathematics for Physicists,Cardoso Barato,Andre,4,4,2,0,0,0,0,3.101
+Spring 2023,GEOL,6354,1,20541,Geomechanics,Suppe,John,3,1,0,0,0,0,0,3.75
+Spring 2023,GEOL,6335,1,20542,Atmospheric Numerical Modeling,Choi,Yunsoo,19,0,0,0,0,0,0,3.965
+Spring 2023,GEOL,4335,1,20543,Numerical Modeling in Atm Sci,Choi,Yunsoo,11,6,1,0,0,0,1,3.372
+Spring 2023,GEOL,4397,1,20545,Selected Topics-Geology,Beverly,Emily Jane,10,8,3,0,0,0,0,3.255
+Spring 2023,WGSS,2350,19,20571,Intro To Women's Studies,Bustillo,Anneliese,12,8,6,0,3,0,0,2.794
+Spring 2023,PSYC,4397,1,20578,Selected Topics in Psychology,Hernandez,Arturo E,12,1,0,0,0,0,2,3.796
+Spring 2023,PSYC,6397,1,20579,Sel Top in Psychology,Hernandez,Arturo E,3,0,0,0,0,0,0,4.0
+Spring 2023,COMD,7170,1,20649,Graduate Seminar in SLP,Cizek,Laura S,29,0,0,0,0,0,0,4.0
+Spring 2023,COMM,2371,1,20673,"Media, Sports and Culture",Crowe,Craig Warren,43,9,2,0,5,0,1,3.469
+Spring 2023,COMM,3312,1,20686,Global Journalism,Camaj,Lindita,15,5,2,0,0,0,2,3.561
+Spring 2023,ENGL,2307,3,20744,Intro To Drama,Presswood,Phillip Hilliard,21,0,0,0,0,0,0,4.0
+Spring 2023,COMM,4312,1,20813,Feature Writing,Bhat,Nandikoor R Prashanth,12,0,0,0,0,0,0,3.945
+Spring 2023,ELCS,6380,2,20820,Educational Planning & Policy,Carales,Vincent D,14,2,0,0,0,0,2,3.648
+Spring 2023,COMM,4328,1,20823,Broadcast & Film Writing,Vaughan,Thomas Michael,8,7,1,0,0,0,1,3.438
+Spring 2023,ELCS,6322,1,20824,Org & Admin Stud. Support Serv,Hernandez,Belkis Pamela,15,1,0,0,0,0,1,3.917
+Spring 2023,ELCS,8335,1,20825,Seminar in Adult Education,McKinney,Lonnie Lyle,17,2,0,0,0,0,0,3.895
+Spring 2023,COMM,4335,1,20826,Crisis Communication,Hudson-Gillan,Gail,31,12,1,1,0,0,0,3.578
+Spring 2023,CNST,6375,1,20840,BIM Applications for CM,Din,Zia Ud,16,1,0,0,0,0,0,3.941
+Spring 2023,PETR,6397,2,20868,Selected Topics,Ehlig-Economides,Christine A,6,0,0,0,0,0,0,3.78
+Spring 2023,PETR,7397,1,20873,Selected Topics,Lee,Kyung Jae,7,2,1,0,0,0,0,3.567
+Spring 2023,MATH,6397,4,20890,Selected Topics in Math,Arregoces,Luis A,11,0,0,0,0,0,0,4.0
+Spring 2023,MATH,6397,5,20891,Selected Topics in Math,Ryan,John M,5,0,0,0,0,0,0,4.0
+Spring 2023,FINA,4360,1,20897,International Financial Mgmt,Hitzemann,Steffen,7,16,3,0,1,0,0,2.964
+Spring 2023,PSYC,7397,1,20902,Selected Topics in Psychology,Derrick,Jaye L,6,3,0,0,0,0,0,3.63
+Spring 2023,SCM,4301,2,20903,Logistics Management,Tibodeau,Dale,21,29,13,2,0,0,1,3.051
+Spring 2023,ENGL,1302,131,20914,First Year Writing II,Braniger,Leslie,2,10,5,2,2,0,3,2.24
+Spring 2023,ENGL,1302,132,20915,First Year Writing II,Rizzo,Kaitlin M,19,2,0,1,2,0,1,3.445
+Spring 2023,BIOL,6223,1,20941,Animal Models of Human Disease,Chung,Sanghyuk,9,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6397,2,20945,Selected Topics in Biology,Daane,Jacob,0,0,0,0,0,5,0,
+Spring 2023,BIOL,6397,3,20946,Selected Topics in Biology,Ziburkus,Jokubas,10,0,0,0,0,0,0,3.934
+Spring 2023,BIOL,6397,4,20947,Selected Topics in Biology,Lin,Chin-Yo,15,1,0,0,0,0,0,3.876
+Spring 2023,BIOL,6397,5,20948,Selected Topics in Biology,Khurana,Seema,4,2,0,0,0,0,0,3.722
+Spring 2023,BIOL,4397,2,20960,Selected Topics in Biology,Nunez,Martin A,15,1,0,0,0,0,1,3.896
+Spring 2023,BIOL,4311,1,20964,Genomic Data Analysis,Meisel,Richard P,14,3,1,1,0,0,1,3.579
+Spring 2023,BIOL,6311,1,20966,Genomic Data Analysis,Meisel,Richard P,12,2,0,0,0,0,0,3.857
+Spring 2023,BIOL,1197,1,20969,Selected Topics in Biology,Ogletree-Hughes,Monique L,17,4,3,1,3,0,4,3.095
+Spring 2023,BIOL,1197,2,20970,Selected Topics in Biology,Ogletree-Hughes,Monique L,8,5,3,0,3,0,2,2.807
+Spring 2023,BIOL,4397,3,20972,Selected Topics in Biology,Wayne,Chad M,29,11,0,0,0,0,0,3.659
+Spring 2023,SCM,4330,4,21105,Bus Modeling and Dec Analysis,Cossick,Kathy L,5,2,4,4,1,0,5,2.375
+Spring 2023,SCM,4350,2,21106,Strategic Supply Management,Wayhan,Victor Brian,57,21,2,1,0,0,0,3.622
+Spring 2023,SCM,4362,3,21107,Demand and Supply Integration,Li,Meng,10,6,1,0,0,0,0,3.491
+Spring 2023,TEPM,6301,40,21108,Project Management Principles,Hopkins,Ronald K,9,1,2,0,1,0,0,3.358
+Spring 2023,TEPM,6302,40,21109,Leadership and Team Building,Hopkins,Ronald K,7,0,0,0,0,0,0,3.953
+Spring 2023,TEPM,6304,40,21110,Quality Improvemnt in Proj Mgt,Kovach,Jamison,5,4,0,0,0,0,2,3.556
+Spring 2023,ARCH,3397,1,21111,Selected Topics,Zweig,Peter J,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6397,1,21112,Sel Tpcs-Arc/Urbn Desgn,Rifaat,Shafik I,8,0,0,0,0,0,0,3.876
+Spring 2023,TEPM,6305,40,21113,Project Manager Tools,Sherman,Dennis Louis,6,0,0,0,1,0,1,3.429
+Spring 2023,SOCW,7340,2,21116,Clinical Practice with Child,Barkwell,Fabeain Damonte,23,2,0,1,0,0,0,3.808
+Spring 2023,TEPM,6303,40,21117,Risk Assessment in Project Mgm,Gadison,Paulette D.,4,1,1,0,0,0,0,3.28
+Spring 2023,SOCW,7356,1,21118,Groups in Clinical Settings,Burkley,Casondra,9,6,0,0,0,0,0,3.6
+Spring 2023,TEPM,6308,40,21119,Project Procurement Practices,Conover,Sharon Cecilia,4,0,0,0,0,0,0,4.0
+Spring 2023,HON,4397,1,21130,Honors Selected Topics,Hallmark,Terrell L,5,0,0,0,0,0,0,3.934
+Spring 2023,MIS,4397,1,21132,Selected Topics in MIS,Wang,Cheng,24,6,0,0,0,0,1,3.778
+Spring 2023,MIS,4397,2,21137,Selected Topics in MIS,Decarlo,Paul Jarrod,40,0,0,0,0,0,0,4.0
+Spring 2023,MIS,4397,3,21138,Selected Topics in MIS,Scott,Carl P,14,7,1,0,0,0,1,3.546
+Spring 2023,SCLT,4386,30,21139,Project Logistics,Poisler,Marco A,19,1,1,0,2,0,0,3.479
+Spring 2023,SOCW,7329,3,21140,SW Practice for Policy Change,Pritzker,Suzanne,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,4397,4,21149,Selected Topics in MIS,Zhao,Keran,6,1,0,0,0,0,0,3.857
+Spring 2023,MIS,7375,2,21151,Transaction Processing Systems,Messinger,Jacob Nelson,15,5,1,0,0,0,0,3.62
+Spring 2023,ENGL,2316,3,21152,Literature and Culture,Decarion,Andrew P,13,6,4,1,1,0,0,3.081
+Spring 2023,MECE,2334,3,21153,Thermodynamics,Ryou,Jae-Hyun,14,36,14,0,1,0,2,2.979
+Spring 2023,MIS,7397,1,21154,Selected Topics in MIS,Pena,Juan F,46,1,0,0,0,0,0,3.972
+Spring 2023,MIS,7397,2,21155,Selected Topics in MIS,Zhao,Keran,21,5,0,0,0,0,0,3.808
+Spring 2023,MIS,7397,3,21156,Selected Topics in MIS,Cooper,Randolph B,5,5,1,0,2,0,2,2.846
+Spring 2023,MECT,4341,1,21158,Materials Select & Management,Robles Hernandez,Francisco C,6,6,0,0,0,0,0,3.363
+Spring 2023,HDCS,4396,1,21162,Tops-Hum Dv & Cnsmr Sci,Polesello,Daiane,15,0,1,0,1,0,1,3.589
+Spring 2023,SGNL,1302,4,21163,Elementary Sign Language II,Brittain,Robyn Michelle,6,13,2,1,0,0,0,3.016
+Spring 2023,MECE,4343,2,21164,Thermal Design,Zhao,Bo,25,32,27,4,0,0,2,2.871
+Spring 2023,MECE,5397,1,21165,Selected Topics,Grigoriadis,Karolos,15,37,23,1,0,0,2,2.864
+Spring 2023,MECE,5397,2,21166,Selected Topics,Ryou,Jae-Hyun,38,42,9,0,0,0,1,3.33
+Spring 2023,MECE,5397,3,21167,Selected Topics,Ardebili,Haleh,57,53,2,0,0,0,1,3.515
+Spring 2023,MECE,6336,1,21169,Engineering Heat Transfer,Ghasemi,Hadi,4,7,5,0,4,0,4,2.284
+Spring 2023,MECE,7397,1,21171,Selected Topics,Joshi,Shailendra Pramod,9,0,0,0,0,0,0,4.0
+Spring 2023,MECE,6397,1,21179,Selected Topics,Floryan,Daniel,3,5,0,0,0,0,1,3.416
+Spring 2023,MECE,6397,2,21180,Selected Topics,Ardebili,Haleh,22,12,0,0,1,0,0,3.486
+Spring 2023,ACCT,2301,10,21183,Prin of Financial Accounting,Goble,Samuel,9,15,4,4,2,0,5,2.823
+Spring 2023,ACCT,2301,11,21186,Prin of Financial Accounting,Sykes,Mary Reeves,24,10,1,1,3,0,1,3.35
+Spring 2023,SOCW,7367,6,21192,Social Policy Analysis,Pang,Melanie Espinosa,24,2,0,0,0,0,0,3.923
+Spring 2023,SOCW,7367,7,21193,Social Policy Analysis,Pang,Melanie Espinosa,29,1,0,0,0,0,0,3.967
+Spring 2023,ENGL,1302,133,21195,First Year Writing II,Alcorn III,Charles William,17,1,0,0,0,0,1,3.889
+Spring 2023,ENGL,1302,134,21197,First Year Writing II,Box,Anthony Joseph,17,2,0,0,1,0,0,3.684
+Spring 2023,ENGL,1302,135,21199,First Year Writing II,Denton,Amy,6,6,3,1,2,0,0,2.777
+Spring 2023,HDCS,3384,1,21201,Consumer Sales,Mudd,Blake Stevens,41,8,1,1,1,0,0,3.673
+Spring 2023,ENGL,1302,136,21202,First Year Writing II,Denton,Amy,3,6,3,3,2,0,2,2.255
+Spring 2023,EDS,6342,1,21205,Intro to Machine Learning,Jegdic,Katarina Svetislav,34,17,18,2,1,0,1,3.125
+Spring 2023,ENGL,1302,137,21207,First Year Writing II,Long,Steven A.,15,2,0,0,2,0,0,3.474
+Spring 2023,EDS,6340,1,21208,Introduction to Data Science,Lendasse,Amaury,38,33,0,0,0,0,0,3.512
+Spring 2023,EDS,6344,1,21209,AI for Engineers,Loganantharaj,Rasiah,25,26,3,1,0,0,0,3.364
+Spring 2023,ENGL,1302,138,21210,First Year Writing II,Cooper-Edwards,Jacquelyn,12,1,0,1,2,0,3,3.188
+Spring 2023,ENGL,1302,139,21212,First Year Writing II,Christensen,Ann C,2,7,0,4,4,0,1,1.999
+Spring 2023,ENGL,2330,5,21214,Writing Discipline English,Charara,Hayan S,5,9,0,0,1,0,5,3.067
+Spring 2023,SGNL,1301,4,21215,Elementary Sign Language I,Brittain,Terrell,6,8,2,0,1,0,0,3.059
+Spring 2023,INDS,2501,3,21234,Industrial Design Studio IV,Jamjoom,Zain Ahmed,1,6,1,1,0,0,0,2.668
+Spring 2023,ACCT,3368,4,21249,Intermediate Accounting II,Sun,Xue,7,18,13,0,0,0,1,2.842
+Spring 2023,COMD,3385,2,21251,Speech Science,Bunta,Ferenc,10,15,6,3,0,0,1,2.883
+Spring 2023,ACCT,4335,3,21253,Financial Statement Auditing,Kuruvilla,Mohan,9,8,13,4,1,0,1,2.609
+Spring 2023,SOCW,7191,1,21254,Field Practicum Elective I,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Spring 2023,SOCW,7290,1,21255,Adv Practicum II in Pol Sw,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Spring 2023,SOCW,7397,1,21256,Selected Topics in Social Work,Pritzker,Suzanne,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,3381,1,21257,Audiology,Schadt,Laura Anne,7,6,3,0,0,0,0,3.25
+Spring 2023,GEOL,1103,9,23463,Physical Geology Lab,Hauptvogel,Daniel William,22,4,0,1,0,0,1,3.741
+Spring 2023,PSYC,4397,2,23471,Selected Topics in Psychology,Alfano,Candice A,10,6,9,4,0,0,1,2.69
+Spring 2023,PHIL,1361,5,23472,Philosophy and the Arts,Drapela,Nick Gerard,18,19,4,4,1,0,3,3.044
+Spring 2023,PSYC,7394,1,23473,Sel Topics-Clinical Psychology,Viana,Andres G,8,0,0,0,0,0,0,3.959
+Spring 2023,PHIL,1361,6,23474,Philosophy and the Arts,Mag Uidhir,Christopher Domh,182,26,15,3,13,0,9,3.487
+Spring 2023,PSYC,4343,1,23475,Perception,Tamber-Rosenau,Benjamin J,8,21,8,4,6,0,1,2.496
+Spring 2023,PHIL,3304,1,23476,History of 17Th Century Phil,Hattab,Helen,0,2,0,0,0,0,3,2.835
+Spring 2023,PSYC,6306,1,23479,Fndatns-Cogntve Psy,Tamber-Rosenau,Benjamin J,5,1,0,0,0,0,0,3.833
+Spring 2023,PHIL,3342,1,23481,Philosophy of Math,Loewenstein,Yael R,19,3,1,0,4,0,1,3.137
+Spring 2023,PHIL,3357,1,23485,Punishment,Sommers,Tamler S,17,6,1,0,2,0,4,3.334
+Spring 2023,PHIL,3377,1,23486,Philosophy of Religion,Oliveira,Luis RG,24,0,1,1,1,0,0,3.63
+Spring 2023,PSYC,4397,3,23487,Selected Topics in Psychology,Alward,Beau Andrew,23,4,2,1,0,0,0,3.567
+Spring 2023,PHIL,3354,1,23488,Medical Ethics,Determeyer,Peggy Lee,10,1,0,0,0,0,0,3.909
+Spring 2023,COMD,7192,1,23493,Advanced Practicum,Eckert,Janet F,0,0,0,0,0,0,1,
+Spring 2023,GEOL,4397,2,23494,Selected Topics-Geology,Zhang,Honghai,3,10,0,0,0,0,0,3.205
+Spring 2023,GEOL,6397,5,23498,Selected Topics in Geology,Zhang,Honghai,9,3,0,0,0,0,0,3.723
+Spring 2023,SOCW,8344,1,23501,Research Methods IV,Walton,Quenette,4,2,0,0,0,0,0,3.667
+Spring 2023,COMD,2376,1,23506,Anatomy for Communication,Daniels,Stephanie K,7,9,12,3,1,0,9,2.593
+Spring 2023,CUIN,7368,1,23510,Digital Imaging in Education,Ahlf,Michael,9,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,7391,1,23513,Curr Dev Health Science Educ,McNeil,Sara G,16,0,0,0,2,0,0,3.556
+Spring 2023,ACCT,5367,2,23521,Intermediate Accounting I,Zhu,Steven Xuanrui,0,1,0,0,0,0,0,3.0
+Spring 2023,BTEC,2322,30,23523,Introduction to Biopython,Chitrala,Kumaraswamy Naidu,14,4,1,0,1,0,0,3.484
+Spring 2023,KIN,3304,3,23524,Human Structure & Phys Perform,Hunt,Rebekah,7,15,11,6,7,0,3,2.145
+Spring 2023,ITEC,1301,2,23525,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,7,15,7,3,9,0,7,2.082
+Spring 2023,ARCH,3112,1,23526,Topics in Design Media,Jacobs,Daniel,5,0,0,0,0,0,0,3.934
+Spring 2023,ITEC,1301,3,23531,Intro To Computer Appl Tech,Shin,Daeun,20,9,6,0,1,0,11,3.296
+Spring 2023,ITEC,1301,4,23532,Intro To Computer Appl Tech,Schroeder,Susan L,20,10,8,3,4,0,3,2.889
+Spring 2023,ARCH,3112,2,23534,Topics in Design Media,Gonzales,Michael A,7,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3112,4,23536,Topics in Design Media,Noldt,Peter,8,2,0,0,0,0,0,3.8
+Spring 2023,ARCH,3112,3,23537,Topics in Design Media,Jackson,Megan H,3,2,0,0,0,0,0,3.732
+Spring 2023,ARCH,3112,5,23539,Topics in Design Media,Noldt,Peter,8,1,0,0,0,0,0,3.816
+Spring 2023,ARCH,3112,6,23540,Topics in Design Media,Noldt,Peter,6,3,0,1,0,0,0,3.268
+Spring 2023,ARCH,3112,7,23542,Topics in Design Media,Noldt,Peter,6,3,0,0,0,0,0,3.52
+Spring 2023,ARCH,3112,8,23543,Topics in Design Media,Noldt,Peter,5,3,0,0,0,0,2,3.708
+Spring 2023,ARCH,3112,9,23545,Topics in Design Media,Noldt,Peter,4,3,0,1,1,0,0,2.779
+Spring 2023,ARCH,3112,11,23548,Topics in Design Media,Jackson,Megan H,12,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3112,12,23549,Topics in Design Media,Jackson,Megan H,4,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3112,14,23551,Topics in Design Media,Smith,Joshua S,11,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4397,4,23552,Selected Topics in Psychology,Williams,Michael W,10,12,4,1,0,0,2,3.038
+Spring 2023,ARCH,3112,15,23554,Topics in Design Media,Kudless,Andrew Justin,11,7,1,0,0,0,0,3.353
+Spring 2023,ACCT,7390,1,23555,Contrl & Secur of Finan Inform,Brant Jr,Robert Edward,32,21,1,0,0,0,0,3.635
+Spring 2023,KIN,4310,3,23556,Measurement Tech Human Perf,Park,Yoonjung,4,15,16,3,5,0,5,2.286
+Spring 2023,PSYC,7363,1,23558,Organizational Psychology,Reyes,Denise Lucia,6,0,0,0,0,0,0,4.0
+Spring 2023,CNE,2211,1,23560,Construction Engr Fundamentals,Safa,Mahdi,1,0,0,0,0,0,0,4.0
+Spring 2023,CNE,2211,2,23561,Construction Engr Fundamentals,Safa,Mahdi,0,1,0,0,0,0,0,3.0
+Spring 2023,CIVE,2332,3,23562,Mechanics of Solids,Safa,Mahdi,4,5,2,0,1,0,1,2.917
+Spring 2023,POLC,1311,1,23563,Public Policy Laboratory,Luttrell,Johanna,9,4,0,2,0,0,1,3.333
+Spring 2023,CIS,4397,30,23568,Selected Topics Comp Info Syst,Miertschin,Susan L,42,34,8,0,1,0,1,3.349
+Spring 2023,POLC,3315,1,23572,Policy Res Methods Stat & Reg,Gottlieb,Jessica Anne,6,6,1,1,0,0,1,3.167
+Spring 2023,KIN,4350,2,23573,Sport Marketing,Cottingham,Michael,12,9,9,5,2,0,1,2.649
+Spring 2023,MECT,4330,1,23577,Valve Design,Andampour,Iraj,20,9,0,0,0,0,0,3.61
+Spring 2023,POLC,4390,1,23578,Public Policy Internship,Cross,Renee D,1,0,0,0,0,0,0,4.0
+Spring 2023,NUTR,3330,2,23581,Mgmt in Food & Nutr Systems,Haubrick,Kevin,6,9,2,0,1,0,3,3.037
+Spring 2023,NUTR,4346,2,23582,Research in Nutrition,Yoon,Cynthia Yursun,9,15,4,2,0,0,0,2.956
+Spring 2023,PSYC,7397,3,23583,Selected Topics in Psychology,Bick,Johanna R,6,0,0,0,0,0,0,4.0
+Spring 2023,POLC,4397,1,23585,Selected Topics Public Policy,Gary,Brant Michael,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4397,5,23586,Selected Topics in Psychology,Leasure,Jennifer Leigh,12,20,6,2,0,0,5,3.025
+Spring 2023,PSYC,6397,2,23588,Sel Top in Psychology,Leasure,Jennifer Leigh,2,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4397,6,23589,Selected Topics in Psychology,Grigorenko,Elena L,8,2,1,0,0,0,0,3.726
+Spring 2023,PHIL,3383,1,23590,His of Ancient Phi,Werner,Andrew Timothy,8,9,2,1,0,0,1,3.167
+Spring 2023,POLC,6397,1,23591,Selected Topics in Pub Policy,Gary,Brant Michael,11,1,0,0,0,0,1,3.944
+Spring 2023,FORE,6355,1,23592,Alternative Perspectives,Hines,Andrew Lewis,18,0,0,0,0,0,0,3.835
+Spring 2023,POLC,6397,2,23593,Selected Topics in Pub Policy,Pinto,Pablo M,9,1,0,0,0,0,0,3.636
+Spring 2023,HRD,6358,1,23594,Global Human Resource Devel,Shirmohammadi,Melika,9,1,0,0,0,0,0,3.834
+Spring 2023,PHIL,3388,1,23596,Hist of 20Th Cent Phi,Morrison,Iain P D,8,5,4,0,0,0,2,3.274
+Spring 2023,HRD,6353,1,23597,Methods of Adult Learning,Shirmohammadi,Melika,16,2,0,0,0,0,0,3.907
+Spring 2023,PHIL,3395,1,23599,Selected Topics in Phil,Buckner,Cameron J,13,4,3,0,2,0,3,2.957
+Spring 2023,PHIL,3395,2,23600,Selected Topics in Phil,Weisberg,Joshua,9,1,1,1,1,0,1,3.155
+Spring 2023,PHIL,6395,1,23601,Seminar Philos Problems,Coates,Daniel J,13,0,0,0,0,0,0,4.0
+Spring 2023,PHIL,6395,2,23602,Seminar Philos Problems,Garson,James W,8,0,0,0,0,0,0,3.794
+Spring 2023,ACCT,4335,4,23603,Financial Statement Auditing,Rousseau,Linette Marie,3,5,1,1,0,0,1,3.066
+Spring 2023,PHIL,6395,3,23604,Seminar Philos Problems,Mag Uidhir,Christopher Domh,15,0,0,0,0,0,0,3.846
+Spring 2023,COMD,3322,1,23605,Code-Switching Ling Justice,Mills,Monique T,30,3,1,0,0,0,1,3.853
+Spring 2023,ACCT,5372,1,23607,Intro-Data Analytics in ACCT,Miles,Carolyn A,1,0,0,0,0,0,0,3.67
+Spring 2023,PEP,7309,1,23608,Sport Finance,Lee,Dong Hun,14,4,1,0,0,0,0,3.667
+Spring 2023,ACCT,7320,1,23609,Intro to Data Analytics-Acct,Miles,Carolyn A,31,2,4,0,0,0,0,3.658
+Spring 2023,PEP,7397,1,23610,Adv Selected Topic Human Perf,Hawkins,Billy J,5,0,0,0,0,0,0,4.0
+Spring 2023,PEP,7397,2,23611,Adv Selected Topic Human Perf,Parikh,Pranav J,5,0,0,0,0,0,0,3.868
+Spring 2023,PEP,7397,3,23612,Adv Selected Topic Human Perf,LaVoy,Emily Claire-Pyle,7,0,0,0,0,0,0,4.0
+Spring 2023,NUTR,7315,1,23614,Advanced NUTR for the Elderly,Scott,Claudia W,2,4,1,0,0,0,0,3.143
+Spring 2023,ARCH,6312,2,23616,Topics in Design Media,Noldt,Peter,2,4,0,0,0,0,0,3.278
+Spring 2023,ARCH,6198,1,23617,Special Problems,Jacobs,Daniel,4,0,0,0,0,0,1,4.0
+Spring 2023,ARCH,6198,2,23618,Special Problems,Smith,Joshua S,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6198,4,23620,Special Problems,Noldt,Peter,3,0,0,0,0,0,0,3.89
+Spring 2023,ARCH,6198,8,23624,Special Problems,Noldt,Peter,0,1,0,0,0,0,0,3.33
+Spring 2023,ARCH,6198,10,23626,Special Problems,Smith,Joshua S,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6198,12,23628,Special Problems,Jackson,Megan H,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6198,15,23631,Special Problems,Kudless,Andrew Justin,4,1,0,0,0,0,0,3.8
+Spring 2023,HIST,2312,1,23684,Western Civilization from 1450,Ittmann,Karl,8,16,7,1,0,0,1,2.866
+Spring 2023,HIST,2374,1,23687,Popular Culture in Latin Amer,Milanesio,Natalia,14,9,3,6,0,0,3,2.958
+Spring 2023,HIST,3307,1,23691,Houston:Migration &Immigration,Harwell,Debbie Z,8,3,0,1,0,0,1,3.445
+Spring 2023,HIST,3317,1,23692,Making of Ethnic America,Goldberg,Mark A,21,6,2,1,1,0,0,3.43
+Spring 2023,HIST,3351,1,23693,Work&Family-Modern Eur,Boyd,Sarah Fishman,13,12,2,0,1,0,0,3.203
+Spring 2023,HIST,3380,1,23695,World Civ Since 1500,Bhattacharya,Nandini Saradindu,16,28,12,2,0,0,2,3.011
+Spring 2023,HIST,3381,1,23696,African Civilizations To 1750,Klieman,Kairn,14,2,2,0,2,0,0,3.201
+Spring 2023,HIST,4340,2,23699,Philosophies of History,Howard,Philip,4,3,3,1,2,0,2,2.462
+Spring 2023,HIST,4340,3,23700,Philosophies of History,Mizelle Jr,Richard M,10,0,0,0,1,0,2,3.576
+Spring 2023,HIST,4340,4,23701,Philosophies of History,Chakrabarti,Pratik,6,4,0,0,1,0,0,3.333
+Spring 2023,HIST,4371,1,23702,Latin American Hist Thru Film,Milanesio,Natalia,22,24,6,8,8,0,0,2.608
+Spring 2023,HIST,4376,1,23703,Revolutionary Cuba,Howard,Philip,3,3,2,1,1,0,2,2.468
+Spring 2023,HIST,4395,1,23704,Sel Tops-European Hist,Golubev,Alexey Valeryevich,7,2,1,0,0,0,0,3.468
+Spring 2023,HIST,6312,1,23705,Mod Latin Am Historiography,Hernandez,Jose A,3,0,0,0,0,0,0,3.78
+Spring 2023,HIST,6351,1,23706,The Professional Historian,Chery,Tshepo Morongwa,10,0,0,0,0,0,0,3.835
+Spring 2023,HIST,6382,1,23707,Research in Public History,Perales,Monica,3,0,0,0,0,0,0,4.0
+Spring 2023,HIST,6393,1,23708,Rdgs Seminar in US History,Rector,Josiah John,6,0,0,0,0,0,0,4.0
+Spring 2023,HIST,6398,1,23709,Special Problems,Howard,Philip,1,0,0,0,0,0,0,3.67
+Spring 2023,HIST,2368,2,23710,Intro to African Studies,Klieman,Kairn,11,11,8,5,3,0,2,2.501
+Spring 2023,STAT,3331,2,23749,Statistical Anal Bus Appl I,Wiley,Briceon C,156,121,59,32,6,0,22,2.998
+Spring 2023,CUIN,7355,1,23780,Team & Org Leadership,Hausmann,Robert Carl,9,0,0,0,0,0,0,4.0
+Spring 2023,LAW,5342,3,23789,Prof Writing Strategies,Warren,Jill,4,6,0,0,0,0,0,3.4
+Spring 2023,HIST,1301,50,23809,The U.S. to 1877,Vale,Timothy Eli,28,0,0,0,0,0,0,3.976
+Spring 2023,LAW,6321,3,23815,Professional Responsibility,Knake,Renee N,15,25,0,0,0,0,0,3.383
+Spring 2023,LAW,6321,4,23818,Professional Responsibility,Davis,Megan Leigh-Wilson,11,18,0,0,0,0,0,3.322
+Spring 2023,ARTS,3313,3,23828,Silkscreen,Gates,Elizabeth Ann,14,0,0,0,0,0,0,4.0
+Spring 2023,LAW,6369,8,23830,Legal Analysis and Writing,Benford Wilson,Myrlintha Patrice,0,0,0,0,0,7,0,
+Spring 2023,ARTS,3315,1,23831,Monoprint/Monotype Printmaking,Masterson,Patrick D,12,0,0,0,0,0,0,4.0
+Spring 2023,LAW,5116,1,23835,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,18,0,
+Spring 2023,LAW,5117,1,23837,Advocacy Board TWO,Lawrence,Jim E,0,0,0,0,0,8,0,
+Spring 2023,LAW,5125,1,23843,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,19,0,
+Spring 2023,LAW,5128,1,23845,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,59,0,
+Spring 2023,LAW,5129,1,23847,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,32,0,
+Spring 2023,LAW,5130,1,23851,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,40,0,
+Spring 2023,HON,4397,2,23854,Honors Selected Topics,Mohan,Chandra,10,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,7310,3,23855,Printmaking Studio,Masterson,Patrick D,4,0,0,0,0,0,0,4.0
+Spring 2023,LAW,5397,2,23867,Selected Topics,Marquez,Ryan Michael,1,1,0,0,0,0,0,3.5
+Spring 2023,ARTS,6397,1,23869,Sel Topics/Studio Arts,Duron-Larson,Angela Marie,1,0,0,0,0,0,0,4.0
+Spring 2023,BZAN,7320,5,23870,Bus Modeling For Comp Adv,Murray,Michael J,2,1,1,0,0,0,2,3.168
+Spring 2023,LAW,5297,3,23874,Selected Topics,Weems,Christine,4,7,0,0,0,0,0,3.304
+Spring 2023,LAW,5297,4,23875,Selected Topics,Laughton,Adam,3,8,1,0,0,0,0,3.304
+Spring 2023,LAW,5297,5,23876,Selected Topics,Gratz,Andrew,2,8,0,0,0,0,0,3.365
+Spring 2023,LAW,5297,6,23877,Selected Topics,Ewer,Michael S,2,4,0,0,0,0,0,3.388
+Spring 2023,LAW,5297,7,23879,Selected Topics,Martin,Scott Andrew,6,6,1,0,0,0,0,3.385
+Spring 2023,LAW,5397,3,23880,Selected Topics,Marquez,Jason R,0,1,0,0,0,0,0,3.33
+Spring 2023,LAW,5397,5,23882,Selected Topics,Hoffman,Lonny,6,5,1,0,0,7,0,3.389
+Spring 2023,LAW,5397,6,23883,Selected Topics,Hanson,Lawrence W,3,8,0,0,0,0,0,3.303
+Spring 2023,LAW,5397,7,23884,Selected Topics,Trujillo,Elizabeth I,1,6,0,0,0,0,0,3.19
+Spring 2023,LAW,5397,8,23885,Selected Topics,Moulton,Cynthia,5,6,0,0,0,4,0,3.395
+Spring 2023,LAW,5397,9,23886,Selected Topics,Booth,Kelly Dingle,6,4,1,0,0,4,0,3.395
+Spring 2023,POLC,3322,1,23887,Public Policy Analysis,Heller,Blake Harrison,7,4,0,0,0,0,0,3.516
+Spring 2023,LAW,5397,10,23888,Selected Topics,Alonso,Yocel,2,2,0,0,0,2,0,3.418
+Spring 2023,LAW,7341,1,23889,WRS: Modern Corporation,Nelson,James D,3,6,0,0,0,0,1,3.37
+Spring 2023,LAW,7397,1,23890,Selected Topics,Cardenas Garcia,Julian Jose,5,5,0,0,0,0,0,3.467
+Spring 2023,LAW,7397,2,23891,Selected Topics,Salib,Peter,4,8,0,0,0,0,0,3.388
+Spring 2023,LAW,7397,3,23893,Selected Topics,Guggenberger,Nikolas,6,6,0,0,0,0,0,3.363
+Spring 2023,LAW,7397,4,23894,Selected Topics,Dow,David R,5,7,0,0,0,0,0,3.389
+Spring 2023,LAW,7318,1,23896,WRS: Corp Criminal Liability,Gilchrist,Gregory,7,4,1,0,0,0,0,3.363
+Spring 2023,LAW,5471,1,23901,Street Law II,Cohen,Lisa Elaine,2,4,0,0,0,0,0,3.388
+Spring 2023,POLC,6397,4,23903,Selected Topics in Pub Policy,Gottlieb,Jessica Anne,10,4,1,0,0,0,0,3.49
+Spring 2023,LAW,5497,2,23905,Selected Topics,Marquez,Jason R,1,0,0,0,0,0,0,3.67
+Spring 2023,LAW,5497,3,23906,Selected Topics,Krasny,Frederick A,1,1,0,0,0,0,0,3.5
+Spring 2023,LAW,5497,4,23907,Selected Topics,Marquez,Ryan Michael,1,0,0,0,0,1,0,3.67
+Spring 2023,LAW,5204,1,23911,Commercial Finance Transaction,Ransom,Robert Todd,4,9,0,0,0,0,0,3.384
+Spring 2023,LAW,5352,1,23913,Corporate Taxation,Wells,Douglas,10,12,0,0,0,6,1,3.38
+Spring 2023,LAW,5341,1,23915,Disabilities and the Law,Roberts,Jessica,7,15,0,0,0,1,0,3.393
+Spring 2023,LAW,5214,1,23916,Elder Law,Abshire,Molly,3,4,2,0,0,4,0,3.184
+Spring 2023,LAW,5244,1,23919,Employee Benefits & Compen,Benskin,Krisa Renee,6,2,0,0,0,1,0,3.668
+Spring 2023,INAR,2501,3,23921,Interior Arch Design Studio IV,Rodriguez Fernandez,Marta,5,0,0,0,0,0,0,3.868
+Spring 2023,ELCS,8360,1,23924,Studies Post Secondary Educatn,Hernandez,Belkis Pamela,6,0,0,0,0,0,0,3.835
+Spring 2023,LAW,5343,1,23926,Employment Law,Swift,Kenneth Richard,14,15,2,0,0,0,0,3.387
+Spring 2023,LAW,5384,1,23933,Endangered Species and Bio,Irvine,Charles W,7,9,0,0,0,0,0,3.376
+Spring 2023,LAW,5101,1,23935,Health Law Research,Lawson,Emily Woolard,3,6,0,0,0,2,0,3.37
+Spring 2023,LAW,5225,1,23937,Financial Products Taxation,Gupta,Ajay,2,5,0,0,0,0,0,3.333
+Spring 2023,LAW,5369,1,23939,Insurance,Chandler,Seth J,3,11,0,0,0,0,0,3.379
+Spring 2023,SAER,8320,1,23940,Ethnog Mthds Educ,Louis,Dave A,14,1,0,0,0,0,0,3.933
+Spring 2023,LAW,5360,1,23942,Licensing and Tech Transfer,Janicke,Paul,13,12,1,0,0,0,0,3.411
+Spring 2023,LAW,5223,1,23957,Post-Mortem Estate Planning,Borrett,Carmen Christine,2,2,0,0,0,0,0,3.5
+Spring 2023,LAW,5234,1,23958,Shale Gas and LNG,Sakmar,Susan Lynn,1,5,0,0,0,2,0,3.332
+Spring 2023,LAW,6307,1,23959,Sports Law,Cooper,Brian Michael,10,15,0,0,0,0,0,3.387
+Spring 2023,LAW,5293,1,23960,Tax Fraud/Money Laundering,Campagna,Larry A,4,3,3,0,0,0,1,3.034
+Spring 2023,LAW,6373,1,23961,Tax Policy,Sheffrin,Steven M,5,7,0,0,0,1,0,3.444
+Spring 2023,LAW,6336,1,23963,The Law and Theology,Buckles,Johnny R,6,11,0,0,0,9,0,3.392
+Spring 2023,LAW,5317,1,23964,Trademark/Unfair Competition,Gebru,Aman K,9,22,2,0,0,7,0,3.212
+Spring 2023,LAW,5397,11,23965,Selected Topics,Koch,Valerie Gutmann,4,6,0,0,0,0,0,3.334
+Spring 2023,LAW,7317,1,23966,WRC: Federal Pretrial Drafting,Brem,Katherine B,4,6,1,0,0,1,0,3.363
+Spring 2023,HLT,3306,2,23970,Environmental Health,Behjat,Amirmohsen,6,5,1,1,1,0,0,2.953
+Spring 2023,COMM,4368,2,24031,Public Relations Campaigns,Reyna,Isidro Ray,12,3,3,0,1,0,0,3.281
+Spring 2023,COMM,4389,1,24038,Media for Social Justice,Harlow,Summer D,7,2,2,0,0,0,0,3.395
+Spring 2023,COMM,4397,1,24039,Selected Topics Communication,Newlin,Julye G,10,7,0,0,0,0,2,3.705
+Spring 2023,ENGL,6367,1,24040,19th-C Amer Lit,Berger,Jason,9,1,0,0,0,0,1,3.801
+Spring 2023,HLT,1353,5,24041,Personal Health,Shamblin,Angel Ann,100,16,2,0,1,0,0,3.79
+Spring 2023,PSYC,3334,1,24047,Psychology & Law,Arroyo-Miranda,Mirna Luz,37,3,1,1,1,0,0,3.675
+Spring 2023,PSYC,3338,1,24049,Psychology of Older Adults,Ochoa Lopez,Andrea Pilar,55,11,4,2,2,0,2,3.545
+Spring 2023,HLT,3300,2,24051,Social Health and Wellness,Farmer,Jennifer,66,21,5,4,3,0,0,3.384
+Spring 2023,PSYC,6334,1,24058,Foundations of Health Psyc,Atherton,Olivia Emile,6,1,0,0,0,0,0,3.857
+Spring 2023,PSYC,8397,1,24062,Selected Topics in Psychology,Damian,Rodica Ioana,7,0,0,0,0,0,0,4.0
+Spring 2023,HLT,4397,1,24063,Selected Topics in Health,Drenner,Kelli Linn,17,2,1,0,0,0,5,3.817
+Spring 2023,PSYC,6397,3,24064,Sel Top in Psychology,Woods,Steven Paul,9,1,0,0,0,0,0,3.9
+Spring 2023,COMM,4397,2,24065,Selected Topics Communication,Trupiano,Jerome,24,0,1,0,0,0,0,3.92
+Spring 2023,PHLS,8320,1,24066,Statistical Survival Analysis,Kim,Han Joe,7,1,0,0,0,0,1,3.834
+Spring 2023,PHLS,8311,1,24067,Educational Disparities,Master,Allison,2,0,0,0,0,0,0,4.0
+Spring 2023,COMM,4397,3,24068,Selected Topics Communication,Grossman,Michael,27,1,0,0,0,0,1,3.976
+Spring 2023,AAS,3375,1,24077,Black Women in U.S. Society,Green,Tara T,4,7,1,1,1,0,2,2.857
+Spring 2023,ARCH,7600,1,24078,Architecture Design Studio V,Race,Bruce Alan,1,0,0,0,0,0,0,3.67
+Spring 2023,AAS,3394,1,24085,Selected Topics Afr Am Stdy,Langa,Neema Michael,3,2,0,1,3,0,0,2.038
+Spring 2023,POLS,3388,1,24109,Politics in Film/Television,Davis,Sharon M,16,5,1,1,0,0,1,3.565
+Spring 2023,GOVT,2305,6,24110,"US Govt: Congress,Pres & Crts",Cortina,Jeronimo,67,66,33,9,16,0,6,2.817
+Spring 2023,GOVT,2305,7,24111,"US Govt: Congress,Pres & Crts",Cortina,Jeronimo,30,33,13,8,4,0,2,2.856
+Spring 2023,GOVT,2305,10,24112,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,57,92,42,13,4,0,8,2.872
+Spring 2023,GOVT,2306,15,24114,US and Texas Const/Politics,Sisman,Ozlem,55,27,5,5,4,0,4,3.226
+Spring 2023,GOVT,2306,18,24115,US and Texas Const/Politics,Littlepage,Kelley G,26,59,42,17,16,0,0,2.377
+Spring 2023,GOVT,2306,11,24118,US and Texas Const/Politics,Littlepage,Kelley G,11,12,3,1,7,0,1,2.559
+Spring 2023,GOVT,2306,13,24119,US and Texas Const/Politics,Marcinek,Elizabeth Nicole Simas,36,47,30,11,5,0,8,2.765
+Spring 2023,GOVT,2306,14,24120,US and Texas Const/Politics,Cooper,Carol B,26,29,26,8,7,0,1,2.611
+Spring 2023,POLS,3312,2,24121,"Arguments, Data, Politics",Karimov,Samad,9,8,5,3,5,0,4,2.422
+Spring 2023,POLS,3312,4,24122,"Arguments, Data, Politics",Marinov,Nikolay,11,10,8,1,2,0,3,2.844
+Spring 2023,POLS,3396,1,24124,Sel Topics Comp Internatl Pol,Jung,Jae Hee,11,0,0,0,0,0,0,3.97
+Spring 2023,POLS,3395,1,24125,Selected Topics Am Gov,Sims,Nancy Lou,19,9,0,0,1,0,1,3.552
+Spring 2023,POLS,4348,1,24126,Cont. Islam Political Thought,Contractor,Cyrus Ali,8,3,0,0,0,0,0,3.757
+Spring 2023,POLS,3391,1,24127,Political Scandals,Basinger,Scott J,30,10,3,0,1,0,1,3.515
+Spring 2023,POLS,3351,1,24128,Law in Literature and Film,Jackson,Jerald W,28,12,3,0,0,0,2,3.566
+Spring 2023,POLS,3365,1,24129,"Polls, Public Opinion, Democra",Jenke,Elizabeth,9,6,4,0,1,0,0,3.084
+Spring 2023,POLS,3397,1,24131,Selected Topics in Public Law,Badas,Alex,2,2,5,2,0,0,1,2.424
+Spring 2023,POLS,3397,2,24132,Selected Topics in Public Law,Kennedy,Ryan P,9,4,1,0,0,0,4,3.524
+Spring 2023,POLS,3341,1,24133,Foundations of Modern Pols,Vassiliou,Constantine,9,6,2,0,2,0,1,2.948
+Spring 2023,POLS,3360,1,24134,Politics & Mass Media,Archer,Allison Michelle Nam,15,13,3,1,4,0,1,2.935
+Spring 2023,POLS,3384,1,24135,Morality and Politics,Clifford,Scott,8,6,4,0,0,0,1,3.186
+Spring 2023,HLT,3304,2,24136,Child and Adolescent Health,Farmer,Jennifer,42,10,2,0,1,0,0,3.673
+Spring 2023,PHLS,8339,1,24137,Sem in Career Coun,Allan,Blake A,8,1,0,0,0,0,0,3.779
+Spring 2023,PHLS,8337,1,24138,Multicul Iss Coun Psych,Allan,Blake A,5,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,7330,1,24139,Adv Thrys of Counseling,Arbona,Consuelo,9,0,0,0,0,0,0,3.963
+Spring 2023,POLS,3386,1,24140,Criminal Law,Abbott Jr,Kenneth Wayne,33,8,0,0,0,0,2,3.732
+Spring 2023,POLS,3397,3,24141,Selected Topics in Public Law,Tiede,Lydia B,10,0,0,0,0,0,0,4.0
+Spring 2023,HLT,3325,3,24142,Medical Terminology,Burk,Kelly Ann,133,12,3,0,0,0,2,3.829
+Spring 2023,HRD,6304,30,24152,Research in Human Resource Dev,Kjerfve,Tania M,2,1,0,0,0,0,0,3.777
+Spring 2023,ARCH,3311,1,24155,Topics in Design History,Binboga,Secil,8,1,0,0,0,0,0,3.816
+Spring 2023,CHEE,6332,1,24156,Math Methods in Chem Engr II,Balakotaiah,Vemuri,9,0,0,0,0,0,1,3.89
+Spring 2023,CHEE,6300,1,24157,Physics & Chem Engr Material,Donnelly,Vincent M,11,3,0,0,0,0,0,3.644
+Spring 2023,CHEE,7397,1,24158,Selected Topics,Bollini,Praveen P,12,0,0,0,0,0,1,3.945
+Spring 2023,ARCH,3311,2,24190,Topics in Design History,Kubo,Michael,7,1,0,0,0,0,0,3.628
+Spring 2023,ARCH,6311,2,24192,Topics in Design History,Kubo,Michael,2,0,0,0,0,0,0,3.835
+Spring 2023,ARCH,3311,3,24193,Topics in Design History,Ramaswamy,Deepa,12,4,0,0,0,0,0,3.544
+Spring 2023,ARCH,3391,1,24199,Preservation of 20th Cent Arch,Brune,Geoffrey,7,2,2,0,0,0,0,3.335
+Spring 2023,ARCH,3397,3,24217,Selected Topics,Adams,Vera A,2,3,0,0,0,0,0,3.466
+Spring 2023,ARCH,3397,4,24218,Selected Topics,Adams,Vera A,1,2,3,0,1,0,0,2.286
+Spring 2023,ARCH,3397,5,24219,Selected Topics,Truitt,William C,7,2,0,0,1,0,1,3.4
+Spring 2023,ARCH,6397,4,24221,Sel Tpcs-Arc/Urbn Desgn,Adams,Vera A,0,0,1,0,0,0,0,2.0
+Spring 2023,ARCH,6397,5,24222,Sel Tpcs-Arc/Urbn Desgn,Truitt,William C,2,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,3363,3,24223,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,0,0,0,0,1,0,1,0.0
+Spring 2023,POLS,6312,1,24224,Institutions and Policy,Zhu,Ling,10,1,0,0,0,0,0,3.849
+Spring 2023,CHEE,5377,1,24229,Intro To Polymer Science,Robertson,Megan L,4,5,0,0,0,0,0,3.444
+Spring 2023,CHEE,6368,1,24231,Chemical Process Economics I,Singhania,Ravi,5,2,0,0,0,0,0,3.573
+Spring 2023,ANTH,3396,2,24234,Selected Tops in Cultural Anth,Picozza,Fiorenza,20,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3311,4,24236,Topics in Design History,Ramirez,Enrique,15,2,1,0,0,0,0,3.686
+Spring 2023,GHL,2155,1,24237,Event Implementation,Haskell,Rebecca Erin,33,0,0,0,2,0,1,3.743
+Spring 2023,GHL,3197,1,24238,Selected Topics in Hospitality,Cheatham,Cathy A,10,1,0,0,0,0,0,3.879
+Spring 2023,GHL,4310,1,24239,Entrepreneurship in Hosp Ind,Kim,Jaewook,2,3,1,0,0,0,0,3.222
+Spring 2023,GHL,4346,1,24240,Texas Wine and Food Experience,Taylor,David C,10,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6311,4,24241,Topics in Design History,Ramirez,Enrique,0,1,1,0,0,0,0,2.5
+Spring 2023,GHL,4397,2,24243,Selected Topics Hosp Mgt,Doudna,Simone P,3,2,1,2,0,0,1,2.874
+Spring 2023,GHL,6197,1,24252,Selected Topics,Padilla,Magdalena Manzano,10,0,0,0,0,0,0,3.967
+Spring 2023,GHL,8188,1,24255,Ph.D. Colloquium,Back,KiJoon,0,0,0,0,0,7,0,
+Spring 2023,GHL,8320,1,24256,Guided Research in Hosp. Ind.,Legendre,Jungyoung Shin,7,0,0,0,0,0,0,4.0
+Spring 2023,GHL,8999,1,24257,Dissertation III in Hosp Admin,Back,KiJoon,0,0,0,0,0,1,0,
+Spring 2023,GHL,8999,2,24258,Dissertation III in Hosp Admin,Legendre,Jungyoung Shin,0,0,0,0,0,1,0,
+Spring 2023,GHL,8999,3,24259,Dissertation III in Hosp Admin,Guchait,Priyanko,0,0,0,0,0,1,0,
+Spring 2023,GHL,6397,2,24261,Selected Topics,Kim,Jaewook,6,1,0,0,0,0,0,3.857
+Spring 2023,GHL,6397,3,24262,Selected Topics,Doudna,Simone P,5,1,1,0,0,0,1,3.571
+Spring 2023,GHL,6397,4,24263,Selected Topics,Taylor,David C,2,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,2384,1,24269,Baroque Art,Nevitt Jr,Hugh R,17,7,0,0,0,0,1,3.708
+Spring 2023,LAW,5128,2,24270,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,2,0,
+Spring 2023,LAW,5130,2,24272,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,1,0,
+Spring 2023,ARTH,3336,1,24273,"Contemporary Art, 1960s-1980s",Lee,Kyoung Yong,3,23,15,7,6,0,4,2.149
+Spring 2023,BUSI,4350,12,24274,Business Law and Ethics,Williams,John M,136,20,2,2,3,0,9,3.653
+Spring 2023,MANA,6A32,5,24276,Organizational Behavior & Mgt,Witt,Lawrence A,11,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6197,2,24277,Selected Topics,Cheatham,Cathy A,3,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,4394,1,24287,Sel Tops in Art History,Zalman,Sandra,3,2,1,0,0,0,0,3.278
+Spring 2023,ARTH,6394,1,24291,Sel Top in Art History,Zalman,Sandra,7,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,3302,1,24304,Contemporary Art Criticism,Rubinstein,Raphael,5,3,0,0,0,0,0,3.543
+Spring 2023,ARTH,6302,1,24305,Contemporary Art Criticism,Rubinstein,Raphael,6,0,0,0,0,0,0,3.945
+Spring 2023,ARTH,4394,2,24311,Sel Tops in Art History,Lee,Kyoung Yong,3,3,2,0,1,0,1,2.851
+Spring 2023,SOC,3315,2,24336,Sexuality and Society,Baumle,Amanda K,20,16,6,5,2,0,1,2.912
+Spring 2023,GHL,6381,1,24348,Strategic Decisions in Hosp.,DeFranco,Agnes L,6,1,0,0,0,0,0,3.857
+Spring 2023,PSYC,7397,4,24353,Selected Topics in Psychology,Vujanovic,Anka Anna,0,0,0,0,0,6,0,
+Spring 2023,PSYC,7397,5,24354,Selected Topics in Psychology,Cirino,Paul,0,0,0,0,0,4,0,
+Spring 2023,ARCH,3397,6,24356,Selected Topics,Rifaat,Shafik I,8,4,0,0,0,0,0,3.667
+Spring 2023,GEOL,6398,1,24363,Special Problems,Jiang,Xun,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,6376,1,24372,Cloud Computing,Yan,Feng,46,1,0,0,1,0,0,3.882
+Spring 2023,ARTS,3300,3,24375,Advanced Drawing,Safaitakhtehfooladi,Farima,20,0,0,0,2,0,0,3.621
+Spring 2023,POLS,3368,1,24381,"Race,Gender & Ethnic Politics",Raychaudhuri,Tanika,20,11,5,0,2,0,0,3.193
+Spring 2023,SPEC,8695,1,24428,Doctoral Thesis,Santi,Kristi L,2,1,0,0,0,0,1,3.557
+Spring 2023,SPEC,8695,2,24429,Doctoral Thesis,Hawkins,Jacqueline McLean,2,0,0,0,0,0,0,4.0
+Spring 2023,ARLD,6371,1,24431,Museum Programming,Veneman,Katherine A,5,0,0,0,0,0,0,4.0
+Spring 2023,ARLD,6372,1,24434,Museum Education,Lee,Jhih-yin Diane,4,1,0,0,0,0,0,3.8
+Spring 2023,SPEC,8395,2,24436,Doctoral Thesis,Hawkins,Jacqueline McLean,1,0,0,0,0,0,0,4.0
+Spring 2023,ARLD,6381,1,24437,Arts and Health in Practice,Townsend,Jennifer Dawn,4,0,0,0,0,0,0,3.835
+Spring 2023,SPEC,6396,1,24438,Clinical Teaching II,Culpepper,Shea Mosley,0,0,0,0,0,1,0,
+Spring 2023,ARLD,6398,1,24445,Special Prob in Arts Leadrshp,Fernando,Fleurette S,5,0,0,0,0,0,0,4.0
+Spring 2023,COSC,4377,1,24490,Intro To Computer Networks,Long,Kevin B,46,130,15,0,1,0,3,3.154
+Spring 2023,MUED,2342,1,24491,Music for Children,McGinnis,Emily Jane,17,2,1,1,0,0,0,3.667
+Spring 2023,ARCH,6397,6,24509,Sel Tpcs-Arc/Urbn Desgn,Bell,Larry S,5,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3397,7,24513,Selected Topics,Bell,Larry S,13,1,0,0,0,0,0,3.858
+Spring 2023,BZAN,6360,1,24525,Capstone Practicum in BZAN I,Aron,Ravi,11,0,0,0,0,0,0,4.0
+Spring 2023,BZAN,6361,1,24528,Capstone Practicum in BZAN II,Aron,Ravi,34,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3397,8,24531,Selected Topics,Mantz,Ophelia,3,5,0,0,0,0,0,3.086
+Spring 2023,MIS,3371,2,24533,Transaction Processing Sys I,Messinger,Jacob Nelson,8,4,3,0,0,0,2,3.267
+Spring 2023,ARCH,6397,7,24536,Sel Tpcs-Arc/Urbn Desgn,Mantz,Ophelia,1,1,0,0,0,0,0,3.5
+Spring 2023,MIS,7374,1,24542,Bus Appls Database Mgt Sys II,Scamell,Richard W,2,0,0,0,0,0,0,3.835
+Spring 2023,DANC,1247,1,24549,Jazz I,Bobet,Jacqueline A,4,1,0,0,0,0,0,3.734
+Spring 2023,MIS,7397,4,24563,Selected Topics in MIS,Campbell,Phillip James,8,2,0,0,0,0,0,3.701
+Spring 2023,FINA,7A10,2,24575,Valuation,Liu,Zesong,14,6,1,1,0,0,0,3.41
+Spring 2023,FINA,7A10,3,24579,Valuation,Liu,Zesong,13,6,6,0,0,0,0,3.254
+Spring 2023,FINA,4330,6,24580,Corporate Finance,Liu,Zesong,15,18,8,0,0,0,3,3.211
+Spring 2023,DANC,4197,1,24582,Selected Topics,Valle,Toni Leago,10,3,1,0,0,0,1,3.643
+Spring 2023,DANC,4197,2,24583,Selected Topics,Estrada,Maria Gabriela,4,0,0,0,0,0,0,3.918
+Spring 2023,ARCH,4397,1,24584,Selected Topics,Race,Bruce Alan,5,2,1,0,0,0,0,3.418
+Spring 2023,ARCH,6397,9,24585,Sel Tpcs-Arc/Urbn Desgn,Race,Bruce Alan,1,2,0,0,0,0,0,3.553
+Spring 2023,FINA,7397,1,24586,Selected Topics in Finance,Smith III,Edwin A,2,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,6395,1,24589,Topics-Lang&Linguistics,Sisk,Christina L,7,3,0,0,0,0,0,3.733
+Spring 2023,FINA,4397,1,24590,Selected Topics in Finance,Smith III,Edwin A,2,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,6395,2,24591,Topics-Lang&Linguistics,Lopez Otero,Julio Cesar,8,1,0,0,0,0,0,3.816
+Spring 2023,FINA,4397,2,24592,Selected Topics in Finance,Pena,Juan F,75,17,3,4,2,0,2,3.584
+Spring 2023,SPAN,6345,1,24594,Las Mujeres Reescriben America,Ventura,Gabriela Baeza,5,1,1,0,0,0,0,3.477
+Spring 2023,FINA,4397,3,24595,Selected Topics in Finance,Stewart,Marcus,8,9,1,0,0,0,1,3.371
+Spring 2023,FINA,7A97,1,24596,Selected Topics in Finance,Shoss,Robert L,37,0,0,0,0,0,0,3.991
+Spring 2023,SPAN,6389,1,24597,Method Teach Span Heritage Lrn,Fairclough,Marta A,17,2,0,0,0,0,0,3.86
+Spring 2023,FINA,7A97,2,24598,Selected Topics in Finance,Shoss,Robert L,16,1,0,0,0,0,1,3.941
+Spring 2023,FINA,8397,1,24599,Selected Topics in Finance,Pirrong,Stephen Craig,2,0,0,0,0,0,0,3.67
+Spring 2023,FINA,8397,2,24600,Selected Topics in Finance,Susmel,Raul,7,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8397,3,24601,Selected Topics in Finance,Kumar,Praveen,2,0,0,0,0,0,0,3.67
+Spring 2023,ARCH,3311,5,24630,Topics in Design History,Diehl,Tom,5,10,3,0,0,0,0,3.038
+Spring 2023,ARTS,4397,1,24655,Sel Topics in Fine Arts,Litos,Joshua David,17,0,0,0,0,0,0,3.942
+Spring 2023,ARTS,6397,2,24659,Sel Topics/Studio Arts,Litos,Joshua David,3,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,4397,2,24668,Sel Topics in Fine Arts,Stern,Lindsey Rose,15,0,0,0,0,0,1,4.0
+Spring 2023,ARTS,6397,3,24669,Sel Topics/Studio Arts,Stern,Lindsey Rose,1,1,0,0,0,0,0,3.665
+Spring 2023,INAR,3112,1,24679,Topics in Design Media,Jacobs,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3112,2,24696,Topics in Design Media,Jackson,Megan H,3,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,3394,1,24700,Sel Tops in Art History,Sicinski,Michael J,11,3,1,1,1,0,1,3.197
+Spring 2023,ARTH,6394,3,24701,Sel Top in Art History,Sicinski,Michael J,2,0,0,0,0,0,0,3.835
+Spring 2023,IART,3395,1,24702,Sel Topics in Interdis Arts,Reed,John G,0,0,1,0,0,0,2,2.33
+Spring 2023,ARTS,6397,4,24708,Sel Topics/Studio Arts,Cone,Marcus Andrew,2,0,0,0,0,0,0,4.0
+Spring 2023,IART,6395,1,24710,Sel Topics in Interdiscip Arts,Cone,Marcus Andrew,1,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,2301,12,24711,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,25,40,16,5,7,0,7,2.856
+Spring 2023,ACCT,2301,14,24713,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,23,21,8,4,4,0,8,2.983
+Spring 2023,ARTS,3396,1,24722,Selected Tops Studio Practice,Chacin,Aisen Carolina,12,2,0,0,0,0,0,3.81
+Spring 2023,ARTS,6397,5,24723,Sel Topics/Studio Arts,Chacin,Aisen Carolina,1,0,0,0,0,0,0,4.0
+Spring 2023,IART,3395,3,24724,Sel Topics in Interdis Arts,Chacin,Aisen Carolina,0,1,0,0,0,0,0,3.0
+Spring 2023,ACCT,3368,5,24730,Intermediate Accounting II,Sun,Xue,6,22,11,0,0,0,1,2.889
+Spring 2023,ARCH,3312,2,24744,Topics in Design Media,Noldt,Peter,5,4,1,1,0,0,0,3.032
+Spring 2023,ARTS,3358,1,24756,Clay Processes,Mayer,Anna W,13,3,0,0,0,0,0,3.751
+Spring 2023,ARTS,6396,1,24759,Sel Topics in Fine Arts Media,Giampietro,Francis A,5,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3112,3,24760,Topics in Design Media,Jackson,Megan H,1,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3112,4,24761,Topics in Design Media,Noldt,Peter,4,0,0,0,0,0,0,3.835
+Spring 2023,INAR,3112,5,24762,Topics in Design Media,Noldt,Peter,2,1,0,0,0,0,0,3.447
+Spring 2023,INAR,3112,6,24763,Topics in Design Media,Noldt,Peter,1,0,0,0,0,0,0,3.67
+Spring 2023,THEA,4397,1,24765,Drama Workshop,Coen,Elizabeth Manya,5,1,1,0,0,0,0,3.43
+Spring 2023,THEA,4693,1,24766,Stage Management Internship,Bush,Rachel R,0,0,0,0,0,1,0,
+Spring 2023,THEA,6389,1,24767,Textile & Couture Techniques,Niederer,Barbara,3,0,0,0,0,0,0,4.0
+Spring 2023,THEA,6396,1,24768,Selected Topics Theatre,Coen,Elizabeth Manya,4,0,0,0,0,0,0,4.0
+Spring 2023,THEA,6398,1,24769,Independent Study,Vlahos,Kalliope,1,0,0,0,0,0,0,3.67
+Spring 2023,ACCT,7320,2,24771,Intro to Data Analytics-Acct,Miles,Carolyn A,13,4,2,1,0,0,0,3.434
+Spring 2023,ACCT,7380,1,24773,Advanced Corporate Taxation,Chen,Xi,17,6,0,0,0,0,0,3.725
+Spring 2023,MUSI,6180,1,24774,Advanced Acting for Opera,Edelson,Lawrence Michael,2,0,0,0,0,0,0,4.0
+Spring 2023,BZAN,6357,1,24818,BZAN-Frameworks & Methods,Ma,Xiao,12,1,0,0,0,0,0,3.872
+Spring 2023,LAW,7297,1,24824,Selected Topics,Dow,David R,5,7,0,0,0,0,0,3.389
+Spring 2023,MUED,8398,1,24853,Research in Music Education,Meals,Cory Dewitt,3,1,0,0,0,0,0,3.668
+Spring 2023,HIST,3339,1,24863,Ancient Greece,Holt,Frank L,18,9,5,1,0,0,1,3.243
+Spring 2023,ARCH,3312,4,24891,Topics in Design Media,Medina Vilela,Mario Andre,0,1,0,1,1,0,1,1.443
+Spring 2023,MUSI,2161,1,24893,French Diction,Suits,Brian J,9,18,3,1,0,0,0,3.097
+Spring 2023,INAR,3312,1,24905,Topics in Design Media,Medina Vilela,Mario Andre,0,0,1,1,0,0,1,1.665
+Spring 2023,MUSI,4197,1,24928,Selected Topics in Music,Suits,Brian J,5,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4363,1,24932,Music - Romantic Period II,Bertagnolli,Paul A,2,1,1,1,2,0,0,1.906
+Spring 2023,MUSI,4380,1,24936,Opera Literature,Caton,Kathryn L.,1,1,0,0,0,0,0,3.5
+Spring 2023,MUSI,6380,1,24937,Opera Literature,Caton,Kathryn L.,9,0,0,1,0,0,0,3.667
+Spring 2023,CIS,6397,5,24938,Selected Topics,Lindner,Peggy,36,0,0,0,0,0,1,4.0
+Spring 2023,MUSI,4397,1,24940,Selected Topics in Music,Guez,Jonathan Charles,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6397,1,24942,Selected Topics-Music,Guez,Jonathan Charles,9,0,0,0,0,0,0,3.927
+Spring 2023,MUSI,4397,2,24944,Selected Topics in Music,Snyder,John L,4,2,0,0,0,0,0,3.722
+Spring 2023,MUSI,6313,1,24945,Intro to Musical Acoustics,Snyder,John L,3,0,1,0,0,0,0,3.418
+Spring 2023,MUSI,6200,2,24958,Accompanying Seminar,Suits,Brian J,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6328,1,24959,Collab Skills for Organists II,Robinson,Daryl Allen,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6363,1,24960,Music-Romantic Period II,Bertagnolli,Paul A,2,4,1,1,0,0,0,2.958
+Spring 2023,MUSI,6397,2,24961,Selected Topics-Music,Maroney,Marcus K,8,1,0,0,0,0,0,3.779
+Spring 2023,MUSI,6397,4,24963,Selected Topics-Music,Koozin,Timothy,9,1,0,0,0,0,0,3.801
+Spring 2023,MUSI,8303,1,24964,Seminar in Music Theory,Koozin,Timothy,6,2,0,0,0,0,0,3.791
+Spring 2023,MUTX,2120,1,24965,Instrument in Clinical Setting,Townsend,Jennifer Dawn,5,0,0,0,0,0,0,3.868
+Spring 2023,COSC,3360,2,24967,Operating Systems,Rincon Castro,Carlos Alberto,38,23,25,3,9,0,28,2.776
+Spring 2023,POLS,6386,1,24968,Measurement Theory,Clark,Jennifer H,14,0,0,0,0,0,0,3.929
+Spring 2023,POLS,6340,1,24969,Ancient and Medieval Thought,Hawley,Michael C,3,0,0,0,0,0,0,3.89
+Spring 2023,POLS,6365,1,24970,Seminar in Public Opinion,Jenke,Elizabeth,9,2,0,0,0,0,0,3.788
+Spring 2023,POLS,6322,1,24971,Comparative Electio,Cantu,Francisco,9,5,0,0,0,0,0,3.549
+Spring 2023,POLS,6395,1,24972,Selected Topics American Pol,Clark,Jennifer H,7,0,0,0,0,0,0,3.859
+Spring 2023,POLS,6360,1,24973,Seminar in State Politics,Shor,Boris,4,0,0,0,0,0,0,3.753
+Spring 2023,HIST,3331,1,24978,Afro-Amer His Snce 1865,Reed,Linda,16,15,2,0,0,0,2,3.544
+Spring 2023,HIST,4389,1,24979,From Blues to Hip Hop World,Reed,Linda,21,3,3,0,3,0,2,3.3
+Spring 2023,INAR,3311,1,24985,Topics in Design History,Binboga,Secil,0,1,1,0,0,0,0,2.5
+Spring 2023,ECON,6394,1,24987,Tpcs-Eco of Socl Issue,Verchenko,Olesia,0,0,0,0,0,0,0,
+Spring 2023,ECON,6394,2,24988,Tpcs-Eco of Socl Issue,Obrizan,Maksym,0,0,0,0,0,0,0,
+Spring 2023,ECON,6394,3,24989,Tpcs-Eco of Socl Issue,Nivievskyi,Oleg,1,5,0,0,0,0,0,3.167
+Spring 2023,PHLS,6370,2,24990,Intro To Cross-Cultural Cslng,McCoy,Leah,8,1,0,0,0,0,0,3.852
+Spring 2023,ECON,6394,5,24992,Tpcs-Eco of Socl Issue,Obrizan,Maksym,0,0,0,0,0,0,0,
+Spring 2023,ECON,6394,6,24993,Tpcs-Eco of Socl Issue,Besedina,Elena,0,0,0,0,0,0,0,
+Spring 2023,ECON,6394,7,24995,Tpcs-Eco of Socl Issue,Besedina,Elena,0,0,0,0,0,0,0,
+Spring 2023,PHLS,7303,2,24996,Internship II,Zatopek,Audrey,0,0,0,0,0,9,0,
+Spring 2023,PHLS,7303,3,24997,Internship II,Smith,Nathaniel Lewis,0,0,0,0,0,11,0,
+Spring 2023,PHLS,7303,4,24998,Internship II,Smith,Nathaniel Lewis,0,0,0,0,0,11,0,
+Spring 2023,PSYC,6371,1,24999,Seminar Personnel Psy,Ng,Vincent,4,2,0,0,0,0,0,3.777
+Spring 2023,ACCT,3377,4,25000,Cost Accounting,Serrato,Darlene Marie  Bohac,8,9,6,5,0,0,4,2.679
+Spring 2023,ACCT,4379,1,25003,Enterprise Risk Management,Neely,Gregory Wayne,7,2,1,0,0,0,0,3.666
+Spring 2023,THEA,6294,2,25005,Design and Production Studio,Vlahos,Kalliope,2,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,6395,3,25009,Topics-Lang&Linguistics,Goodin-Mayeda,Carrie Elizabeth,6,0,0,0,0,0,0,3.945
+Spring 2023,INAR,3112,7,25047,Topics in Design Media,Gonzales,Michael A,1,0,0,0,0,0,0,4.0
+Spring 2023,INDS,3112,2,25048,Topics in Design Media,Gonzales,Michael A,4,0,0,0,0,0,0,4.0
+Spring 2023,INDS,6197,3,25050,Selected Topics,Gonzales,Michael A,1,0,0,0,0,0,0,4.0
+Spring 2023,CNST,2360,1,25051,Communication in Construction,Zerwas,Philip,17,26,3,0,0,0,3,3.304
+Spring 2023,ARTS,3396,2,25062,Selected Tops Studio Practice,Leen,Noah,8,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,5372,2,25071,Intro-Data Analytics in ACCT,Miles,Carolyn A,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6198,17,25077,Special Problems,Jackson,Megan H,1,0,0,0,0,0,1,4.0
+Spring 2023,ARTS,3396,3,25080,Selected Tops Studio Practice,Patzke,Katie,11,1,0,0,0,0,0,3.862
+Spring 2023,INDS,3112,3,25082,Topics in Design Media,Jackson,Megan H,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,3379,2,25099,Introductn to Higher Geometry,George,Rebecca Ann,21,6,0,0,0,0,0,3.766
+Spring 2023,ARTS,4392,1,25152,Sel Top in Contemporary Art,Conrad,Jillian,4,0,0,0,0,0,0,3.918
+Spring 2023,ARTS,6394,1,25154,Sel Tops in Contemporary Art,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Spring 2023,IART,3395,4,25155,Sel Topics in Interdis Arts,Conrad,Jillian,1,0,0,0,0,0,0,4.0
+Spring 2023,IART,6395,2,25156,Sel Topics in Interdiscip Arts,Conrad,Jillian,3,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,4392,2,25159,Sel Top in Contemporary Art,Tuttle,Martha,4,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,6394,2,25160,Sel Tops in Contemporary Art,Tuttle,Martha,7,0,0,0,0,0,0,4.0
+Spring 2023,IART,3395,5,25161,Sel Topics in Interdis Arts,Tuttle,Martha,2,0,0,0,0,0,0,4.0
+Spring 2023,MECE,4398,4,25166,Independent Study,Bering,Edgar A,2,3,1,1,0,0,0,2.857
+Spring 2023,ARCH,3312,5,25167,Topics in Design Media,Smith,Joshua S,3,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3312,3,25169,Topics in Design Media,Smith,Joshua S,1,0,0,0,0,0,0,4.0
+Spring 2023,INDS,3312,3,25170,Topics in Design Media,Smith,Joshua S,2,0,0,0,0,0,0,4.0
+Spring 2023,BTEC,4301,31,25172,Principles of Bioprocessing,Khan,Abdul Latif,16,5,1,0,0,0,0,3.652
+Spring 2023,BTEC,4101,30,25173,Principle of Bioprocessing Lab,Hosseinzadeh,Hemen,13,6,3,0,0,0,0,3.38
+Spring 2023,MARK,7380,1,25177,Advanced Marketing Analytics,Hess,James D,21,2,0,0,1,0,1,3.736
+Spring 2023,ENGL,3340,2,25179,Advanced Composition,Garcia,Sylvia A,11,4,1,0,2,0,0,3.094
+Spring 2023,FINA,7324,1,25180,Inv & Portfolio Mgt Project I,Shoss,Robert L,4,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7325,1,25181,Inv & Portfolio Mgt Project II,Shoss,Robert L,4,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7355,1,25185,Stochas Calc & Comptl Finance,Pirrong,Stephen Craig,4,2,0,0,0,0,1,3.612
+Spring 2023,FINA,7397,2,25186,Selected Topics in Finance,Goudie,Thomas Lawrence,5,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7A97,3,25187,Selected Topics in Finance,Berta,Dom,8,4,0,0,0,0,0,3.584
+Spring 2023,FINA,7380,1,25188,Real Estate Finance,Bruce,Andrew James,4,6,0,0,0,0,1,3.367
+Spring 2023,COMM,4375,1,25189,Propaganda & Mass Comm,Golubev,Alexey Valeryevich,14,2,0,0,2,0,0,3.298
+Spring 2023,INAR,3312,4,25190,Topics in Design Media,Noldt,Peter,2,0,0,0,1,0,1,2.557
+Spring 2023,LAW,5297,9,25194,Selected Topics,Drake,Alyson,9,7,0,0,0,0,0,3.398
+Spring 2023,INDS,3112,7,25195,Topics in Design Media,Jackson,Megan H,1,0,0,0,0,0,0,4.0
+Spring 2023,LAW,5197,1,25196,Selected Topics,Brownell,Robert Bruce Anthony,2,6,0,0,0,1,0,3.456
+Spring 2023,ATP,7297,1,25198,Case Study Prep & Submission,Knoblauch,Mark Alan,15,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3112,9,25199,Topics in Design Media,Jackson,Megan H,3,0,0,0,0,0,0,4.0
+Spring 2023,BTEC,6397,31,25203,Selected Topics in BTEC,Khan,Abdul Latif,1,1,0,0,0,0,0,3.5
+Spring 2023,BTEC,6198,31,25204,Special Problems,Hosseinzadeh,Hemen,1,0,0,0,0,0,0,4.0
+Spring 2023,INDS,3112,9,25205,Topics in Design Media,Noldt,Peter,1,0,0,0,1,0,0,1.835
+Spring 2023,ENGL,3351,2,25210,Am Lit Since 1865,Zachow,Alix V,12,8,5,0,0,0,2,3.306
+Spring 2023,INAR,3112,10,25211,Topics in Design Media,Noldt,Peter,3,0,0,0,0,0,0,3.67
+Spring 2023,PSYC,3347,2,25214,Problems of Normal Life,Anderson,Jill Annette,36,25,7,3,1,0,1,3.241
+Spring 2023,PSYC,3347,3,25215,Problems of Normal Life,Anderson,Jill Annette,41,26,6,1,1,0,0,3.325
+Spring 2023,MIS,4397,5,25221,Selected Topics in MIS,Boren,Patrick,5,6,3,1,0,0,0,3.0
+Spring 2023,MIS,4397,6,25223,Selected Topics in MIS,Eierdam,Richard R,16,6,2,0,0,0,5,3.583
+Spring 2023,MIS,4397,7,25224,Selected Topics in MIS,Gonzalez Jr,Frederick,27,0,0,0,0,0,1,4.0
+Spring 2023,MIS,4397,9,25226,Selected Topics in MIS,Zhao,Keran,28,2,0,0,0,0,0,3.933
+Spring 2023,BTEC,6397,33,25227,Selected Topics in BTEC,Khan,Abdul Latif,9,0,0,0,0,0,0,3.853
+Spring 2023,INAR,3112,12,25228,Topics in Design Media,Noldt,Peter,1,0,0,0,0,0,0,4.0
+Spring 2023,CNST,4397,1,25230,Sel Tops in Construction Mgmt,Din,Zia Ud,1,1,2,2,0,0,0,2.442
+Spring 2023,EGRP,1131,1,25231,Engineering Applications II,Luna Singh,Jennifer Austin,0,0,0,0,0,8,0,
+Spring 2023,MIS,7397,5,25237,Selected Topics in MIS,Boren,Patrick,12,3,0,0,0,0,0,3.8
+Spring 2023,MIS,7397,6,25238,Selected Topics in MIS,Boren,Patrick,10,4,0,0,0,0,1,3.714
+Spring 2023,MIS,7397,7,25240,Selected Topics in MIS,Knighton,William B,4,0,0,0,0,0,0,4.0
+Spring 2023,MIS,7397,8,25241,Selected Topics in MIS,Gonzalez Jr,Frederick,21,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3311,2,25242,Topics in Design History,Kubo,Michael,3,1,0,0,0,0,0,3.503
+Spring 2023,ACCT,4105,2,25245,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,47,2,
+Spring 2023,ACCT,4106,2,25246,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,36,0,
+Spring 2023,ACCT,5379,1,25247,Enterprise Risk Management,Neely,Gregory Wayne,4,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,7362,1,25250,Tax Research,Meade,Janet,4,1,0,0,0,0,0,3.734
+Spring 2023,ACCT,7384,1,25251,Enterprise Risk Management,Neely,Gregory Wayne,11,1,0,0,0,0,0,3.944
+Spring 2023,ACCT,8397,1,25252,Selected Topics in Accounting,Lu,Tong,1,0,0,0,0,0,0,4.0
+Spring 2023,BUSI,4336,1,25253,Consulting-Small Business Need,Bailey-Rihawi,Esther Elizabeth,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7397,3,25254,Selected Topics in Finance,Khumawala,Saleha B,7,1,0,0,0,0,1,3.875
+Spring 2023,FINA,7A97,4,25257,Selected Topics in Finance,Shoss,Robert L,2,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7A97,5,25258,Selected Topics in Finance,Berta,Dom,4,4,0,0,0,0,1,3.624
+Spring 2023,FINA,4397,4,25259,Selected Topics in Finance,Stewart,Marcus,4,2,1,0,0,0,2,3.429
+Spring 2023,FINA,4397,5,25260,Selected Topics in Finance,Goudie,Thomas Lawrence,6,2,0,0,0,0,1,3.75
+Spring 2023,BUSI,4397,2,25261,Selected Topics in GENB,Bean,Gregory S,18,1,0,0,0,0,1,3.947
+Spring 2023,MANA,7397,4,25262,Selected Topics in Management,Vera,Dusya M,23,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,8345,1,25263,Research Methods V,Borja,Sharon G,6,0,0,0,0,0,0,4.0
+Spring 2023,MATH,2415,11,25266,Calculus III,Winkle,James J,57,44,35,21,19,0,27,2.578
+Spring 2023,MECT,6397,1,25272,Selected Topics,Andampour,Iraj,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,3332,7,25274,Prin of Financial Management,Chisholm,Darla,12,11,5,3,0,0,0,2.947
+Spring 2023,MATH,1332,2,25275,Contemporary Mathematics,Weber,Thomas Christian,20,13,7,3,11,0,6,2.5
+Spring 2023,MARK,7397,3,25276,Selected Topics in Marketing,Krishnamurthy,Parthasarathy,15,3,0,0,0,0,0,3.833
+Spring 2023,MARK,7397,4,25277,Selected Topics in Marketing,Krishnamurthy,Parthasarathy,4,1,0,0,0,0,0,3.8
+Spring 2023,MATH,1332,3,25278,Contemporary Mathematics,Ansari,Haseeb E,19,14,16,5,11,0,2,2.38
+Spring 2023,PHIL,3395,3,25279,Selected Topics in Phil,Zaretsky,Robert D,2,2,4,0,0,0,2,2.709
+Spring 2023,CHEM,4336,2,25282,Fundamentl Biochemistry,Cai,Chengzhi,3,7,9,1,0,0,2,2.6
+Spring 2023,PSYC,3339,4,25284,Intro To Clinical Psychology,Healy,Nathaniel Andrew,23,30,19,2,0,0,5,2.911
+Spring 2023,PHAR,5297,1,25285,Selected Topics in Pharmacy,Tolleson,Shane Russell,3,1,0,0,0,0,0,3.75
+Spring 2023,MECE,6365,1,25288,Semiconductor Materials and Ph,Ryou,Jae-Hyun,8,15,2,0,0,0,2,3.293
+Spring 2023,INDS,6397,1,25294,Selected Topics,Kimbrough,Mark S,0,1,0,0,0,0,0,3.0
+Spring 2023,MUSA,4189,1,25301,Senior Recital,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4189,2,25302,Senior Recital,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4189,3,25303,Senior Recital,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,3133,2,25304,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,5,10,0,0,0,0,0,3.443
+Spring 2023,MUSA,3478,1,25305,Applied Jazz Guitar,Wheeler,Michael L,2,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,4311,1,25306,Advances in Vision Research,Naash,Muna,4,4,1,0,0,0,0,3.26
+Spring 2023,BIOE,6311,1,25308,Advances in Vision Research,Naash,Muna,2,2,0,0,0,0,0,3.253
+Spring 2023,CUIN,6319,1,25311,Instr Design & Tech 2nd Lang,Leon,Maredil Josefina,9,1,0,0,0,0,0,3.801
+Spring 2023,PHAR,5297,2,25315,Selected Topics in Pharmacy,Hatfield,Catherine L,4,1,0,0,0,0,0,3.8
+Spring 2023,MATH,7321,1,25318,Functional Analysis,Bodmann,Bernhard G,7,1,1,0,0,0,0,3.63
+Spring 2023,INDE,7397,1,25322,Selected Topics,Xiang,Yisha,11,3,0,0,0,0,0,3.715
+Spring 2023,INDE,7397,2,25323,Selected Topics,Lin PhD,Ying,27,4,0,0,0,0,0,3.754
+Spring 2023,PHIL,3357,2,25324,Punishment,Tierney,Robert Barkley,13,3,3,0,0,0,0,3.422
+Spring 2023,BIOL,4397,4,25328,Selected Topics in Biology,Bering,Edgar A,2,0,0,0,0,0,0,4.0
+Spring 2023,COSC,8698,132,25334,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Spring 2023,COSC,6321,1,25338,Research Methods in COSC,Gnawali,Omprakash D,0,0,0,0,0,26,0,
+Spring 2023,CLAS,6305,1,25343,Fifth-Century Athens,Due Hackney,Casey L,1,0,0,0,0,0,0,4.0
+Spring 2023,FREN,3350,1,25347,Intro to Francophone Lit,Gnanwo Hounfodji,Raymond,7,0,3,0,1,0,0,2.971
+Spring 2023,PSYC,6397,5,25349,Sel Top in Psychology,Kosten,Therese A,6,0,0,0,0,0,0,4.0
+Spring 2023,IART,3395,6,25350,Sel Topics in Interdis Arts,Flynn,Nicholas,3,0,0,0,0,0,0,4.0
+Spring 2023,IART,6395,4,25351,Sel Topics in Interdiscip Arts,Flynn,Nicholas,6,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,6358,1,25355,Terrigenous Depositional Systm,Dupre,William Roark,3,0,0,0,0,0,1,3.67
+Spring 2023,GEOL,6363,1,25356,Carbonate Sedimentalogy,Dravis,Jeffrey James,3,1,0,0,0,0,1,3.503
+Spring 2023,GEOL,6372,2,25357,Petroleum Geochemistry,Van Nieuwenhuise,Donald S,3,1,0,0,0,0,1,3.75
+Spring 2023,GEOL,7323,1,25358,Borehole Geophysics,Stewart,Robert R,1,0,0,0,0,0,0,3.67
+Spring 2023,GEOL,7330,2,25359,Potntl Fld Mtds-Geophys,Bird,Dale E,1,0,0,0,0,0,0,4.0
+Spring 2023,MAS,2340,2,25361,Intro Mexican American Studies,Rodriguez,Andre,10,8,1,0,0,0,0,3.456
+Spring 2023,MUSA,4189,4,25362,Senior Recital,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Spring 2023,SPAN,7395,1,25363,Sel Topics in US Hispanic Lit,Kanellos,Nicolas,10,0,0,0,0,0,0,3.967
+Spring 2023,PSYC,2301,9,25364,Introduction to Psychology,Gehm,Kevan H,22,11,7,0,1,0,1,3.333
+Spring 2023,PSYC,2301,10,25365,Introduction to Psychology,Kim,Jinu,51,11,4,4,7,0,2,3.139
+Spring 2023,WGSS,3322,1,25366,Intersectionalities,Pegoda,Andrew Joseph,9,7,5,0,0,0,6,3.222
+Spring 2023,HIST,1302,26,25367,The U.S. Since 1877,Schafer Jr,James A,113,94,30,5,10,0,12,3.152
+Spring 2023,HIST,2397,3,25368,Selected Topics in History,Hopkins,Kelly Y,5,5,2,0,1,0,0,3.0
+Spring 2023,HIST,3395,3,25369,Sel Top-European Hist,Holt,Frank L,14,9,5,2,1,0,3,3.065
+Spring 2023,MATH,6315,7,25370,Masters Tutorial,He,Jiwen,1,0,0,0,0,0,0,4.0
+Spring 2023,CIS,6326,40,25372,Critical Thinking in Info Sec,Conklin,William A,8,1,0,0,0,0,0,3.889
+Spring 2023,ELET,6318,40,25374,Analysis of Data Networks,Yuan,Xiaojing,1,0,0,0,0,0,0,3.67
+Spring 2023,BTEC,6100,40,25378,Seminar in Biotechnology,Balan,Venkatesh,3,0,0,0,0,0,0,3.89
+Spring 2023,BTEC,6302,40,25379,Intro to Regulatory Affairs,Flavier,Albert B,2,1,0,0,0,0,0,3.447
+Spring 2023,BTEC,6303,40,25380,Protein Engineering Technology,Flavier,Albert B,0,0,1,0,0,0,0,1.67
+Spring 2023,BTEC,6397,40,25381,Selected Topics in BTEC,Khan,Abdul Latif,3,0,0,0,0,0,0,3.78
+Spring 2023,HIST,3309,1,25389,History through Fiction,Zaretsky,Robert D,5,1,1,0,1,0,2,3.125
+Spring 2023,HIST,4395,2,25390,Sel Tops-European Hist,Zaretsky,Robert D,3,1,0,0,0,0,0,3.75
+Spring 2023,HIST,3394,2,25391,Sel Tops-Us History,Pegoda,Andrew Joseph,3,2,3,0,2,0,3,2.367
+Spring 2023,MUSA,1330,3,25394,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,1332,1,25396,Applied Oboe,Dinitz,Adam L,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,1334,3,25398,Applied Clarinet,Potiomkin,Alexander,5,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3400,5,25401,Applied Voice,Evans,Joseph,5,0,0,0,0,0,0,3.934
+Spring 2023,MUSA,3400,7,25402,Applied Voice,Sonnenberg,Melanie,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6300,1,25408,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6300,2,25409,Applied Voice,Evans,Joseph,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6300,3,25410,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6300,4,25411,Applied Voice,Sonnenberg,Melanie,5,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6300,5,25412,Applied Voice,Vasquez,Hector A,3,0,0,0,0,0,0,4.0
+Spring 2023,DIGM,4398,31,25413,Independent Study,Rodwell,Elizabeth Ann,9,0,0,0,0,0,0,4.0
+Spring 2023,ECE,5397,1,25419,Selected Topics,Becker,Aaron T,6,4,1,1,0,0,1,3.14
+Spring 2023,ECE,5397,2,25420,Selected Topics,Le,Hung Quang,0,0,1,0,0,0,0,2.0
+Spring 2023,ECE,6397,1,25421,Selected Topics,Le,Hung Quang,6,7,18,1,0,0,4,2.449
+Spring 2023,ECE,6397,2,25422,Selected Topics,Provence,Robert S,11,1,0,1,0,0,0,3.616
+Spring 2023,ECE,6397,3,25423,Selected Topics,Yao,Yan,8,3,0,0,0,0,0,3.667
+Spring 2023,ECE,5319,1,25434,Introduction to Nanotechnology,Brankovic,Stanko R,2,1,0,0,0,0,0,3.557
+Spring 2023,ECE,6306,1,25435,Introduction to Nanotechnology,Brankovic,Stanko R,7,6,0,0,0,0,1,3.589
+Spring 2023,SCLT,6399,31,25436,Master's Thesis,Dong,Zhijie,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,3331,4,25440,Beg Creative Writing-Poetry,Bradley,Jari,14,1,2,0,0,0,0,3.706
+Spring 2023,PHYS,7356,1,25441,Intro Particle Physics,Bellwied,Rene,14,0,0,0,0,0,0,3.953
+Spring 2023,CIS,3368,32,25450,Adv Info Systems Development,Peddoju,Suresh Kumar,12,5,11,3,0,0,5,2.828
+Spring 2023,SOCW,8995,1,25452,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,3,0,
+Spring 2023,SOCW,8995,2,25453,Pre-Dissertation Research,Robbins,Susan P,0,0,0,0,0,1,0,
+Spring 2023,ENGL,4397,1,25457,"Topics in Film, Lit, & Culture",Zaretsky,Robert D,3,1,0,0,0,0,0,3.585
+Spring 2023,ELET,6319,1,25461,App of Fuel Cell Technology,Bose,Anima B,2,2,0,0,0,0,0,3.418
+Spring 2023,ARCH,6376,1,25464,Urban Determinants,Rogers,Susan,21,6,0,0,0,0,0,3.729
+Spring 2023,NURS,8205,1,25465,Interdisciplinary Care Seminar,Schrader PhD,Patricia K,0,0,0,0,0,6,0,
+Spring 2023,NURS,8306,1,25466,Interdisciplinary Focus Clinic,Dwyer,Carol Ann,0,0,0,0,0,6,0,
+Spring 2023,NURS,6313,1,25467,Thries & Methds of Tching Nur,Boozer,Kathileen,1,1,0,0,0,0,0,3.5
+Spring 2023,NURS,6317,1,25468,Hum Res Mgmt in Healthcare,Brohard,Cheryl L,4,1,0,0,0,0,0,3.8
+Spring 2023,NURS,6355,1,25469,Mgmt of Hlth Dsordrs Across Lf,Dwyer,Carol Ann,2,2,0,0,0,0,0,3.5
+Spring 2023,NURS,6356,1,25470,Mgmt of Hlth Dsordrs Acrs Lfsp,Ecby,Chanique,0,0,0,0,0,4,0,
+Spring 2023,NURS,3310,1,25471,Prof Role Dev & Practice Issue,Phan,Huong Thi,6,4,0,0,0,0,0,3.6
+Spring 2023,NURS,3311,2,25473,Health Assess Across Life Span,Kleinhans,Alicia Diane,3,6,0,0,0,0,2,3.333
+Spring 2023,NURS,3315,1,25474,Pathophysiology,Edwards-Maddox,Shermel Vinese,3,7,0,1,0,0,1,3.091
+Spring 2023,NURS,4521,1,25475,Community Health Nursing,McWilliams,Lenora A,4,5,0,0,0,0,0,3.444
+Spring 2023,MANA,7353,2,25478,Regional Issues in Global Mgmt,Celly,Nikhil,15,0,0,0,0,0,0,4.0
+Spring 2023,MANA,7397,5,25479,Selected Topics in Management,Werner,Steve,17,0,0,0,0,0,0,4.0
+Spring 2023,MATH,3325,1,25480,Transition to Advanced Math,Leger,Nicholas M,8,16,8,2,2,0,2,2.741
+Spring 2023,MATH,3333,3,25481,Intermediate Analysis,Nicol,Matthew J,7,3,0,1,1,0,3,3.194
+Spring 2023,PHIL,3351,1,25494,Contemporary Moral Issues,Ebert,Rainer,2,13,5,2,0,0,1,2.592
+Spring 2023,PHIL,3351,2,25495,Contemporary Moral Issues,Ebert,Rainer,6,9,4,1,1,0,1,2.841
+Spring 2023,PHLS,8399,1,25496,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,2,0,
+Spring 2023,MUSI,4298,10,25497,Independent Study,Robinson,Daryl Allen,3,0,0,0,0,0,0,3.89
+Spring 2023,SPAN,7302,1,25500,Adv Research & Writing Seminar,Hasbun,Rodrigo,10,0,0,0,0,0,0,4.0
+Spring 2023,ECE,6333,1,25501,Signal Detec & Est Thry,Han,Zhu,16,2,0,0,0,0,1,3.797
+Spring 2023,ECE,6346,1,25502,Vlsi Design,Joardar,Biresh Kumar,21,9,1,0,0,0,2,3.613
+Spring 2023,BIOL,4399,3,25504,Senior Honors Thesis,Cole,Blaine J,1,0,0,0,0,0,0,4.0
+Spring 2023,HDFS,4398,1,25509,Independent Study,Frankel,Leslie Ann,1,0,0,0,0,0,0,4.0
+Spring 2023,ARTH,2389,1,25510,Modern and Contemporary Art,Buske,Zoie,13,4,6,0,1,0,1,3.208
+Spring 2023,IART,4300,1,25511,Collaboration Among the Arts,Noble,Melissa Lynn,17,0,0,0,0,0,0,3.981
+Spring 2023,IART,2300,2,25512,The Arts in Houston,Bispo,Layla Moreira,21,0,0,0,1,0,0,3.803
+Spring 2023,ENGL,7396,4,25515,Topics in Language & Literatre,Harrell,Haylee C,10,0,0,0,0,0,0,3.967
+Spring 2023,BIOE,4314,1,25518,Engineering of the Human Body,Romero Ortega,Mario Ignacio,5,3,1,0,1,0,0,3.067
+Spring 2023,BIOE,6314,1,25520,Engineering of the Human Body,Romero Ortega,Mario Ignacio,4,5,0,0,0,0,0,3.481
+Spring 2023,MECE,2334,4,25521,Thermodynamics,Love,Holley Carole,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,5318,1,25537,Intro to Biomed Informatics,Akay PhD,Metin,6,0,0,0,0,0,1,3.89
+Spring 2023,BIOE,6345,1,25539,Biomedical Informatics,Akay PhD,Metin,10,2,0,0,0,0,0,3.806
+Spring 2023,MIS,3376,5,25540,Busn Appls Database Mgmt I,Kniffen,Richard Chad,4,20,17,1,2,0,2,2.523
+Spring 2023,COSC,4397,1,25542,Sel Top-Computer Science,Yun,Changhoon,9,6,0,3,0,0,1,3.24
+Spring 2023,COSC,6397,1,25543,Topics Computer Science,Yun,Changhoon,5,0,0,0,0,0,0,4.0
+Spring 2023,PHIL,4399,1,25544,Senior Honors Thesis,Coates,Daniel J,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,3331,2,25545,Environmental Engineering,Shaffer,Devin,13,11,6,0,1,0,1,3.086
+Spring 2023,CIVE,3332,1,25546,Engineering Materials,Mo,Larry Yi-Lung,16,17,0,0,0,0,0,3.495
+Spring 2023,CIVE,5397,1,25548,Selected Topics,Milillo,Pietro,2,0,0,0,0,0,2,4.0
+Spring 2023,CIVE,5397,3,25550,Selected Topics,Kalliontzis,Dimitrios,0,3,0,0,1,0,1,2.498
+Spring 2023,CIVE,6350,3,25551,Advanced Mechs of Matls,Nakshatrala,Kalyana,5,12,1,0,1,0,1,2.948
+Spring 2023,ARCH,3397,9,25552,Selected Topics,Munenzon Titelboim,Dalia,0,1,0,0,0,0,0,3.33
+Spring 2023,ARCH,6397,10,25553,Sel Tpcs-Arc/Urbn Desgn,Munenzon Titelboim,Dalia,3,2,0,0,0,0,0,3.666
+Spring 2023,CIVE,6374,1,25554,Digital Imaging Metrology,Glennie,Craig Len,7,3,0,0,0,0,0,3.568
+Spring 2023,CIVE,6376,1,25555,Physical Geodesy,Xie,Surui,2,2,0,0,0,0,1,3.418
+Spring 2023,CIVE,7397,1,25556,Selected Topics,Milillo,Pietro,6,1,0,0,0,0,0,3.857
+Spring 2023,CIVE,7397,2,25557,Selected Topics,Rahimi,Mohammad,8,3,0,0,0,0,0,3.757
+Spring 2023,CIVE,7397,3,25558,Selected Topics,Rahimi,Mohammad,3,0,1,0,0,0,0,3.5
+Spring 2023,CIVE,7397,4,25559,Selected Topics,Kalliontzis,Dimitrios,4,3,1,0,1,0,0,2.89
+Spring 2023,CIVE,7397,5,25560,Selected Topics,Nakshatrala,Kalyana,21,3,0,0,0,0,0,3.834
+Spring 2023,CIVE,7397,7,25562,Selected Topics,Ballarini,Roberto,6,0,0,0,0,0,0,4.0
+Spring 2023,SOC,3312,3,25569,Sociology of Deviance,Colbert,Sharla Stettnisch,14,6,4,1,4,0,4,2.908
+Spring 2023,SOC,3382,3,25570,Sociology of Drug Use & Recove,Colbert,Sharla Stettnisch,8,3,5,0,3,0,4,2.615
+Spring 2023,SOC,3371,2,25571,Sociology of Family,Cooper,Chelsey Wells,34,8,2,0,0,0,2,3.705
+Spring 2023,ENGL,4385,2,25573,Fiction Forms,Howell,Robert Houston,12,0,0,0,0,0,0,4.0
+Spring 2023,PHIL,4398,1,25578,Independent Study,Loewenstein,Yael R,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,3324,50,25579,Human Physiology,Dryer,Stuart E,4,12,9,0,1,0,6,2.654
+Spring 2023,DIGM,4398,32,25581,Independent Study,Liao,Tony Chung-Li,9,1,0,0,0,0,0,3.801
+Spring 2023,MUSA,6220,2,25582,Applied Violin,Austin,Alan S,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4189,5,25583,Senior Recital,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Spring 2023,INAR,3112,13,25584,Topics in Design Media,Smith,Joshua S,2,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,3112,18,25589,Topics in Design Media,Smith,Joshua S,7,0,0,0,0,0,1,4.0
+Spring 2023,INDS,2170,2,25590,Digital Sketch Techniques I,Kimbrough,Mark S,4,3,5,3,1,0,0,2.334
+Spring 2023,ARCH,6198,18,25591,Special Problems,Smith,Joshua S,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,7398,2,25592,Independent Study,Brower,Samuel Richard,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4189,6,25594,Senior Recital,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,1,25595,Independent Study,Zvolensky,Michael J,14,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,2,25596,Independent Study,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,2302,15,25597,Prin of Managerial Accounting,Weber,Catherine K,45,39,20,4,1,0,3,3.174
+Spring 2023,MUSI,6374,1,25598,Music and Nationalism,Lange,Barbara Rose,7,3,1,0,0,0,1,3.455
+Spring 2023,MUSI,4197,2,25599,Selected Topics in Music,Kubos,Cameron Kade,6,0,0,0,0,0,0,4.0
+Spring 2023,QSS,4393,4,25601,QSS Research Project,Jung,Jae Hee,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8399,2,25603,Doctoral Dissertation,de Dios,Marcel A,0,0,0,0,0,3,0,
+Spring 2023,MUSA,6312,1,25604,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,2197,1,25607,Selected Topics,De La Rosa-Pohl,Diana,18,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6310,1,25623,Applied Piano,Hester,Timothy E,8,0,0,0,0,0,0,3.918
+Spring 2023,MUSA,6310,2,25624,Applied Piano,Morgulis,Tali,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6310,3,25625,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7A97,6,25626,Selected Topics in Finance,Levy,Clayton V,7,0,0,0,0,0,0,4.0
+Spring 2023,ECE,5346,1,25630,Vlsi Design,Joardar,Biresh Kumar,3,3,0,0,0,0,0,3.5
+Spring 2023,ARCH,3393,1,25631,Thesis Preparation,Beneytez-Duran,Rafael,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,8391,1,25633,COMD Research,Dial,Heather Raye,0,0,0,0,0,1,0,
+Spring 2023,COMD,8391,2,25634,COMD Research,Thiessen,Amber L,0,0,0,0,0,1,0,
+Spring 2023,COMD,8391,3,25635,COMD Research,Maher,Lynn M,0,0,0,0,0,1,0,
+Spring 2023,COMD,8391,4,25636,COMD Research,Bunta,Ferenc,0,0,0,0,0,1,0,
+Spring 2023,ARTS,4396,1,25637,Sel Topics in Studio Practice,Politzer,David,5,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,1,25641,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Spring 2023,MUSA,4189,7,25642,Senior Recital,Vasquez,Hector A,0,0,0,0,0,0,0,
+Spring 2023,ELCS,8398,1,25643,Independent Study,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,2,25644,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,3,0,
+Spring 2023,GEOL,8698,1,25645,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,2,0,
+Spring 2023,GEOL,7340,1,25648,Machine Learning for Geo,Sun,Jiajia,18,2,1,0,0,0,0,3.81
+Spring 2023,GEOL,8998,3,25651,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8698,2,25652,Doctoral Research,Castagna,John P,0,0,0,0,0,4,0,
+Spring 2023,SOCW,8995,3,25653,Pre-Dissertation Research,Narendorf,Sarah C,0,0,0,0,0,1,0,
+Spring 2023,PHLS,7398,1,25656,Candidacy Research,de Dios,Marcel A,0,0,0,0,0,1,0,
+Spring 2023,FINA,4341,2,25657,Commercial Bank Management,Lara,Alexander J,27,3,1,0,0,0,0,3.807
+Spring 2023,MANA,4341,2,25659,Leading Organizational Change,Barrett,Beverly,36,17,5,1,0,0,0,3.486
+Spring 2023,DANC,3203,1,25660,Contact Improvisation,Chapman,Teresa Lynn,1,0,0,0,0,0,0,4.0
+Spring 2023,CIS,6324,1,25661,Cybersecurity Risk Management,Conklin,William A,24,10,1,0,0,0,0,3.619
+Spring 2023,SPAN,6398,13,25668,Special Problems,Ventura,Gabriela Baeza,2,0,0,0,0,0,0,4.0
+Spring 2023,POLC,6311,2,25669,Leader and Prof Development,Witt,Lawrence A,18,0,1,0,0,0,0,3.895
+Spring 2023,ARCH,6198,19,25670,Special Problems,Phan,Trang Anh Thuc,2,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,8695,1,25671,Pre-Dissertation Research,Narendorf,Sarah C,0,0,0,0,0,2,0,
+Spring 2023,PHLS,8399,3,25673,Doctoral Dissertation,Arbona,Consuelo,0,0,0,0,0,2,0,
+Spring 2023,MUSA,8330,1,25674,Doctoral Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Spring 2023,INDS,6397,2,25675,Selected Topics,Morshedzadeh,Elham,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,7350,2,25678,Integrating Tech in Curriculum,Nguyen,Phuong Thi Mai,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,3399,1,25691,Senior Honors Thesis,Thiessen,Amber L,1,0,0,0,0,0,0,4.0
+Spring 2023,ECON,4399,1,25695,Senior Honors Thesis,Yi,Kei-Mu,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6198,1,25697,Special Problems,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6198,2,25698,Special Problems,Legendre,Jungyoung Shin,1,0,0,0,0,0,0,4.0
+Spring 2023,NUTR,6302,1,25699,Adv Medical Nutrition Therapy,Ferrell,Carla Denise,4,1,2,0,0,0,1,3.286
+Spring 2023,LAW,7397,5,25703,Selected Topics,Trujillo,Elizabeth I,5,6,0,0,0,0,0,3.395
+Spring 2023,BIOL,8998,1,25704,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Spring 2023,HIST,6399,1,25707,Masters Thesis,Goldberg,Mark A,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,7399,1,25708,Masters Thesis,Goldberg,Mark A,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,4399,1,25711,Senior Honors Thesis,Grabow,Lars C,2,1,0,0,0,0,0,3.777
+Spring 2023,CHEE,4399,2,25712,Senior Honors Thesis,Orman,Mehmet,1,0,0,0,0,0,0,4.0
+Spring 2023,INDS,3298,1,25716,Independent Study,Chow,George K,3,2,0,0,0,0,0,3.6
+Spring 2023,MECE,6334,2,25723,Convection Heat Transfr,Liu,Dong,5,3,0,0,0,0,0,3.749
+Spring 2023,MECE,6334,3,25724,Convection Heat Transfr,Liu,Dong,1,1,0,1,0,0,4,2.447
+Spring 2023,MECE,6363,2,25725,Physical Metallurgy,Sun,Li,3,3,3,0,1,0,0,2.7
+Spring 2023,MECE,6363,3,25726,Physical Metallurgy,Sun,Li,2,1,0,0,0,0,2,3.667
+Spring 2023,MECE,6364,2,25727,Phase Transform in Materials,Selvamanickam,Venkat,2,1,0,0,0,0,0,3.557
+Spring 2023,MECE,6364,3,25728,Phase Transform in Materials,Selvamanickam,Venkat,1,2,0,0,0,0,1,3.443
+Spring 2023,MECE,6374,2,25729,Nonlinear Control Syst Design,Grigoriadis,Karolos,10,14,4,0,0,0,0,3.155
+Spring 2023,MECE,6374,3,25730,Nonlinear Control Syst Design,Grigoriadis,Karolos,1,5,2,0,0,0,0,2.999
+Spring 2023,MECE,6365,2,25732,Semiconductor Materials and Ph,Ryou,Jae-Hyun,18,10,3,0,1,0,0,3.375
+Spring 2023,MECE,6365,3,25733,Semiconductor Materials and Ph,Ryou,Jae-Hyun,5,3,1,0,0,0,1,3.334
+Spring 2023,MECE,6384,2,25734,Methods of Applied Math I,Chen,Yi-Chao,7,5,6,0,0,0,1,3.037
+Spring 2023,MECE,6384,3,25735,Methods of Applied Math I,Chen,Yi-Chao,0,3,1,0,2,0,0,1.778
+Spring 2023,ARTS,4398,10,25736,Independent Study,Parazette,Aaron,8,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,6353,3,25737,Planetary Materials,Lapen,Thomas J,4,0,0,0,0,0,0,3.918
+Spring 2023,GEOL,8398,2,25739,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,3,0,
+Spring 2023,SOCW,8695,2,25742,Pre-Dissertation Research,Jennings,Sheara Williams,0,0,0,0,0,1,0,
+Spring 2023,SOCW,8995,4,25743,Pre-Dissertation Research,Cheung,Monit,0,0,0,0,0,1,0,
+Spring 2023,THEA,6171,1,25745,Techniques and Styles,Niederer,Barbara,0,0,0,0,0,0,0,
+Spring 2023,INDE,6370,1,25746,Operation Research-Digital Sim,Khator,Suresh K,3,2,2,0,0,0,2,3.001
+Spring 2023,THEA,6377,1,25747,Draping for Theatrical Costume,Niederer,Barbara,2,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8698,3,25749,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,3,0,
+Spring 2023,COMM,4397,4,25751,Selected Topics Communication,Carter,Nestor Gregory,11,3,2,0,0,0,1,3.563
+Spring 2023,PHLS,8399,4,25758,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Spring 2023,ENTR,4393,2,25760,RED Labs Pre-accelerator,Wilbur,Stephen,7,2,0,0,0,0,0,3.704
+Spring 2023,ENTR,7393,2,25762,RED Labs Pre-accelerator,Wilbur,Stephen,4,0,0,0,0,0,0,3.918
+Spring 2023,ELCS,6393,3,25763,Practicum,Carales,Vincent D,1,0,0,0,0,0,1,4.0
+Spring 2023,ELCS,8398,2,25764,Independent Study,Carales,Vincent D,0,0,0,0,0,4,0,
+Spring 2023,MATH,5397,1,25765,Selected Topics in Mathematics,Etgen,Garret J,2,0,0,0,0,0,0,4.0
+Spring 2023,PEP,8350,1,25768,HHP Candidacy Project Research,Gorniak,Stacey,5,0,0,0,0,0,0,4.0
+Spring 2023,COMM,4399,1,25773,Senior Honors Thesis,Camaj,Lindita,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,7398,3,25776,Candidacy Research,Margulis,Milena A,0,0,0,0,0,0,0,
+Spring 2023,ELCS,8398,3,25782,Independent Study,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8398,4,25783,Independent Study,Messa,Emily Alice,3,0,0,0,0,0,0,4.0
+Spring 2023,HIST,1302,1,25784,The U.S. Since 1877,Johnson,Michele R,13,7,4,3,0,0,6,3.099
+Spring 2023,FINA,7324,2,25787,Inv & Portfolio Mgt Project I,Shoss,Robert L,6,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7399,7,25789,Essay,Peynado,Brenda,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,8397,1,25790,Selected Topics in MIS,Chin,Wynne W,1,0,0,0,0,0,0,4.0
+Spring 2023,MANA,3335,11,25791,Intro Org Behavior and Mgmt,Kim,Jaewoo,6,3,1,0,0,0,0,3.533
+Spring 2023,FINA,7325,2,25792,Inv & Portfolio Mgt Project II,Shoss,Robert L,6,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,7333,1,25795,Molecular Pharmacology,Eriksen,Jason,5,4,2,0,0,0,0,3.273
+Spring 2023,POLS,3316,3,25799,Stats for Political Scientists,Zhou,Hui,8,6,4,3,6,0,6,2.259
+Spring 2023,ECE,6498,1,25813,Research,Han,Zhu,0,0,0,0,0,1,0,
+Spring 2023,ECE,6298,3,25814,Research,Han,Zhu,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,4,25815,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,4,0,
+Spring 2023,GEOL,8998,5,25816,Doctoral Research,Mann,Paul,0,0,0,0,0,1,0,
+Spring 2023,COMD,7391,2,25819,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,3,25820,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,0,0,0,0,0,3.67
+Spring 2023,PEP,7398,1,25821,Adv Special Problem Human Perf,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,4398,2,25823,Independent Study,Harrell,Haylee C,1,0,0,0,0,0,0,4.0
+Spring 2023,CIS,4339,3,25825,Enterprise Appls Development,Wu,Xuqing,18,7,1,0,1,0,2,3.409
+Spring 2023,ENGL,6302,2,25826,Creative Writing Pedagogy,Colombe,Audrey A,9,0,0,0,0,0,0,4.0
+Spring 2023,SPAC,6398,1,25827,Special Problems,Kennedy,Kriss Jon,6,0,0,0,0,0,0,3.78
+Spring 2023,SPAC,6298,1,25828,Special Problems,Bell,Larry S,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,5397,4,25830,Selected Topics,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,7391,4,25834,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,5,25835,Clinic in Speech Lang Disorder,Lantaco,Perla Judith,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,6,25836,Clinic in Speech Lang Disorder,Tragesser,Bridgid Jane,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,8,25838,Clinic in Speech Lang Disorder,Townsend,Alayna,2,0,0,0,0,0,0,3.67
+Spring 2023,COMD,7391,16,25840,Clinic in Speech Lang Disorder,Walker,Dionne A,0,1,0,0,0,0,0,3.33
+Spring 2023,COMD,7391,18,25842,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,1,1,0,0,0,0,0,3.335
+Spring 2023,PHOP,6867,3,25844,Research Practicum A,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,7392,10,25846,Adv Pract Sp & Lang Dis,Hoppe,Martha Ann,2,0,0,0,0,0,0,3.835
+Spring 2023,PHOP,8798,1,25852,Doctoral Research,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8299,6,25853,Doctoral Dissertation,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8698,1,25854,Doctoral Research,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6767,5,25855,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6567,7,25856,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6167,7,25857,Research Practicum A,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,6798,1,25858,Spec Prob-Physio Optics,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8698,2,25859,Doctoral Research,Patel,Nimesh Bhikhu,0,1,0,0,0,0,0,3.0
+Spring 2023,PHOP,8898,1,25860,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,6,25861,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,7,25862,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,3,0,
+Spring 2023,INDS,6397,3,25864,Selected Topics,Kang,Chul Min,1,0,0,0,0,0,0,3.67
+Spring 2023,GEOL,8998,8,25868,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,5,0,
+Spring 2023,GHL,4398,1,25869,Independent Study,Ginapp,Kathrine,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,3,25870,Independent Study,Kieffer,Suzanne C,0,0,0,0,0,1,0,
+Spring 2023,CIVE,7397,8,25871,Selected Topics,Louie,Stacey M,5,2,0,0,0,0,0,3.761
+Spring 2023,HIST,6398,2,25872,Special Problems,Chakrabarti,Pratik,1,0,0,0,0,0,0,3.67
+Spring 2023,CIVE,6331,1,25875,Hydraulics Open Channel Flow,Wang,Keh-Han,2,2,3,0,0,0,2,2.857
+Spring 2023,CIVE,6331,2,25876,Hydraulics Open Channel Flow,Wang,Keh-Han,0,0,1,0,0,0,0,1.67
+Spring 2023,BCHS,8999,5,25877,Doctoral Dissertation,Briggs,James M,0,0,0,0,0,1,0,
+Spring 2023,PEP,8999,5,25881,Doctoral Dissertation,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Spring 2023,PEP,8699,5,25882,Doctoral Dissertation,LaVoy,Emily Claire-Pyle,0,0,0,0,0,1,0,
+Spring 2023,GCEE,6320,1,25886,Global Climate: Physical Model,Li,Hongyi,8,1,0,0,0,0,0,3.779
+Spring 2023,GCEE,6320,2,25887,Global Climate: Physical Model,Li,Hongyi,4,0,0,0,1,0,0,3.2
+Spring 2023,ENGL,8398,1,25888,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Spring 2023,HIST,4398,2,25889,Independent Study,Patterson,Catherine F,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,6340,2,25890,Augmentative and Alternative C,Thiessen,Amber L,45,14,0,0,0,0,0,3.729
+Spring 2023,GEOL,8398,3,25893,Doctoral Research,Mann,Paul,0,0,0,0,0,5,0,
+Spring 2023,BTEC,6399,1,25894,Thesis,Khan,Abdul Latif,2,0,0,0,0,0,0,4.0
+Spring 2023,BTEC,6399,2,25897,Thesis,Balan,Venkatesh,0,0,0,0,0,2,0,
+Spring 2023,MECE,8699,1,25898,Doctoral Dissertation,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,1,25899,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,9,25900,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Spring 2023,ENGL,3399,2,25901,Senior Honors Thesis,Zentz,Lauren R,0,0,0,0,0,0,0,
+Spring 2023,WCL,6398,1,25908,Special Problems,Majumder,Sarasij,2,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,6398,1,25909,Rd&Research in Lang&Lit,Serpas,Martha R,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,10,25910,Doctoral Research,Suppe,John,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8399,5,25911,Doctoral Dissertation,Obasi,Ezemenari M,0,0,0,0,0,1,0,
+Spring 2023,ECON,8391,1,25912,PhD Internship,Sorensen,Bent E,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8999,27,25914,Doctoral Dissertation,Casellas,Jason,0,0,0,0,0,1,0,
+Spring 2023,BZAN,6356,2,25915,Adv DB Mgt Tools Bus Analytics,Grimes,George M,20,0,0,0,0,0,0,4.0
+Spring 2023,FINA,7376,2,25916,Energy Trading,Smith III,Edwin A,3,0,0,0,0,0,0,3.78
+Spring 2023,MANA,8395,1,25919,Teaching Practicum,Carlin,Barbara A,2,0,0,0,0,0,0,4.0
+Spring 2023,SCM,7335,3,25920,Logistics Management,Robinson Jr,Powell Ersell,6,3,0,0,0,0,0,3.593
+Spring 2023,CIVE,4363,2,25921,Concrete Design,Belarbi,Abdeldjelil,13,9,8,3,3,0,0,2.722
+Spring 2023,CIVE,4369,2,25922,Foundation Engineering,Phatak,Tejasree Mohan,6,13,10,3,0,0,0,2.688
+Spring 2023,ECE,3340,2,25923,Numerical Methods for ECE,Mayerich,David Matthew,18,25,1,0,0,0,0,3.491
+Spring 2023,ECE,4371,1,25924,Advanced Telecomm Engineering,Han,Zhu,20,18,3,0,0,0,0,3.374
+Spring 2023,ECE,4117,1,25925,Telecommunications Laboratory,Han,Zhu,37,3,0,0,0,0,0,3.917
+Spring 2023,MECE,3338,2,25926,Dynamic & Control of Mech Syst,Hammami,Farah,8,10,15,0,0,0,0,2.748
+Spring 2023,MECE,3381,2,25927,Finite Elements for Mech Engr,Baxevanis,Theocharis,8,13,12,0,0,0,0,2.879
+Spring 2023,MECE,4331,2,25928,Design of Machine Elements,Chang,Christiana,10,17,6,0,0,0,0,3.131
+Spring 2023,MECE,5397,6,25929,Selected Topics,Chen,Tian,7,18,8,0,0,0,0,2.94
+Spring 2023,MECE,3336,6,25930,Mechanics II,Chen,Xuemei,14,41,34,7,6,0,1,2.458
+Spring 2023,MECE,2334,5,25931,Thermodynamics,Love,Holley Carole,19,40,48,3,0,0,1,2.7
+Spring 2023,CIVE,2332,5,25932,Mechanics of Solids,Phatak,Tejasree Mohan,5,21,16,3,0,0,1,2.622
+Spring 2023,ECE,3331,4,25933,Program Appl in Elec Comp Engr,Sheth,Bhavin R,26,19,11,2,1,0,0,3.158
+Spring 2023,ECE,2202,11,25936,Circuit Analysis II,Ramachandran,Deepa,10,27,22,2,1,0,0,2.651
+Spring 2023,SOCW,8398,1,25938,Independent Study,Gearing,Robin Edward,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,11,25941,Doctoral Research,Sager,William W,0,0,0,0,0,1,0,
+Spring 2023,LAW,5197,2,25942,Selected Topics,Davis,Megan Leigh-Wilson,0,0,0,0,0,10,0,
+Spring 2023,LAW,5197,3,25943,Selected Topics,Simmons,Laurel Ellis Parker,0,0,0,0,0,13,0,
+Spring 2023,LAW,5197,4,25944,Selected Topics,Hastings,Madison Alexandra Nicole,0,0,0,0,0,6,0,
+Spring 2023,CIVE,3434,1,25945,Fluid Mech and Hydraulic Engr,Wang,Keh-Han,7,14,11,5,0,0,0,2.613
+Spring 2023,GERM,3381,3,25947,German Cinema,Kleinheider,Julia D,3,11,4,4,3,0,3,2.293
+Spring 2023,COSC,3320,3,25949,Algorithms and Data Structures,Ordonez,Carlos,14,29,22,2,4,0,10,2.639
+Spring 2023,CUIN,8399,7,25950,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,2,0,
+Spring 2023,KIN,4398,1,25952,Independent Study,Cottingham,Michael,2,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8998,1,25954,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,4,0,
+Spring 2023,MUSA,8240,16,25955,Doctoral Recital I,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8312,15,25956,Lab of Practice-Res Meth Devel,Peters-Hawkins,April,1,0,0,0,0,0,0,4.0
+Spring 2023,LAW,6347,10,25957,Secured Financing,Moll,Douglas Keith,10,11,1,0,0,16,0,3.364
+Spring 2023,SOCW,8398,2,25958,Independent Study,Cheung,Monit,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6298,1,25959,Special Problems,Taylor,David C,1,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8330,1,25960,Statistical Analyses,Templeton,Toni,11,0,0,0,0,0,0,3.97
+Spring 2023,PHLS,8398,1,25961,Special Problems,Margulis,Milena A,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,4378,4,25962,Admin of Computer-Based MIS,Porra,Jaana,41,0,0,0,0,0,0,3.976
+Spring 2023,ENGL,6398,2,25963,Rd&Research in Lang&Lit,Peynado,Brenda,0,0,0,0,0,1,0,
+Spring 2023,BIOL,4399,4,25964,Senior Honors Thesis,McKeon,Frank D,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8398,4,25965,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8398,5,25966,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8699,1,25967,Doctoral Dissertation,Wang,Yuxuan,2,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,18,25968,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Spring 2023,MARK,7381,1,25969,Technology Commercialization,Kamal,Saiyid Zafar,5,1,0,0,0,0,0,3.833
+Spring 2023,ENTR,7381,1,25970,Technology  Commercialization,Kamal,Saiyid Zafar,0,1,0,0,0,0,0,2.67
+Spring 2023,COMD,8699,1,25971,Dissertation,Castilla-Earls,Anny,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8399,19,25973,Doctoral Dissertation,Tejada,Roberto Jose,2,0,0,0,0,1,0,4.0
+Spring 2023,CNST,1361,2,25975,Construction Management I,Kim,Kinam,20,12,1,2,3,0,3,3.184
+Spring 2023,GEOL,8998,12,25976,Doctoral Research,Stewart,Robert R,0,0,0,0,0,2,0,
+Spring 2023,POLS,8999,1,25978,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,2,0,
+Spring 2023,POLS,8999,2,25979,Doctoral Dissertation,Rottinghaus,Brandon J,0,0,0,0,0,1,0,
+Spring 2023,HDFS,1311,3,25982,Personal Dev and College Succ,Kamdar-Sharif,Amber,20,3,0,0,0,0,0,3.798
+Spring 2023,ENGL,6398,3,25983,Rd&Research in Lang&Lit,Prufer,Kevin D,0,0,0,0,0,2,0,
+Spring 2023,MUED,2342,10,25986,Music for Children,Bigwood,Cora Morgan,16,1,0,0,0,0,0,3.922
+Spring 2023,HIST,6398,3,25987,Special Problems,Young,Nancy Beck,0,0,0,0,0,0,0,
+Spring 2023,HDFS,4316,2,25990,Dynamics of Family Relations,Schroder,Kathleen Anne,31,8,3,3,0,0,0,3.416
+Spring 2023,BIOL,8399,3,25992,Doctoral Dissertation,Sater,Amy,1,0,0,0,0,0,0,4.0
+Spring 2023,HDFS,4325,3,25996,Theory to Practice in HDFS,Jordan,Erica F,29,8,1,2,1,0,0,3.504
+Spring 2023,MUSI,8499,1,25998,Doctoral Document,Koozin,Timothy,1,0,0,0,0,0,0,4.0
+Spring 2023,INDE,6361,2,26000,Prod Planning & Invent Control,Rypien,David V,57,2,1,0,0,0,0,3.933
+Spring 2023,HLT,3381,4,26001,Hlt Promotn & Disease Preventn,Markowitz,Eliz,48,29,3,0,2,0,1,3.431
+Spring 2023,ECON,6397,1,26004,Topics in Eco Research,Friedman,Willa H,1,1,0,0,0,0,0,3.665
+Spring 2023,MECE,6385,1,26008,Mtds of Appld Mthmtcs,Sharma,Pradeep,5,1,0,0,0,0,0,3.668
+Spring 2023,PCOL,6198,12,26009,Special Problems,Eriksen,Jason,5,4,2,0,0,0,0,3.273
+Spring 2023,PHYS,8698,1,26012,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Spring 2023,THEA,4398,1,26013,Independent Study,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Spring 2023,THEA,4398,2,26014,Independent Study,Shimko,Robert B,2,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8998,2,26015,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,1,0,
+Spring 2023,PCOL,8199,2,26016,Dissertation,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,3,26018,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,4,26019,Doctoral Research,Bellwied,Rene,0,0,0,0,0,2,0,
+Spring 2023,MUSA,4189,8,26021,Senior Recital,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8998,3,26024,Doctoral Research,Bellwied,Rene,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8698,8,26025,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,9,26026,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,6,26029,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8998,9,26032,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,12,26036,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,13,26037,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,14,26038,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8998,11,26040,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,13,26042,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8998,15,26044,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,16,26045,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,17,26046,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,18,26047,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,20,26049,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8998,21,26050,Doctoral Research,Stokes,Donna,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,23,26052,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,25,26054,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8698,17,26061,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,24,26068,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Spring 2023,PHYS,8698,25,26069,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8698,28,26072,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Spring 2023,PHYS,8998,31,26077,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,2,0,
+Spring 2023,BIOL,8998,2,26078,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6198,13,26079,Special Problems,Garey,Kevin W,0,0,0,0,0,0,1,
+Spring 2023,PSYC,6393,12,26082,Clinical Research Practicum,Babcock,Julia,0,0,0,0,0,3,0,
+Spring 2023,PSYC,4398,4,26087,Independent Study,Leasure,Jennifer Leigh,2,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8398,2,26088,Graduate English Resrch,Womble,David Avari Patrick,0,0,0,0,0,2,0,
+Spring 2023,ELCS,8398,5,26089,Independent Study,Zou,Yali,4,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,7699,9,26091,Thesis,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4189,9,26092,Senior Recital,Hester,Timothy E,0,0,0,0,0,0,0,
+Spring 2023,BIOL,4398,1,26093,Independent Study,Nunez,Martin A,1,0,0,0,0,0,0,4.0
+Spring 2023,ELET,6396,3,26094,Master's Project,Abdelhadi,Ahmed,1,1,0,0,0,0,0,3.665
+Spring 2023,PCEU,6342,1,26095,Advanced Pharmaceutics I,Guo,Bin,2,6,0,0,0,0,0,3.25
+Spring 2023,ENGL,8698,3,26096,Graduate Research,Peynado,Brenda,0,0,0,0,0,1,0,
+Spring 2023,PCEU,6345,1,26097,Advanced Pharmaceutics II,Ghose,Romi,6,16,2,0,0,0,0,3.167
+Spring 2023,ELET,6399,1,26100,Master's Thesis,Abdelhadi,Ahmed,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7399,1,26101,Masters Thesis,Capuano,Regina M,0,0,0,0,0,0,0,
+Spring 2023,MUSA,6210,1,26106,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8393,6,26107,Adv Internship & Prac,Gist,Conra D,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7399,2,26110,Masters Thesis,Robinson,Alexander C,0,0,0,0,0,1,0,
+Spring 2023,GEOL,7698,1,26111,Masters Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6143,4,26112,Graduate Recital IV,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,6399,4,26115,Masters Thesis,Wu,Tianfu,0,0,0,0,0,1,0,
+Spring 2023,MECE,7399,1,26116,Masters Thesis,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8398,6,26117,Doctoral Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,13,26118,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8398,7,26119,Doctoral Research,Murphy,Michael,0,0,0,0,0,2,0,
+Spring 2023,HIST,6398,4,26120,Special Problems,Goldberg,Mark A,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8398,3,26122,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8698,4,26123,Graduate Research,Tejada,Roberto Jose,0,0,0,0,0,1,0,
+Spring 2023,CIS,6324,2,26128,Cybersecurity Risk Management,Conklin,William A,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6384,1,26129,Gourmet Night Management,Haskell,Rebecca Erin,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,4398,1,26131,Independent Study,Dial,Heather Raye,2,0,0,0,0,0,0,4.0
+Spring 2023,MIS,4397,10,26133,Selected Topics in MIS,Lewis,Michael Joseph,2,3,4,0,0,0,3,2.631
+Spring 2023,ENTR,7393,3,26134,RED Labs Pre-accelerator,Wilbur,Stephen,3,0,1,0,0,0,0,3.583
+Spring 2023,GEOL,7398,1,26135,Masters Research,Khan,Shuhab D,0,0,0,0,0,3,0,
+Spring 2023,MATH,6315,8,26145,Masters Tutorial,Bodmann,Bernhard G,2,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,14,26146,Doctoral Research,Capuano,Regina M,0,0,0,0,0,0,0,
+Spring 2023,HIST,6399,2,26147,Masters Thesis,Neumann,Kristina Marie,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4422,1,26148,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2023,HIST,7399,2,26149,Masters Thesis,Neumann,Kristina Marie,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8298,4,26151,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8698,5,26155,Graduate Research,Lee,Eunjeong,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8398,4,26156,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2023,GEOL,1103,10,26157,Physical Geology Lab,Hauptvogel,Daniel William,5,3,1,1,0,0,2,3.068
+Spring 2023,GEOL,8999,1,26158,Doctoral Dissertation,Choi,Yunsoo,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,8598,103,26163,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8698,6,26164,Graduate Research,Shepley,Nathan,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8398,5,26165,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2023,PCEU,8998,5,26166,Doctoral Research,Guo,Bin,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8398,6,26167,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2023,IART,6300,1,26168,Collaboration Among the Arts,Noble,Melissa Lynn,2,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,6398,4,26169,Rd&Research in Lang&Lit,Boswell,Robert L,0,0,0,0,0,1,0,
+Spring 2023,HIST,8399,4,26170,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6398,6,26171,Special Problems,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Spring 2023,CUIN,8310,3,26172,Laboratory of Practice,Reis,Nancy,2,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,15,26174,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6342,2,26177,Applied French Horn,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,4398,3,26180,Independent Study,Rector,Josiah John,0,0,0,0,0,0,0,
+Spring 2023,GEOL,7399,3,26181,Masters Thesis,Sun,Jiajia,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEM,4398,1,26184,Independent Study,Daugulis,Olafs,0,0,0,0,0,1,0,
+Spring 2023,ENTR,6398,1,26185,Research,Wilbur,Stephen,6,2,0,0,0,0,0,3.709
+Spring 2023,MARK,4397,2,26186,Selected Topics in Mkt,Richards,Sean Wesley,16,14,0,0,0,0,1,3.423
+Spring 2023,ENGL,4372,2,26188,Literature and the Environment,Vollrath,Lesli A,3,1,1,0,0,0,0,3.4
+Spring 2023,IDNS,2197,4,26189,Top-Natrl Sci & Mth,Stokes,Donna,15,1,0,0,0,0,0,3.876
+Spring 2023,OPTO,5198,1,26190,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,10,0,
+Spring 2023,MUSA,8241,8,26191,Doctoral Recital II,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Spring 2023,SOC,3357,3,26192,Urban Sociology,Anderson,Kathryn,12,15,3,3,1,0,1,2.951
+Spring 2023,ENGL,8398,7,26193,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2023,GHL,6398,2,26194,Special Problems,Kim,Jaewook,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,6330,1,26195,Human Growth-Developmnt,Whitaker,Rachael Gwin,7,1,0,0,0,0,0,3.916
+Spring 2023,CHEM,4396,2,26196,Senior Research Project,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,5397,7,26197,Selected Topics,Prosperetti,Andrea,2,12,5,0,0,0,2,2.825
+Spring 2023,PSYC,8199,1,26198,Doctoral Dissertation,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,4398,5,26199,Independent Study,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,6397,5,26200,Selected Topics,Becker,Aaron T,5,7,0,0,0,0,1,3.279
+Spring 2023,GEOL,7399,4,26202,Masters Thesis,Li,Aibing,0,0,0,0,0,1,0,
+Spring 2023,SPAN,6398,14,26203,Special Problems,Lopez Otero,Julio Cesar,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5297,3,26205,Selected Topics in Pharmacy,Zhang,Yang,0,0,0,0,0,1,0,
+Spring 2023,PHAR,5397,1,26206,Selected Topics in Pharmacy,Cuny,Gregory D,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,20,26207,Doctoral Dissertation,Davies,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8699,7,26208,Doctoral Dissertation,Cantu,Francisco,0,0,0,0,0,1,0,
+Spring 2023,PEP,7398,2,26209,Adv Special Problem Human Perf,LaVoy,Emily Claire-Pyle,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,6399,1,26210,Masters Thesis,Khan,Shuhab D,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8396,1,26212,Doctoral Research,Master,Allison,0,0,0,0,0,1,0,
+Spring 2023,HIST,3312,1,26213,American Civil War in Film,Young,Nancy Beck,26,4,0,0,2,0,3,3.553
+Spring 2023,PEP,7398,3,26214,Adv Special Problem Human Perf,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8998,32,26215,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Spring 2023,PCEU,6198,1,26216,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Spring 2023,PCEU,6198,2,26217,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Spring 2023,PCEU,6198,3,26218,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,2,0,
+Spring 2023,PSYC,8199,2,26219,Doctoral Dissertation,Viana,Andres G,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5297,4,26220,Selected Topics in Pharmacy,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5297,5,26221,Selected Topics in Pharmacy,Trivedi PhD,Meghana,0,0,0,0,0,1,0,
+Spring 2023,COMD,7391,23,26222,Clinic in Speech Lang Disorder,Cizek,Laura S,1,0,0,0,0,0,0,3.67
+Spring 2023,MIS,4374,5,26224,Info Technology Project Mgmt,Jagtap,Pankaj,5,17,18,0,1,0,0,2.586
+Spring 2023,ECON,3399,1,26234,Senior Honor Thesis,Friedman,Willa H,0,0,0,0,0,0,0,
+Spring 2023,MUSA,4189,10,26236,Senior Recital,Maroney,Marcus K,2,1,0,0,0,0,0,3.557
+Spring 2023,GHL,8398,1,26237,Research Proposal in Hosp Adm,Back,KiJoon,0,0,0,0,0,1,0,
+Spring 2023,GHL,8699,1,26238,Dissertation II in Hosp. Admin,Back,KiJoon,0,0,0,0,0,1,0,
+Spring 2023,OPTO,5198,2,26240,Spec Prob Phys Optics,Della Santina,Luca,0,0,0,0,0,36,0,
+Spring 2023,OPTO,5198,3,26241,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,11,0,
+Spring 2023,OPTO,5198,4,26262,Spec Prob Phys Optics,Herring,Ralph Jay,0,0,0,0,0,9,0,
+Spring 2023,ENGL,3341,2,26268,Bus & Prof Writing,Butler,Paul G,11,4,0,0,0,0,0,3.689
+Spring 2023,GEOL,8698,4,26269,Doctoral Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,16,26270,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8998,17,26271,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8399,1,26273,Doctoral Dissertation,Zhou,Hua-Wei,1,0,0,0,0,0,0,4.0
+Spring 2023,WGSS,3322,2,26275,Intersectionalities,Pegoda,Andrew Joseph,5,8,2,0,4,0,6,2.439
+Spring 2023,GEOL,8998,18,26276,Doctoral Research,Li,Aibing,0,0,0,0,0,1,0,
+Spring 2023,SOCW,8699,4,26278,Dissertation,Cheung,Monit,0,0,0,0,0,1,0,
+Spring 2023,CIVE,7397,10,26280,Selected Topics,Kalliontzis,Dimitrios,2,4,2,0,0,0,0,2.959
+Spring 2023,PHLS,8199,7,26281,Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8396,2,26282,Doctoral Research,Smith,Nathan G,0,0,0,0,0,2,0,
+Spring 2023,PCOL,6398,7,26283,Special Problems,Zhang,Ruiwen,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6320,1,26284,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6320,2,26285,Applied Violin,Yon,Kirsten A,5,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,6198,27,26286,Research,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,4396,1,26287,Senior Research Project,Mann,Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,IDNS,2297,1,26289,Top-Natrl Sci & Mth,Stokes,Donna,14,4,3,4,0,0,1,3.16
+Spring 2023,IDNS,2297,2,26290,Top-Natrl Sci & Mth,Stokes,Donna,14,4,3,1,0,0,0,3.364
+Spring 2023,PCOL,6298,7,26292,Special Problems,Statsyuk,Alexander V,2,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6898,1,26294,Special Problems,Schwartz,Robert J,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6998,1,26295,Special Problems,Mohan,Chandra,0,0,0,0,0,2,0,
+Spring 2023,PCOL,8698,4,26296,Doctoral Research,Bond,Richard A,0,0,0,0,0,1,0,
+Spring 2023,HDFS,4318,4,26297,Parent-Child Relationships,Frankel,Leslie Ann,28,4,1,0,0,0,0,3.748
+Spring 2023,GEOL,6399,2,26298,Masters Thesis,Wu,Jonathan En Lin,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6206,1,26305,Molec Modeling Biol Macromols,Amaral Antunes,Dinler,13,0,0,0,0,0,0,4.0
+Spring 2023,EDS,6397,3,26307,Selected Topics,Grimes,George M,61,15,1,1,0,0,0,3.744
+Spring 2023,BCHS,8798,1,26308,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2023,HIST,2311,1,26315,Western Civilization to 1450,Corsi,Maria Riis Dahlstrom,4,5,2,0,1,0,0,2.972
+Spring 2023,BIOL,4397,5,26322,Selected Topics in Biology,Azevedo,Ricardo,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,8698,2,26323,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8898,1,26324,Doctoral Research,Feng,Qin,0,0,0,0,0,3,0,
+Spring 2023,BIOL,8998,3,26325,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8898,2,26326,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Spring 2023,MUSI,4198,1,26327,Special Problems in Repertoire,Lo,Mann-Wen,3,0,0,0,0,0,0,3.78
+Spring 2023,ARTH,7398,1,26328,Ind Grad Stdy Art Hist,Koontz,Rex A,2,0,0,0,0,0,0,4.0
+Spring 2023,MATH,6698,1,26330,Special Problems,Timofeyev,Ilya,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8999,2,26335,Doctoral Dissertation,Zheng,Yingcai,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7398,2,26336,Masters Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Spring 2023,ARCH,2501,29,26339,Architecture Design Studio IV,Murray,Cara,3,4,2,0,0,0,0,3.001
+Spring 2023,THEA,3374,1,26341,Intelligent Lighting,Rigdon,Kevin L,3,0,0,0,2,0,0,2.4
+Spring 2023,GEOL,8999,3,26342,Doctoral Dissertation,Rappenglueck,Bernhard,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,1501,24,26344,Arc/Int Arc Design Studio II,Mehta,Ami,9,5,0,0,0,0,0,3.549
+Spring 2023,GEOL,8698,5,26346,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8399,2,26349,Doctoral Dissertation,Stewart,Robert R,2,0,0,0,0,1,0,4.0
+Spring 2023,GEOL,8998,19,26350,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8399,3,26352,Doctoral Dissertation,Zheng,Yingcai,2,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8999,4,26353,Doctoral Dissertation,Zhou,Hua-Wei,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,6398,5,26354,Special Problems,Archer,Allison Michelle Nam,1,0,0,0,0,0,0,3.67
+Spring 2023,ARTS,7398,1,26355,Independent Graduate Study,Mayer,Anna W,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,8598,3,26356,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8598,4,26357,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Spring 2023,MUSI,8499,2,26358,Doctoral Document,Dirst,Matthew C,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,6368,2,26362,Chemical Process Economics I,Singhania,Ravi,2,4,1,0,0,0,0,2.954
+Spring 2023,ECON,8399,9,26363,Doctoral Dissertation,Szabo,Andrea,0,0,0,0,0,1,0,
+Spring 2023,PCEU,6498,4,26368,Special Problems,Hao,Jiukuan,0,1,0,0,0,0,0,3.33
+Spring 2023,PCEU,6298,1,26369,Special Problems,Hao,Jiukuan,0,1,0,0,0,0,0,3.33
+Spring 2023,PHYS,6398,3,26371,Special Problems,Chu,Ching Wu,0,0,0,0,0,1,0,
+Spring 2023,PETR,6397,3,26372,Selected Topics,Mohamed,Mohamed Ibrahim,103,13,0,0,0,0,2,3.84
+Spring 2023,ENGI,4198,7,26375,Independent Study,Burleson,Daniel W,0,0,0,0,0,19,0,
+Spring 2023,ENGL,8399,21,26377,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Spring 2023,PSYC,4398,5,26386,Independent Study,Atherton,Olivia Emile,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,4322,3,26391,Chemical Engineering Design II,Gopalakrishnan,Murali,69,22,0,0,0,0,0,3.74
+Spring 2023,WGSS,3395,1,26396,Sel Tops in Women's Studies,Green,Tara T,0,1,0,0,0,0,0,3.33
+Spring 2023,BIOL,6898,1,26397,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,2,0,
+Spring 2023,BIOL,8598,5,26398,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8898,3,26399,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Spring 2023,PSYC,3331,3,26400,Psychology of Gender,Mayorga,Nubia Angelina,25,11,4,0,2,0,0,3.381
+Spring 2023,PCEU,6498,6,26405,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,3,0,
+Spring 2023,PSYC,6398,23,26420,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,2,0,
+Spring 2023,PSYC,6359,12,26422,Directed Rsch in Clinical Psyc,Cirino,Paul,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8798,1,26423,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,
+Spring 2023,MUSI,8296,8,26431,Doctoral Essay,Lange,Barbara Rose,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8243,9,26442,Doctoral Lecture Recital,Snyder,John L,0,0,0,0,0,0,0,
+Spring 2023,BIOE,8198,3,26443,Doctoral Research,Naash,Muna,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6998,2,26445,Special Problems,Cirino,Patrick C,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8998,4,26446,Doctoral Research,Lekven,Arne,0,0,0,0,0,2,0,
+Spring 2023,BIOL,8898,4,26447,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8898,5,26448,Doctoral Research,Warner,Margaret,0,0,0,0,0,1,0,
+Spring 2023,IDNS,4397,1,26449,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,7,0,0,0,0,0,0,4.0
+Spring 2023,IDNS,4397,2,26450,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,6,0,0,0,1,0,0,3.429
+Spring 2023,MATH,6698,2,26451,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Spring 2023,HIST,1302,53,26452,The U.S. Since 1877,Harwell,Debbie Z,46,42,22,5,13,0,5,2.784
+Spring 2023,HIST,1302,54,26453,The U.S. Since 1877,Mizelle Jr,Richard M,79,21,1,5,12,0,8,3.232
+Spring 2023,HIST,3380,2,26454,World Civ Since 1500,Bhattacharya,Nandini Saradindu,4,16,18,20,2,0,0,2.011
+Spring 2023,HIST,2311,2,26455,Western Civilization to 1450,Patterson,Catherine F,7,9,5,0,1,0,2,2.985
+Spring 2023,COMM,4398,2,26456,Independent Study,Houk,Keith R,2,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7399,5,26457,Masters Thesis,Khan,Shuhab D,1,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,2356,5,26459,Fundamentals of Photo/DM,Castillo,James Phillip,14,2,0,0,0,0,3,3.834
+Spring 2023,PCEU,6498,1,26460,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Spring 2023,THEA,4398,3,26462,Independent Study,Vintu,Tatiana,2,0,0,0,0,0,0,4.0
+Spring 2023,DANC,4298,1,26463,Independent Study,Chapman,Teresa Lynn,4,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,4398,1,26465,Independent Study,Rixey,William G,0,1,0,0,0,0,0,2.67
+Spring 2023,WCL,2351,3,26466,World Cultures Thru Lit & Arts,Nguyen,Duy,7,8,1,0,3,0,7,2.807
+Spring 2023,WCL,2352,4,26467,World Cinema,Nguyen,Duy,5,7,2,6,6,0,3,1.949
+Spring 2023,ECE,8398,29,26470,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Spring 2023,ECE,8298,41,26471,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Spring 2023,SOCI,1301,17,26474,Introduction To Sociology,Cooper,Chelsey Wells,31,7,4,1,3,0,1,3.276
+Spring 2023,SOC,7399,5,26477,Masters Thesis,Katz,Sheila,2,0,0,0,0,0,0,4.0
+Spring 2023,IDNS,2197,5,26479,Top-Natrl Sci & Mth,Stokes,Donna,14,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,8898,1,26483,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6798,1,26484,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8999,5,26486,Doctoral Dissertation,Fu,Qi,0,0,0,0,0,2,0,
+Spring 2023,GEOL,8398,8,26487,Doctoral Research,Castagna,John P,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8698,6,26489,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,1,0,
+Spring 2023,ECON,8399,10,26490,Doctoral Dissertation,Nygaard,Vegard Mokleiv,0,0,0,0,0,1,0,
+Spring 2023,ENGL,8399,22,26494,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Spring 2023,POLS,8699,8,26497,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6698,1,26499,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2023,BCHS,8898,2,26501,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8898,6,26502,Doctoral Research,Sater,Amy,0,0,0,0,0,1,0,
+Spring 2023,BCHS,8998,1,26503,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8399,4,26504,Doctoral Dissertation,Bissada,Kadry K,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8698,7,26505,Doctoral Research,Bissada,Kadry K,0,0,0,0,0,1,0,
+Spring 2023,BCHS,8898,3,26507,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Spring 2023,BCHS,8998,2,26508,Doctoral Research,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Spring 2023,ECE,7399,6,26510,Masters Thesis,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2023,PHIL,6398,1,26515,Special Problems,Oliveira,Luis RG,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,6498,2,26516,Research,Chen,Ji,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8698,8,26517,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8898,7,26524,Doctoral Research,Khurana,Seema,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6998,3,26525,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Spring 2023,SOCW,8398,3,26526,Independent Study,Pritzker,Suzanne,1,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,7398,2,26527,Independent Graduate Study,Hecker,Rachel G,0,1,0,0,0,0,0,3.0
+Spring 2023,PUBL,6398,2,26529,Special Probs Publ Adm/Policy,Thurmond,James H,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,3450,2,26530,Applied Percussion,Warren,Paul Alexander,1,1,0,0,0,0,0,3.335
+Spring 2023,CIVE,8399,10,26532,Doctoral Dissertation,Louie,Stacey M,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8298,22,26533,Doctoral Research,Wen,Mingjian,0,0,0,0,0,2,0,
+Spring 2023,CHEE,8398,22,26534,Doctoral Research,Wen,Mingjian,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6998,4,26570,Special Problems,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6212,1,26571,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSI,6298,1,26573,Research,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6898,2,26576,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Spring 2023,GEOL,7399,6,26578,Masters Thesis,Voarintsoa,Ny Riavo Gilbertinie,1,0,0,0,0,0,0,4.0
+Spring 2023,COMD,4399,1,26579,Senior Honors Thesis in COMD,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,8898,4,26580,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6498,6,26583,Special Problems,Wu,Mingfu,0,0,0,0,0,0,0,
+Spring 2023,PCOL,6398,8,26584,Special Problems,Wu,Mingfu,0,0,0,0,0,0,0,
+Spring 2023,PCOL,6498,9,26588,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6298,9,26589,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8398,9,26593,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Spring 2023,INAR,3310,2,26600,Materials/Methods of Int Arch,Wienert,Ross George,1,1,0,0,0,0,0,3.665
+Spring 2023,SOC,7396,3,26601,Internship in Sociology,Karner,Tracy Xavia,1,0,0,0,0,0,0,3.67
+Spring 2023,SOC,7399,6,26603,Masters Thesis,Baumle,Amanda K,0,0,0,0,0,1,0,
+Spring 2023,PEP,7397,4,26608,Adv Selected Topic Human Perf,Johnston,Craig Allen,9,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8398,6,26609,Independent Study,Davis,Tiffany J,0,0,0,0,0,0,0,
+Spring 2023,BIOL,6798,2,26611,Special Problems,Graur,Dan,0,0,0,0,0,1,0,
+Spring 2023,PHLS,7398,4,26612,Candidacy Research,Smith,Bradley,0,0,0,0,0,0,0,
+Spring 2023,PHLS,8199,8,26613,Dissertation,Smith,Bradley,0,0,0,0,0,2,0,
+Spring 2023,PHLS,8398,2,26615,Special Problems,Smith,Bradley,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,8198,2,26621,Doctoral Research,Grabow,Lars C,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8396,3,26623,Doctoral Research,Arbona,Consuelo,0,0,0,0,0,3,0,
+Spring 2023,MUSA,8243,11,26629,Doctoral Lecture Recital,Witt,Woodrow W,0,0,0,0,0,0,0,
+Spring 2023,MUSA,8240,17,26630,Doctoral Recital I,Mueller,Jebediah Lee,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSI,8296,9,26631,Doctoral Essay,Snyder,John L,0,0,0,0,0,0,0,
+Spring 2023,CIVE,7399,2,26632,Master's Thesis,Shaffer,Devin,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7399,7,26633,Masters Thesis,Fu,Qi,0,0,0,0,0,1,0,
+Spring 2023,PEP,8699,6,26634,Doctoral Dissertation,Markofski,Melissa,0,0,0,0,0,0,0,
+Spring 2023,POLS,4198,3,26635,Independent Study,Littlepage,Kelley G,10,3,0,0,0,0,0,3.845
+Spring 2023,PCOL,8998,7,26637,Doctoral Research,Ruan,Ke-He,0,0,0,0,0,1,0,
+Spring 2023,PSYC,3339,5,26638,Intro To Clinical Psychology,Li,Xinge,43,24,12,3,2,0,0,3.144
+Spring 2023,COSC,1437,7,26641,Introduction to Programming,Rincon Castro,Carlos Alberto,28,13,27,4,16,0,26,2.345
+Spring 2023,HLT,3399,1,26643,Senior Honors Thesis,Carmack,Chakema,0,0,0,0,0,1,0,
+Spring 2023,PSYC,8199,3,26646,Doctoral Dissertation,Sharp,Carla,2,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8398,3,26647,Special Problems,Fan,Weihua,2,0,0,0,0,0,0,4.0
+Spring 2023,INDE,7397,3,26648,Selected Topics,Wiggins,Nathanial David,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4189,11,26649,Senior Recital,Evans,Joseph,0,0,0,0,0,0,1,
+Spring 2023,PCOL,6498,10,26651,Special Problems,Garey,Kevin W,0,0,0,0,0,0,0,
+Spring 2023,PCOL,6398,10,26652,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6298,10,26653,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,4398,1,26656,Independent Study,Brown,Kenneth L,2,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,6498,11,26657,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6398,11,26658,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2023,PCOL,6298,11,26659,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2023,DANC,4298,2,26660,Independent Study,Valle,Toni Leago,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,8699,16,26661,Doctoral Dissertation,Malki,Heidar A,1,0,0,0,0,0,0,4.0
+Spring 2023,THEA,6398,2,26663,Independent Study,Noble,Adam S,2,1,0,0,0,0,0,3.557
+Spring 2023,HIST,6399,3,26664,Masters Thesis,Young,Nancy Beck,2,0,0,0,0,0,0,4.0
+Spring 2023,HIST,7399,3,26665,Masters Thesis,Young,Nancy Beck,2,0,0,0,0,0,0,4.0
+Spring 2023,COMM,4398,3,26671,Independent Study,Crowe,Craig Warren,4,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,8898,9,26678,Doctoral Research,Liu,Xinli,0,0,0,0,0,1,0,
+Spring 2023,ANTH,4399,1,26679,Senior Honors Thesis,Rasmussen,Susan J,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8998,20,26683,Doctoral Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2023,MECE,6399,30,26684,Masters Thesis,Ardebili,Haleh,1,0,0,0,0,0,0,4.0
+Spring 2023,PHCA,8311,1,26686,Proposal Development,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8498,26,26688,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Spring 2023,PHCA,6298,5,26690,Special Problems,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8999,2,26693,Doctoral Dissertation,Mo,Larry Yi-Lung,1,0,0,0,0,0,0,4.0
+Spring 2023,ARED,4345,2,26694,Art in Elem & Secondary School,Chung,Sheng Kuan,10,0,0,0,0,0,0,3.967
+Spring 2023,ARED,6345,3,26696,Art in Elem & Secondary School,Chung,Sheng Kuan,2,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6698,2,26698,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2023,BCHS,8698,3,26699,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2023,ECON,3399,2,26701,Senior Honor Thesis,Friedman,Willa H,0,0,0,0,0,0,0,
+Spring 2023,CUIN,7392,2,26703,Internship,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,6398,3,26704,Special Problems,Reynolds,Dennis Edward,1,0,0,0,0,0,0,4.0
+Spring 2023,SOC,7399,7,26705,Masters Thesis,Tuthill,Zelma,2,0,0,0,0,0,0,4.0
+Spring 2023,LAAF,8400,1,26709,Study Abroad for Law Students,Gabriel,Derrick Earl,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6798,3,26710,Special Problems,Meisel,Richard P,0,0,0,0,0,2,0,
+Spring 2023,CIVE,8699,3,26712,Doctoral Dissertation,Vipulanandan,Cumaraswamy,0,0,0,0,0,0,0,
+Spring 2023,MECE,8298,8,26714,Doctoral Research,Prosperetti,Andrea,0,0,0,0,0,1,0,
+Spring 2023,GEOL,7398,3,26717,Masters Research,Carlson,Brandee Nicole,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8398,4,26718,Special Problems,Gonzalez,Jorge E,2,0,0,0,0,0,0,4.0
+Spring 2023,ECON,8399,11,26720,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,0,0,
+Spring 2023,BCHS,8998,3,26728,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2023,BIOL,8998,6,26729,Doctoral Research,Fujita,Masaya,0,0,0,0,0,1,0,
+Spring 2023,THEA,6303,1,26730,Scenic Structures,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,3396,3,26731,Senior Research Project,Nunez,Martin A,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,7398,5,26732,Candidacy Research,Wiesner,Margit F,0,0,0,0,0,1,0,
+Spring 2023,HLT,4392,4,26734,Field Work in Community Health,Solari Williams,Kayce D,18,5,3,1,1,0,1,3.31
+Spring 2023,BIOL,6698,2,26736,Special Problems,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6698,3,26737,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Spring 2023,BCHS,8698,4,26738,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2023,COSC,6305,7,26739,Intro to Computer Science II,Rincon Castro,Carlos Alberto,2,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8498,9,26740,Doctoral Research,Momen,Mostafa,0,0,0,0,0,1,0,
+Spring 2023,MECE,8298,10,26741,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,4,0,
+Spring 2023,BIOL,6898,3,26742,Special Problems,Pennings,Steven C,0,0,0,0,0,1,0,
+Spring 2023,CUIN,8393,7,26743,Adv Internship & Prac,Gronseth,Susie L B,1,0,0,0,0,0,0,4.0
+Spring 2023,PCOL,8998,9,26745,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2023,SOCW,7397,3,26746,Selected Topics in Social Work,Cheung,Monit,1,0,0,0,0,0,0,4.0
+Spring 2023,ELED,7320,1,26751,Foundations of Literacy Instru,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,8898,6,26752,Doctoral Research,Briggs,James M,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8198,4,26755,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Spring 2023,THEA,4398,4,26756,Independent Study,Willson,Paige A,3,1,0,0,0,0,0,3.833
+Spring 2023,THEA,4398,5,26757,Independent Study,Niederer,Barbara,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6898,4,26759,Special Problems,Graur,Dan,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8398,5,26760,Special Problems,Hurt,Kara Marie,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7397,4,26761,Selected Topics in Social Work,Ortiz,Lillian Aguirre,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7397,5,26762,Selected Topics in Social Work,Pang,Melanie Espinosa,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7397,6,26763,Selected Topics in Social Work,Acquati,Chiara,0,0,0,0,0,0,0,
+Spring 2023,PHLS,7398,6,26765,Candidacy Research,Dunsmore,Julie C,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,8698,5,26768,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Spring 2023,MATH,6398,26,26775,Special Problems,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Spring 2023,MATH,6398,27,26776,Special Problems,Papadakis,Emanuel Ioannis,0,0,0,0,0,3,0,
+Spring 2023,ARTS,4398,3,26777,Independent Study,Duron-Larson,Angela Marie,1,0,0,0,0,0,0,4.0
+Spring 2023,PEP,7398,4,26780,Adv Special Problem Human Perf,Hamilton,Marc,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8220,3,26783,Doctoral Applied Music,Vasquez,Hector A,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8398,11,26784,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,1,0,
+Spring 2023,PHIL,4398,2,26785,Independent Study,Garson,James W,0,0,0,0,0,0,1,
+Spring 2023,GEOL,7399,8,26786,Masters Thesis,Wu,Jonathan En Lin,0,0,0,0,0,1,0,
+Spring 2023,PSYC,6393,13,26787,Clinical Research Practicum,Williams,Michael W,0,0,0,0,0,1,0,
+Spring 2023,ARTH,4398,1,26788,Independent Study,Koontz,Rex A,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8398,13,26790,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Spring 2023,ENGL,4399,2,26791,Senior Honors Thesis,Backus,Margot Gayle,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6898,5,26795,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Spring 2023,BCHS,6698,3,26797,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2023,ECE,6298,4,26807,Research,Yao,Yan,0,0,0,0,0,2,0,
+Spring 2023,ECE,8398,32,26809,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Spring 2023,BIOL,6998,5,26813,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Spring 2023,DANC,4398,1,26818,Independent Study,Lockett,KeyAira,3,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,27,26819,Doctoral Research,Xu,Ben,0,0,0,0,0,2,0,
+Spring 2023,ELCS,8191,2,26823,Special Field Projects,Shockley,Gerald,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,3376,6,26829,Busn Appls Database Mgmt I,Scamell,Richard W,12,13,3,1,0,0,3,3.184
+Spring 2023,MECE,8198,1,26831,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Spring 2023,MECE,8298,2,26834,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8298,23,26837,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8391,1,26839,Special Field Projects,McKinney,Lonnie Lyle,0,0,0,0,0,0,0,
+Spring 2023,OPTO,5198,5,26842,Spec Prob Phys Optics,Duong,Kim,0,0,0,0,0,2,0,
+Spring 2023,OPTO,5198,6,26843,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,1,0,
+Spring 2023,MUSI,4197,3,26844,Selected Topics in Music,Fernando,Fleurette S,2,0,0,0,0,0,0,4.0
+Spring 2023,ECON,6394,8,26846,Tpcs-Eco of Socl Issue,Nivievskyi,Oleg,1,2,0,0,0,0,0,3.553
+Spring 2023,BIOE,2397,1,26847,Selected Topics,Li,Zhengwei,1,6,0,0,0,0,0,3.096
+Spring 2023,BIOE,4399,1,26848,Senior Honors Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,8398,2,26853,Research in Pedagogy,Evans,Joseph,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,30,26856,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8240,18,26857,Doctoral Recital I,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,4399,4,26859,Senior Honors Thesis,Cescon,Marzia,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,8320,45,26860,Doctoral Applied Music,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2023,PHYS,8998,33,26862,Doctoral Research,Bittner,Eric R,0,0,0,0,0,1,0,
+Spring 2023,ENRG,4398,1,26864,Indep Stdy-Enrgy & Sustainblty,Hallmark,Terrell L,1,0,1,0,0,0,0,3.0
+Spring 2023,SCM,4302,2,26869,Energy Supply Chain,Kumar,Mridul,19,21,13,0,0,0,8,3.063
+Spring 2023,CHEE,4398,1,26870,Independent Study,Robertson,Megan L,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6430,1,26875,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8396,1,26880,Research Practicum,Yerramilli,Vijay,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,6142,1,26884,Graduate Recital III,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,8398,2,26889,Special Problems,Crawford,Steven,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8398,5,26894,Special Problems,Doshi,Hitesh B,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7398,4,26898,Masters Research,Wu,Jonathan En Lin,0,0,0,0,0,1,0,
+Spring 2023,PEP,7398,5,26899,Adv Special Problem Human Perf,Ogunrinde,Joyce,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8396,2,26901,Research Practicum,Doshi,Hitesh B,0,0,0,0,0,1,0,
+Spring 2023,DIGM,3353,35,26902,Visual Communications Tech,Dozier,Devin K,22,7,7,0,2,0,2,3.124
+Spring 2023,PETR,6326,2,26905,Applied Reservoir Simulation,Rietz,Dean C,3,0,0,0,0,0,0,3.67
+Spring 2023,PETR,6336,2,26907,Petroleum Energy Markets,Hollo,Reuven,1,0,0,0,0,0,0,4.0
+Spring 2023,MARK,8396,1,26908,Research Practicum,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8698,9,26909,Doctoral Research,Mann,Paul,0,0,0,0,0,1,0,
+Spring 2023,FINA,8396,3,26913,Research Practicum,Liu,Zesong,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8699,8,26915,Doctoral Dissertation,Cole,Mikel Walker,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,8699,1,26916,Doctoral Dissertation,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,6395,5,26917,Selected Topics in Ant,Ramirez,Marie Theresa,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,4298,1,26918,Independent Study,Shi,Weidong,0,0,0,0,0,1,0,
+Spring 2023,TLIM,3363,37,26923,Technical Communications,Piercy,Penelope Junker,26,4,3,0,4,0,2,3.208
+Spring 2023,INDS,6397,4,26928,Selected Topics,Ramirez,Enrique,2,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8399,7,26929,Doctoral Dissertation,Fan,Weihua,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,7398,7,26935,Candidacy Research,Arbona,Consuelo,0,0,0,0,0,0,0,
+Spring 2023,MUSA,8320,46,26936,Doctoral Applied Music,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Spring 2023,SUBS,6310,3,26939,Flow Assurance,Hallai,Julian,2,1,0,0,0,0,1,3.667
+Spring 2023,MUSI,6260,1,26940,Internship in Piano Teaching I,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8242,9,26942,Doctoral Recital III,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,8199,4,26944,Doctoral Dissertation,Cirino,Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8699,14,26946,Doctoral Dissertation,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,3396,1,26947,Senior Research Project,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8240,19,26948,Doctoral Recital I,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2023,DRAM,1310,15,26949,Introduction to Theatre,Brincks,Alan,21,17,2,2,6,0,2,2.903
+Spring 2023,BIOL,4498,1,26950,Independent Study,Frankino,William A,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8398,5,26954,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Spring 2023,PHIL,6398,2,26955,Special Problems,Sommers,Tamler S,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,3399,1,26956,Senior Honors Thesis,Grigoriadis,Karolos,0,0,0,0,0,0,0,
+Spring 2023,PEP,7398,6,26957,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Spring 2023,PHIL,6398,3,26958,Special Problems,Weisberg,Joshua,1,0,0,0,0,0,0,4.0
+Spring 2023,PHLS,8999,4,26963,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Spring 2023,COMM,6395,1,26964,Comprehensive Examination,Huang,Yan,0,0,0,0,0,1,0,
+Spring 2023,COMM,6395,2,26965,Comprehensive Examination,Yamasaki,Jill S,0,0,0,0,0,1,0,
+Spring 2023,COMM,6395,3,26966,Comprehensive Examination,Harlow,Summer D,0,0,0,0,0,1,0,
+Spring 2023,COMM,6395,4,26967,Comprehensive Examination,Olson,Beth M,0,0,0,0,0,2,0,
+Spring 2023,POLS,8399,6,26968,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Spring 2023,MANA,8336,2,26972,Seminar in OBM Theory,Avery,Derek Reynold,5,0,0,0,0,0,0,3.934
+Spring 2023,CIS,6357,4,26973,Control Systems Security,Conklin,William A,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,8999,3,26975,Doctoral Dissertation,Shevkoplyas,Sergey,1,0,0,0,0,0,0,4.0
+Spring 2023,DANC,6298,1,26977,Special Problems,Bobet,Jacqueline A,5,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8199,1,26979,Dissertation,Horn,Catherine Lynn,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8420,2,26980,Doctoral Applied Music,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2023,ECE,6398,30,26982,Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8698,10,26983,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Spring 2023,GEOL,7398,5,26985,Masters Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8398,12,26987,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Spring 2023,THEA,6335,1,26988,Scenery/Lighting Design,Rigdon,Kevin L,1,1,0,0,0,0,0,3.5
+Spring 2023,HDFS,4198,1,26989,Independent Study,Shockley,Gerald,4,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8420,3,26990,Doctoral Applied Music,Hester,Timothy E,1,0,0,0,0,0,0,3.67
+Spring 2023,PEP,7398,7,26993,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Spring 2023,CIVE,8398,14,26994,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,1,0,
+Spring 2023,MUSA,4189,12,26995,Senior Recital,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Spring 2023,PHOP,8998,1,26996,Doctoral Research,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Spring 2023,INDE,6333,3,26997,Probability Stat For Engineers,Feng,Qianmei,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,8301,1,27000,Seminar in Perform Pedagogy,Reed,Gavin Davis,4,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,6,27001,Independent Study,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8398,13,27002,Doctoral Research,Flynn III,James Howard,0,0,0,0,0,1,0,
+Spring 2023,PHCA,8199,7,27003,Doctoral Dissertation Defense,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8698,11,27005,Doctoral Research,Sager,William W,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8999,4,27007,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,6398,1,27011,Special Problems,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,4398,1,27013,Independent Study,Sater,Amy,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7698,2,27018,Masters Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2023,GEOL,6399,3,27019,Masters Thesis,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8699,2,27020,Doctoral Dissertation,Stewart,Robert R,0,1,0,0,0,0,0,3.33
+Spring 2023,SCM,8999,1,27023,Dissertation,Robinson Jr,Powell Ersell,0,0,0,0,0,1,0,
+Spring 2023,MUSA,4189,13,27024,Senior Recital,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2023,POLS,8699,9,27025,Doctoral Dissertation,Scarrow,Susan E,0,0,0,0,0,1,0,
+Spring 2023,CIVE,8298,6,27026,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Spring 2023,MUSA,8320,47,27028,Doctoral Applied Music,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,8240,20,27029,Doctoral Recital I,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,3311,2,27033,Methods/Tech in Bilingual Educ,Leon,Maredil Josefina,13,1,0,0,0,0,0,3.929
+Spring 2023,FINA,8398,6,27034,Special Problems,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Spring 2023,CUIN,4361,6,27035,Second Language Methodology,Elshafie,Marwa,30,8,1,0,0,0,1,3.718
+Spring 2023,PHIL,6398,4,27036,Special Problems,Hattab,Helen,0,1,0,0,0,0,0,3.33
+Spring 2023,MARK,8398,2,27039,Special Problems,Rudd,Melanie R,1,0,0,0,0,0,0,4.0
+Spring 2023,MIS,8399,1,27040,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Spring 2023,CHEE,8198,3,27044,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,1,0,
+Spring 2023,CIVE,4398,2,27045,Independent Study,Hoskere,Vedhus,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8698,1,27046,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6204,3,27049,Conducting,Marmolejo,Noe J,2,0,0,0,0,0,0,4.0
+Spring 2023,PHAR,5297,6,27050,Selected Topics in Pharmacy,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2023,PSYC,4498,1,27055,Independent Study,Haile,Colin Nichols,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7398,6,27057,Masters Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Spring 2023,DRAM,1310,16,27058,Introduction to Theatre,Brincks,Alan,23,9,6,0,7,0,4,2.845
+Spring 2023,COMM,4398,4,27059,Independent Study,Vardeman,Jennifer E,1,0,0,0,0,0,0,3.67
+Spring 2023,COMM,4398,5,27061,Independent Study,Uhrick,Jan,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,4440,4,27066,Applied Trumpet,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Spring 2023,PEP,7398,8,27070,Adv Special Problem Human Perf,LaVoy,Emily Claire-Pyle,1,0,0,0,0,0,0,4.0
+Spring 2023,BCHS,6598,7,27072,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Spring 2023,RELS,3398,1,27073,Independent Study,Mummert,Claire Elizabeth,0,1,0,0,0,0,0,3.33
+Spring 2023,MUSA,6214,1,27075,Applied Harpsichord,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2023,CHEE,6398,2,27076,Research,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2023,CHEE,6398,3,27077,Research,Vekilov,Peter,0,0,0,0,0,1,0,
+Spring 2023,CUIN,7398,3,27078,Independent Study,Dogan,Bulent,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,4398,6,27081,Independent Study,Huang,Yan,1,0,0,0,0,0,0,4.0
+Spring 2023,FINA,8396,4,27082,Research Practicum,Susmel,Raul,0,0,0,0,0,1,0,
+Spring 2023,ACCT,8398,3,27083,Special Problems,Li,Bin,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,7,27090,Independent Study,Yoshida,Hanako,0,0,0,0,0,0,0,
+Spring 2023,ARCH,6198,20,27091,Special Problems,Kyropoulou,Amygdalia,1,0,0,0,0,0,0,4.0
+Spring 2023,ARCH,6198,21,27092,Special Problems,Kyropoulou,Amygdalia,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8699,2,27093,Doctoral Dissertation,Agrawal,Ashutosh,0,0,0,0,0,0,1,
+Spring 2023,MECE,8698,2,27094,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8398,15,27095,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Spring 2023,BIOE,6399,7,27096,Masters Thesis,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Spring 2023,PHCA,6398,2,27097,Special Problems,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8898,1,27098,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,1,0,
+Spring 2023,ARTS,7398,3,27101,Independent Graduate Study,Cone,Marcus Andrew,1,0,0,0,0,0,0,4.0
+Spring 2023,ENGL,8399,23,27103,Doctoral Dissertation,Serpas,Martha R,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOE,6399,6,27104,Masters Thesis,Zhang,Yingchun,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,8399,6,27106,Doctoral Dissertation,Romero,Todd,0,0,0,0,0,1,0,
+Spring 2023,BIOE,7399,8,27107,Masters Thesis,Ince,Nuri Firat,1,0,0,0,0,0,0,3.67
+Spring 2023,COSC,4398,1,27108,Independent Study,Ordonez,Carlos,0,0,0,0,0,2,0,
+Spring 2023,ECE,7399,7,27111,Masters Thesis,Prasad,Saurabh,0,0,0,0,0,0,0,
+Spring 2023,ACCT,8398,4,27112,Special Problems,Larson,Chad R,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8298,3,27113,Doctoral Research,Chen,Tian,0,0,0,0,0,2,0,
+Spring 2023,ARTS,4398,4,27114,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,6398,5,27115,Special Problems,Hernandez,Jose A,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,4198,40,27116,Independent Study,Bell,Priscilla Garrett,1,0,0,0,0,0,0,4.0
+Spring 2023,MECE,8999,3,27117,Doctoral Dissertation,Sun,Li,2,0,0,0,0,0,0,4.0
+Spring 2023,HON,3399,3,27118,Senior Honors Thesis,Fujita,Masaya,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,2330,3,27119,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,3.67
+Spring 2023,GEOL,8398,16,27120,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Spring 2023,MECE,8999,4,27122,Doctoral Dissertation,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8398,17,27123,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,1,0,
+Spring 2023,MUSA,6424,2,27124,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2023,MUSI,8499,3,27125,Doctoral Document,Evans,Joseph,1,0,0,0,0,0,0,4.0
+Spring 2023,HIST,6398,6,27127,Special Problems,Hernandez,Jose A,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSI,6100,3,27129,Chamber Music,Hester,Timothy E,5,0,0,0,0,0,0,3.934
+Spring 2023,MUSI,6100,4,27130,Chamber Music,Suits,Brian J,5,0,0,0,0,0,0,3.934
+Spring 2023,GEOL,7398,7,27131,Masters Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8698,12,27132,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,1,0,
+Spring 2023,BIOE,8498,3,27133,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Spring 2023,GEOL,7399,9,27135,Masters Thesis,Lapen,Thomas J,0,0,0,0,0,1,0,
+Spring 2023,GEOL,8999,1,27136,Doctoral Dissertation,Sun,Jiajia,0,0,0,0,0,1,0,
+Spring 2023,GEOL,4399,1,27140,Senior Honors Thesis,Lapen,Thomas J,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,8,27143,Independent Study,Zvolensky,Michael J,2,0,0,0,0,0,0,4.0
+Spring 2023,MUSA,3448,2,27147,Applied Euphonium,Kauk,Brian Keith,2,0,0,0,0,0,0,3.835
+Spring 2023,CIVE,7399,3,27148,Master's Thesis,Kalliontzis,Dimitrios,1,0,0,0,0,0,0,4.0
+Spring 2023,ELCS,8398,7,27149,Independent Study,Carales,Vincent D,0,0,0,0,0,0,0,
+Spring 2023,COMM,4398,8,27150,Independent Study,Vardeman,Jennifer E,1,0,0,0,0,0,0,4.0
+Spring 2023,MATH,7315,9,27151,Masters Tutorial,Kalantar,Mehrdad,1,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,7398,10,27161,Independent Graduate Study,Politzer,David,1,0,0,0,0,0,0,4.0
+Spring 2023,COMM,4398,9,27162,Independent Study,Carter,Nestor Gregory,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,7199,1,27163,Master Thesis,Robinson,Alexander C,0,0,0,0,0,1,0,
+Spring 2023,DANC,4298,3,27167,Independent Study,Estrada,Maria Gabriela,1,0,0,0,0,0,0,4.0
+Spring 2023,ACCT,8699,2,27168,Doctoral Dissertation,Larson,Chad R,0,0,0,0,0,1,0,
+Spring 2023,GEOL,7199,2,27171,Master Thesis,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2023,COMM,4398,10,27172,Independent Study,Trigg,Katishia Leonna,0,1,0,0,0,0,0,3.33
+Spring 2023,POLS,6360,1,27174,Seminar in State Politics,Shor,Boris,0,0,0,0,0,0,0,
+Spring 2023,POLS,7399,1,27177,Masters Thesis,Marcinek,Elizabeth Nicole Simas,1,0,0,0,0,0,0,4.0
+Spring 2023,COSC,8399,425,27179,Doctoral Dissertation,Shi,Weidong,0,0,0,0,0,1,0,
+Spring 2023,ELCS,8695,10,27180,Doctoral Thesis,Lopez,Ruth Maria,0,0,0,0,0,1,0,
+Spring 2023,DANC,4398,2,27181,Independent Study,Lockett,KeyAira,0,0,0,0,0,0,0,
+Spring 2023,COMM,4392,2,27183,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,1,0,
+Spring 2023,MATH,4396,7,27184,Senior Research Project,Azencott,Robert Guy,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,4198,2,27189,Independent Study,Wellner,Julia S,0,0,0,0,0,1,0,
+Spring 2023,CHEE,4398,1,27190,Independent Study,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Spring 2023,QSS,4393,5,27196,QSS Research Project,Friedman,Willa H,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,8399,20,27197,Doctoral Dissertation,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Spring 2023,BIOL,4398,3,27198,Independent Study,Ogletree-Hughes,Monique L,0,0,0,0,0,0,0,
+Spring 2023,PSYC,2319,7,27199,Intro to Social Psychology,Bartlett,Brooke Ashley,12,10,7,7,14,0,5,1.973
+Spring 2023,HON,4398,40,27203,Independent Study,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Spring 2023,GEOL,8398,1,27205,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Spring 2023,ARTH,7398,2,27206,Ind Grad Stdy Art Hist,Koontz,Rex A,1,0,0,0,0,0,0,4.0
+Spring 2023,ARTS,4398,8,27207,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Spring 2023,ANTH,6315,2,27209,Sem-Ethnographic Anlys,Ghazali,Marwa,1,0,0,0,0,0,0,3.67
+Spring 2023,ANTH,6363,2,27210,"Race, Racialization",De Genova,Nicholas Paul,0,0,0,0,0,0,0,
+Spring 2023,HON,4399,15,27215,Senior Honors Thesis,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Spring 2023,PSYC,4398,9,27216,Independent Study,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Spring 2023,SOC,3398,1,27217,Ind Study in Soc,Haltom,Trenton Matthews,0,1,0,0,0,0,0,3.33
+Spring 2023,COMM,4398,11,27218,Independent Study,Crixell,Charles A,0,1,0,0,0,0,0,3.0
+Spring 2023,GEOL,8398,1,27229,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Spring 2023,BIOL,4396,2,27234,Senior Research Project,Lekven,Arne,1,0,0,0,0,0,0,3.67
+Spring 2023,MUSA,4189,1,27236,Senior Recital,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2023,SOCW,7367,7,27239,Social Policy Analysis,Pritzker,Suzanne,0,0,0,0,0,0,0,
+Spring 2023,BCHS,3396,2,27240,Senior Research Project,Rappenglueck,Bernhard,1,0,0,0,0,0,0,4.0
+Spring 2023,GHL,4198,1,27243,Independent Study,Ginapp,Kathrine,1,0,0,0,0,0,0,3.67
+Spring 2023,CIS,6398,2,27246,Special Problems,Conklin,William A,0,0,1,0,0,0,0,2.0
+Spring 2023,IDNS,2197,6,27247,Top-Natrl Sci & Mth,Stokes,Donna,1,0,0,0,0,0,0,4.0
+Spring 2023,BIOL,6398,25,27248,Special Problems,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Spring 2023,PHLS,8393,4,27253,Doctoral Practicum in Psy,Fein,Rachel,0,0,0,0,0,1,0,
+Spring 2023,COSC,8399,624,27255,Doctoral Dissertation,Shah,Shishir,1,0,0,0,0,0,0,4.0
+Spring 2023,NURS,3440,3,27258,Intro to Evid-Based Nurs Prac,Edwards-Maddox,Shermel Vinese,5,55,0,2,0,0,9,3.016
+Spring 2023,MUSA,4189,16,27261,Senior Recital,Smith,Robert Thomas,1,0,0,0,0,0,0,3.67
+Spring 2023,MATH,4396,8,27264,Senior Research Project,Onofrei,Daniel T,0,2,0,0,0,0,0,3.33
+Spring 2023,PHYS,4396,7,27296,Senior Research Project,Bering,Edgar A,1,0,0,0,0,0,0,4.0

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2023-02 (Summer 2023).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2023-02 (Summer 2023).csv
@@ -1,0 +1,1735 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Summer 2023,MIS,6341,1,10003,Information Systems,Silva,Leiser O,7,0,0,0,0,0,0,3.953
+Summer 2023,BZAN,7320,1,10004,Bus Modeling For Comp Adv,Wiley,Briceon C,12,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5493,1,10007,Introduction to Community IPPE,Hatfield,Catherine L,64,45,2,0,0,0,0,3.559
+Summer 2023,PHAR,4280,1,10008,Med/Pt Safety & Informatics,Varkey,Divya A,111,2,0,0,0,0,0,3.982
+Summer 2023,BIOE,8398,2,10009,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Summer 2023,MARK,3336,1,10022,Introduction to Marketing,Zahn,William J,24,37,12,5,2,0,1,2.95
+Summer 2023,MARK,6398,1,10023,Research,Herman,Carl,7,0,0,0,0,0,0,4.0
+Summer 2023,INDE,2333,1,10032,Engineering Statistics I,Wiggins,Nathanial David,1,3,0,0,0,0,0,3.25
+Summer 2023,LAW,5210,1,10038,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2023,LAW,5410,1,10042,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2023,LAW,6209,1,10043,Health Law Journal,Mantel,Jessica,0,0,0,0,0,1,0,
+Summer 2023,LAW,6211,1,10044,Houston Buiness/Tax Journal,Wells,Douglas,0,0,0,0,0,1,0,
+Summer 2023,LAW,6318,1,10045,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,1,0,
+Summer 2023,ECON,3332,1,10053,Intermediate Microeconomics,Lin,Shuan-Wen,11,2,2,3,1,0,1,2.948
+Summer 2023,ECON,8699,1,10062,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,1,0,
+Summer 2023,SOC,6399,3,10074,Masters Thesis,Anderson,Kathryn,0,0,0,0,0,0,0,
+Summer 2023,SPAN,2311,1,10075,Intermediate Spanish I,Pueyo Castan,Josefa,1,6,14,2,0,0,0,2.189
+Summer 2023,SPAN,2311,3,10076,Intermediate Spanish I,Miranda Moreno,Sujaila Abigail,4,12,6,0,1,0,0,2.768
+Summer 2023,SPAN,2312,1,10077,Intermediate Spanish II,Mejia Lara,Airy Sindik,2,9,5,1,0,0,0,2.57
+Summer 2023,SPAN,2307,1,10078,Span for Heritage Learners I,Hernandez,Estela,15,3,2,0,0,0,0,3.584
+Summer 2023,SPAN,7298,1,10084,Reading & Research,Rivera Garza,Cristina,0,0,0,0,0,1,0,
+Summer 2023,ECON,2302,1,10090,Principles of Microeconomics,Melendez Lugo,Joel,12,22,20,4,1,0,2,2.661
+Summer 2023,BIOL,1106,1,10096,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,0,0,0,0,1,3.743
+Summer 2023,BIOL,1106,2,10097,Biol for Science Majors I(Lab),Medrano,Ana I,15,6,1,0,0,0,0,3.561
+Summer 2023,BIOL,1106,4,10099,Biol for Science Majors I(Lab),Medrano,Ana I,12,3,0,0,1,0,0,3.501
+Summer 2023,BIOL,1306,1,10100,Biology for Science Majors I,Gifford,Jenifer,20,17,18,11,5,0,2,2.456
+Summer 2023,BIOL,6398,1,10101,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,1,10104,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2023,CHEM,1111,2,10105,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,0,0,0,0,0,3.4
+Summer 2023,CHEM,2123,1,10106,Organic Chemistry Lab I,Zaitsev,Vladimir G,7,14,0,0,1,0,2,3.122
+Summer 2023,CHEM,2123,3,10108,Organic Chemistry Lab I,Zaitsev,Vladimir G,5,10,7,1,0,0,0,2.898
+Summer 2023,MATH,1324,2,10109,Finite Math with Applications,Sosa,Moses,30,18,2,14,14,0,8,2.462
+Summer 2023,MATH,2413,3,10110,Calculus I,Sosa,Moses,24,18,8,8,10,0,16,2.569
+Summer 2023,MATH,4377,1,10113,Advanced Linear Algebra I,Ru,Min,1,4,1,0,1,0,0,2.524
+Summer 2023,MATH,6398,12,10126,Special Problems,Ru,Min,0,0,0,0,0,1,0,
+Summer 2023,PHYS,1301,1,10161,College Physics I (lecture),Cardoso Barato,Andre,45,27,18,1,1,0,13,3.193
+Summer 2023,PHYS,8398,5,10259,Doctoral Research,Cardoso Barato,Andre,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8398,6,10260,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8398,7,10261,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8398,15,10269,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,2,0,
+Summer 2023,PHYS,8398,16,10270,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8398,20,10274,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8398,23,10276,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8398,24,10277,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,3,0,
+Summer 2023,PHYS,8398,27,10280,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,4,0,
+Summer 2023,PHYS,8398,28,10281,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8399,5,10290,Doctoral Dissertation,Bellwied,Rene,1,0,0,0,0,0,0,4.0
+Summer 2023,PHYS,8399,6,10291,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8399,16,10301,Doctoral Dissertation,Gunaratne,Gemunu,1,0,0,0,0,0,0,4.0
+Summer 2023,PHYS,8399,19,10304,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8399,25,10310,Doctoral Dissertation,Pinsky,Lawrence S,0,1,0,0,0,0,0,3.33
+Summer 2023,PHYS,1101,1,10412,College Physics I (lab),Wood,Lowell T,0,10,7,0,0,0,0,2.608
+Summer 2023,PHYS,1101,2,10413,College Physics I (lab),Wood,Lowell T,0,11,6,0,0,0,0,2.608
+Summer 2023,PHYS,1101,3,10414,College Physics I (lab),Wood,Lowell T,1,13,3,0,0,0,0,2.805
+Summer 2023,PHYS,8398,39,10417,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Summer 2023,SCM,3301,1,10420,SCM Fundamentals,Khumawala,Basheer M,131,54,11,0,1,0,1,3.562
+Summer 2023,HLT,3301,1,10421,Health Behavior Theories,Bennett,Kristin C,63,6,0,0,0,0,1,3.841
+Summer 2023,SPAN,1501,5,10471,Elementary Spanish I,Benalcazar Astudillo,Diana Salome,5,7,3,1,4,0,0,2.334
+Summer 2023,SPAN,1502,1,10473,Elementary Spanish II,Cervantes Figueroa,Ana Silvia,14,7,2,0,0,0,1,3.565
+Summer 2023,SPAN,1502,3,10475,Elementary Spanish II,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,6,13,0,0,0,0,0,3.212
+Summer 2023,ACCT,2301,3,10478,Prin of Financial Accounting,Sykes,Mary Reeves,18,4,9,1,1,0,2,3.131
+Summer 2023,ACCT,2302,2,10479,Prin of Managerial Accounting,Weber,Catherine K,11,13,9,2,0,0,2,3.018
+Summer 2023,ACCT,4396,1,10480,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,6,0,
+Summer 2023,ENTR,3312,1,10484,Corporate Entrepreneurship,Karonika,John R,36,11,2,0,0,0,1,3.687
+Summer 2023,ENTR,3312,2,10485,Corporate Entrepreneurship,Karonika,John R,31,15,1,1,0,0,1,3.521
+Summer 2023,LAW,5110,2,10496,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2023,LAW,5198,3,10498,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,3.67
+Summer 2023,LAW,5210,2,10499,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2023,ECON,4390,2,10509,Economics Internship,Thornton,Rebecca Achee,2,0,0,0,0,0,0,4.0
+Summer 2023,SPAN,2312,6,10513,Intermediate Spanish II,Bello Malagon,Ana Maribel,4,16,6,0,0,0,1,2.961
+Summer 2023,SPAN,2312,12,10514,Intermediate Spanish II,Ruffino,Maythe,7,12,0,0,0,0,1,3.386
+Summer 2023,SPAN,2308,1,10515,Span for Heritage Learners II,Martinez,Raquel,9,8,4,1,0,0,0,3.196
+Summer 2023,ENGL,3328,1,10527,Masterpieces of British Lit II,Wood,Barry Albert,12,10,2,2,1,0,2,3.026
+Summer 2023,BIOL,1107,1,10531,Biology for Science Majors II,Hanke,Marc H,8,8,1,0,1,0,1,3.186
+Summer 2023,BIOL,1107,2,10532,Biology for Science Majors II,Hanke,Marc H,11,6,0,0,0,0,0,3.608
+Summer 2023,BIOL,1107,3,10533,Biology for Science Majors II,Hanke,Marc H,9,5,1,0,0,0,1,3.533
+Summer 2023,BIOL,1307,1,10535,Biology for Science Majors II,Farmer,Lisa M,16,16,11,7,3,0,5,2.679
+Summer 2023,CHEM,6398,4,10539,Special Problems,Gilbertson,Scott R,0,0,0,0,0,3,0,
+Summer 2023,CHEM,6398,13,10547,Special Problems,Harth,Eva M,0,0,0,0,0,2,0,
+Summer 2023,CHEM,6398,19,10552,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6399,6,10557,Masters Thesis,Do,Loi H,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,1,10576,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Summer 2023,CHEM,6698,2,10577,Special Problems,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Summer 2023,CHEM,6698,4,10578,Special Problems,Teets,Thomas,0,0,0,0,0,3,0,
+Summer 2023,CHEM,6698,5,10579,Special Problems,May,Jeremy A,0,0,0,0,0,3,0,
+Summer 2023,CHEM,6698,6,10580,Special Problems,Xu,Shoujun,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,7,10581,Special Problems,Lee,T Randall,0,0,0,0,0,5,0,
+Summer 2023,CHEM,6698,10,10584,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,4,0,
+Summer 2023,CHEM,6698,11,10585,Special Problems,Baldelli,Steve,0,0,0,0,0,2,0,
+Summer 2023,CHEM,6698,13,10586,Special Problems,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,14,10587,Special Problems,Bittner,Eric R,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,15,10588,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,16,10589,Special Problems,Daugulis,Olafs,0,0,0,0,0,2,0,
+Summer 2023,CHEM,6698,18,10590,Special Problems,Comito,Robert Joseph,0,0,0,0,0,4,0,
+Summer 2023,CHEM,6698,19,10591,Special Problems,Carrow,Bradley,0,0,0,0,0,6,0,
+Summer 2023,CHEM,8398,9,10635,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Summer 2023,CHEM,8398,18,10642,Doctoral Research,Harth,Eva M,0,0,0,0,0,3,0,
+Summer 2023,CHEM,8399,2,10644,Doctoral Dissertation,Lee,T Randall,2,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,8399,16,10656,Doctoral Dissertation,Chen,Tai-Yen,2,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,8698,1,10658,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,1,0,
+Summer 2023,CHEM,8698,2,10659,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,2,0,
+Summer 2023,CHEM,8698,4,10660,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Summer 2023,CHEM,8698,5,10661,Doctoral Research,Lee,T Randall,0,0,0,0,0,3,0,
+Summer 2023,CHEM,8698,6,10662,Doctoral Research,Do,Loi H,0,0,0,0,0,1,0,
+Summer 2023,CHEM,8698,7,10663,Doctoral Research,May,Jeremy A,0,0,0,0,0,6,0,
+Summer 2023,CHEM,8698,9,10665,Doctoral Research,Teets,Thomas,0,0,0,0,0,3,0,
+Summer 2023,CHEM,8698,14,10669,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Summer 2023,CHEM,8698,15,10670,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,2,0,
+Summer 2023,CHEM,8698,31,10674,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Summer 2023,CHEM,8699,4,10677,Doctoral Dissertation,Cuny,Gregory D,0,0,0,0,0,1,0,
+Summer 2023,MATH,1324,5,10691,Finite Math with Applications,Chang,James A,26,8,8,12,4,0,12,2.724
+Summer 2023,MATH,2312,4,10692,Precalculus,Caputo,Matthew G,32,28,14,8,6,0,16,2.773
+Summer 2023,MATH,2414,3,10693,Calculus II,Haynes,Alan K,30,14,7,0,4,0,4,3.176
+Summer 2023,MATH,3321,1,10696,Engineering Mathematics,Etgen,Garret J,4,8,6,4,3,0,2,2.24
+Summer 2023,MATH,4378,1,10697,Advanced Linear Algebra II,Torok,Andrei S,1,2,6,0,0,0,1,2.408
+Summer 2023,PHYS,1302,1,10760,College Physics II (lecture),Su,Wu-Pei,10,15,21,11,4,0,8,2.268
+Summer 2023,PHYS,1102,1,10761,College Physics II (lab),Wood,Lowell T,0,7,5,0,0,0,0,2.611
+Summer 2023,PHYS,1102,2,10762,College Physics II (lab),Wood,Lowell T,0,7,4,0,0,0,0,2.696
+Summer 2023,PHYS,1102,3,10763,College Physics II (lab),Wood,Lowell T,3,7,6,0,0,0,0,2.792
+Summer 2023,CHEM,1112,7,10764,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,8,4,0,0,0,0,3.0
+Summer 2023,MARK,3337,1,10767,Professional Selling,Tueffert,Curt F,54,2,0,0,0,0,1,3.953
+Summer 2023,AAS,2320,2,10770,Intro To African American Stdy,Thompson,Kevin Bernard,27,5,3,0,0,0,0,3.714
+Summer 2023,CHEM,1112,8,10790,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,7,0,2,0,0,0,3.023
+Summer 2023,ARCH,6602,1,10792,Arch Design/Build Workshop,Peters,Patrick A,10,1,0,0,0,0,0,3.849
+Summer 2023,ACCT,5331,1,10796,Federal Income Tax-Individual,Fernandez,Ramon,1,2,3,0,0,0,1,2.832
+Summer 2023,ACCT,5335,1,10797,Financial Statement Auditing,Kuruvilla,Mohan,2,2,0,0,1,0,1,2.866
+Summer 2023,ACCT,5367,1,10798,Intermediate Accounting I,Kuruvilla,Mohan,2,1,0,0,1,0,2,2.833
+Summer 2023,HDFS,4394,1,10805,Internship in HDFS,Conston,Toya,4,0,1,0,1,0,0,3.055
+Summer 2023,HLT,4392,1,10806,Field Work in Community Health,Solari Williams,Kayce D,17,6,1,0,0,0,0,3.68
+Summer 2023,CHEE,6298,1,10808,Research,Harold,Michael P,0,0,0,0,0,1,0,
+Summer 2023,CHEE,6498,1,10822,Research,Harold,Michael P,0,0,0,0,0,1,0,
+Summer 2023,CHEE,8399,3,10861,Doctoral Dissertation,Vekilov,Peter,1,0,0,0,0,0,0,4.0
+Summer 2023,CHEE,8399,9,10867,Doctoral Dissertation,Nikolaou,Michael,0,0,0,0,0,1,0,
+Summer 2023,CHEE,8399,11,10869,Doctoral Dissertation,Karim,Alamgir,3,0,0,0,0,0,0,4.0
+Summer 2023,CHEE,8399,12,10870,Doctoral Dissertation,Harold,Michael P,2,0,0,0,0,0,0,4.0
+Summer 2023,ECE,8399,1,10906,Doctoral Dissertation,Wolfe,John C,1,0,0,0,0,0,0,4.0
+Summer 2023,INDE,8399,1,10921,Doctoral Dissertation,Lim,Gino Jinho,1,0,0,0,0,0,0,4.0
+Summer 2023,GHL,6360,1,10929,Graduate Directed Practicum,Back,KiJoon,13,0,0,0,0,0,0,4.0
+Summer 2023,LAW,5298,1,10931,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,4.0
+Summer 2023,LAW,5398,1,10932,Special Research and Writing,Vetter,Greg R,2,1,0,0,0,0,0,3.777
+Summer 2023,COMD,7391,2,10937,Clinic in Speech Lang Disorder,Chapman,Amanda,0,1,0,0,0,0,0,3.0
+Summer 2023,COMD,7391,3,10938,Clinic in Speech Lang Disorder,Chapman,Amanda,1,1,0,0,0,0,0,3.5
+Summer 2023,COMD,7391,4,10939,Clinic in Speech Lang Disorder,Hernandez,Michelle,1,0,0,0,0,0,0,3.67
+Summer 2023,COMD,7391,6,10940,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,1,0,0,0,0,0,0,3.67
+Summer 2023,COMD,7391,7,10941,Clinic in Speech Lang Disorder,Devore,Danielle R,1,0,0,0,0,0,0,4.0
+Summer 2023,COMD,7391,8,10942,Clinic in Speech Lang Disorder,Walker,Dionne A,0,2,0,0,0,0,0,3.165
+Summer 2023,COMD,7391,9,10943,Clinic in Speech Lang Disorder,Devore,Danielle R,0,1,0,0,0,0,0,3.33
+Summer 2023,COMM,4392,1,10945,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,19,0,
+Summer 2023,COMD,7391,10,10948,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,0,1,0,0,0,0,0,3.33
+Summer 2023,COMD,7391,12,10949,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,1,0,0,0,0,0,0,3.67
+Summer 2023,MATH,1325,1,10967,Calc for Bus & Social Sciences,Constante,Beatrice,30,16,2,2,8,0,16,2.954
+Summer 2023,MATH,2413,1,10969,Calculus I,Perepelitsa,Irina,42,20,26,12,40,0,8,2.086
+Summer 2023,MATH,2414,1,10971,Calculus II,Xhabli,Blerina,23,19,18,9,10,0,6,2.418
+Summer 2023,MATH,6398,69,10977,Special Problems,Josic,Kresimir,0,0,0,0,0,2,0,
+Summer 2023,MATH,6398,5,10980,Special Problems,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Summer 2023,GEOL,1340,1,10993,Earth Systems,Lytwyn,Jennifer N,51,54,35,13,11,0,6,2.69
+Summer 2023,OPTO,6251,1,10994,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,20,0,
+Summer 2023,OPTO,7150,1,10995,Developmental Optometry,Chandler,Moriah Adine,84,14,2,0,0,0,0,3.82
+Summer 2023,OPTO,7493,1,10996,General Clinic IIIA,Dempsey,Robert L,0,0,0,0,0,95,0,
+Summer 2023,OPTO,8338,1,10997,Recent Developments/Round,Dempsey,Robert L,12,16,0,0,0,0,0,3.381
+Summer 2023,OPTO,8384,1,10998,Practice Management II,Davis,Mark K,20,4,0,0,0,0,0,3.71
+Summer 2023,OPTO,8696,1,10999,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,25,0,
+Summer 2023,OPTO,8990,1,11000,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,56,0,
+Summer 2023,OPTO,8991,1,11001,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,53,0,
+Summer 2023,PHOP,6160,1,11002,Gen Sem Visual Sciences,Porter,Jason,21,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6372,1,11003,Experimental Quant in VS,Benoit,Julia S,4,4,1,0,0,0,0,3.333
+Summer 2023,PHAR,5642,1,11005,Emergency Medicine,Truong,Mabel,2,3,0,0,0,0,0,3.4
+Summer 2023,PHAR,5660,1,11007,Pharmaceutical Industry,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5668,1,11010,Managed Care Pharmacy,Tolleson,Shane Russell,2,2,0,0,0,0,0,3.5
+Summer 2023,PHAR,5670,1,11011,Community Pharmaceutical Care,Tolleson,Shane Russell,12,3,0,0,0,0,0,3.8
+Summer 2023,PHAR,5674,1,11013,Nutritional Support,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5675,1,11014,Disease State Management,Tolleson,Shane Russell,23,3,0,0,0,0,0,3.885
+Summer 2023,PHAR,5678,1,11015,Transplant Therapeutics,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5680,1,11017,Oncology,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5681,3,11019,Infectious Diseases,Garey,Kevin W,2,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5685,1,11020,Critical Care,Truong,Mabel,3,3,0,0,0,0,0,3.5
+Summer 2023,PHAR,5690,1,11022,Internal Medicine,Truong,Mabel,23,6,0,0,0,0,0,3.793
+Summer 2023,PHAR,5690,2,11023,Internal Medicine,Sherer,Jeffrey T,2,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5691,1,11024,Drug Information,Tolleson,Shane Russell,0,0,0,0,0,0,0,
+Summer 2023,PHAR,5692,1,11025,Advanced Hospital Pharmacy,Truong,Mabel,32,1,0,0,0,0,0,3.97
+Summer 2023,PHAR,5693,1,11026,Advanced Community Pharmacy,Tolleson,Shane Russell,29,3,0,0,0,0,0,3.906
+Summer 2023,PHAR,5694,1,11027,Pediatrics,Truong,Mabel,1,1,0,0,1,0,0,2.333
+Summer 2023,PHAR,5695,1,11028,Geriatrics,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5663,2,11031,Pharmacy Management,Truong,Mabel,5,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7384,1,11032,Field Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,9,0,
+Summer 2023,SOCW,7388,1,11033,Field Practicum III Macro,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Summer 2023,SOCW,7391,1,11034,Field Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,10,0,
+Summer 2023,HDCS,2301,1,11035,Consumer Science,Stewart,Juliana Floriene,17,1,0,0,1,0,0,3.702
+Summer 2023,MATH,1314,1,11036,College Algebra,Constante,Beatrice,4,2,3,5,5,0,6,1.719
+Summer 2023,MATH,2415,5,11037,Calculus III,West,James David,7,8,10,9,5,0,3,2.094
+Summer 2023,LAW,5470,1,11042,Innocence Investigations,Dow,David R,1,0,0,0,0,0,0,3.67
+Summer 2023,COMM,3353,1,11043,Information & Comm Tech I,Liu,Youmei,9,11,6,1,0,0,3,3.074
+Summer 2023,ACCT,5337,1,11050,Management Accounting,Serrato,Darlene Marie  Bohac,1,2,2,0,0,0,0,2.8
+Summer 2023,GOVT,2306,1,11051,US and Texas Const/Politics,Cole,Jeffrey Bryan,17,3,4,0,0,0,1,3.555
+Summer 2023,SOCW,7385,1,11052,Field Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,22,0,
+Summer 2023,SOCW,7389,1,11053,Field Practicum IV Macro,Gonzales,Shelley A,0,0,0,0,0,8,0,
+Summer 2023,COMM,3368,1,11054,Principles of Public Relations,Ashley,Laura B,21,3,0,0,0,0,1,3.875
+Summer 2023,ECON,3370,1,11055,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,8,2,1,0,0,0,0,3.606
+Summer 2023,PHYS,1101,4,11056,College Physics I (lab),Wood,Lowell T,1,8,6,0,0,0,0,2.689
+Summer 2023,PHYS,1102,4,11057,College Physics II (lab),Wood,Lowell T,2,10,4,0,0,0,0,2.793
+Summer 2023,MANA,8398,1,11097,Special Problems,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Summer 2023,KIN,4310,1,11129,Measurement Tech Human Perf,Parikh,Pranav J,42,7,0,0,1,0,0,3.694
+Summer 2023,KIN,4345,1,11130,Econ and Finc Aspects of Sport,Lee,Dong Hun,31,6,0,1,0,0,0,3.676
+Summer 2023,KIN,4390,1,11131,Internship in PE,Betts,Randi Jill,3,1,0,0,0,0,0,3.75
+Summer 2023,KIN,4690,1,11132,Internship in Sport Admin 1,Walsh,David W,19,1,0,0,0,0,0,3.934
+Summer 2023,KIN,4691,1,11133,Internship in Sport Admin 2,Walsh,David W,16,1,0,1,0,0,0,3.759
+Summer 2023,KIN,4350,1,11134,Sport Marketing,Walsh,David W,15,50,12,2,0,0,1,2.941
+Summer 2023,NUTR,3334,1,11135,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,45,12,3,1,0,0,0,3.575
+Summer 2023,PEP,7393,1,11136,Internship & Practicum,Walsh,David W,1,0,0,0,0,0,0,4.0
+Summer 2023,COMM,2320,1,11137,Fundamentals Media Production,Crowe,Craig Warren,20,3,1,0,1,0,1,3.561
+Summer 2023,LAW,5283,1,11138,Mediation Externship,Willis,Tasha L,0,0,0,0,0,4,0,
+Summer 2023,LAW,5183,1,11139,Mediation Process,Willis,Tasha L,0,4,0,0,0,0,0,3.33
+Summer 2023,GHL,4343,1,11140,Financial Admin for Hosp.Ind.,Koh,Yoon,7,11,8,0,0,0,0,2.923
+Summer 2023,KIN,4340,1,11141,Sport Governance,Walsh,David W,8,5,2,0,0,0,0,3.422
+Summer 2023,GEOL,1303,1,11143,Physical Geology,Lytwyn,Jennifer N,38,60,31,18,9,0,4,2.603
+Summer 2023,ACCT,3367,1,11144,Intermediate Accounting I,Kuruvilla,Mohan,5,2,4,4,1,0,8,2.437
+Summer 2023,GOVT,2305,1,11146,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,20,15,1,2,1,0,1,3.308
+Summer 2023,HDFS,3350,1,11147,Observation and Assessment,Schroder,Kathleen Anne,22,6,2,0,2,0,1,3.365
+Summer 2023,NUTR,3336,1,11153,Nutritional Pathophysiology,Haubrick,Kevin,35,19,3,0,0,0,1,3.509
+Summer 2023,COMD,7381,1,11154,Medical SLP Seminar,Cizek,Laura S,12,0,0,0,0,0,0,4.0
+Summer 2023,SPAN,1501,1,11176,Elementary Spanish I,del Castillo Garza,Alejandro,6,8,3,0,2,0,3,2.877
+Summer 2023,MATH,5389,1,11215,Survey of Mathematics,Etgen,Garret J,8,6,0,0,1,0,0,3.289
+Summer 2023,PHAR,5663,1,11216,Pharmacy Management,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5683,1,11217,Cardiology,Truong,Mabel,5,1,0,0,0,0,0,3.833
+Summer 2023,BIOL,2101,1,11219,Anatomy & Physiology Lab I,Gill,Tejendra,3,10,0,0,0,0,1,3.155
+Summer 2023,BIOL,2101,2,11220,Anatomy & Physiology Lab I,Gill,Tejendra,4,14,2,0,1,0,0,2.874
+Summer 2023,BIOL,2101,3,11221,Anatomy & Physiology Lab I,Gill,Tejendra,4,16,2,0,1,0,0,2.928
+Summer 2023,BIOL,2101,4,11222,Anatomy & Physiology Lab I,Gill,Tejendra,6,13,0,1,0,0,2,3.167
+Summer 2023,GHL,4132,1,11224,Bev Mgmt & Mktg Internship,Taylor,David C,3,0,0,0,0,0,0,4.0
+Summer 2023,KIN,1304,1,11225,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,191,16,5,0,5,0,5,3.806
+Summer 2023,PEP,6309,1,11226,Policies & Govt of Sport Org.,Hawkins,Billy J,7,0,0,0,0,0,0,4.0
+Summer 2023,ELET,3405,1,11228,Microprocessor Architecture,Soneja,Chandrayee,5,6,3,0,0,0,0,3.237
+Summer 2023,MATH,8398,5,11230,Doctoral Research,Labate,Demetrio,0,0,0,0,0,3,0,
+Summer 2023,MATH,8398,9,11231,Doctoral Research,Josic,Kresimir,0,0,0,0,0,1,0,
+Summer 2023,ENGL,1302,2,11232,First Year Writing II,Krajniak,Matthew J,8,8,1,0,7,0,1,2.389
+Summer 2023,ENGL,1302,3,11233,First Year Writing II,Anderson,Claire F,19,2,1,1,1,0,1,3.555
+Summer 2023,MECT,3342,1,11235,Elements of Plant Design,El Nahas,Medhat A,1,5,9,0,0,0,1,2.379
+Summer 2023,FINA,3332,1,11238,Prin of Financial Management,Chisholm,Darla,15,21,29,22,7,0,7,2.089
+Summer 2023,MATH,8398,18,11240,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,1,0,
+Summer 2023,PUBL,6325,1,11241,Capstone Problem Project,Koelling,Peter,0,0,0,0,0,0,0,
+Summer 2023,PHAR,5675,2,11242,Disease State Management,Gee,Jodie Sue,2,1,0,0,0,0,0,3.667
+Summer 2023,MECE,3360,1,11251,Experimental Methods,Chang,Christiana,5,7,2,0,0,0,0,3.191
+Summer 2023,CHEM,2125,3,11253,Organic Chemistry Lab II,Zaitsev,Vladimir G,2,16,2,0,0,0,0,3.017
+Summer 2023,MATH,6398,58,11254,Special Problems,Fitzgibbon,William E,0,0,0,0,0,3,0,
+Summer 2023,HDFS,4393,2,11282,Internship in HDFS,Conston,Toya,4,0,0,2,0,0,0,3.0
+Summer 2023,PSYC,2319,2,11285,Intro to Social Psychology,Kamar,Jennifer Lindsay Thompson,34,8,0,0,1,0,0,3.667
+Summer 2023,MATH,6398,59,11295,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Summer 2023,BIOL,2301,1,11302,Anatomy & Physiology I (lect),Wayne,Chad M,9,11,18,4,3,0,4,2.437
+Summer 2023,BIOL,2102,2,11304,Anatomy & Physiology II (lab),Gill,Tejendra,6,11,0,1,1,0,0,3.018
+Summer 2023,BIOL,2102,3,11305,Anatomy & Physiology II (lab),Gill,Tejendra,4,15,2,0,1,0,1,2.94
+Summer 2023,BIOL,2102,4,11306,Anatomy & Physiology II (lab),Gill,Tejendra,1,16,1,1,1,0,1,2.701
+Summer 2023,BIOL,2302,1,11308,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,13,13,12,3,2,0,3,2.729
+Summer 2023,ACCT,2301,2,11309,Prin of Financial Accounting,Sykes,Mary Reeves,26,11,4,3,1,0,3,3.333
+Summer 2023,MIS,3360,1,11311,Systems Analysis and Design,Porra,Jaana,28,6,1,0,0,0,0,3.705
+Summer 2023,ACCT,4332,1,11314,Corporate Taxation,Fernandez,Ramon,1,4,0,0,0,0,0,3.134
+Summer 2023,ACCT,7375,1,11315,Corporate Taxation,Fernandez,Ramon,7,11,4,0,0,0,1,3.196
+Summer 2023,CHEM,1111,9,11316,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,3,0,0,0,0,3.078
+Summer 2023,ENGL,1302,4,11321,First Year Writing II,Khalil,Rand Omar,19,4,1,1,0,0,0,3.587
+Summer 2023,PHYS,8399,46,11364,Doctoral Dissertation,Vilalta,Ricardo,1,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5644,1,11370,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,1111,14,11371,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,2,0,0,0,0,3.229
+Summer 2023,COMD,6399,3,11376,Masters Thesis,Mills,Monique T,1,0,0,0,0,0,0,4.0
+Summer 2023,HRD,6396,1,11389,Internship in Human Res. Dev.,Shirmohammadi,Melika,1,0,0,0,0,0,0,4.0
+Summer 2023,HDCS,3303,1,11401,Retailing and Consumer Science,Rifai,Rana Ihsan,10,3,4,1,0,0,0,3.222
+Summer 2023,HDCS,4375,1,11403,Strategies in Digital Retail,Kellough,James David,40,8,1,0,1,0,0,3.687
+Summer 2023,MATH,2318,3,11406,Linear Algebra,Perepelitsa,Mikhail Antolyevic,11,9,4,1,0,0,4,3.226
+Summer 2023,NUTR,4333,1,11408,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,4,5,6,1,1,0,0,2.491
+Summer 2023,NUTR,4347,1,11409,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,3,14,4,2,1,0,1,2.694
+Summer 2023,MARK,4362,1,11410,Applied Buyer Behavior,Noriega,Jaime L,26,19,4,0,1,0,0,3.307
+Summer 2023,ACCT,2302,1,11412,Prin of Managerial Accounting,Weber,Catherine K,22,13,9,5,0,0,0,3.108
+Summer 2023,MANA,6A25,1,11415,Ethical Leadrshp & Crit Reason,Celly,Nikhil,31,0,0,0,0,0,0,3.979
+Summer 2023,MIS,6A41,1,11416,Information Systems,Silva,Leiser O,45,0,1,0,0,0,0,3.906
+Summer 2023,KIN,4300,1,11417,Phys Activity Older Adults,Alastuey,Lisa L,24,14,5,2,5,0,0,2.914
+Summer 2023,KIN,3350,1,11418,Psych Aspects Sport Exercise,Gray,Jon Phillip,59,9,1,0,0,0,1,3.817
+Summer 2023,INTB,3355,1,11419,Global Environment of Business,Miljanic,Andra Olivia,104,10,2,0,0,0,0,3.839
+Summer 2023,LAW,5328,1,11421,Judicial Externship I,Archer,Anna M,0,0,0,0,0,9,0,
+Summer 2023,LAW,5328,2,11422,Judicial Externship I,Archer,Anna M,0,0,0,0,0,6,0,
+Summer 2023,LAW,5329,3,11424,Judicial Externship II,Archer,Anna M,0,0,0,0,0,3,0,
+Summer 2023,LAW,5400,2,11425,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2023,LAW,5407,10,11426,Judicial Externship I,Archer,Anna M,0,0,0,0,0,4,0,
+Summer 2023,LAW,5415,3,11427,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2023,LAW,6300,2,11428,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,6,0,
+Summer 2023,LAW,6300,3,11429,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2023,LAW,6355,3,11431,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,
+Summer 2023,LAW,5357,1,11432,Evidence,Gomez,Alissa R,14,23,3,0,0,6,0,3.201
+Summer 2023,CIS,3355,1,11433,Integrated Information Systems,Peddoju,Suresh Kumar,30,13,3,0,0,0,2,3.515
+Summer 2023,KIN,3306,1,11434,Physiology-Human Performance,Park,Yoonjung,10,20,8,5,2,0,0,2.726
+Summer 2023,ECE,3331,1,11435,Program Appl in Elec Comp Engr,Hebert,Thomas James,6,3,7,1,0,0,0,2.959
+Summer 2023,ECE,3337,1,11436,Signals and Systems Analysis,Hebert,Thomas James,5,8,6,0,0,0,1,3.104
+Summer 2023,KIN,1352,3,11437,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,91,4,2,0,1,0,1,3.878
+Summer 2023,MANA,4396,1,11439,Management Internship,Carlin,Barbara A,0,0,0,0,0,14,0,
+Summer 2023,MARK,4396,1,11440,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,25,0,
+Summer 2023,MAS,3340,1,11441,Mexican Amer Urban Communities,Pino,Diana,5,15,3,0,2,0,1,2.761
+Summer 2023,MANA,4355,1,11442,Selection and Staffing,Phillips,James S,35,11,5,1,1,0,0,3.353
+Summer 2023,ELCS,6332,1,11451,Student Develop/Student Affair,Messa,Emily Alice,9,0,0,0,0,0,1,3.963
+Summer 2023,MATH,1324,6,11454,Finite Math with Applications,Caglar,Atife,20,14,6,4,0,0,4,3.181
+Summer 2023,MATH,2312,5,11455,Precalculus,Chang,James A,4,4,4,4,18,0,14,1.196
+Summer 2023,COMD,7383,2,11457,Pediatric SLP Seminar,Cizek,Laura S,10,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,6698,21,11458,Special Problems,Harth,Eva M,0,0,0,0,0,2,0,
+Summer 2023,CHEM,8698,32,11459,Doctoral Research,Baldelli,Steve,0,0,0,0,0,1,0,
+Summer 2023,HON,3301,1,11460,Readings in Medicine & Society,Reynolds,Aaron E,7,1,0,0,0,0,1,3.834
+Summer 2023,MIS,6A41,2,11461,Information Systems,Silva,Leiser O,15,0,0,0,0,0,1,3.956
+Summer 2023,MATH,8398,75,11463,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,23,11476,Special Problems,Chiang,Naihao,0,0,0,0,0,2,0,
+Summer 2023,MECE,3245,1,11481,Materials Science Laboratory,Hammami,Farah,16,9,0,0,0,0,0,3.561
+Summer 2023,PHCA,8298,1,11486,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Summer 2023,PHIL,1321,1,11487,Logic I,Haaga,Curtis W,13,11,4,0,6,0,8,2.706
+Summer 2023,BIOL,2101,6,11491,Anatomy & Physiology Lab I,Gill,Tejendra,4,8,0,0,0,0,1,3.278
+Summer 2023,HIST,8699,1,11520,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Summer 2023,PEP,8399,1,11522,Doctoral Dissertation,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5690,3,11527,Internal Medicine,Fernandez,Julianna M,2,0,0,0,0,0,0,4.0
+Summer 2023,ECON,6691,1,11532,Master's Internship,Thornton,Rebecca Achee,6,1,0,0,0,0,0,3.81
+Summer 2023,ECON,6693,1,11533,Master's Research Project,Zhivan,Natalia A,2,0,0,0,0,0,0,4.0
+Summer 2023,HRD,4396,1,11534,Internship in HRD,Owens-Shepard,Toya,17,2,0,0,0,0,1,3.877
+Summer 2023,HRD,3340,1,11535,Principles of HRD,Hattier,Beth,21,12,0,1,1,0,1,3.457
+Summer 2023,HRD,4344,1,11537,Designing E-Learning,Bennett,LaTasha,22,7,0,0,1,0,0,3.589
+Summer 2023,HDCS,3300,1,11538,Org Decisions,Hitchman Sr,Cal M,12,4,2,1,1,0,0,3.184
+Summer 2023,HDCS,4386,1,11539,Communication Strategies,Hitchman Sr,Cal M,14,1,0,0,1,0,0,3.688
+Summer 2023,GHL,2160,1,11540,Professional Development,Kenyan,Erin Oeser,13,0,0,0,2,0,0,3.401
+Summer 2023,FORE,6396,1,11541,Internship,Hines,Andrew Lewis,2,0,0,0,0,0,0,4.0
+Summer 2023,MANA,7346,1,11542,Global Human Resource Mgmt,Werner,Steve,9,0,0,0,0,0,0,3.963
+Summer 2023,MANA,6A25,2,11543,Ethical Leadrshp & Crit Reason,Celly,Nikhil,32,1,0,0,0,0,0,3.94
+Summer 2023,MANA,6A83,1,11544,Strategic Analysis,Celly,Nikhil,23,1,0,0,0,0,0,3.876
+Summer 2023,MATH,3339,3,11545,Statistics for the Sciences,Papadakis,Emanuel Ioannis,12,1,0,1,0,0,1,3.644
+Summer 2023,DIGM,2352,30,11546,Digital Photography,Waite,Jerry J,15,7,3,0,0,0,2,3.546
+Summer 2023,BIOL,2121,2,11550,Microbiology for Science Major,Knapp,Richard D,5,4,0,0,0,0,0,3.446
+Summer 2023,COMM,3353,2,11552,Information & Comm Tech I,Liu,Youmei,19,3,4,0,0,0,2,3.59
+Summer 2023,PUBL,6321,1,11553,Seminar in Urban Politics,Thurmond,James H,6,2,0,0,0,0,0,3.626
+Summer 2023,CUST,6370,1,11554,Cultural Found Amer Edu,Hernandez,Belkis Pamela,8,1,0,0,0,0,0,3.926
+Summer 2023,GENB,5303,1,11555,Prof Acct Communication,Newman,Michael Ray,3,4,0,0,0,0,0,3.429
+Summer 2023,GENB,7303,1,11556,Prof Accounting Communication,Newman,Michael Ray,11,4,0,0,0,0,0,3.711
+Summer 2023,GOVT,2305,5,11557,"US Govt: Congress,Pres & Crts",Davis,Shelby,21,8,0,1,0,0,0,3.578
+Summer 2023,NUTR,4312,1,11558,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,6,17,2,1,0,0,0,3.052
+Summer 2023,NUTR,4334,1,11559,Community Nutrition,Cepni,Aliye Beyza,28,19,3,1,1,0,1,3.366
+Summer 2023,SGNL,1302,1,11560,Elementary Sign Language II,Brittain,Terrell,3,4,5,0,0,0,0,2.806
+Summer 2023,MATH,1314,5,11562,College Algebra,Constante,Beatrice,9,3,2,5,3,0,3,2.395
+Summer 2023,MATH,1342,5,11563,Elementary Statistical Methods,Wang,Wenshuang,16,8,12,16,6,0,2,2.275
+Summer 2023,SCM,6A01,1,11565,SCM Concepts,Sahin,Funda,22,14,4,0,0,0,0,3.45
+Summer 2023,FINA,4320,1,11566,Investment Management,Doshi,Hitesh B,22,15,5,0,0,0,1,3.389
+Summer 2023,PHAR,5681,2,11567,Infectious Diseases,Truong,Mabel,5,1,0,0,1,0,0,3.286
+Summer 2023,PHAR,5645,1,11568,Pharmacy Informatics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2023,ATP,6191,1,11571,Clinical Experience I,Harrison,Layci,15,0,0,0,0,0,0,4.0
+Summer 2023,ATP,6301,1,11572,Anatomy,Harrison,Layci,4,11,1,0,0,0,0,3.188
+Summer 2023,ATP,6302,1,11573,Emergency Care,Knoblauch,Mark Alan,9,5,0,1,0,0,0,3.467
+Summer 2023,ATP,7194,1,11574,Clinical Experience IV,Knoblauch,Mark Alan,14,0,0,0,0,0,0,4.0
+Summer 2023,KIN,4190,1,11575,Sport Administration Seminar,Walsh,David W,7,0,2,0,0,0,2,3.482
+Summer 2023,ATP,7101,1,11576,"Head, Neck & Spine Eval Lab",Harrison,Layci,14,1,0,0,0,0,0,3.933
+Summer 2023,ATP,7301,1,11577,"Head, Neck & Spine Evaluation",Harrison,Layci,12,3,0,0,0,0,0,3.8
+Summer 2023,ATP,7302,1,11578,Gen Med/Pharm 2-Pathophysiolog,Knoblauch,Mark Alan,11,3,0,0,0,0,0,3.786
+Summer 2023,CUIN,7301,1,11579,CUIN Capstone Seminar,Brower,Samuel Richard,11,1,0,0,0,0,0,3.917
+Summer 2023,ENGL,1301,2,11580,First Year Writing I,O'Bryan,Ann Patricia,14,1,2,0,4,0,1,2.906
+Summer 2023,CNST,3205,1,11581,Construction Safety Management,Hart,Lee J,16,10,0,0,0,0,0,3.615
+Summer 2023,HIST,6651,1,11602,Public History Internship,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Summer 2023,ACCT,4331,1,11603,Federal Income Tax-Individual,Fernandez,Ramon,8,23,11,0,0,0,2,3.031
+Summer 2023,FINA,4396,1,11627,Finance Internship,Kumar,Praveen,0,0,0,0,0,61,0,
+Summer 2023,COMM,2311,1,11641,Writing for Print and Digital,Radcliffe Andre,Jennifer,17,3,3,0,2,0,0,3.307
+Summer 2023,DIGM,3351,30,11644,Individ Comm Processes,De Vega,Jaime M,25,4,1,0,0,0,0,3.745
+Summer 2023,DIGM,3354,30,11646,Video Production 1,Snyder,Philip Charles,17,11,1,0,3,0,0,3.229
+Summer 2023,SCLT,3387,30,11650,Procurement,Velarde,Jose Manuel,12,18,3,1,2,0,0,2.973
+Summer 2023,DIGM,1350,30,11651,Graphics for Digital Media,Beyl,Charles Eugene,12,9,0,1,1,0,0,3.362
+Summer 2023,DIGM,2353,30,11652,Page Layout and Design,De Vega,Jaime M,16,3,0,0,1,0,2,3.584
+Summer 2023,HDFS,1300,1,11655,Dev of Contemporary Families,Jordan,Erica F,37,21,6,1,1,0,3,3.379
+Summer 2023,HLT,4310,1,11657,Program Planning for Hlt Prof,Markowitz,Eliz,19,4,3,4,1,0,1,3.097
+Summer 2023,PSYC,3310,1,11658,Indstrl-Orgnztnl Psy,Schoolfield,Lucy,31,18,9,2,2,0,0,3.225
+Summer 2023,PSYC,2316,1,11659,Psychology of Personality,Ravey,Eriksen,38,14,1,0,0,0,0,3.63
+Summer 2023,MANA,7375,1,11660,Global Leadership,Walker,William A,29,0,0,0,0,0,1,4.0
+Summer 2023,SOCW,7368,1,11664,Trauma Treatment for Children,Amtsberg,Donna K,19,4,0,0,0,0,0,3.826
+Summer 2023,MATH,3339,1,11667,Statistics for the Sciences,Poliak,Cathy Dawn,18,8,12,5,5,0,1,2.59
+Summer 2023,GOVT,2306,10,11668,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,8,20,10,2,2,0,0,2.683
+Summer 2023,PSYC,2330,2,11669,Biological Psychology,Bodet III,Jean Philippe,16,24,7,3,6,0,1,2.815
+Summer 2023,MIS,4477,1,11671,Network & Security Infrastruct,Khan,Hina F,18,3,0,0,0,0,0,3.7
+Summer 2023,WGSS,2350,2,11673,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,27,2,0,0,0,0,1,3.931
+Summer 2023,CUIN,8310,3,11674,Laboratory of Practice,Reis,Nancy,2,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,2301,5,11676,Introduction to Psychology,Capuozzo,Kristen Irene,6,5,0,0,0,0,0,3.575
+Summer 2023,PSYC,3339,1,11677,Intro To Clinical Psychology,Szafranski,Derek D,38,8,1,1,1,0,0,3.633
+Summer 2023,MECE,2334,1,11678,Thermodynamics,Love,Holley Carole,11,6,4,1,0,0,0,3.152
+Summer 2023,NURS,3636,1,11680,Nur Process for Colabrtive Prc,Uwaezuoke,Precious,8,52,0,0,0,0,1,3.133
+Summer 2023,HDFS,3318,1,11681,Human Ecol of Adult Developmt,Rab,Saira,40,3,1,0,1,0,0,3.763
+Summer 2023,NURS,3337,1,11682,Rdg/Interpreting Sci Lit,Quintana,Danielle,37,21,0,4,0,0,0,3.468
+Summer 2023,PSYC,8121,1,11684,Clinical Psychology Internship,Vincent,John P,0,0,0,0,0,5,0,
+Summer 2023,PSYC,8399,1,11685,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6392,1,11687,Intervention Practicum,Vincent,John P,0,0,0,0,0,12,0,
+Summer 2023,PSYC,6399,1,11688,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Summer 2023,PSYC,7399,2,11689,Masters Thesis,Sharp,Carla,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,3,11690,Masters Thesis,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,2,11692,Doctoral Dissertation,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8321,1,11693,Clinical Psyc Internship,Vincent,John P,0,0,0,0,0,4,0,
+Summer 2023,PSYC,8390,1,11694,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,3,11696,Doctoral Dissertation,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,4,11697,Doctoral Dissertation,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7392,1,11698,Psychology Practicum,Fetterman,Adam Kent,0,0,0,0,0,2,0,
+Summer 2023,ELED,3320,1,11700,Survey Literature Child Adol,Tyson,Eleanore S,17,0,0,0,0,0,0,3.942
+Summer 2023,PSYC,7399,5,11701,Masters Thesis,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Summer 2023,CHEM,6698,25,11703,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,5,11711,Doctoral Dissertation,Derrick,Jaye L,0,0,0,0,0,1,0,
+Summer 2023,CHEM,8698,20,11715,Doctoral Research,Xu,Shoujun,0,0,0,0,0,2,0,
+Summer 2023,LAW,5514,1,11726,Judicial Externship I,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,7,11728,Doctoral Dissertation,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Summer 2023,ACCT,4331,2,11732,Federal Income Tax-Individual,Fernandez,Ramon,9,24,5,1,0,0,1,3.136
+Summer 2023,LAW,5602,1,11738,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,5,0,
+Summer 2023,PSYC,8399,10,11739,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,7399,4,11744,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6157,2,11751,Research Practicum B,Burns,Alan R,2,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,6398,5,11752,Independent Studies,Ng,Vincent,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,12,11753,Doctoral Dissertation,Cirino,Paul,1,0,0,0,0,0,0,4.0
+Summer 2023,LAW,5500,1,11756,Government and Nonprofit Exter,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,
+Summer 2023,PSYC,7390,1,11758,Clin Neuropsychology Practicum,Woods,Steven Paul,0,0,0,0,0,3,0,
+Summer 2023,CHEM,8399,21,11766,Doctoral Dissertation,Cai,Chengzhi,0,1,0,0,0,0,0,3.33
+Summer 2023,MATH,8698,2,11772,Doctoral Research,Labate,Demetrio,0,0,0,0,0,1,0,
+Summer 2023,PHAR,5681,5,11774,Infectious Diseases,Sofjan,Amelia Kartikasari,2,0,0,0,0,0,0,4.0
+Summer 2023,MIS,4378,1,11779,Admin of Computer-Based MIS,Porra,Jaana,40,2,0,0,0,0,1,3.96
+Summer 2023,MATH,8698,6,11796,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Summer 2023,HLT,4307,1,11801,Research and Eval in Health,Kamdar-Sharif,Amber,29,5,0,0,0,0,0,3.834
+Summer 2023,WGSS,4360,1,11820,Capstone Internship Course,Gregory,Elizabeth,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8698,8,11828,Doctoral Research,Cappanera,Loic,0,0,0,0,0,1,0,
+Summer 2023,MATH,8698,9,11829,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7393,1,11837,Field Practicum in Psychology,Vincent,John P,0,0,0,0,0,15,0,
+Summer 2023,ECON,4390,3,11839,Economics Internship,Thornton,Rebecca Achee,2,0,0,0,0,0,0,4.0
+Summer 2023,KIN,3304,2,11840,Human Structure & Phys Perform,Breslin,Whitney L,2,9,7,1,2,0,2,2.412
+Summer 2023,ENGL,1301,6,11843,First Year Writing I,Murray,Christopher Brean,15,5,3,0,1,0,1,3.334
+Summer 2023,PSYC,2301,4,11855,Introduction to Psychology,Wu,Dongjie,25,14,2,2,0,0,2,3.403
+Summer 2023,PSYC,2317,1,11856,Intro to Psychology Statistics,Le,Giang Xuan,15,13,9,1,4,0,3,2.794
+Summer 2023,PSYC,2317,2,11857,Intro to Psychology Statistics,Browne,Lindsay J,16,16,6,1,4,0,4,2.907
+Summer 2023,MATH,3325,1,11859,Transition to Advanced Math,Leger,Nicholas M,4,3,6,2,2,0,0,2.294
+Summer 2023,PHLS,8193,1,11860,Internship in Psychology,Allan,Blake A,0,0,0,0,0,8,0,
+Summer 2023,LAW,5424,1,11861,Death Penalty Clinic,Dow,David R,1,2,0,0,0,0,0,3.333
+Summer 2023,LAW,5600,1,11862,Judicial Externship I,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2023,DIGM,3353,30,11864,Visual Communications Tech,Dozier,Devin K,22,2,6,2,2,0,1,3.089
+Summer 2023,DIGM,2357,30,11867,Content Strategy & Development,Alters,Monika Joanna,20,4,3,0,0,0,0,3.507
+Summer 2023,LAW,5385,1,11872,Introduction to the Laws of EU,Willis,Tasha L,2,5,0,0,0,0,0,3.38
+Summer 2023,LAW,5228,1,11874,Judicial Externship I,Archer,Anna M,0,0,0,0,0,3,0,
+Summer 2023,LAW,5228,2,11875,Judicial Externship I,Archer,Anna M,0,0,0,0,0,4,0,
+Summer 2023,LAW,5229,2,11877,Judicial Externship II,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2023,LAW,5203,4,11879,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2023,LAW,5206,4,11880,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2023,TMTH,3360,1,11881,Applied Technical Statistics,Schroeder,Susan L,5,9,6,3,1,0,4,2.515
+Summer 2023,MANA,3335,1,11882,Intro Org Behavior and Mgmt,Currie,Daniel David,105,20,3,1,0,0,2,3.75
+Summer 2023,MANA,3335,2,11883,Intro Org Behavior and Mgmt,Currie,Daniel David,78,19,2,1,1,0,0,3.664
+Summer 2023,MANA,4336,1,11884,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,8,9,0,1,0,0,0,3.26
+Summer 2023,SOCW,7326,1,11885,Disparities in Health,Torres,Isabel,19,2,1,0,0,0,0,3.818
+Summer 2023,SOCW,7365,1,11886,Crisis Intervention,Battle,Jennifer Alene,28,0,0,0,0,0,0,4.0
+Summer 2023,HLT,3381,1,11891,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,60,14,3,1,0,0,1,3.65
+Summer 2023,ELCS,8191,1,11895,Special Field Projects,Davis,Bradley,7,1,0,0,1,0,0,3.371
+Summer 2023,PHIL,1361,1,11896,Philosophy and the Arts,Drapela,Nick Gerard,7,14,8,2,1,0,4,2.74
+Summer 2023,PHIL,1361,2,11897,Philosophy and the Arts,Drapela,Nick Gerard,7,9,9,1,0,0,4,2.859
+Summer 2023,ECE,2202,1,11898,Circuit Analysis II,Shattuck,David P,6,8,3,0,0,0,1,3.196
+Summer 2023,COSC,1437,301,11900,Introduction to Programming,Rincon Castro,Carlos Alberto,35,13,13,3,11,0,3,2.778
+Summer 2023,SOCW,8336,1,11901,Required Research Internship,Berger Cardoso,Jodi A,5,0,0,0,0,0,0,4.0
+Summer 2023,HDCS,1300,2,11902,Human Ecosystems & Tech Change,Gatterson,Beverly,41,4,1,0,2,0,1,3.688
+Summer 2023,GHL,6191,1,11903,Project Development,Ramirez,Arlene D,0,0,0,0,0,11,0,
+Summer 2023,ENTR,4394,1,11904,RED Labs Accelerator,Gonzalez,Liana,2,0,0,0,0,0,0,4.0
+Summer 2023,MARK,7373,1,11906,Business to Business Marketing,Kamal,Saiyid Zafar,6,1,0,0,0,0,0,3.763
+Summer 2023,THEA,6284,1,11907,Program Management,Allen,Robert Scott,11,0,0,0,0,0,0,4.0
+Summer 2023,THEA,6386,1,11908,Drama in Context,Shimko,Robert B,11,0,0,0,0,0,0,4.0
+Summer 2023,GOVT,2305,6,11912,"US Govt: Congress,Pres & Crts",Davis,Sharon M,16,12,5,1,0,0,3,3.284
+Summer 2023,THEA,6382,1,11914,Dramaturgy for H.S. Director,Shimko,Robert B,8,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8351,1,11915,Hist & Philosophy of Psyc Syst,Reyna,Ronda,21,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8357,1,11916,Clinical Interventions,de Dios,Marcel A,4,0,0,0,0,0,0,3.918
+Summer 2023,PHLS,8364,1,11917,"Prof Prac Psy: Eth,Law,& Iss",Anderson,Jacqueline R,23,0,0,0,0,0,0,3.9
+Summer 2023,PHLS,8366,1,11918,"Assmt Child/Adol Aff, Beh, Per",Kahn,David Andrew,6,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8393,2,11920,Doctoral Practicum in Psy,Frye,Kennetha,0,0,0,0,0,5,0,
+Summer 2023,HDFS,4316,1,11921,Dynamics of Family Relations,Rab,Saira,20,6,2,0,1,0,0,3.54
+Summer 2023,HDFS,3320,1,11922,Careers in HDFS,Jordan,Erica F,11,3,2,0,2,0,1,3.185
+Summer 2023,HDFS,2314,1,11923,Human Dev and Interventions,Schoger,Kimberly,52,5,1,1,3,0,1,3.603
+Summer 2023,MUSI,1117,1,11925,Aural Skills II,Garza,Paul Victor,3,5,3,0,1,0,1,2.75
+Summer 2023,MUSI,1312,1,11926,Music Theory II,Garza,Paul Victor,8,1,2,0,0,0,1,3.425
+Summer 2023,NUTR,2332,4,11927,Intro To Human Nutrition,Alastuey,Lisa L,12,18,11,2,3,0,0,2.675
+Summer 2023,MUSI,1182,1,11928,Group Piano II,Van Kekerix,Todd Evan,6,0,0,0,0,0,1,3.945
+Summer 2023,ECE,2201,1,11929,Circuit Analysis I,Ruchhoeft,Paul,2,5,5,0,0,0,1,2.64
+Summer 2023,GOVT,2306,50,11930,US and Texas Const/Politics,LeVeaux,Christine,12,1,0,0,0,0,0,3.796
+Summer 2023,MECE,5388,1,11932,Intelligent Structural Systems,Song,Gangbing,17,59,13,1,0,0,0,3.022
+Summer 2023,MECE,3381,1,11933,Finite Elements for Mech Engr,Joshi,Shailendra Pramod,7,18,10,0,0,0,0,2.895
+Summer 2023,MUSI,2302,2,11934,Listening to Jazz,Marmolejo,Noe J,19,3,3,0,1,0,0,3.5
+Summer 2023,THEA,6280,1,11935,The teaching of Acting,Ferrarone,Jessica,7,1,0,0,0,0,0,3.916
+Summer 2023,THEA,6281,1,11936,The teaching of Voice,Wetzel,Molly Elizabeth,8,0,0,0,0,0,0,4.0
+Summer 2023,THEA,6381,1,11937,Scenic Des for H.S. Director,Krouskop,Mark,8,0,0,0,0,0,0,4.0
+Summer 2023,THEA,6384,1,11938,Directing,Cook,Rena R,12,0,0,0,0,0,0,4.0
+Summer 2023,THEA,6383,1,11939,Light/Cost Des for HS Director,Giannelli,Christina Rose,12,0,0,0,0,0,0,3.808
+Summer 2023,THEA,6385,1,11940,Technical Direction/Shop Maint,Middents,Jonathan Mark,11,0,0,0,0,0,0,4.0
+Summer 2023,THEA,6180,1,11941,Applying Methods Acting/Voice,Ferrarone,Jessica,11,1,0,0,0,0,0,3.889
+Summer 2023,THEA,6181,1,11942,Applying Method Des/Dramaturgy,Shimko,Robert B,12,0,0,0,0,0,0,4.0
+Summer 2023,THEA,6182,1,11943,Applying Methods Light/Costume,Willson,Paige A,11,0,0,0,0,0,0,4.0
+Summer 2023,GOVT,2305,2,11945,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,15,15,5,1,2,0,1,3.044
+Summer 2023,ENGL,3352,1,11946,19th Century American Fiction,Wood,Barry Albert,15,10,1,0,0,0,1,3.386
+Summer 2023,ELCS,6393,1,11947,Practicum,Carales,Vincent D,4,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,6330,1,11951,Finance & School-Based Budgtng,Ude,Audra Diane,10,1,0,0,0,0,1,3.909
+Summer 2023,PSYC,7392,2,11978,Psychology Practicum,Knee,Clifford R,3,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,2301,3,11987,Introduction to Psychology,Orr,Michael F,14,20,5,3,2,0,1,3.052
+Summer 2023,PHAR,5696,5,11992,Ambulatory Care - Primary Care,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2023,KIN,3305,2,11997,Sport Sociology,Graham,Marilynn Hadassah,78,10,8,2,4,0,1,3.491
+Summer 2023,PSYC,8399,14,12005,Doctoral Dissertation,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,6315,1,12011,Masters Tutorial,Jun,Mikyoung,17,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,1112,15,12028,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,1,0,0,0,0,3.214
+Summer 2023,PCOL,8399,1,12029,Doctoral Dissertation,McConnell,Bradley K,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,15,12031,Doctoral Dissertation,Zvolensky,Michael J,1,0,0,0,0,1,0,4.0
+Summer 2023,LAW,6300,11,12037,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,
+Summer 2023,KIN,4398,1,12043,Independent Study,Cottingham,Michael,2,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,4344,2,12056,Cultural Psychology,Jewell,Rebecca D,24,17,7,4,0,0,0,3.249
+Summer 2023,DIGM,2325,30,12058,Info Tech for Digital Media,Hargrove,Mark Stephen,8,1,7,0,1,0,0,2.844
+Summer 2023,ECON,6691,2,12060,Master's Internship,Nivievskyi,Oleg,6,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,2316,2,12061,Psychology of Personality,Serrano Holden,Surizaday,47,2,1,1,0,0,0,3.856
+Summer 2023,PSYC,2316,3,12062,Psychology of Personality,Liu,Tingshu,42,12,2,2,0,0,0,3.587
+Summer 2023,PSYC,3350,1,12063,Intro to Cognitive Psychology,Racioppo,Keith,18,38,7,1,0,0,0,3.161
+Summer 2023,MANA,4330,1,12064,Intro to Strategic HR Mgt,Sebastijanovic,Marina,32,24,3,1,0,0,0,3.423
+Summer 2023,SOCW,7303,1,12065,Child Abuse and Neglect,Berger Cardoso,Jodi A,23,5,0,0,0,0,0,3.821
+Summer 2023,COMM,4303,1,12066,Communication Law and Ethics,Dulin,Matthew D,1,9,5,1,1,0,0,2.393
+Summer 2023,COMM,4365,2,12067,Digital PR and Advertising,Choi,Ho Joon,20,3,2,0,0,0,0,3.68
+Summer 2023,MATH,1314,2,12069,College Algebra,Chang,James A,9,4,3,2,3,0,2,2.651
+Summer 2023,MATH,2312,2,12070,Precalculus,Caglar,Atife,26,22,22,2,2,0,2,2.865
+Summer 2023,MATH,3333,1,12071,Intermediate Analysis,Kalantar,Mehrdad,3,4,4,0,2,0,4,2.614
+Summer 2023,HRD,3351,1,12072,Instructional Design for HRD,Pereira-Leon,Maura Josefina,12,33,0,0,0,0,0,3.201
+Summer 2023,GHL,3341,1,12074,Hospitality Managerial Acct,Johnson,Tucker A,8,8,1,1,1,0,0,3.071
+Summer 2023,NUTR,4352,1,12076,Child and Adolescent Nutrition,Vollrath,Kirstin,21,34,8,2,0,0,1,3.072
+Summer 2023,KIN,4360,1,12077,Adaptive Athletics Management,Cottingham,Michael,14,1,0,0,0,0,0,3.867
+Summer 2023,PHYS,2325,1,12078,University Physics I (lecture),Bassler,Kevin E,8,10,2,0,0,0,4,3.234
+Summer 2023,PHYS,2326,1,12080,University Physics II(lecture),Varghese,Oomman K,6,4,7,0,0,0,0,2.941
+Summer 2023,ENGI,2304,3,12082,Technical Communications,Wilson,Chad A,9,7,2,1,0,0,1,3.263
+Summer 2023,POLS,3311,2,12084,Intro Compar Politics,Vardy,Ronald V,16,5,2,0,0,0,2,3.594
+Summer 2023,LAW,5303,1,12085,Criminal Law,Kaufman,Zachary Daniel,16,15,6,0,0,0,0,3.315
+Summer 2023,LAW,5378,1,12086,Statutory Interpretation & Rea,Bush,Darren,15,21,0,0,0,0,0,3.398
+Summer 2023,SOCW,7340,1,12092,Clinical Practice with Child,Rivera,Jaime,15,4,0,0,0,0,0,3.789
+Summer 2023,SOCW,7371,1,12093,Trauma & SW,Amtsberg,Donna K,25,0,1,0,0,0,0,3.923
+Summer 2023,SOCW,7378,1,12094,Integrated Behav Healthcare,Eisenbaum,Stephanie,11,5,0,0,0,0,2,3.688
+Summer 2023,AAS,2320,1,12097,Intro To African American Stdy,Lyons,Da' Vonte,18,16,0,0,0,0,0,3.597
+Summer 2023,PETR,8399,1,12098,Doctoral Dissertation,Soliman,Mohamed Yousef,1,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,1311,1,12112,Fundamentals of Chemistry,Czader,Arkadiusz,4,24,28,20,17,0,5,1.771
+Summer 2023,CHEM,1312,1,12113,Fundamentals of Chemistry 2,Czader,Arkadiusz,4,22,28,22,25,0,7,1.61
+Summer 2023,NURS,4216,1,12115,Perioperative Nursing,Quintana,Danielle,30,0,0,0,0,0,0,4.0
+Summer 2023,OPTO,6115,1,12116,Clinical Integration,Dempsey,Robert L,22,0,0,0,0,0,0,4.0
+Summer 2023,MIS,3370,1,12118,Info Systems Development Tools,Knighton,William B,11,19,14,7,3,0,3,2.519
+Summer 2023,ENGL,2306,1,12119,Intro To Poetry,Loan,Leisa Marie,18,1,0,1,3,0,1,3.19
+Summer 2023,PSYC,7399,6,12120,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Summer 2023,DRAM,1310,1,12121,Introduction to Theatre,Young,Courtney Leigh,41,10,2,1,0,0,1,3.679
+Summer 2023,PSYC,8399,16,12122,Doctoral Dissertation,Alfano,Candice A,1,0,0,0,0,1,0,4.0
+Summer 2023,DRAM,1310,2,12123,Introduction to Theatre,Young,Courtney Leigh,44,5,1,0,1,0,1,3.7
+Summer 2023,ITEC,1301,1,12124,Intro To Computer Appl Tech,Roberts,Phyllis Rayburn,13,11,2,1,1,0,0,3.155
+Summer 2023,MATH,6315,2,12125,Masters Tutorial,He,Jiwen,1,0,0,0,0,0,0,4.0
+Summer 2023,ENGL,1301,4,12126,First Year Writing I,Coleman,Quintin,11,0,2,0,2,0,1,3.2
+Summer 2023,ENGL,1302,7,12127,First Year Writing II,Downey,Carlton M,19,0,0,0,4,0,1,3.304
+Summer 2023,MATH,6315,4,12128,Masters Tutorial,Fitzgibbon,William E,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,6315,6,12129,Masters Tutorial,Kalantar,Mehrdad,1,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8193,2,12172,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,8,0,
+Summer 2023,PHOP,6257,3,12175,Research Practicum B,Cheng,Han,1,0,0,0,0,0,0,4.0
+Summer 2023,CNST,3185,1,12184,Construction Experience,Beadle,Dwight D,21,2,5,0,1,0,0,3.448
+Summer 2023,PHAR,5675,4,12187,Disease State Management,De La Cruz,Austin Isaac,3,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5675,5,12188,Disease State Management,Asias-Dinh,Bernadette De Leon,3,0,0,0,0,0,0,4.0
+Summer 2023,HRD,6354,1,12192,Facilitating Adult Group Proc.,Pereira-Leon,Maura Josefina,7,0,0,0,0,0,1,4.0
+Summer 2023,CHEM,1112,17,12193,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,3,0,0,0,0,3.024
+Summer 2023,PHOP,6198,1,12198,Spec Prob-Physio Optics,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,8690,2,12199,Doctoral Thesis,Hutchison,Laveria F,7,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8398,1,12203,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Summer 2023,PHCA,8199,2,12204,Doctoral Dissertation Defense,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Summer 2023,PHCA,8298,2,12205,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Summer 2023,COMD,7391,15,12210,Clinic in Speech Lang Disorder,Bolling,Kenyetta,0,1,0,0,0,0,0,3.33
+Summer 2023,CHEM,8399,23,12213,Doctoral Dissertation,Comito,Robert Joseph,3,0,0,0,0,0,0,4.0
+Summer 2023,POLS,4398,1,12219,Independent Study,Cross,Renee Danielle,6,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8399,17,12233,Doctoral Dissertation,Gallagher,Matthew Ward,0,0,0,0,0,1,0,
+Summer 2023,PCEU,8399,1,12236,Doctoral Dissertation,Tam,Vincent H,0,0,0,0,0,1,0,
+Summer 2023,CNST,3372,1,12237,Soil Mechanics & Foundations,Meyer,Joseph Ray,8,11,3,0,0,0,0,3.242
+Summer 2023,MATH,6398,65,12240,Special Problems,Timofeyev,Ilya,0,0,0,0,0,4,0,
+Summer 2023,SPAN,3307,1,12245,Public Speaking in Spanish,Martinez,Jacqueline Aguilar,13,3,0,0,0,0,0,3.792
+Summer 2023,CHEM,1112,18,12246,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,0,0,0,0,0,3.333
+Summer 2023,SPEC,4353,1,12247,Technology in Special Pops,Goodrich,Elizabeth A,9,4,0,0,1,0,1,3.405
+Summer 2023,SPEC,6353,1,12248,Technology in Special Pops,Goodrich,Elizabeth A,5,1,0,0,0,0,1,3.833
+Summer 2023,SPEC,7391,1,12249,Collab Consulting & Coaching,Carp,Charlotte Lynn,18,1,0,0,0,0,0,3.93
+Summer 2023,MIS,4374,1,12250,Info Technology Project Mgmt,Campbell,Phillip James,18,12,1,1,0,0,0,3.355
+Summer 2023,CUIN,1350,1,12253,Mathematics for Teachers 1,Burris,Justin T,15,2,0,0,0,0,0,3.824
+Summer 2023,SPEC,7341,1,12255,Assessment of Learning Diff,Hassett,Kristen Spring,14,1,0,0,0,0,0,3.911
+Summer 2023,SPEC,8360,1,12256,Instruct Probs in Special Pop,Rigby-Wills,Hope,7,1,0,0,0,0,0,3.628
+Summer 2023,MATH,1342,3,12258,Elementary Statistical Methods,Caputo,Matthew G,8,46,20,14,6,0,16,2.292
+Summer 2023,MATH,5341,1,12259,Mathematical Modeling,He,Jiwen,4,0,0,0,0,0,1,3.753
+Summer 2023,ECON,6693,2,12260,Master's Research Project,Shpak,Solomiya,4,0,0,0,0,0,0,3.835
+Summer 2023,SOCW,6293,1,12261,Field Practicum I - Foundation,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Summer 2023,SOCW,6294,1,12262,Field Practicum II,Gonzales,Shelley A,0,0,0,0,0,3,0,
+Summer 2023,CNST,3155,1,12263,Const Materials & Testing,Meyer,Joseph Ray,8,13,2,0,0,0,0,3.275
+Summer 2023,CNST,3331,1,12264,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,8,16,3,0,0,0,0,3.185
+Summer 2023,CNST,3355,1,12265,Strength of Construction Mtrls,Senouci,Ahmed,16,4,11,0,3,0,0,2.882
+Summer 2023,SOCW,7320,1,12266,Empowerment,Boyd,Reiko K,23,1,1,0,0,0,0,3.88
+Summer 2023,CNST,4302,1,12267,Construction Law and Ethics,Ducran,Denis George,3,10,3,0,0,0,0,2.979
+Summer 2023,HDFS,3300,1,12268,Educational Psychology,Conston,Toya,46,4,0,0,0,0,0,3.9
+Summer 2023,PSYC,4344,3,12270,Cultural Psychology,Hernandez Ortiz,Jessica G,36,14,5,0,3,0,0,3.431
+Summer 2023,ELCS,8355,1,12271,Policy Pol & Gov of Education,Causey,Ashley,2,1,0,0,0,0,0,3.667
+Summer 2023,EDRS,8382,1,12272,Statistical Analyses in Eductn,Davis,Bradley,0,1,1,0,1,0,0,1.777
+Summer 2023,NUTR,4346,1,12273,Research in Nutrition,Haubrick,Kevin,24,19,5,0,2,0,3,3.207
+Summer 2023,PHLS,6310,2,12274,Intro To Educ Research,Lee,Jungeun,16,2,0,0,0,0,0,3.834
+Summer 2023,MARK,7376,1,12275,Brand Management,Koch,Steven F,33,0,0,0,0,0,0,4.0
+Summer 2023,MANA,7351,1,12276,Mgt of  Global Organizations,Keller,Robert T,23,4,0,0,0,0,0,3.803
+Summer 2023,POLS,3356,1,12278,Intro-Constitutionl Law,Abbott Jr,Kenneth Wayne,12,3,0,0,0,0,0,3.69
+Summer 2023,HRD,6358,30,12279,Global Human Resource Devel,Waight,Consuelo L,8,0,0,0,0,0,0,4.0
+Summer 2023,KIN,3360,1,12280,Professional Prep for Sp Admin,Hu,Tiao,9,33,11,3,1,0,0,2.801
+Summer 2023,WCL,3366,2,12281,Latin American and Latino Film,Centeno,Daniel,10,14,4,1,0,0,1,3.024
+Summer 2023,NUTR,6304,1,12282,Adv Nutr Counseling & Educ,Ledoux,Tracey A,3,1,0,0,0,0,0,3.668
+Summer 2023,NUTR,6301,1,12283,Clinic Aspects of Nutr Support,Ferrell,Carla Denise,9,3,0,0,2,0,1,3.167
+Summer 2023,SOCW,7339,1,12284,Prof. Grant Writing for SW,Stagg,Helen Ruth,14,0,0,0,0,0,1,4.0
+Summer 2023,SOCW,7366,1,12285,Grief/Bereave Therapy,Rodgers,Beverly J,23,4,0,0,0,0,0,3.852
+Summer 2023,SOCW,7373,1,12286,Human Sexuality & Sw,Gracely,Jill Marie,25,0,0,0,0,0,0,4.0
+Summer 2023,COSC,6368,301,12287,Artificial Intelligence,Vilalta,Ricardo,38,15,0,0,0,0,1,3.58
+Summer 2023,GOVT,2306,4,12288,US and Texas Const/Politics,Lothamer,Lucas J,26,8,3,0,0,0,1,3.577
+Summer 2023,LAW,6217,1,12289,Negotia & Creative Prblm Slvng,Block,Nathan Matthew,3,8,0,0,0,0,0,3.273
+Summer 2023,LAW,5199,13,12292,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Summer 2023,LAW,5299,19,12294,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Summer 2023,LAW,5299,17,12295,Special Problems,Vetter,Greg R,0,0,0,0,0,3,0,
+Summer 2023,ACCT,5331,2,12296,Federal Income Tax-Individual,Fernandez,Ramon,1,4,1,0,0,0,0,3.11
+Summer 2023,GOVT,2306,3,12297,US and Texas Const/Politics,Cole,Jeffrey Bryan,15,11,5,1,2,0,0,3.049
+Summer 2023,GOVT,2305,3,12298,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,13,15,1,1,0,0,0,3.311
+Summer 2023,THEA,6184,1,12299,Applying Methods in Dir/Styles,Cook,Rena R,11,0,0,0,0,0,0,3.91
+Summer 2023,THEA,6287,1,12301,Acting Styles,White,Ashley,6,6,0,0,0,0,0,3.418
+Summer 2023,COMM,1302,1,12302,Intro To Comm Theory,Lee,Jaesub,4,8,9,3,1,0,2,2.4
+Summer 2023,COMM,3360,1,12303,Principles of Strategic Comm,Choi,Ho Joon,20,2,1,0,1,0,0,3.612
+Summer 2023,COMM,4355,1,12304,Organizational Comm,Liu,Wenlin,19,9,0,0,0,0,0,3.69
+Summer 2023,PSYC,2319,3,12305,Intro to Social Psychology,Anderson,Jill Annette,7,32,9,1,2,0,1,2.817
+Summer 2023,DANC,2303,2,12307,Introduction to Dance,Bobet,Jacqueline A,48,18,20,8,0,0,4,3.093
+Summer 2023,NURS,4220,1,12308,Clinical Decision Making,Obey,Faye B,4,18,0,0,0,0,0,3.182
+Summer 2023,SPAN,3375,2,12309,US Hispanic Culture & Civiliza,Cuesta,Mabel,18,5,1,0,0,0,1,3.722
+Summer 2023,CNST,4341,1,12310,Project Controls,Bouhou,Nour-El Imane,4,8,1,1,0,0,0,3.024
+Summer 2023,SPAN,3308,1,12311,Written Com-Hisp Herit Learner,Martinez,Jacqueline Aguilar,22,3,0,0,0,0,0,3.867
+Summer 2023,NUTR,6311,1,12312,Capstone I,Haubrick,Kevin,7,2,0,0,1,0,1,3.301
+Summer 2023,WGSS,3322,1,12314,Intersectionalities,De Los Reyes Heredia,Jose Guillermo,15,4,1,3,2,0,0,3.12
+Summer 2023,WGSS,2360,2,12315,Introduction to LGBT Studies,Stone,Lauren Michelle,15,1,1,0,1,0,0,3.574
+Summer 2023,SOCI,1301,4,12317,Introduction To Sociology,Smith,Chance Adam,16,19,5,2,4,0,2,2.913
+Summer 2023,ENGL,8399,1,12318,Doctoral Dissertation,Voskuil,Lynn M,1,0,0,0,0,0,0,4.0
+Summer 2023,CIS,2334,1,12320,Information Systems Applicatns,Lendasse,Amaury,27,9,3,0,2,0,1,3.399
+Summer 2023,IRW,1300,1,12321,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,14,0,
+Summer 2023,IRW,1300,2,12322,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,1,0,
+Summer 2023,DIGM,4396,30,12324,Internship in Digital Media,Liao,Tony Chung-Li,5,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6257,4,12343,Research Practicum B,Porter,Jason,0,0,0,0,0,1,0,
+Summer 2023,CUIN,8310,1,12346,Laboratory of Practice,Hutchison,Laveria F,6,0,0,0,0,0,0,4.0
+Summer 2023,FINA,7361,1,12347,Risk Management,Hogan,Kenneth David,5,0,0,0,0,0,0,3.934
+Summer 2023,PHAR,5683,3,12361,Cardiology,Wang,Elisabeth,2,0,0,0,0,0,0,4.0
+Summer 2023,SPAN,8399,8,12366,Dissertation,Rivera Garza,Cristina,0,0,0,0,0,2,0,
+Summer 2023,EDUC,2301,1,12367,Intro to Special Populations,Hassett,Kristen Spring,37,4,0,0,1,0,0,3.786
+Summer 2023,EDUC,2301,2,12368,Intro to Special Populations,Carp,Charlotte Lynn,16,4,0,1,0,0,2,3.635
+Summer 2023,SPEC,4367,1,12369,Consultation and Coaching,Carp,Charlotte Lynn,23,4,0,0,0,0,0,3.84
+Summer 2023,ACCT,5332,1,12384,Corporate Taxation,Fernandez,Ramon,0,2,0,0,0,0,2,3.0
+Summer 2023,MATH,8398,7,12385,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Summer 2023,MATH,8398,8,12389,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Summer 2023,PHYS,4398,1,12390,Independent Study,Koerner,Lisa Whitehead,0,1,0,0,0,0,0,3.33
+Summer 2023,PHYS,1101,5,12391,College Physics I (lab),Wood,Lowell T,0,9,4,0,0,0,2,2.718
+Summer 2023,PHYS,1102,5,12392,College Physics II (lab),Wood,Lowell T,0,9,4,1,0,0,0,2.595
+Summer 2023,PSYC,6352,4,12398,Directed Rsch in I/O Psyc,Ng,Vincent,0,0,0,0,0,4,0,
+Summer 2023,SPAN,8399,9,12400,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Summer 2023,CIVE,7399,1,12427,Master's Thesis,Mo,Larry Yi-Lung,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,2317,4,12429,Intro to Psychology Statistics,Nguyen,My Viet Ha,15,15,11,1,5,0,5,2.667
+Summer 2023,ELCS,6310,1,12437,Strategic Engagement,Simpson,Susan Collins,11,1,0,0,0,0,0,3.889
+Summer 2023,COMM,2311,5,12445,Writing for Print and Digital,Radcliffe Andre,Jennifer,22,1,2,0,0,0,0,3.774
+Summer 2023,COMM,2356,1,12447,Business & Professional Comm,Uhrick,Jan,36,4,2,2,0,0,0,3.644
+Summer 2023,PSYC,2301,6,12450,Introduction to Psychology,Gehm,Kevan H,33,10,4,0,0,0,2,3.603
+Summer 2023,PSYC,2305,1,12451,Intro to Methods in Psychology,Shen,Shutian,36,13,5,2,3,0,0,3.327
+Summer 2023,PSYC,2330,4,12455,Biological Psychology,Leonard,Samuel J,36,20,2,0,0,0,0,3.637
+Summer 2023,PSYC,2320,3,12457,Abnormal Psychology,Kim,Jinu,29,10,4,0,2,0,1,3.378
+Summer 2023,SPEC,6327,1,12458,Measurement Eval Research,Cole,Jana Belinda,21,1,0,0,0,0,0,3.91
+Summer 2023,ELCS,8371,1,12459,Legal Issues Sch District Levl,Goree,Tonya,13,2,1,0,0,0,1,3.75
+Summer 2023,CUIN,7375,1,12460,Capstone for Literacy Educ,Hale,Margaret Ann,11,1,0,0,0,0,0,3.889
+Summer 2023,PSYC,2305,9,12464,Intro to Methods in Psychology,Yoruk,Harun,38,11,4,1,1,0,4,3.497
+Summer 2023,PSYC,2305,11,12466,Intro to Methods in Psychology,Anderson,Jill Annette,31,14,1,1,0,0,0,3.554
+Summer 2023,PSYC,2319,4,12468,Intro to Social Psychology,Anderson,Jill Annette,6,24,8,1,0,0,0,2.872
+Summer 2023,KIN,4315,1,12469,Motor Learning and Control,Layne,Charles S,4,35,15,3,0,0,1,2.609
+Summer 2023,KIN,4370,1,12470,Exercise Testing,Markofski,Melissa,8,16,2,0,0,0,0,3.294
+Summer 2023,GHL,4361,1,12475,Marketing Strategies,Taylor,David C,33,2,1,1,0,0,1,3.748
+Summer 2023,MATH,3321,3,12477,Engineering Mathematics,West,James David,2,6,10,3,4,0,5,1.92
+Summer 2023,MATH,3363,1,12479,Introduction To Pde,Perepelitsa,Mikhail Antolyevic,3,7,7,0,0,0,0,2.765
+Summer 2023,POLC,6391,1,12480,Public Policy Internship,Bronk,Robert C,8,0,0,0,0,0,0,3.959
+Summer 2023,MANA,4338,1,12482,Performance Management Systems,Bozeman,Dennis,19,23,10,4,2,0,0,2.959
+Summer 2023,MANA,4348,1,12483,Global Leadership,Walker,William A,22,3,2,0,0,0,2,3.753
+Summer 2023,SOCW,7371,2,12484,Trauma & SW,O'Neal,Vaughn,24,1,0,0,0,0,0,3.96
+Summer 2023,ENTR,3310,3,12485,Entrepreneurship,Ortega,Carlos Alberto,79,20,1,0,0,0,0,3.747
+Summer 2023,CIS,2348,1,12486,Info Systems Appl Development,Ratner,Edward,4,8,13,5,3,0,2,2.142
+Summer 2023,CIS,3347,1,12487,IS Infrastructure and Networks,Viseh,Mehran,12,14,6,0,0,0,0,3.198
+Summer 2023,COSC,3380,201,12488,Database Systems,Hilford,Victoria,67,21,7,0,0,0,0,3.562
+Summer 2023,COSC,4353,101,12489,Software Design,Singh,Raj Kumar,55,5,0,0,0,0,1,3.911
+Summer 2023,COSC,6353,101,12490,Software Design,Singh,Raj Kumar,10,1,0,0,0,0,0,3.909
+Summer 2023,ACCT,3377,2,12491,Cost Accounting,Serrato,Darlene Marie  Bohac,7,13,3,2,1,0,0,2.859
+Summer 2023,CHEM,2323,1,12493,Organic Chemistry I,Zaitsev,Vladimir G,14,20,19,12,18,0,9,1.972
+Summer 2023,HDCS,1300,3,12496,Human Ecosystems & Tech Change,Mudd,Blake Stevens,22,9,5,2,6,0,1,2.864
+Summer 2023,SOCW,7347,1,12497,SW Practice & Interv in School,Jennings,Sheara Williams,20,3,0,0,1,0,1,3.708
+Summer 2023,HRD,6303,30,12498,Assessment & Evaluation in Hrd,Alston,Carmen M,8,0,0,0,0,0,0,3.918
+Summer 2023,MATH,6386,1,12500,Big Data Analytics,Shastri,Dvijesh J,17,3,2,0,0,0,0,3.577
+Summer 2023,CNST,4315,1,12501,Steel Construction,Chang,Chi Chung,9,17,0,0,0,0,0,3.333
+Summer 2023,FINA,4328,1,12502,Principles of Personal Finance,Coleman,Alfred G,9,5,3,1,1,0,0,3.001
+Summer 2023,TLIM,3345,1,12505,Human Resources in Technology,Mehring,Brian George,12,13,7,1,4,0,0,2.757
+Summer 2023,TLIM,3355,30,12507,Project Management Principles,Moore,George P,15,4,2,0,0,0,0,3.588
+Summer 2023,TLIM,3363,30,12508,Technical Communications,Tangeman,Anthony C,17,12,1,0,1,0,0,3.451
+Summer 2023,TLIM,3363,33,12509,Technical Communications,Tangeman,Anthony C,18,9,2,0,0,0,2,3.54
+Summer 2023,TLIM,3363,31,12510,Technical Communications,Piercy,Penelope Junker,14,7,2,0,1,0,0,3.279
+Summer 2023,TLIM,3363,34,12511,Technical Communications,Piercy,Penelope Junker,17,8,6,0,1,0,0,3.168
+Summer 2023,TLIM,3363,32,12512,Technical Communications,Peterson,Kathryn Marie,20,0,0,0,0,0,0,3.951
+Summer 2023,HLT,3381,2,12513,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,32,4,0,0,0,0,0,3.806
+Summer 2023,TLIM,4341,32,12514,Production & Service Operation,Chance,Michael Dean,9,13,0,0,2,0,0,3.056
+Summer 2023,TLIM,4341,30,12515,Production & Service Operation,Terrell,John Allen,18,11,2,0,0,0,1,3.474
+Summer 2023,TLIM,4342,31,12516,Quality Improvement Methods,O'Kelley,Donna K,8,11,6,1,2,0,0,2.715
+Summer 2023,TLIM,4342,30,12518,Quality Improvement Methods,Chance,Michael Dean,26,5,5,1,0,0,0,3.478
+Summer 2023,TLIM,4371,30,12519,Leading Change in the Wrkplace,Evans,Gerald S,20,7,2,0,1,0,0,3.423
+Summer 2023,TLIM,4372,30,12520,Proposal and Project Writing,Thomas,Jamie M,4,4,1,0,2,0,0,2.637
+Summer 2023,CHEM,1305,1,12522,Foundations of Chemistry,St Hill,Lydia Ruth,4,11,11,5,14,0,11,1.638
+Summer 2023,BIOL,1308,1,12523,Biology for Non-Science Majors,Ibrahim,Abdalla Zanouny,16,8,0,1,0,0,1,3.468
+Summer 2023,PHAR,5206,1,12525,Pharmacy and Geriatrics,Fernandez,Julianna M,16,16,2,1,0,0,0,3.343
+Summer 2023,PHAR,5207,1,12526,Herbal Medicine,Ruan,Ke-He,19,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5217,1,12527,Pediatric Therapeutics,Martinez,Brigetta,40,9,0,0,0,0,0,3.816
+Summer 2023,PHAR,5457,1,12528,Institutional IPPE,Hatfield,Catherine L,85,21,2,0,0,0,0,3.769
+Summer 2023,FINA,7374,1,12531,Midstream Energy Finance,Broxson,John Robert,31,1,0,0,0,0,0,3.928
+Summer 2023,LAW,6347,1,12532,Secured Financing,Dole,Richard F,2,5,0,0,0,5,0,3.286
+Summer 2023,NURS,6338,1,12533,Advanced Pathophysiology,Schrader,Patricia K,2,2,0,0,0,0,1,3.5
+Summer 2023,NUTR,4353,2,12534,Cultural Comp for Nutr Prof,Yoon,Cynthia Yursun,22,4,0,0,0,0,0,3.795
+Summer 2023,ARTS,2356,1,12537,Fundamentals of Photo/DM,Hillerbrand,Stephan C,10,5,0,0,0,0,1,3.733
+Summer 2023,NUTR,6312,1,12538,Capstone II,Haubrick,Kevin,2,1,0,0,0,0,0,3.777
+Summer 2023,MUED,2342,1,12539,Music for Children,Edwards,Zachary B,11,4,1,0,0,0,2,3.625
+Summer 2023,KIN,4302,1,12543,Fitness and Human Sexuality,Alastuey,Lisa L,21,3,2,1,1,0,0,3.429
+Summer 2023,FINA,7377,1,12544,Electric Power Markets,Gasca,Amparo Amy,12,1,0,0,0,0,0,3.822
+Summer 2023,FINA,4330,1,12545,Corporate Finance,Chen,Xi,15,23,9,2,0,0,2,3.068
+Summer 2023,COSC,8398,102,12553,Doctoral Research,Chen,Guoning,0,0,0,0,0,1,0,
+Summer 2023,COSC,8398,107,12558,Doctoral Research,Eick,Christoph F,0,0,0,0,0,2,0,
+Summer 2023,COSC,8398,109,12560,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,2,0,
+Summer 2023,COSC,8398,112,12562,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,3,0,
+Summer 2023,COSC,8398,117,12567,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,2,0,
+Summer 2023,COSC,8398,118,12568,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Summer 2023,COSC,8398,122,12572,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Summer 2023,COSC,8398,124,12573,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Summer 2023,COSC,8398,125,12574,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Summer 2023,COSC,8398,127,12576,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,2,0,
+Summer 2023,COSC,8398,128,12577,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Summer 2023,COSC,8398,130,12579,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Summer 2023,ELCS,6301,1,12610,Leadership for Equity,Stewart,Cedric Benjamin,28,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,8390,2,12611,Doctoral Thesis,Hutchison,Laveria F,0,0,0,0,0,0,0,
+Summer 2023,PHIL,1301,1,12612,Intro To Philosophy,Haaga,Curtis W,27,7,1,0,1,0,1,3.611
+Summer 2023,GEOL,3355,1,12619,Field Geology I,Robinson,Alexander C,4,5,3,0,0,0,0,3.056
+Summer 2023,GEOL,3360,3,12621,Field Geology II,Lindline,Jennifer,6,5,1,0,0,0,0,3.362
+Summer 2023,COSC,4377,301,12626,Intro To Computer Networks,Long,Kevin B,47,56,30,0,1,0,2,3.104
+Summer 2023,COSC,3337,201,12627,Data Science I,Rizk,Nouhad J,10,14,9,1,2,0,5,2.806
+Summer 2023,COMM,3370,1,12628,History of Cinema,Houk,Keith R,35,1,1,1,1,0,1,3.727
+Summer 2023,ENGL,2305,1,12629,Intro To Fiction,Bose,Godhuly,18,3,1,0,1,0,1,3.551
+Summer 2023,COSC,3340,201,12631,Intro. to Automata and Comp.,Leiss,Ernst L,11,12,3,0,1,0,1,3.1
+Summer 2023,ENGI,1331,3,12632,Computing for Engineers,Burleson,Daniel W,10,6,6,4,2,0,7,2.69
+Summer 2023,ENGI,2304,7,12633,Technical Communications,Anderson,Roshawnda M,16,6,1,0,2,0,0,3.36
+Summer 2023,ENGI,2304,8,12634,Technical Communications,Anderson,Roshawnda M,20,3,2,0,0,0,0,3.654
+Summer 2023,MECE,3336,1,12635,Mechanics II,Hammami,Farah,8,11,4,1,0,0,1,3.028
+Summer 2023,MECE,3363,1,12637,Intro To Fluid Mechanics,Love,Holley Carole,12,7,2,0,0,0,1,3.398
+Summer 2023,PSYC,6393,1,12638,Clinical Research Practicum,Alfano,Candice A,2,0,0,0,0,0,0,4.0
+Summer 2023,COSC,6309,201,12640,Intro Automata & Computability,Leiss,Ernst L,0,1,0,0,0,0,0,3.33
+Summer 2023,BIOL,6355,1,12641,Introduction to Health Systems,Valier,Helen K,22,0,0,0,0,0,0,3.925
+Summer 2023,HIST,1301,1,12642,The U.S. to 1877,Clavin,Matthew J,50,52,9,7,11,0,4,2.907
+Summer 2023,BIOE,5319,1,12645,Intro to Global Healthcare,Akay,Metin,5,1,0,0,0,0,0,3.723
+Summer 2023,ECON,3320,1,12646,Intro to Econ Data Analysis,Zhivan,Natalia A,5,7,12,0,2,0,3,2.513
+Summer 2023,OPTO,6115,2,12647,Clinical Integration,Dempsey,Robert L,21,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,4303,1,12648,Biomaterials,Abidian,Mohammad Reza,7,0,0,0,0,0,0,3.764
+Summer 2023,BIOE,6303,1,12649,Biomaterials,Abidian,Mohammad Reza,5,0,0,0,0,0,0,3.934
+Summer 2023,BIOE,6343,1,12650,Global Healthcare,Akay,Metin,12,2,0,0,0,0,0,3.763
+Summer 2023,WGSS,2350,1,12651,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,28,1,0,0,0,0,0,3.954
+Summer 2023,WGSS,2360,1,12652,Introduction to LGBT Studies,Stone,Lauren Michelle,18,6,2,0,1,0,1,3.494
+Summer 2023,WGSS,3321,1,12653,Gender in Transnational Persp,Pegoda,Andrew Joseph,4,9,3,0,2,0,5,2.704
+Summer 2023,NUTR,2332,2,12654,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,37,16,3,1,2,0,1,3.469
+Summer 2023,NUTR,2332,3,12655,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,11,5,0,0,1,0,0,3.432
+Summer 2023,PSYC,6336,1,12657,Directed Rsch in Social Psyc,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,6393,3,12658,Clinical Research Practicum,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4.0
+Summer 2023,ENGL,8399,2,12660,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Summer 2023,PHOP,6257,6,12661,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6257,9,12664,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2023,ATP,6303,1,12674,Gen Med/Pharm 1 -System & Eval,Knoblauch,Mark Alan,14,3,0,0,0,0,0,3.824
+Summer 2023,MATH,6398,70,12677,Special Problems,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Summer 2023,ENGL,1302,11,12679,First Year Writing II,Salome,Melanie Rebecca,8,6,5,0,1,0,2,2.918
+Summer 2023,ENGL,1302,12,12680,First Year Writing II,Rolater,Sara C,11,7,1,1,1,0,4,3.191
+Summer 2023,ENGL,1302,13,12681,First Year Writing II,Downey,Carlton M,16,2,0,0,0,0,1,3.907
+Summer 2023,ENGL,2315,1,12684,Literature and Film,Pegoda,Andrew Joseph,4,3,5,2,2,0,6,2.251
+Summer 2023,MARK,4389,1,12686,Marketing Strategy & Planning,Agrawal,Arpit,6,0,0,0,0,0,0,3.945
+Summer 2023,FINA,3332,2,12691,Prin of Financial Management,Chisholm,Darla,9,11,8,9,1,0,2,2.387
+Summer 2023,HIST,8699,3,12693,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6365,1,12709,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,2,0,0,0,0,0,0,4.0
+Summer 2023,PHYS,1101,6,12716,College Physics I (lab),Wood,Lowell T,0,7,2,0,0,0,1,2.594
+Summer 2023,PHYS,1102,6,12717,College Physics II (lab),Wood,Lowell T,1,4,7,0,0,0,1,2.61
+Summer 2023,SCM,4311,1,12720,Project Management,Wayhan,Victor Brian,70,52,13,0,0,0,2,3.4
+Summer 2023,PHOP,6567,3,12725,Research Practicum A,Yoon,Geunyoung,2,0,0,0,0,0,0,3.67
+Summer 2023,PHOP,6267,2,12729,Research Practicum A,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,3339,2,12736,Statistics for the Sciences,Wang,Wenshuang,20,12,5,3,4,0,2,2.939
+Summer 2023,ENGL,8399,4,12737,Doctoral Dissertation,Shepley,Nathan,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6365,2,12738,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,3,0,
+Summer 2023,PSYC,6365,3,12743,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,6336,3,12747,Directed Rsch in Social Psyc,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,8698,122,12750,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,2,0,
+Summer 2023,COSC,8698,106,12752,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Summer 2023,HLT,3301,2,12753,Health Behavior Theories,Bennett,Kristin C,47,15,1,0,1,0,0,3.605
+Summer 2023,COSC,8399,101,12754,Doctoral Dissertation,Alipour,Mohammad Amin,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,8698,128,12755,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Summer 2023,COSC,8698,124,12756,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Summer 2023,HLT,3325,1,12757,Medical Terminology,Bloom,Joel A,91,2,2,1,0,0,0,3.865
+Summer 2023,HLT,3325,2,12758,Medical Terminology,Bloom,Joel A,53,5,5,2,0,0,0,3.606
+Summer 2023,HLT,3325,3,12759,Medical Terminology,Burk,Kelly Ann,74,2,6,0,0,0,1,3.757
+Summer 2023,HLT,1353,2,12762,Personal Health,Rafique,Kiran Sajid,76,18,2,0,0,0,1,3.678
+Summer 2023,SPAN,1501,3,12763,Elementary Spanish I,Ruffino,Gustavo,7,0,0,0,0,0,0,3.953
+Summer 2023,SPAN,2311,4,12767,Intermediate Spanish I,Jager Lopezllera,Valentina Kathe,6,4,1,0,0,0,0,3.455
+Summer 2023,MATH,6308,1,12768,Advanced Linear Algebra I,Ru,Min,2,1,0,0,0,0,0,3.667
+Summer 2023,MATH,6309,1,12769,Advanced Linear Algebra II,Torok,Andrei S,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8698,15,12773,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Summer 2023,MATH,8698,16,12774,Doctoral Research,Mang,Andreas,0,0,0,0,0,2,0,
+Summer 2023,PHCA,8199,3,12776,Doctoral Dissertation Defense,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Summer 2023,ENGL,8399,5,12778,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,1,0,
+Summer 2023,MATH,8698,10,12780,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Summer 2023,MATH,8698,12,12781,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Summer 2023,COSC,8698,102,12784,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Summer 2023,HDFS,4316,2,12785,Dynamics of Family Relations,Rab,Saira,28,3,5,0,1,0,1,3.532
+Summer 2023,HDFS,2314,3,12786,Human Dev and Interventions,Schoger,Kimberly,20,2,0,0,0,0,2,3.849
+Summer 2023,COSC,8698,127,12788,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Summer 2023,PHOP,6157,4,12790,Research Practicum B,O'Brien,John,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,8698,114,12793,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,4,0,
+Summer 2023,PEP,8399,2,12794,Doctoral Dissertation,Ledoux,Tracey A,1,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,7193,1,12795,Internship and Practicum,Gonzalez,Jorge E,1,0,0,0,0,0,0,4.0
+Summer 2023,ENGL,8698,1,12800,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Summer 2023,COSC,8698,112,12801,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Summer 2023,COMD,7391,11,12809,Clinic in Speech Lang Disorder,Cadavid,Kelsey Lee,1,0,0,0,0,0,0,3.67
+Summer 2023,COMD,7391,16,12810,Clinic in Speech Lang Disorder,Cizek,Laura S,1,0,0,0,0,0,0,4.0
+Summer 2023,COMD,7391,17,12811,Clinic in Speech Lang Disorder,Ross,Byron L,0,1,0,0,0,0,0,3.0
+Summer 2023,COMD,7391,18,12812,Clinic in Speech Lang Disorder,Ross,Byron L,0,1,0,0,0,0,0,3.33
+Summer 2023,COMD,7391,19,12813,Clinic in Speech Lang Disorder,Townsend,Alayna,1,0,0,0,0,0,0,3.67
+Summer 2023,COMD,7391,1,12815,Clinic in Speech Lang Disorder,Walker,Dionne A,0,1,0,0,0,0,0,3.33
+Summer 2023,COSC,8698,117,12830,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,
+Summer 2023,COSC,8698,129,12832,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,2,0,
+Summer 2023,PSYC,6365,5,12833,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,2,0,
+Summer 2023,COMM,1303,1,12834,Writing for Communicators,Lyn,Robyn,36,5,1,0,3,0,0,3.57
+Summer 2023,COMD,7391,21,12869,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,1,0,0,0,0,0,0,3.67
+Summer 2023,WGSS,2350,3,12873,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,0,1,0,0,0,3,3.936
+Summer 2023,MANA,4347,1,12880,Ethics and Corp Soc Respon.,Salaiz,Ashley,41,11,4,2,0,0,0,3.535
+Summer 2023,CIVE,8399,1,12883,Doctoral Dissertation,Mo,Larry Yi-Lung,1,0,0,0,0,0,0,4.0
+Summer 2023,WGSS,2350,4,12888,Intro To Women's Studies,Martinez,Itzel Areli,22,4,2,0,1,0,0,3.552
+Summer 2023,ENTR,3310,4,12890,Entrepreneurship,Ortega,Carlos Alberto,82,14,2,0,0,0,1,3.705
+Summer 2023,ENGL,1302,14,12891,First Year Writing II,Long,Steven A.,15,0,0,0,1,0,0,3.75
+Summer 2023,PSYC,6365,6,12892,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Summer 2023,COMM,2327,1,12906,Introduction to Screen Writing,Vaughan,Thomas Michael,12,5,2,0,1,0,0,3.317
+Summer 2023,COMM,3317,2,12907,Multimedia Journalism,Smith,Camilo Hannibal,15,1,0,0,0,0,0,3.938
+Summer 2023,COMM,3328,1,12908,Intro to Sports Production,Freedman,Michael,14,1,1,2,0,0,0,3.5
+Summer 2023,COMM,3300,1,12909,Health Communication,Yamasaki,Jill S,36,13,7,1,2,0,0,3.356
+Summer 2023,COMM,3369,2,12910,Strategic Comm. Writing,Belton,Stephanie,18,2,0,0,0,0,0,3.884
+Summer 2023,COMM,4303,3,12913,Communication Law and Ethics,Dulin,Matthew D,10,22,7,2,2,0,2,2.86
+Summer 2023,GEOL,3355,2,12916,Field Geology I,Kalakay,Thomas J,1,6,2,1,0,0,0,2.7
+Summer 2023,MATH,3336,1,12917,Discrete Mathematics,Papadakis,Emanuel Ioannis,17,19,5,0,0,0,0,3.252
+Summer 2023,MATH,1324,3,12918,Finite Math with Applications,Hong,Yuqi,10,28,14,16,20,0,4,1.849
+Summer 2023,MATH,5383,1,12920,Number Theory,Ru,Min,4,6,0,0,0,0,0,3.4
+Summer 2023,BIOL,6352,1,12921,Molecular Mech Disease,Lin,Chin-Yo,18,4,0,0,0,0,0,3.713
+Summer 2023,GHL,4352,1,12922,Hosp Organizational Behavior,Doudna,Simone P,31,2,0,0,0,0,0,3.899
+Summer 2023,GHL,4360,1,12923,Hospitality Internship,Shepherd,Ashley,19,7,3,0,0,0,0,3.506
+Summer 2023,LAW,6220,1,12924,Trademark Prosecution,Hunt,Lee Burton,2,8,0,0,0,0,0,3.2
+Summer 2023,SOCW,7376,1,12926,Social Work-LGBTQ Communities,Keo,Bec Sokha,13,0,1,0,0,0,0,3.857
+Summer 2023,SOCW,7325,1,12927,Assessment in SW Practice,Borja,Sharon G,15,6,1,1,0,0,0,3.522
+Summer 2023,SOCW,7325,2,12928,Assessment in SW Practice,Borja,Sharon G,20,2,0,0,0,0,0,3.909
+Summer 2023,SOCW,7325,3,12929,Assessment in SW Practice,Boyd,Reiko K,24,1,0,0,0,0,0,3.96
+Summer 2023,CUIN,4375,1,12932,Classroom Management,Thompson,Alan M,9,2,0,0,0,0,0,3.848
+Summer 2023,ENGI,2304,9,12934,Technical Communications,Chatham,Donna Marie,9,5,0,0,1,0,0,3.356
+Summer 2023,ELCS,6330,2,12935,Finance & School-Based Budgtng,Bergman,Heather Sanford,10,1,0,0,0,0,0,3.819
+Summer 2023,SPEC,6367,1,12936,Special Education for Leaders,Rigby-Wills,Hope,15,7,0,0,0,0,0,3.607
+Summer 2023,SPEC,6367,2,12937,Special Education for Leaders,Hill,Deena Clair,12,1,0,0,1,0,1,3.643
+Summer 2023,ELCS,8399,4,12939,Doctoral Dissertation,Zou,Yali,1,0,0,0,0,0,0,4.0
+Summer 2023,DIGM,1376,30,12941,User Experience (UX)Principles,Rodwell,Elizabeth Ann,21,24,4,0,0,0,0,3.354
+Summer 2023,DIGM,3152,30,12942,Graphic Comm Output Lab,Dawson,Michael John,1,0,0,0,0,0,0,4.0
+Summer 2023,LAW,5200,1,12943,Depositions,Chung,Jennifer,5,8,0,0,0,0,0,3.385
+Summer 2023,TLIM,3360,30,12944,Law & Ethics-Tech & Innovation,Feriante,Chris,54,4,2,0,0,0,3,3.845
+Summer 2023,TLIM,3340,32,12945,Org Leadership & Supervision,Evans,Gerald S,62,5,2,0,0,0,0,3.85
+Summer 2023,ELCS,8330,1,12948,Statistical Analyses,Pettersson Cobb,Jennifer,6,2,0,0,0,0,0,3.709
+Summer 2023,SPEC,8365,1,12949,Admin-Supv Special Educ,Malechuk,Brian Edward,8,0,0,0,0,0,0,3.959
+Summer 2023,SPEC,8391,2,12950,Leadership Coaching,McCormick,Marina,12,0,0,0,1,0,0,3.667
+Summer 2023,CUST,8378,1,12951,Current Issues in Educ,Barnes,Yolanda Michelle,17,0,0,0,0,0,1,4.0
+Summer 2023,ECON,2302,3,12954,Principles of Microeconomics,Loaeza Albino,Eva Davinia,4,3,7,0,2,0,1,2.314
+Summer 2023,BCIS,1305,1,12955,Business Computer Applications,Felvegi,Emese,52,7,7,0,2,0,2,3.501
+Summer 2023,BUSI,3300,1,12956,Intro to Personal Finance,Harvey,Danny,50,0,0,0,0,0,0,3.987
+Summer 2023,BUSI,3300,3,12957,Intro to Personal Finance,Munchbach,Jim,47,2,1,0,1,0,0,3.798
+Summer 2023,KIN,3304,1,12958,Human Structure & Phys Perform,Breslin,Whitney L,3,8,7,1,2,0,2,2.381
+Summer 2023,KIN,3370,2,12959,Sport Facility Management,Pearson,Demetrius W,2,3,1,0,0,0,0,3.112
+Summer 2023,BUSI,2305,1,12960,Business Statistics,Wiley,Briceon C,28,36,32,32,8,0,16,2.333
+Summer 2023,PEP,7308,2,12962,Sports Facility Administration,Pearson,Demetrius W,5,0,0,0,0,0,0,3.934
+Summer 2023,MANA,4336,2,12964,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,18,16,1,0,0,0,1,3.476
+Summer 2023,MANA,4346,1,12965,Leadership Development,Evans,Klavdia Markelova,55,0,1,0,1,0,0,3.895
+Summer 2023,MANA,4353,1,12966,Mgmt Training and Career Devel,Bozeman,Dennis,36,15,6,1,2,0,0,3.422
+Summer 2023,ECON,3334,1,12967,Intermediate Macroeconomics,Mcgregor,Ryan P,15,3,3,0,2,0,2,3.261
+Summer 2023,MANA,4355,2,12968,Selection and Staffing,Bozeman,Dennis,33,14,2,2,1,0,3,3.538
+Summer 2023,PSYC,3339,2,12969,Intro To Clinical Psychology,Healy,Nathaniel Andrew,13,17,6,0,0,0,3,3.103
+Summer 2023,MANA,6A25,3,12970,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,4,1,0,0,0,0,0,3.668
+Summer 2023,MANA,6A32,2,12971,Organizational Behavior & Mgt,Krylova,Ksenia O,7,6,0,0,0,0,0,3.665
+Summer 2023,MANA,6A83,2,12972,Strategic Analysis,Celly,Nikhil,5,0,0,0,0,0,0,3.934
+Summer 2023,FINA,7364,1,12974,Intl Bus & Political Risk Mgt,Miljanic,Andra Olivia,9,3,0,0,0,0,0,3.64
+Summer 2023,BUSI,1301,1,12977,Business Principles,Thompson,Joseph Lee,103,5,2,2,2,0,3,3.798
+Summer 2023,PSYC,2308,1,12978,Child Development,Trent,Erika S,39,5,0,0,0,0,0,3.864
+Summer 2023,BIOE,4349,1,12979,Biomedical Microdevices,Majd,Sheereen,6,0,0,0,0,0,0,3.89
+Summer 2023,BIOE,6349,1,12980,Biomedical Microdevices,Majd,Sheereen,4,1,0,0,0,0,0,3.734
+Summer 2023,ACCT,3367,4,12983,Intermediate Accounting I,Kuruvilla,Mohan,2,2,2,1,3,0,4,1.933
+Summer 2023,CIS,2336,1,12984,Internet Application Developmt,Faiyaz,Sajida,31,5,4,0,0,0,1,3.7
+Summer 2023,WGSS,2350,5,12985,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,2,0,1,0,0,2,3.774
+Summer 2023,WGSS,2350,6,12986,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,21,2,1,0,1,0,3,3.667
+Summer 2023,ACCT,4335,1,12987,Financial Statement Auditing,Kuruvilla,Mohan,5,5,2,0,1,0,1,3.025
+Summer 2023,AAS,2330,1,12988,Black Liberation Theology,Johnson,Alexander Emmitt Maurice,14,4,0,1,0,0,0,3.562
+Summer 2023,HDCS,1300,4,12989,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,43,3,1,1,0,0,0,3.806
+Summer 2023,HDCS,4302,1,12990,Apparel Analysis,Gatterson,Beverly,30,6,2,2,0,0,0,3.592
+Summer 2023,HDCS,4380,1,12991,Merchandising,Gatterson,Beverly,13,13,2,0,2,0,1,3.09
+Summer 2023,MANA,7340,1,12992,Management of High Tech Org.,Keller,Robert T,21,2,0,0,0,0,0,3.813
+Summer 2023,ENGI,1331,4,12993,Computing for Engineers,Burleson,Daniel W,2,8,7,2,1,0,0,2.433
+Summer 2023,CNST,3351,1,12994,Construction Estimating II,Molina,Mariel,11,4,2,0,1,0,0,3.333
+Summer 2023,FINA,7361,2,12995,Risk Management,Hogan,Kenneth David,15,0,0,0,0,0,1,4.0
+Summer 2023,NURS,3634,1,13001,Clinical Nursing Practice II,Quintana,Danielle,56,3,0,1,0,0,1,3.9
+Summer 2023,NURS,4218,1,13002,Emergency Nursing,Edwards-Maddox,Shermel Vinese,29,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,6335,1,13007,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,10,0,0,0,0,0,0,3.934
+Summer 2023,PHLS,6335,2,13008,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,8,0,0,0,0,0,0,3.959
+Summer 2023,MECE,6387,1,13015,Intelligent Structural Systems,Song,Gangbing,7,12,0,0,0,0,0,3.334
+Summer 2023,TLIM,3330,30,13016,Innovation Principles,Feriante,Chris,19,12,5,3,2,0,2,3.033
+Summer 2023,HLT,3380,1,13017,Culture and Health,Kamdar-Sharif,Amber,40,7,2,0,1,0,0,3.641
+Summer 2023,HLT,4302,1,13018,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,24,14,0,1,1,0,1,3.417
+Summer 2023,INDE,6336,1,13020,Reliability Engineering,Keedy,Elias,4,2,0,0,0,0,0,3.612
+Summer 2023,TLIM,3371,30,13021,Budgeting and Financial Princ,Burns,Maria,28,0,0,0,0,0,0,3.988
+Summer 2023,BUSI,4350,1,13022,Business Law and Ethics,Williams,John M,162,25,4,4,2,0,3,3.666
+Summer 2023,BUSI,4350,3,13024,Business Law and Ethics,Williams,John M,44,0,0,0,0,0,0,3.888
+Summer 2023,BUSI,4396,1,13025,Business Internship,Wortzel,Zachary,0,0,0,0,0,77,0,
+Summer 2023,IEEM,6360,1,13026,Data Analytics for Engr. Mgt,Chang PhD,Feng-Chang Roger,19,25,3,0,0,0,1,3.369
+Summer 2023,SPEC,6367,3,13028,Special Education for Leaders,Malechuk,Brian Edward,18,1,0,0,0,0,0,3.913
+Summer 2023,ARCH,6303,3,13029,Visual Studies III,Logan,Jason,8,3,0,0,0,0,0,3.727
+Summer 2023,BUSI,4350,5,13033,Business Law and Ethics,Williams,John M,114,20,5,2,1,0,1,3.683
+Summer 2023,HLT,4310,2,13039,Program Planning for Hlt Prof,Markowitz,Eliz,10,3,2,3,1,0,1,2.861
+Summer 2023,INDE,8399,4,13073,Doctoral Dissertation,Feng,Qianmei,1,0,0,0,0,0,0,4.0
+Summer 2023,BUSI,4396,2,13087,Business Internship,Wortzel,Zachary,0,0,0,0,0,12,0,
+Summer 2023,GEOL,3360,4,13088,Field Geology II,Murphy,Michael,4,3,2,0,0,0,1,3.112
+Summer 2023,PHOP,6198,5,13099,Spec Prob-Physio Optics,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6457,1,13109,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6198,9,13116,Spec Prob-Physio Optics,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6557,2,13118,Research Practicum B,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Summer 2023,WCL,2352,1,13127,World Cinema,Centeno,Daniel,10,12,3,1,0,0,1,3.065
+Summer 2023,MANA,4385,1,13130,Intro to Strategic Management,Tabesh,Pooya,21,2,0,0,0,0,0,3.77
+Summer 2023,MANA,7343,1,13131,Intl Legal Environment of Mgmt,Abbott,Jeanna L,9,0,0,0,0,0,0,4.0
+Summer 2023,ACCT,2301,5,13132,Prin of Financial Accounting,Newman,Michael Ray,7,3,0,0,0,0,0,3.7
+Summer 2023,ACCT,2302,7,13133,Prin of Managerial Accounting,Newman,Michael Ray,9,5,0,0,0,0,1,3.643
+Summer 2023,ACCT,2302,8,13134,Prin of Managerial Accounting,Newman,Michael Ray,5,5,0,0,0,0,1,3.467
+Summer 2023,ACCT,3368,3,13136,Intermediate Accounting II,Kraten,Michael,5,2,1,0,0,0,0,3.418
+Summer 2023,ACCT,3368,4,13137,Intermediate Accounting II,Kraten,Michael,14,7,1,0,3,0,0,3.12
+Summer 2023,ACCT,5368,1,13138,Intermediate Accounting II,Kraten,Michael,3,2,0,0,0,0,0,3.534
+Summer 2023,ACCT,3371,1,13139,Accounting Information Systems,Seijas,Nuria S,20,20,5,0,1,0,2,3.247
+Summer 2023,ACCT,5371,1,13140,Accounting Information Systems,Seijas,Nuria S,3,1,0,0,1,0,0,2.868
+Summer 2023,ACCT,4330,2,13143,Advanced Accounting,Ramaswamy,Vinita,2,2,0,0,0,0,0,3.5
+Summer 2023,ACCT,5330,2,13144,Advanced Accounting,Ramaswamy,Vinita,0,1,0,0,0,0,0,3.0
+Summer 2023,ACCT,7330,2,13145,Advanced Accounting,Ramaswamy,Vinita,12,6,0,0,0,0,0,3.667
+Summer 2023,ACCT,4335,2,13146,Financial Statement Auditing,Kuruvilla,Mohan,7,3,4,1,0,0,1,3.111
+Summer 2023,ACCT,5301,1,13147,Financial and Managerial Acct,Kuruvilla,Mohan,5,3,2,1,1,0,4,2.861
+Summer 2023,CUIN,1103,11,13149,Educator Dispositions,Culpepper,Shea Mosley,11,1,0,0,0,0,0,3.944
+Summer 2023,ACCT,7364,1,13150,Transf Pricing: Theory & Pract,Mangano,Clifford A,26,4,1,0,0,0,0,3.7
+Summer 2023,BUSI,4305,1,13151,Business Ethics for Accountant,Newman,Michael Ray,5,0,0,0,0,0,0,3.934
+Summer 2023,GENB,7304,2,13153,Bus Ethics for Accountants,Newman,Michael Ray,16,2,0,0,0,0,0,3.852
+Summer 2023,BUSI,4396,3,13154,Business Internship,Newman,Michael Ray,0,0,0,0,0,17,0,
+Summer 2023,EDUC,3101,11,13157,Practicum for Preservice Tchrs,Thompson,Amber M,11,0,0,0,0,0,0,4.0
+Summer 2023,TLIM,3350,30,13158,Emergency Management Principle,Freedkin,Aaron Samuel,15,6,3,1,1,0,0,3.18
+Summer 2023,PHLS,8393,1,13159,Doctoral Practicum in Psy,Roche,Meghan K,0,0,0,0,0,8,0,
+Summer 2023,DIGM,3353,31,13160,Visual Communications Tech,Dozier,Devin K,18,11,3,0,0,0,1,3.397
+Summer 2023,ECON,2301,1,13161,Principles of Macroeconomics,Clarke,Christopher Arthur,15,18,17,6,4,0,12,2.583
+Summer 2023,AAS,2320,3,13164,Intro To African American Stdy,Boyce,Stephanie,15,10,4,2,2,0,1,3.13
+Summer 2023,CNST,3265,1,13166,Construction Layout & Site Dvp,Lupher,Jacob John,16,11,1,0,0,0,0,3.465
+Summer 2023,CNST,4381,1,13167,Reinforced Conc & Bldg Codes,Elzafraney,Mohamed,12,9,0,0,0,0,0,3.556
+Summer 2023,MATH,1332,1,13169,Contemporary Mathematics,Hafeez,Shahinda,4,4,6,5,6,0,6,1.76
+Summer 2023,MARK,4332,1,13170,Social Media Marketing,Noriega,Jaime L,32,5,2,0,2,0,2,3.521
+Summer 2023,SPEC,8301,1,13177,Professional Writing,Martens,Monica Lynn Curry,10,0,0,0,1,0,0,3.576
+Summer 2023,SPEC,6350,1,13178,Nature/Needs of Students w/GT,Hawkins,Jacqueline McLean,1,0,0,0,0,0,0,4.0
+Summer 2023,SCLT,4389,33,13180,Practicum in Supply Chain,Kidd,Margaret A,6,2,0,0,1,0,2,3.223
+Summer 2023,GHL,3154,1,13182,Rest. Mrktg Chicago Style,Legendre,Jungyoung Shin,5,0,0,0,0,0,0,3.934
+Summer 2023,GHL,4350,1,13184,Strategy&Innovation Hosp Ind,Morosan,Cristian,9,9,4,4,2,0,0,2.702
+Summer 2023,GHL,7337,1,13187,Human Resources in Hospitality,Madera,Juan Manuel,11,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,7327,1,13190,Counseling Children,Hurt,Kara Marie,13,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,7327,2,13191,Counseling Children,Hurt,Kara Marie,10,0,0,0,0,0,0,4.0
+Summer 2023,ENGI,2304,10,13192,Technical Communications,Downey,Carlton M,14,2,0,0,0,0,0,3.896
+Summer 2023,ENGI,2304,11,13193,Technical Communications,Downey,Carlton M,13,1,2,0,0,0,0,3.708
+Summer 2023,COMM,4357,1,13194,Intercultural Communication,Liu,Wenlin,18,3,0,0,1,0,0,3.637
+Summer 2023,ENGI,2304,12,13195,Technical Communications,Salvo,Deborah C,12,3,0,0,0,0,0,3.756
+Summer 2023,ENGI,2304,13,13196,Technical Communications,Brooks,Stuart,13,2,0,0,0,0,0,3.845
+Summer 2023,ENGI,2304,14,13197,Technical Communications,Brooks,Stuart,13,1,1,0,0,0,0,3.822
+Summer 2023,ENGI,2304,15,13198,Technical Communications,Ettelson,Jennifer Jane,6,7,1,1,0,0,0,3.288
+Summer 2023,BIOL,3330,1,13201,Biological Field Research,Cheek,Ann Oliver,6,3,0,0,0,0,0,3.777
+Summer 2023,HIST,1302,50,13205,The U.S. Since 1877,Higgins,Patrick Donovan,9,0,0,0,0,0,0,4.0
+Summer 2023,CHEE,3369,1,13213,Chemical Engr Transport Proc,Zerze,Hasan,7,14,2,1,0,0,0,3.125
+Summer 2023,HDCS,4369,1,13214,Entrepreneurship,Hitchman Sr,Cal M,14,6,0,0,2,0,1,3.364
+Summer 2023,INDE,3333,1,13219,Engineering Economy I,Wiggins,Nathanial David,44,3,0,0,0,0,1,3.908
+Summer 2023,INDE,4372,1,13227,Operation Control,Hu,Minxiang,10,5,0,0,0,0,0,3.645
+Summer 2023,INDE,6332,1,13229,Egr Project Mgt,Wiggins,Nathanial David,17,0,0,0,0,0,0,3.981
+Summer 2023,IEEM,6335,1,13230,Engr Mgmt of Organizations,Chang PhD,Feng-Chang Roger,36,2,0,0,0,0,1,3.93
+Summer 2023,ELCS,6330,3,13231,Finance & School-Based Budgtng,Lewis-Skinner,Dametra N.,14,1,0,0,0,0,0,3.845
+Summer 2023,EDRS,8382,2,13233,Statistical Analyses in Eductn,Davis,Bradley,4,0,1,0,1,0,0,3.0
+Summer 2023,SOC,3390,1,13236,Sociology of Gender,Brailey,Carla,41,3,3,0,1,0,1,3.709
+Summer 2023,BIOL,4340,1,13241,Research Methods,Ekeoba,Jacqueline Njideka,7,0,0,0,0,0,0,3.906
+Summer 2023,PHYS,4340,1,13242,Research Methods,Ekeoba,Jacqueline Njideka,1,0,0,0,0,0,0,4.0
+Summer 2023,CHEM,4340,1,13243,Research Methods,Ekeoba,Jacqueline Njideka,1,1,0,0,0,0,0,3.17
+Summer 2023,ARTS,2311,1,13245,"Color, Materials and Methods",Williams,Ian Harrison,6,2,0,0,0,0,1,3.75
+Summer 2023,KIN,3306,2,13253,Physiology-Human Performance,Breslin,Whitney L,14,31,8,1,0,0,0,3.068
+Summer 2023,HLT,4307,2,13256,Research and Eval in Health,Haq,Arooba A,11,8,4,4,1,0,0,2.822
+Summer 2023,CIS,2332,1,13257,Info Tech Hdwr & Systems Sftwr,Peddoju,Suresh Kumar,33,4,0,0,0,0,1,3.865
+Summer 2023,CIS,2337,1,13258,Fund of Information Security,Peddoju,Suresh Kumar,28,3,3,1,0,0,2,3.657
+Summer 2023,HRD,6355,30,13259,Designing OD Interventions,Hausmann,Robert Carl,7,0,0,0,0,0,0,3.953
+Summer 2023,COSC,2436,201,13261,Programming and Data Structure,Rizk,Nouhad J,7,11,19,3,9,0,4,2.088
+Summer 2023,MUED,2342,2,13267,Music for Children,Edwards,Zachary B,10,7,1,0,1,0,0,3.351
+Summer 2023,INDE,2333,3,13269,Engineering Statistics I,Wang,Yaping,41,46,38,11,1,0,0,2.791
+Summer 2023,BTEC,4350,30,13274,Biotech Capstone Experience,Balan,Venkatesh,1,3,0,0,0,0,1,3.333
+Summer 2023,CIS,2348,2,13275,Info Systems Appl Development,Ratner,Edward,3,11,14,1,4,0,0,2.212
+Summer 2023,COSC,3360,301,13276,Operating Systems,Rincon Castro,Carlos Alberto,15,11,12,1,12,0,3,2.307
+Summer 2023,PHYS,2325,3,13277,University Physics I (lecture),Chen,Shuo,67,128,53,3,2,0,0,2.974
+Summer 2023,NURS,4322,1,13280,Policy &Ethics in Prof Nursing,Quintana,Danielle,60,2,0,0,0,0,0,3.968
+Summer 2023,NURS,6316,1,13281,Healthcare Organizatn Behavior,Brohard,Cheryl L,1,0,0,0,0,0,0,4.0
+Summer 2023,NURS,6335,1,13282,Mgmt of Hlth Disrdrs in Adults,Dwyer,Carol Ann,3,2,0,0,0,0,0,3.6
+Summer 2023,NURS,6336,1,13283,Mgmt of Hlth Disordrs Clinical,Dwyer,Carol Ann,0,0,0,0,0,5,0,
+Summer 2023,FINA,4323,1,13285,Investment & Mutual Fund Mgt,Blanchfield,Craig,23,21,2,1,0,0,1,3.418
+Summer 2023,NUTR,2332,1,13286,Intro To Human Nutrition,Hughes,Lindsay,19,16,8,0,1,0,2,3.099
+Summer 2023,CUIN,7331,5,13287,Supporting Striving Readers,Reis,Nancy,7,0,0,0,0,0,0,4.0
+Summer 2023,DRAM,1310,3,13288,Introduction to Theatre,Brincks,Alan,39,8,3,3,1,0,0,3.451
+Summer 2023,DRAM,1310,7,13289,Introduction to Theatre,Egging,Jon Leo,37,7,3,1,5,0,1,3.308
+Summer 2023,BIOE,4313,1,13291,Intro to Neural Computation,Francis,Joseph Thachil,1,0,1,0,0,0,0,3.165
+Summer 2023,BIOE,6306,1,13293,Adv Artificial Neural Networks,Francis,Joseph Thachil,19,4,2,0,0,0,0,3.601
+Summer 2023,PSYC,2317,3,13299,Intro to Psychology Statistics,Griep,Christina Diaz,16,22,10,0,0,0,3,3.118
+Summer 2023,PSYC,2320,2,13301,Abnormal Psychology,Grigorenko,Elena L,7,8,7,1,2,0,1,2.627
+Summer 2023,PSYC,2320,4,13302,Abnormal Psychology,Ridgely,Natalie,20,20,3,2,1,0,2,3.146
+Summer 2023,ENGL,2307,1,13304,Intro To Drama,Presswood,Phillip Hilliard,23,1,0,0,0,0,0,3.903
+Summer 2023,ENGL,2315,2,13305,Literature and Film,Sicinski,Michael J,16,5,1,0,1,0,1,3.436
+Summer 2023,CUIN,7305,3,13311,"Design,Dev & Eval Presentation",Dogan,Bulent,23,0,0,0,0,0,0,4.0
+Summer 2023,ECE,2100,1,13320,Circuit Analysis Laboratory,Ramachandran,Deepa,9,0,0,0,0,0,0,3.963
+Summer 2023,PHED,1306,1,13323,Emergency Care & First Aid,Brown,Korey J,24,0,0,0,1,0,0,3.84
+Summer 2023,COMD,4489,1,13326,Clinical Procedures,Ermgodts,Katherine Natalie,13,0,0,0,0,0,0,4.0
+Summer 2023,COSC,4351,201,13332,Fundamentals of Software Engr,Hilford,Victoria,20,15,6,0,0,0,1,3.325
+Summer 2023,NUTR,4351,1,13334,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,37,14,2,1,1,0,1,3.509
+Summer 2023,PHYS,2125,2,13335,University Physics Lab I,Wood,Lowell T,7,91,16,5,0,0,0,2.81
+Summer 2023,OPTO,6230,1,13344,Contact Lens Pathology,Bergmanson,Jan Pg,0,0,0,0,0,29,0,
+Summer 2023,OPTO,6274,1,13345,Spec Contact Lens Workshops,Dempsey,Robert L,0,0,0,0,0,18,0,
+Summer 2023,OPTO,6254,1,13347,Optom & Special Needs Children,Dempsey,Robert L,0,0,0,0,0,15,0,
+Summer 2023,CHEE,8399,21,13349,Doctoral Dissertation,Krishnamoorti,Ramanan,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,3320,202,13357,Algorithms and Data Structures,Leiss,Ernst L,30,13,6,2,2,0,3,3.189
+Summer 2023,MANA,4341,1,13393,Leading Organizational Change,Evans,Klavdia Markelova,46,1,1,0,0,0,0,3.896
+Summer 2023,GEOL,8399,2,13394,Doctoral Dissertation,Wang,Yuxuan,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,8698,2,13395,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2023,GEOL,8698,2,13399,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Summer 2023,GEOL,8698,3,13401,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,
+Summer 2023,CIVE,8198,2,13404,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Summer 2023,CIVE,8598,2,13407,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Summer 2023,ELET,2300,1,13408,Introductn To C++ Programming,Soneja,Chandrayee,15,4,4,0,1,0,0,3.278
+Summer 2023,GEOL,8698,4,13412,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Summer 2023,CIVE,8198,19,13427,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Summer 2023,CIVE,8598,19,13443,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Summer 2023,PHOP,6557,3,13446,Research Practicum B,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,8398,5,13452,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Summer 2023,BIOE,8398,11,13458,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Summer 2023,PHOP,6457,3,13469,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,8399,7,13479,Doctoral Dissertation,Ince,Nuri Firat,1,0,0,0,0,0,0,4.0
+Summer 2023,PCOL,8698,2,13500,Doctoral Research,Ruan,Ke-He,0,0,0,0,0,1,0,
+Summer 2023,PSYC,3339,3,13506,Intro To Clinical Psychology,Szafranski,Derek D,39,1,0,0,0,0,0,3.942
+Summer 2023,ARTS,4398,2,13513,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Summer 2023,OPTO,7495,1,13518,General Clinic IIIc,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Summer 2023,CIVE,8399,2,13519,Doctoral Dissertation,Louie,Stacey M,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,8398,23,13520,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2023,BIOE,8198,7,13522,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Summer 2023,BIOE,8298,7,13523,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Summer 2023,OPTO,5250,1,13545,Seminar Scientific Investigatn,Frishman,Laura J,5,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8199,2,13550,Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Summer 2023,MECE,8399,20,13565,Doctoral Dissertation,Ghasemi,Hadi,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8399,3,13577,Doctoral Dissertation,Azevedo,Ricardo,1,0,0,0,0,0,0,4.0
+Summer 2023,MECE,8399,22,13585,Doctoral Dissertation,Joshi,Shailendra Pramod,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8698,5,13589,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Summer 2023,PETR,8198,5,13601,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Summer 2023,PETR,8198,10,13606,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Summer 2023,DRAM,1310,5,13614,Introduction to Theatre,Hinkel,Heidi Anne,28,6,1,0,4,0,0,3.402
+Summer 2023,DRAM,1310,6,13615,Introduction to Theatre,Hinkel,Heidi Anne,16,7,3,4,8,0,1,2.483
+Summer 2023,BIOL,8698,4,13627,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Summer 2023,MECE,8399,1,13631,Doctoral Dissertation,Sun,Li,0,0,0,0,0,1,0,
+Summer 2023,PHLS,8199,3,13638,Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2023,PHOP,6557,5,13642,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Summer 2023,PHOP,6457,4,13645,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2023,ECE,8399,6,13689,Doctoral Dissertation,Contreras-Vidal,Jose Luis,2,0,0,0,0,2,0,4.0
+Summer 2023,PHOP,6457,5,13692,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,8299,2,13694,Doctoral Dissertation,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8399,18,13696,Doctoral Dissertation,Viana,Andres G,1,0,0,0,0,1,0,4.0
+Summer 2023,PSYC,8399,19,13697,Doctoral Dissertation,Vujanovic,Anka Anna,0,0,0,0,0,2,0,
+Summer 2023,PSYC,7399,7,13698,Masters Thesis,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Summer 2023,GEOL,8698,6,13699,Doctoral Research,Wu,Jonathan En Lin,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,5,13700,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,7,13705,Doctoral Research,Feng,Qin,0,0,0,0,0,2,0,
+Summer 2023,PHLS,8199,4,13731,Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,
+Summer 2023,BCHS,8698,4,13736,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,8,13756,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Summer 2023,BCHS,8698,5,13764,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,9,13765,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,
+Summer 2023,PSYC,6352,5,13767,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,2,0,
+Summer 2023,PSYC,6398,11,13768,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Summer 2023,BCHS,8698,6,13777,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,11,13782,Doctoral Research,Fujita,Masaya,0,0,0,0,0,1,0,
+Summer 2023,OPTO,8992,1,13786,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Summer 2023,OPTO,8993,1,13787,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6359,7,13788,Directed Rsch in Clinical Psyc,Viana,Andres G,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,7399,10,13789,Masters Thesis,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Summer 2023,ECE,8399,10,13798,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8398,6,13805,Doctoral Research,Cappanera,Loic,0,0,0,0,0,2,0,
+Summer 2023,PSYC,8399,21,13810,Doctoral Dissertation,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Summer 2023,KIN,4398,2,13811,Independent Study,Cottingham,Michael,2,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8698,9,13813,Doctoral Research,Castagna,John P,0,0,0,0,0,1,0,
+Summer 2023,GEOL,8698,10,13814,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,14,0,
+Summer 2023,GEOL,8698,11,13824,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,3,0,
+Summer 2023,PSYC,3350,4,13830,Intro to Cognitive Psychology,Carlos,Brandon J,39,19,5,0,0,0,0,3.482
+Summer 2023,MATH,8398,7,13832,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Summer 2023,ELED,4320,2,13836,Social Studies Ele Sch,Carr,Bianca Shaunte,25,2,1,0,0,0,0,3.81
+Summer 2023,GEOL,8698,13,13844,Doctoral Research,Mann,Paul,0,0,0,0,0,2,0,
+Summer 2023,PHLS,8699,4,13861,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6365,7,13863,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Summer 2023,GEOL,8698,15,13875,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Summer 2023,GEOL,8698,16,13880,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,11,13883,Masters Thesis,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,8698,9,13887,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,2,0,
+Summer 2023,BIOL,8698,13,13888,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Summer 2023,BIOL,8698,14,13890,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2023,PHCA,8199,4,13892,Doctoral Dissertation Defense,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Summer 2023,PHCA,8298,4,13893,Doctoral Dissertation Research,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Summer 2023,PHCA,8199,5,13898,Doctoral Dissertation Defense,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2023,PHCA,8298,5,13899,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2023,MECE,8399,9,13905,Doctoral Dissertation,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Summer 2023,COMD,7391,6,13912,Clinic in Speech Lang Disorder,Trevino,Alexandra Hanson,0,1,0,0,0,0,0,3.33
+Summer 2023,PHLS,8199,6,13913,Dissertation,Master,Allison,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,12,13914,Masters Thesis,Alfano,Candice A,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6336,4,13923,Directed Rsch in Social Psyc,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Summer 2023,PHLS,8199,7,13924,Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Summer 2023,BIOL,2120,2,13926,Microbiology for Non-Science,Knapp,Richard D,3,5,1,0,0,0,0,3.186
+Summer 2023,COSC,8698,118,13942,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Summer 2023,GEOL,7399,4,13955,Masters Thesis,Lapen,Thomas J,0,0,0,0,0,2,0,
+Summer 2023,HON,4398,2,13958,Independent Study,Rhoden,Brenda,2,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,8498,5,13964,Doctoral Research,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Summer 2023,PCEU,6698,1,13965,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Summer 2023,ANTH,7399,1,13979,Masters Thesis,Sen,Debarati,0,0,0,0,0,1,0,
+Summer 2023,COSC,6398,103,13982,Special Problems,Cheng,Albert M K,0,0,0,0,0,1,0,
+Summer 2023,PHLA,6260,1,13984,Healthcare Finance,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Summer 2023,PHLA,6220,1,13985,Leadership Concepts II,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Summer 2023,PHLA,7199,1,13986,Masters Thesis,Varkey,Divya A,0,0,0,0,0,7,0,
+Summer 2023,PSYC,8399,22,13991,Doctoral Dissertation,Sharp,Carla,2,0,0,0,0,1,0,4.0
+Summer 2023,COSC,8399,127,14004,Doctoral Dissertation,Subhlok,Jaspal,1,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,8399,5,14008,Doctoral Dissertation,Chauvot,Jennifer B,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,14,14013,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,23,14016,Doctoral Dissertation,Bick,Johanna R,1,0,0,0,0,0,0,4.0
+Summer 2023,CIS,6396,1,14019,Internship in Infor. Security,Conklin,William A,4,0,0,0,0,0,0,4.0
+Summer 2023,HON,3399,1,14020,Senior Honors Thesis,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Summer 2023,DIGM,4398,1,14024,Independent Study,Rodwell,Elizabeth Ann,0,0,1,0,1,0,0,1.0
+Summer 2023,BIOE,8198,15,14032,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Summer 2023,BIOE,8298,14,14033,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Summer 2023,HIST,4398,1,14039,Independent Study,Harwell,Debbie Z,1,0,0,0,0,0,0,4.0
+Summer 2023,ECON,8699,6,14046,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,1,0,
+Summer 2023,PSYC,8399,24,14054,Doctoral Dissertation,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,6399,2,14055,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6365,8,14056,Dir Rsch in Dev Cog Beh Neuro,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Summer 2023,FINA,4396,2,14057,Finance Internship,Kumar,Praveen,0,0,0,0,0,8,0,
+Summer 2023,CHEM,3396,1,14069,Senior Research Project,Meen,James K,1,0,0,0,0,0,0,4.0
+Summer 2023,CHEE,5397,1,14256,Selected Topics,Kaushik,Krishna R,4,2,0,0,0,0,0,3.612
+Summer 2023,CHEE,6397,1,14257,Selected Topics,Kaushik,Krishna R,1,2,0,0,0,0,0,3.333
+Summer 2023,CHEE,6397,2,14259,Selected Topics,Kaushik,Krishna R,1,0,0,0,0,0,0,3.67
+Summer 2023,CHEE,3321,1,14262,Analytical Methods Chem Engr,Nikolaou,Michael,7,8,4,0,3,0,2,2.667
+Summer 2023,CHEE,3321,2,14263,Analytical Methods Chem Engr,Nikolaou,Michael,0,1,0,0,0,0,0,3.0
+Summer 2023,CHEE,2332,1,14265,Chem Engr Thermodyn I,Fleischer,Miguel T,1,5,7,2,1,0,9,2.188
+Summer 2023,GEOL,1103,1,14266,Physical Geology Lab,Hauptvogel,Daniel William,8,6,0,0,0,0,0,3.619
+Summer 2023,GEOL,4397,1,14269,Selected Topics-Geology,Khan,Shuhab D,8,3,0,0,0,0,0,3.667
+Summer 2023,MANA,7397,1,14270,Selected Topics in Management,Witt,Lawrence A,12,0,0,0,0,0,0,4.0
+Summer 2023,GENB,7397,1,14271,Selected Topics,Miljanic,Andra Olivia,9,2,0,0,0,0,0,3.818
+Summer 2023,GENB,7397,2,14272,Selected Topics,Miljanic,Andra Olivia,6,1,0,0,0,0,0,3.857
+Summer 2023,BZAN,7320,2,14273,Bus Modeling For Comp Adv,Wiley,Briceon C,8,0,0,0,0,0,0,4.0
+Summer 2023,ECON,4370,1,14285,International Trade,Yi,Kei-Mu,7,7,1,0,0,0,1,3.4
+Summer 2023,PHLS,8398,1,14344,Special Problems,Hurt,Kara Marie,1,0,0,0,0,0,0,4.0
+Summer 2023,ECON,2302,4,14345,Principles of Microeconomics,Melendez Lugo,Joel,11,38,30,11,3,0,6,2.406
+Summer 2023,LAW,6230,1,14346,Current Crisis Middle East,Foteh,Samir Jabra,3,3,0,0,0,2,0,3.445
+Summer 2023,LAW,7335,1,14348,WRS: Animal Law,Morath,Sarah,6,6,0,0,0,0,0,3.39
+Summer 2023,LAW,5116,1,14352,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2023,LAW,5116,2,14355,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2023,LAW,5125,2,14357,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2023,LAW,5128,1,14358,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,5,0,
+Summer 2023,LAW,5128,2,14359,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2023,LAW,5130,1,14360,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,3,0,
+Summer 2023,LAW,5130,2,14361,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2023,LAW,5129,1,14362,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2023,LAW,5129,2,14363,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,2,0,
+Summer 2023,CUIN,7322,5,14429,Curric Dev in Sci Ed,Rodriguez,Alberto J,15,1,0,0,0,0,0,3.917
+Summer 2023,SEDE,7340,1,14430,Reading in Middle and Secondar,Hutchison,Laveria F,16,0,0,0,0,0,0,3.979
+Summer 2023,CUIN,7375,5,14432,Capstone for Literacy Educ,Wong,Sissy S,17,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,3302,5,14433,Social Education,Thomas,Dustine J,19,0,0,0,0,0,0,3.983
+Summer 2023,CUIN,3347,1,14434,Reading in the Content Area,Stubbs,Susan,13,1,0,0,0,0,1,3.952
+Summer 2023,CUIN,7305,5,14435,"Design,Dev & Eval Presentation",McNeil,Sara G,5,1,0,0,0,0,0,3.833
+Summer 2023,CUIN,7389,1,14436,Digital Media,McNeil,Sara G,5,1,0,0,0,0,0,3.833
+Summer 2023,CUIN,7389,5,14437,Digital Media,Dogan,Bulent,18,0,0,0,0,0,1,4.0
+Summer 2023,GEOL,6397,1,14439,Selected Topics in Geology,Khan,Shuhab D,4,1,0,0,0,0,0,3.668
+Summer 2023,CUIN,7305,6,14502,"Design,Dev & Eval Presentation",Smith,Adrienne Linette,6,3,0,0,0,0,0,3.667
+Summer 2023,ELCS,8338,1,14503,Admin Higher Educ Multiculset,Hernandez,Belkis Pamela,17,1,0,0,0,0,1,3.926
+Summer 2023,CUIN,8310,5,14504,Laboratory of Practice,Thomas,Dustine J,2,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,8395,2,14511,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,8,0,
+Summer 2023,ELCS,8395,3,14512,Doctoral Thesis,Butcher,Keith,0,0,0,0,0,1,0,
+Summer 2023,ELCS,8395,4,14513,Doctoral Thesis,Freelon,Rhoda,0,0,0,0,0,1,0,
+Summer 2023,ELCS,8395,7,14516,Doctoral Thesis,Lopez,Ruth Maria,0,0,0,0,0,1,0,
+Summer 2023,ELCS,8350,2,14519,Resource Management,Stallworth,Lance,17,0,0,0,0,0,0,3.922
+Summer 2023,ELCS,8199,1,14521,Dissertation,Davis,Tiffany J,0,0,0,0,0,1,0,
+Summer 2023,MANA,4358,1,14612,Compensation and Benefits,Zamanipour,Tina,22,4,1,1,3,0,1,3.323
+Summer 2023,MANA,4397,2,14613,Selected Topics in Mana,Salaiz,Ashley,16,0,0,0,0,0,0,4.0
+Summer 2023,MANA,7397,2,14614,Selected Topics in Management,Vera,Dusya M,29,1,1,0,0,0,0,3.903
+Summer 2023,MANA,4397,1,14615,Selected Topics in Mana,Sebastijanovic,Marina,11,4,7,0,0,0,1,3.077
+Summer 2023,SCM,4362,1,14617,Demand and Supply Integration,Dillibe,Onyinye,10,6,3,1,0,0,0,3.3
+Summer 2023,MANA,3335,3,14634,Intro Org Behavior and Mgmt,Evans,Klavdia Markelova,28,1,3,2,0,0,0,3.598
+Summer 2023,MANA,3335,4,14636,Intro Org Behavior and Mgmt,Salaiz,Ashley,35,4,2,0,0,0,0,3.773
+Summer 2023,MANA,7397,3,14676,Selected Topics in Management,Miljanic,Andra Olivia,9,3,0,0,0,0,0,3.805
+Summer 2023,MIS,4397,1,14805,Selected Topics in MIS,Messinger,Jacob Nelson,5,0,0,0,1,0,1,3.333
+Summer 2023,MIS,7397,1,14806,Selected Topics in MIS,Campbell,Phillip James,5,1,0,0,0,0,0,3.723
+Summer 2023,SOCW,7313,1,14823,Global SW: Women & Human Right,Bromfield,Nicole,23,1,0,0,0,0,0,3.958
+Summer 2023,SOCW,7397,1,14824,Selected Topics in Social Work,Bromfield,Nicole,11,6,0,0,0,0,1,3.647
+Summer 2023,SOCW,7397,2,14825,Selected Topics in Social Work,Dettlaff,Alan J,13,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7361,1,14826,Clinical SW Practice w Elders,Miyawaki,Christina E,8,3,0,0,0,0,0,3.727
+Summer 2023,SOCW,7374,1,14827,Mediation for Social Workers,Robbins,Susan P,6,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7301,1,14828,Confronting Oppression & Injus,Shepherd,Donisha Shanice,8,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7397,3,14829,Selected Topics in Social Work,Flores,Vanessa Marie,9,3,0,0,0,0,0,3.75
+Summer 2023,SOCW,7340,2,14830,Clinical Practice with Child,McMorris,Saralyn Dionne,27,0,0,0,0,0,0,4.0
+Summer 2023,ACCT,7370,1,14837,Adv Fin Statement Auditing,Seltz,Joe D,16,4,6,0,0,0,3,3.448
+Summer 2023,ACCT,5376,1,14838,Adv Fin Statement Auditing,Seltz,Joe D,1,2,3,0,0,0,0,2.667
+Summer 2023,ACCT,5368,2,14839,Intermediate Accounting II,Kraten,Michael,0,0,0,0,1,0,0,0.0
+Summer 2023,ECON,6394,1,14840,Tpcs-Eco of Socl Issue,Verchenko,Olesia,0,3,0,0,0,0,0,3.22
+Summer 2023,ECON,6394,2,14841,Tpcs-Eco of Socl Issue,Besedina,Elena,2,1,0,0,0,0,0,3.447
+Summer 2023,ECON,6394,3,14842,Tpcs-Eco of Socl Issue,Obrizan,Maksym,1,1,0,0,0,0,0,3.665
+Summer 2023,CIS,3343,33,14844,Info Systems Analysis & Design,Faiyaz,Sajida,20,12,5,0,1,0,0,3.429
+Summer 2023,ACCT,3366,3,14858,Financial Reporting Frameworks,Serrato,Darlene Marie  Bohac,0,4,0,2,1,0,2,2.0
+Summer 2023,ACCT,3366,4,14859,Financial Reporting Frameworks,Serrato,Darlene Marie  Bohac,0,3,15,9,3,0,6,1.6
+Summer 2023,ACCT,3377,3,14860,Cost Accounting,Serrato,Darlene Marie  Bohac,1,2,1,0,0,0,1,3.083
+Summer 2023,ACCT,5337,3,14861,Management Accounting,Serrato,Darlene Marie  Bohac,1,0,0,0,0,0,0,3.67
+Summer 2023,SOCW,7397,4,14862,Selected Topics in Social Work,Kennedy,Priscilla P,23,1,0,0,0,0,0,3.931
+Summer 2023,SOCW,7397,5,14863,Selected Topics in Social Work,Webb,Ann E,12,5,0,0,0,0,1,3.706
+Summer 2023,SOCW,7302,1,14864,SW in Health Care Settings,Fernandez,Jason,25,0,0,0,0,0,0,4.0
+Summer 2023,SCLT,2380,30,14873,Distribution Channels,Elliott,Stephen Dwight,6,6,12,0,5,0,3,2.287
+Summer 2023,SCLT,4375,30,14874,Global Supply Chain,Dong,Zhijie,7,6,2,0,1,0,0,3.104
+Summer 2023,SCLT,3389,30,14875,Transportation Law,Blount,James,25,4,4,0,1,0,1,3.452
+Summer 2023,SCLT,3384,30,14876,Logistics Tech and Processes,Blount,James,31,3,0,0,0,0,0,3.854
+Summer 2023,SCLT,4396,30,14879,Internship in Supply Chain,Kidd,Margaret A,10,2,0,0,0,0,1,3.751
+Summer 2023,ELED,4315,11,14880,Mathematics in Elem School II,Shelton,Laura,1,1,0,0,0,0,0,3.335
+Summer 2023,NUTR,6316,1,14882,ADV Diabetes Management & Edu,Scott,Claudia W,2,2,0,0,0,0,1,3.665
+Summer 2023,SCLT,2362,31,14883,Intro To Logistics Technology,Kidd,Margaret A,12,11,4,1,0,0,1,3.132
+Summer 2023,FINA,4320,2,14908,Investment Management,Tian,Zhe,8,1,1,0,0,0,0,3.634
+Summer 2023,MANA,7397,4,14912,Selected Topics in Management,Abbott,Jeanna L,28,0,0,0,0,0,0,3.941
+Summer 2023,CNST,2360,1,14913,Communication in Construction,Samm,Ira,8,12,5,0,0,0,0,3.12
+Summer 2023,FINA,4360,1,14914,International Financial Mgmt,Susmel,Raul,1,0,3,0,0,0,0,2.748
+Summer 2023,FINA,4397,1,14915,Selected Topics in Finance,Kapatos,Nick Gus,11,8,1,1,0,0,1,3.287
+Summer 2023,FINA,4397,3,14917,Selected Topics in Finance,Kapatos,Nick Gus,9,7,2,1,0,0,2,3.246
+Summer 2023,FINA,7397,2,14919,Selected Topics in Finance,Berta,Dominique,9,10,1,0,0,0,0,3.433
+Summer 2023,ARCH,5500,1,14930,Architecture Design Studio IX,Diehl,Tom,2,4,0,2,0,0,0,2.75
+Summer 2023,ARCH,7600,3,14932,Architecture Design Studio V,Diehl,Tom,2,2,0,0,0,0,0,3.5
+Summer 2023,ARCH,4397,1,14934,Selected Topics,Diehl,Tom,1,6,1,0,0,0,0,3.041
+Summer 2023,ARCH,6397,2,14935,Sel Tpcs-Arc/Urbn Desgn,Diehl,Tom,2,2,0,0,0,0,0,3.418
+Summer 2023,ARCH,6397,4,14936,Sel Tpcs-Arc/Urbn Desgn,Diehl,Tom,1,3,0,0,0,0,0,3.333
+Summer 2023,ARCH,3397,3,14937,Selected Topics,Diehl,Tom,1,5,2,0,0,0,0,2.916
+Summer 2023,ARCH,5500,3,14938,Architecture Design Studio IX,Wienert,Ross George,6,1,0,0,0,0,0,3.81
+Summer 2023,ARCH,7600,5,14940,Architecture Design Studio V,Wienert,Ross George,2,1,0,0,0,0,0,3.557
+Summer 2023,FORE,6395,1,14959,Master's Project in Foresight,Hines,Andrew Lewis,2,0,0,0,0,0,0,3.835
+Summer 2023,FORE,6397,1,14960,Selected Topics in Foresight,Cowart,Adam David,15,0,0,0,0,0,0,4.0
+Summer 2023,IDNS,2197,1,14976,Top-Natrl Sci & Mth,Pattison,Donna,0,0,0,0,0,56,0,
+Summer 2023,HRD,3310,1,14990,Talent Management,Shakir,Khalimah,16,8,2,1,2,0,0,3.207
+Summer 2023,PSYC,2305,3,14991,Intro to Methods in Psychology,Anderson,Jill Annette,31,27,2,0,0,0,0,3.472
+Summer 2023,PSYC,2307,1,14993,Psychology of Adolescence,Cifre,Anthony Ballachie,9,20,8,4,2,0,2,2.667
+Summer 2023,ARCH,3311,1,14994,Topics in Design History,Wienert,Ross George,3,4,0,0,0,0,0,3.523
+Summer 2023,ARCH,6397,7,14995,Sel Tpcs-Arc/Urbn Desgn,Wienert,Ross George,1,1,0,0,0,0,0,3.5
+Summer 2023,ARCH,6397,8,14996,Sel Tpcs-Arc/Urbn Desgn,Wienert,Ross George,2,1,0,0,0,0,0,3.667
+Summer 2023,ARCH,3312,1,14997,Topics in Design Media,Wienert,Ross George,5,2,0,0,0,0,0,3.62
+Summer 2023,LAW,7397,2,15002,Selected Topics,Swift,Kenneth Richard,6,6,0,0,0,0,0,3.39
+Summer 2023,LAW,7397,3,15003,Selected Topics,Knake,Renee N,8,1,2,0,0,0,0,3.395
+Summer 2023,INDS,3500,1,15005,Industrial Design Studio V,Feng,Jeff Feng,0,1,0,0,0,0,0,3.33
+Summer 2023,INDS,4500,1,15007,Industrial Design Studio VII,Feng,Jeff Feng,10,1,0,0,0,0,0,3.729
+Summer 2023,INDS,6360,1,15009,Industrial Design Studio,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Summer 2023,INDS,4360,1,15011,Design Issues,Feng,Jeff Feng,11,0,0,0,0,0,0,3.76
+Summer 2023,INDS,6397,1,15012,Selected Topics,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Summer 2023,INDS,6397,2,15013,Selected Topics,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Summer 2023,INDS,3397,1,15014,Selected Topics,Feng,Jeff Feng,9,3,0,0,0,0,0,3.668
+Summer 2023,MATH,4389,1,15015,Survey of Undergraduate Math,Blecher,David P,4,3,2,0,0,0,0,3.076
+Summer 2023,MATH,1351,1,15020,Intro to Geometric Reasoning,Chang,James A,14,10,2,2,2,0,2,3.067
+Summer 2023,PSYC,2308,2,15023,Child Development,Merrill,Livia Christine,18,16,2,0,0,0,0,3.399
+Summer 2023,MATH,1342,1,15026,Elementary Statistical Methods,Wang,Wenshuang,24,32,24,26,24,0,16,1.995
+Summer 2023,PSYC,4344,4,15027,Cultural Psychology,Beltran-Najera,Ilex,36,10,1,2,2,0,1,3.535
+Summer 2023,PSYC,2317,7,15031,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,13,24,7,3,2,0,0,2.851
+Summer 2023,PSYC,3339,4,15032,Intro To Clinical Psychology,Li,Xinge,22,14,6,0,1,0,0,3.31
+Summer 2023,HLT,4397,1,15033,Selected Topics in Health,Solari Williams,Kayce D,6,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,6397,1,15914,Selected Topics,Solari Williams,Kayce D,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,3338,2,15921,Probability,Haynes,Alan K,19,6,1,0,0,0,0,3.616
+Summer 2023,COMM,2311,7,15928,Writing for Print and Digital,Crixell,Charles A,5,8,4,0,1,0,0,2.852
+Summer 2023,COMM,3311,3,15930,Editing Print & Digital Media,Crixell,Charles A,10,4,0,0,0,0,0,3.714
+Summer 2023,COMM,3381,1,15932,Short Film Practicum,Houk,Keith R,0,0,0,0,0,19,0,
+Summer 2023,LAW,6235,1,15933,Juvenile Representation,Cepeda Hendrickson,Grecia,0,0,0,0,0,3,0,
+Summer 2023,LAW,5497,2,15937,Selected Topics,Krasny,Frederick A,1,0,0,0,0,0,0,3.67
+Summer 2023,LAW,5405,1,15940,Immigration Clinic,Messer,Teresa Pham,3,0,1,0,0,0,0,3.335
+Summer 2023,LAW,5205,1,15942,Immigration Clinic II,Messer,Teresa Pham,1,1,0,0,0,0,0,3.5
+Summer 2023,LAW,6321,1,15945,Professional Responsibility,Knake,Renee N,21,20,0,0,0,0,2,3.4
+Summer 2023,COMM,3306,1,15950,End of Life Communication,Hudson-Gillan,Gail,30,6,2,0,0,0,2,3.711
+Summer 2023,POLS,6368,1,16071,Political Psychology,Clifford,Scott,7,1,0,0,0,0,0,3.751
+Summer 2023,CNST,4331,1,16072,Construction Management II,Menendez,Daniel,0,0,0,0,0,0,1,
+Summer 2023,MARK,4389,2,16098,Marketing Strategy & Planning,Lish,Alan D,18,12,1,0,0,0,1,3.485
+Summer 2023,ELED,4310,11,16103,Reading/Language in Elementary,Christensen,Caroline,8,3,1,0,0,0,0,3.556
+Summer 2023,GHL,2343,1,16115,Hospitality Cost Controls,Haskell,Rebecca Erin,8,4,0,1,0,0,0,3.411
+Summer 2023,GHL,3349,1,16116,Hosp Procurement & Purchasing,Jarvis,Nathan Alexander,8,9,1,1,2,0,0,2.952
+Summer 2023,GHL,3352,1,16117,Human Resource Management,Guchait,Priyanko,13,2,4,0,0,0,0,3.474
+Summer 2023,GHL,4388,1,16118,Managing Diversity in Hosp Ind,Madera,Juan Manuel,26,3,1,0,2,0,0,3.614
+Summer 2023,GHL,6197,1,16120,Selected Topics,Legendre,Jungyoung Shin,5,0,0,0,0,0,0,4.0
+Summer 2023,ECON,4390,4,16137,Economics Internship,Saboury,Piruz,10,0,0,0,0,0,0,4.0
+Summer 2023,PHIL,3388,1,16155,Hist of 20Th Cent Phi,Weisberg,Joshua,9,11,2,1,1,0,1,3.07
+Summer 2023,PHIL,1334,1,16156,Minds and Machines,Weisberg,Joshua,2,6,2,2,1,0,1,2.487
+Summer 2023,COMM,4384,1,16161,Strategic Comm Applications,Williams,Uniqua Janae,16,0,0,0,1,0,0,3.668
+Summer 2023,NUTR,2332,5,16168,Intro To Human Nutrition,Hughes,Lindsay,21,16,7,1,2,0,1,3.043
+Summer 2023,MARK,7A97,1,16190,Selected Topics in Marketing,Kelly,Robert J,5,0,0,0,0,0,0,4.0
+Summer 2023,MARK,7A97,2,16191,Selected Topics in Marketing,Kelly,Robert J,4,0,0,0,0,0,0,4.0
+Summer 2023,LAW,5233,1,16237,Education Law: K-12,Brush,Jonathan Griffin,2,3,0,0,0,3,1,3.4
+Summer 2023,GHL,6197,1,16248,Selected Topics,Padilla,Magdalena Manzano,10,1,0,0,0,0,0,3.939
+Summer 2023,GHL,6364,1,16249,Hosp. Managerial Accounting,Johnson,Tucker A,5,0,0,0,0,0,0,4.0
+Summer 2023,GHL,6388,1,16250,Managing for Diversity in Hosp,Madera,Juan Manuel,9,0,0,0,0,0,0,4.0
+Summer 2023,GHL,7361,1,16251,Hospitality Marketing Analysis,Taylor,David C,10,1,1,0,0,0,0,3.668
+Summer 2023,LAW,5421,1,16269,Business Organizations,Moll,Douglas Keith,5,9,0,0,0,13,0,3.334
+Summer 2023,BIOL,4320,1,16280,Molecular Biology,Scott,Sean-Patrick,6,12,8,0,0,0,1,2.885
+Summer 2023,BCHS,4397,1,16281,Topics-Biochem & Biophys Sci,Scott,Sean-Patrick,2,2,0,0,0,0,0,3.5
+Summer 2023,PSYC,3331,3,16284,Psychology of Gender,Kehoe,Caitlin,22,38,3,0,0,0,1,3.401
+Summer 2023,PETR,6397,1,16349,Selected Topics,Mohamed,Mohamed Ibrahim,3,2,2,0,0,0,1,3.143
+Summer 2023,POLS,3312,1,16365,"Arguments, Data, Politics",Marinov,Nikolay,13,11,5,3,0,0,2,3.001
+Summer 2023,FREN,2311,1,16385,Intermediate French I,Giacchetti,Claudine A,1,3,0,0,0,0,0,3.415
+Summer 2023,FREN,2312,1,16386,Intermediate French II,Giacchetti,Claudine A,3,5,0,0,0,0,0,3.499
+Summer 2023,FREN,3312,1,16387,Oral Communication,Giacchetti,Claudine A,5,1,0,0,0,0,0,3.833
+Summer 2023,FREN,3316,1,16388,Survey of French Culture/Civ,Giacchetti,Claudine A,5,1,0,0,0,0,0,3.723
+Summer 2023,CHIN,2311,1,16392,Intermediate Chinese I,Wen,Xiaohong Sharon,8,2,0,0,0,0,0,3.8
+Summer 2023,CHIN,3198,1,16393,Special Problems,Wen,Xiaohong Sharon,4,0,0,0,0,0,0,4.0
+Summer 2023,FREN,4397,1,16395,Sel Tops in French Literature,Giacchetti,Claudine A,1,0,0,0,0,0,0,3.67
+Summer 2023,SOCW,7340,3,16396,Clinical Practice with Child,Winfield,Emily,20,2,0,1,0,0,0,3.783
+Summer 2023,SOCW,7361,2,16397,Clinical SW Practice w Elders,Miyawaki,Christina E,9,1,1,0,0,0,1,3.727
+Summer 2023,CHIN,2312,1,16398,Intermediate Chinese II,Wen,Xiaohong Sharon,10,0,0,0,0,0,0,3.967
+Summer 2023,GERM,3381,1,16401,German Cinema,Kleinheider,Julia D,7,8,4,0,2,0,1,2.92
+Summer 2023,SOCW,7397,6,16402,Selected Topics in Social Work,Flores,Vanessa Marie,11,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7397,7,16403,Selected Topics in Social Work,Dettlaff,Alan J,13,0,0,0,0,0,0,4.0
+Summer 2023,COMM,1307,6,16404,Media and Society,Lyn,Robyn,37,3,2,0,3,0,0,3.541
+Summer 2023,COMM,1307,7,16405,Media and Society,Olson,Beth M,3,20,9,5,2,0,5,2.436
+Summer 2023,COMM,3349,1,16406,Nonverbal Communication,Lee,Jaesub,21,7,3,0,0,0,0,3.474
+Summer 2023,CHIN,3301,1,16408,Advanced Mandarin Chinese I,Wen,Xiaohong Sharon,3,0,0,0,0,0,0,4.0
+Summer 2023,CHIN,3302,1,16409,Advanced Mandarin Chinese II,Wen,Xiaohong Sharon,3,0,0,0,0,0,0,4.0
+Summer 2023,CHIN,4301,1,16410,Public Speaking in Chinese,Wen,Xiaohong Sharon,5,0,0,0,0,0,0,4.0
+Summer 2023,CHIN,4302,1,16411,Integrated Chinese,Wen,Xiaohong Sharon,5,0,0,0,0,0,0,4.0
+Summer 2023,ARAB,3377,1,16412,"Energy, Society & Middle East",El-Badawi,Emran,11,6,2,0,2,0,3,3.127
+Summer 2023,CHIN,3359,1,16413,Chinese Culture thru History,Zhang,Jing,3,1,0,0,0,0,0,3.668
+Summer 2023,CHIN,3352,1,16414,Chin Cul & Soc Thru Mod Lit,Wen,Xiaohong Sharon,2,0,0,0,0,0,0,4.0
+Summer 2023,SPAN,3306,1,16415,Intro Study Span Language,Lopez Otero,Julio Cesar,6,1,0,1,0,0,0,3.5
+Summer 2023,LAW,5297,3,16416,Selected Topics,Jones,Karen Lynn,1,1,0,0,0,0,0,3.5
+Summer 2023,HISP,2374,1,16421,Spanish American Culture & Civ,De Los Reyes Heredia,Jose Guillermo,16,5,1,1,0,0,0,3.58
+Summer 2023,ARTS,1304,1,16477,Art Hist II(15th C to Present),Buske,Zoie,12,2,2,0,0,0,0,3.625
+Summer 2023,ARTS,1316,1,16479,Fundamentals of Drawing,Alderson,Saran,10,0,0,0,0,0,0,4.0
+Summer 2023,ARTS,2333,1,16480,Fundamentals of Printmaking,Alderson,Saran,15,0,0,0,0,0,0,4.0
+Summer 2023,ARTS,3374,1,16481,Computer Imaging,Chen,Shang-Yee Mark,10,3,0,1,0,0,0,3.571
+Summer 2023,HDFS,3300,2,16522,Educational Psychology,Kamdar-Sharif,Amber,44,4,0,0,1,0,0,3.79
+Summer 2023,HLT,2320,1,16523,Introduction to Public Health,Drenner,Kelli Linn,58,5,7,0,0,0,1,3.677
+Summer 2023,THEA,6297,1,16524,Selected Topics,Ferrarone,Jessica,31,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,6381,1,16527,Petroleum Geology,Van Nieuwenhuise,Donald S,3,2,0,0,0,0,0,3.534
+Summer 2023,GEOL,6350,1,16528,Advanced Structural Geology,Naruk,Stephen,6,0,0,0,0,0,0,3.945
+Summer 2023,GEOL,6380,1,16529,Sequence Stratigraphy,Bhattacharya,Janok P,1,4,1,0,0,0,0,3.0
+Summer 2023,ENGL,3347,1,16530,Classics of Adolescent Lit,Wood,Barry Albert,8,16,3,0,0,0,0,3.173
+Summer 2023,CNST,6320,1,16531,Cost Analysis and Bidding,Eldin,Neil N,14,0,0,0,0,0,0,4.0
+Summer 2023,CNST,6308,1,16532,Data Analysis in Construc Mgmt,Gao,Lu,6,3,0,0,0,0,0,3.63
+Summer 2023,HLT,3306,1,16534,Environmental Health,Behjat,Amirmohsen,21,18,12,3,7,0,1,2.705
+Summer 2023,SOC,3311,3,16535,Sociology of Law,Nelson,Steven M,18,19,6,0,0,0,4,3.21
+Summer 2023,SOC,3382,1,16536,Sociology of Drug Use & Recove,Adams,Jennifer Lauren,42,4,2,1,0,0,1,3.715
+Summer 2023,SOCI,1301,2,16537,Introduction To Sociology,Smith,Chance Adam,20,6,2,3,0,0,0,3.376
+Summer 2023,SOC,3313,1,16538,Criminology,Nelson,Steven M,6,9,0,2,0,0,2,3.118
+Summer 2023,GEOL,8699,3,16541,Doctoral Dissertation,Jiang,Xun,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8699,4,16542,Doctoral Dissertation,Wang,Yuxuan,1,0,0,0,0,0,0,4.0
+Summer 2023,SOCI,1301,5,16543,Introduction To Sociology,Dorsey,Patricia Lynne,9,11,5,0,1,0,0,3.038
+Summer 2023,INDE,3330,1,16544,Financial and Cost Management,Wiggins,Nathanial David,23,5,0,0,0,0,0,3.798
+Summer 2023,CIS,6397,1,16547,Selected Topics,Conklin,William A,22,0,0,0,0,0,1,4.0
+Summer 2023,INDE,2333,2,16548,Engineering Statistics I,Wiggins,Nathanial David,20,4,0,0,0,0,0,3.751
+Summer 2023,OPTO,6115,3,16549,Clinical Integration,Dempsey,Robert L,27,0,0,0,0,0,0,4.0
+Summer 2023,OPTO,6115,4,16550,Clinical Integration,Dempsey,Robert L,27,0,0,0,0,0,0,4.0
+Summer 2023,COMM,6395,1,16551,Comprehensive Examination,Camaj,Lindita,0,0,0,0,0,1,0,
+Summer 2023,FINA,7397,3,16552,Selected Topics in Finance,Levy,Clayton V,4,0,0,0,0,0,0,3.753
+Summer 2023,FINA,7397,4,16553,Selected Topics in Finance,Levy,Clayton V,5,0,0,0,0,0,1,3.868
+Summer 2023,GEOL,8398,4,16554,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Summer 2023,PSYC,2305,5,16557,Intro to Methods in Psychology,Kennedy,Caitlin Grace,33,11,7,0,4,0,4,3.249
+Summer 2023,POLS,3313,1,16564,Intro Internatl Relatns,Vardy,Ronald V,28,5,1,0,0,0,3,3.794
+Summer 2023,MARK,7399,1,16596,MS Marketing Prof Project,Koch,Steven F,3,2,0,0,0,0,0,3.6
+Summer 2023,MARK,7399,2,16597,MS Marketing Prof Project,Koch,Steven F,0,0,0,0,0,0,0,
+Summer 2023,ENTR,4397,1,16598,Sel Topics in Entrepreneurship,McCormick,Kelly,18,2,2,1,0,0,0,3.594
+Summer 2023,ENTR,7397,1,16599,Sel Topics in Entrepreneurship,McCormick,Kelly,9,0,0,0,0,0,0,3.963
+Summer 2023,HIST,1302,1,16610,The U.S. Since 1877,Clavin,Matthew J,21,26,13,3,7,0,8,2.653
+Summer 2023,HIST,4379,2,16611,Sex and Violence in Old South,Deyle,Steven H,0,0,0,0,0,0,0,
+Summer 2023,HIST,1302,2,16612,The U.S. Since 1877,Johnson,Michele R,81,25,5,7,6,0,6,3.363
+Summer 2023,HIST,2397,1,16613,Selected Topics in History,Johnson,Michele R,9,9,1,3,4,0,2,2.628
+Summer 2023,HIST,3394,1,16614,Sel Tops-Us History,Young,Nancy Beck,22,0,5,0,0,0,2,3.593
+Summer 2023,HIST,6394,1,16615,Res Seminar in US History,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Summer 2023,CHEE,4398,1,16616,Independent Study,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,8398,1,16617,Independent Study,Messa,Emily Alice,2,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5297,1,16621,Selected Topics in Pharmacy,Asias-Dinh,Bernadette De Leon,31,19,1,0,0,0,0,3.588
+Summer 2023,PHLS,7301,1,16622,Practicum,Smith,Nathaniel Lewis,0,0,0,0,0,8,0,
+Summer 2023,PHLS,7301,2,16623,Practicum,Lee,Jungeun,0,0,0,0,0,10,0,
+Summer 2023,PHLS,7301,3,16624,Practicum,Lee,Jungeun,0,0,0,0,0,10,0,
+Summer 2023,PHLS,7301,4,16625,Practicum,McCoy,Leah,0,0,0,0,0,8,0,
+Summer 2023,CUIN,7312,1,16627,Curr Design in Bilingual Ed,Burgess,Miguel,12,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8399,1,16628,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,1,0,
+Summer 2023,ENGL,4310,1,16629,His of English Language,Zentz,Lauren R,20,4,4,0,0,0,2,3.536
+Summer 2023,ENGL,4322,1,16630,Grammar & Usage,Zentz,Lauren R,9,10,5,3,1,0,2,2.798
+Summer 2023,NURS,4297,1,16633,Special Topic in Nursing,Phan,Huong Thi,17,0,0,0,0,0,0,4.0
+Summer 2023,NURS,4297,2,16634,Special Topic in Nursing,Tart,Kathryn Marie,5,0,0,0,0,0,0,4.0
+Summer 2023,NURS,6319,1,16635,Healthcare Finance,Brohard,Cheryl L,5,0,0,0,0,0,0,4.0
+Summer 2023,NURS,6366,1,16636,FNP Capstone Clinical,Dwyer,Carol Ann,4,0,0,0,0,0,0,4.0
+Summer 2023,NURS,8304,1,16637,Systems Management Vulnerable,Kleinhans,Alicia Diane,3,3,0,0,0,0,0,3.5
+Summer 2023,DRAM,1310,4,16638,Introduction to Theatre,Brincks,Alan,34,10,3,3,2,0,2,3.296
+Summer 2023,MIS,3371,1,16641,Transaction Processing Sys I,Messinger,Jacob Nelson,17,15,3,1,1,0,1,3.216
+Summer 2023,NUTR,4354,2,16650,Adv Diab Mgmt & Ed,Scott,Claudia W,5,4,2,0,0,0,0,3.153
+Summer 2023,PHLS,8396,1,16658,Doctoral Research,Correa-Fernandez,Virmarie,0,0,0,0,0,1,0,
+Summer 2023,CIVE,5397,1,16660,Selected Topics,Vipulanandan,Cumaraswamy,12,0,0,0,0,0,0,4.0
+Summer 2023,CIVE,5397,2,16661,Selected Topics,Norris,Debra B,2,0,0,0,0,0,1,4.0
+Summer 2023,CIVE,7397,1,16662,Selected Topics,Vipulanandan,Cumaraswamy,6,0,0,0,0,0,0,4.0
+Summer 2023,CIVE,7397,2,16663,Selected Topics,Norris,Debra B,3,0,2,0,0,0,1,3.134
+Summer 2023,GEOL,7399,7,16669,Masters Thesis,Robinson,Alexander C,0,0,0,0,0,1,0,
+Summer 2023,POLS,6398,1,16670,Special Problems,Jenke,Elizabeth,1,0,0,0,0,0,0,4.0
+Summer 2023,ARTS,3384,1,16674,Sound Art,Meza,Abinadi,20,3,0,2,0,0,1,3.587
+Summer 2023,ENGI,2304,1,16677,Technical Communications,Smith-Irving,Brandi,13,5,2,0,1,0,0,3.381
+Summer 2023,ENGI,2304,2,16678,Technical Communications,Smith-Irving,Brandi,13,5,2,0,0,0,0,3.534
+Summer 2023,ENGI,2304,4,16679,Technical Communications,Contos,Ashlie Meghan,10,8,3,0,0,0,0,3.349
+Summer 2023,COMD,7391,7,16681,Clinic in Speech Lang Disorder,Walker,Dionne A,1,0,0,0,0,0,0,4.0
+Summer 2023,CIVE,4337,1,16682,Transportation Engineering,Phatak,Tejasree Mohan,25,5,1,0,0,0,0,3.774
+Summer 2023,MECE,3245,3,16683,Materials Science Laboratory,Chen,Xuemei,9,23,2,0,0,0,0,3.216
+Summer 2023,MECE,3360,5,16685,Experimental Methods,Chen,Xuemei,11,14,7,1,0,0,0,3.011
+Summer 2023,ECE,3366,1,16687,Intro To Digital Signal Proc,Sheth,Bhavin R,12,21,6,1,0,0,0,3.084
+Summer 2023,MATH,4366,1,16695,Numerical Linear Algebra,He,Jiwen,8,4,2,0,0,0,1,3.405
+Summer 2023,KIN,3309,1,16703,Biomechanics,Thomas,Shernice Avionne,19,22,11,1,0,0,1,3.163
+Summer 2023,RELS,3342,1,16708,"Religion, Politics, & History",Pegoda,Andrew Joseph,5,7,2,1,5,0,2,2.185
+Summer 2023,PHOP,7399,7,16712,Masters Thesis,Stevenson,Scott Bailli,2,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6357,4,16713,Research Practicum B,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6257,12,16714,Research Practicum B,Twa,Michael D,0,0,1,0,0,0,0,2.0
+Summer 2023,PHLS,7398,1,16716,Candidacy Research,Smith,Nathan G,1,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,7305,4,16717,"Design,Dev & Eval Presentation",Ahlf,Michael,15,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,7389,6,16718,Digital Media,Dogan,Bulent,15,0,0,0,0,0,0,4.0
+Summer 2023,TLIM,4396,30,16722,Internship in TLIM,Burns,Maria,1,0,0,0,0,0,0,4.0
+Summer 2023,PEP,7193,1,16723,Internship & Practicum,Ferrell,Carla Denise,0,0,0,0,0,7,0,
+Summer 2023,MARK,4379,2,16725,Personal Branding,Richards,Sean Wesley,20,1,0,0,0,0,0,3.905
+Summer 2023,MATH,8398,1,16730,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Summer 2023,CNST,6308,40,16731,Data Analysis in Construc Mgmt,Gao,Lu,2,6,0,0,0,0,0,3.291
+Summer 2023,CNST,6320,40,16732,Cost Analysis and Bidding,Eldin,Neil N,1,0,0,0,0,0,0,4.0
+Summer 2023,MECE,7399,3,16735,Masters Thesis,Kulkarni,Yashashree,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,7399,8,16736,Masters Thesis,Li,Aibing,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8698,17,16737,Doctoral Research,Jiang,Xun,0,0,0,0,0,2,0,
+Summer 2023,BCHS,8398,2,16738,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6698,1,16739,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,3,0,
+Summer 2023,FREN,4396,1,16740,Sel Topics-Fren-lang & culture,Giacchetti,Claudine A,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,6698,3,16741,Special Problems,Daane,Jacob,0,0,0,0,0,4,0,
+Summer 2023,BIOL,6698,4,16742,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Summer 2023,MATH,8399,3,16743,Doctoral Dissertation,Heier,Gordon,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8199,3,16744,Doctoral Dissertation,Zvolensky,Michael J,1,0,0,0,0,1,0,4.0
+Summer 2023,PHYS,8698,2,16748,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,0,0,
+Summer 2023,PHYS,8698,3,16749,Doctoral Research,Bellwied,Rene,0,0,0,0,0,5,0,
+Summer 2023,PHYS,8698,5,16751,Doctoral Research,Chen,Shuo,0,0,0,0,0,2,0,
+Summer 2023,PHYS,8698,6,16752,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,7,16753,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,2,0,
+Summer 2023,PHYS,8698,8,16754,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,10,16756,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,11,16757,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,3,0,
+Summer 2023,TECH,3365,2,16758,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,25,1,0,0,0,0,3,3.949
+Summer 2023,PHYS,8698,13,16760,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,4,0,
+Summer 2023,PHYS,8698,15,16762,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,3,0,
+Summer 2023,PHYS,8698,16,16763,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,19,16766,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,20,16767,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,3,0,
+Summer 2023,BCHS,6698,2,16770,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Summer 2023,BCHS,8398,3,16772,Doctoral Research,Briggs,James M,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,23,16773,Doctoral Research,Ratti,Claudia,0,0,0,0,0,4,0,
+Summer 2023,PHYS,8698,24,16774,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,3,0,
+Summer 2023,PHYS,8698,25,16775,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,3,0,
+Summer 2023,PHYS,8698,26,16776,Doctoral Research,Stokes,Donna,0,0,0,0,0,1,0,
+Summer 2023,PHYS,8698,28,16778,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,2,0,
+Summer 2023,PHYS,8698,29,16779,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,2,0,
+Summer 2023,PHYS,8698,30,16780,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,2,0,
+Summer 2023,GEOL,4398,1,16783,Independent Study,Murphy,Michael,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8398,2,16791,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6698,5,16792,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,2,0,
+Summer 2023,BIOL,6698,7,16794,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6698,8,16795,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6398,5,16797,Special Problems,Briggs,James M,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6398,4,16798,Special Problems,Schwartz,Robert J,0,0,0,0,0,1,0,
+Summer 2023,ELCS,8398,2,16799,Independent Study,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,6397,1,16800,Selected Topics in Math,Timofeyev,Ilya,8,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,4398,1,16802,Independent Study,Zvolensky,Michael J,4,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,8698,10,16804,Doctoral Research,Wang,Yuhong,0,0,0,0,0,2,0,
+Summer 2023,BIOL,6698,9,16807,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6698,10,16808,Special Problems,Khan,Abdul Latif,0,0,0,0,0,1,0,
+Summer 2023,BTIS,3300,1,16809,Intro to Homeland Security,Burns,Maria,4,2,0,0,0,0,1,3.722
+Summer 2023,BCHS,6698,3,16811,Special Problems,Wang,Yuhong,0,0,0,0,0,2,0,
+Summer 2023,PHOP,6257,13,16816,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6557,6,16817,Research Practicum B,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,8698,1,16818,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,8698,2,16819,Doctoral Research,Burns,Alan R,1,0,0,0,0,0,0,3.67
+Summer 2023,PHOP,6557,7,16820,Research Practicum B,Ribelayga,Christophe Pierre,2,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6257,14,16822,Research Practicum B,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6457,6,16824,Research Practicum B,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6557,9,16826,Research Practicum B,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6198,11,16827,Spec Prob-Physio Optics,Sayah,Diane Noel,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6367,3,16828,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6367,4,16829,Research Practicum A,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6657,1,16830,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,8695,2,16832,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,15,16844,Masters Thesis,Fetterman,Adam Kent,0,0,0,0,0,3,0,
+Summer 2023,BCHS,6398,6,16845,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Summer 2023,PEP,7393,2,16846,Internship & Practicum,Arellano,Christopher,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,7398,1,16847,Statistics in PSYC Practicum,Gallagher,Matthew Ward,2,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,6359,8,16851,Directed Rsch in Clinical Psyc,Woods,Steven Paul,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7392,3,16852,Psychology Practicum,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8399,8,16854,Doctoral Dissertation,Zhou,Hua-Wei,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6398,1,16855,Spec Prob-Physio Optics,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Summer 2023,PHOP,6257,15,16857,Research Practicum B,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Summer 2023,GEOL,8399,9,16863,Doctoral Dissertation,Fu,Qi,2,0,0,0,0,0,0,4.0
+Summer 2023,ECE,7399,4,16864,Masters Thesis,Krishnamoorthy,Harish Sarma,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8698,17,16865,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,2,0,
+Summer 2023,BIOL,6698,13,16867,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6698,14,16868,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6398,7,16871,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6398,3,16874,Special Problems,Chung,Sanghyuk,0,0,0,0,0,3,0,
+Summer 2023,MATH,8399,7,16875,Doctoral Dissertation,Papadakis,Emanuel Ioannis,1,0,0,0,0,0,0,4.0
+Summer 2023,PEP,8350,1,16876,HHP Candidacy Project Research,Gorniak,Stacey,2,0,0,0,0,0,0,4.0
+Summer 2023,TLIM,3363,35,16879,Technical Communications,Piercy,Penelope Junker,1,0,0,0,0,0,0,4.0
+Summer 2023,ECE,8399,11,16882,Doctoral Dissertation,Yao,Yan,1,0,0,0,0,0,0,4.0
+Summer 2023,PHYS,8698,33,16883,Doctoral Research,Bittner,Eric R,0,0,0,0,0,2,0,
+Summer 2023,PHYS,8698,34,16884,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Summer 2023,ECE,8399,12,16885,Doctoral Dissertation,Li,Xingpeng,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8399,6,16886,Doctoral Dissertation,Meisel,Richard P,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,8398,4,16887,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6398,4,16888,Special Problems,Cirino,Patrick C,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6398,5,16889,Special Problems,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Summer 2023,COMD,7391,4,16890,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,1,0,0,0,0,0,0,3.67
+Summer 2023,COMD,7391,5,16891,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,0,0,0,0,0,0,0,
+Summer 2023,BIOL,6698,18,16893,Special Problems,Yi,Ping,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6698,15,16894,Special Problems,Dryer,Stuart E,0,0,0,0,0,1,0,
+Summer 2023,GHL,6198,1,16896,Special Problems,Back,KiJoon,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,6698,16,16898,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Summer 2023,MATH,8399,4,16899,Doctoral Dissertation,Mang,Andreas,1,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,8398,3,16902,Independent Study,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,7399,16,16905,Masters Thesis,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,7397,3,16908,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,17,16910,Masters Thesis,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8698,18,16915,Doctoral Research,Liu,Xinli,0,0,0,0,0,1,0,
+Summer 2023,DRAM,1310,9,16916,Introduction to Theatre,Hinkel,Heidi Anne,35,10,2,3,6,0,0,3.143
+Summer 2023,DRAM,1310,10,16917,Introduction to Theatre,Hinkel,Heidi Anne,43,10,2,1,2,0,0,3.575
+Summer 2023,MATH,4366,2,16918,Numerical Linear Algebra,He,Jiwen,4,4,0,0,0,0,2,3.624
+Summer 2023,FINA,7323,2,16923,Applied Equity Fund Management,George,Thomas J,10,1,0,0,0,0,0,3.909
+Summer 2023,SPAN,7396,1,16926,Sel Topics Hist Hispanic Ideas,Solino,Maria Elena,1,0,0,0,0,0,0,4.0
+Summer 2023,HISP,2373,1,16927,Spanish Culture and Civ,Solino,Maria Elena,1,0,0,0,0,0,0,4.0
+Summer 2023,PCOL,6398,1,16928,Special Problems,Wu,Mingfu,0,0,0,0,0,1,0,
+Summer 2023,PCOL,6398,2,16929,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Summer 2023,OPTO,5198,1,16931,Spec Prob Phys Optics,Berntsen,David A,0,0,0,0,0,9,0,
+Summer 2023,OPTO,5298,1,16932,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,17,0,
+Summer 2023,MARK,3337,3,16933,Professional Selling,Suki,Yara D,36,0,2,2,0,0,0,3.767
+Summer 2023,MATH,8399,5,16936,Doctoral Dissertation,Climenhaga,Vaughn,2,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,8198,1,16939,Independent Study,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,8199,1,16940,Dissertation,Berger Cardoso,Jodi A,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,6698,20,16941,Special Problems,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Summer 2023,MECE,8399,2,16942,Doctoral Dissertation,Yang,Di,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,6698,4,16943,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2023,COMD,7692,1,16945,Advanced Practicum,Eckert,Janet F,0,1,0,0,0,0,0,3.33
+Summer 2023,COSC,8399,128,16947,Doctoral Dissertation,Tsekos,Nikolaos V,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8199,4,16948,Doctoral Dissertation,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8398,2,16950,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,0,0,
+Summer 2023,GEOL,7398,1,16956,Masters Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6393,4,16958,Clinical Research Practicum,Walker,Rheeda L,0,0,0,0,0,1,0,
+Summer 2023,SOCW,8199,2,16961,Dissertation,Cheung,Monit,2,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,6698,21,16967,Special Problems,Warner,Margaret,0,0,0,0,0,1,0,
+Summer 2023,POLS,4398,5,16968,Independent Study,Pegoda,Andrew Joseph,1,0,0,0,0,0,0,4.0
+Summer 2023,POLS,4398,6,16969,Independent Study,Pegoda,Andrew Joseph,0,1,0,0,0,0,0,2.67
+Summer 2023,HON,4399,1,16970,Senior Honors Thesis,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8399,7,16981,Doctoral Dissertation,Chung,Sanghyuk,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,6698,22,16983,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Summer 2023,COSC,8698,132,16984,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Summer 2023,GEOL,6399,1,16985,Masters Thesis,Lapen,Thomas J,0,0,0,0,0,1,0,
+Summer 2023,BIOL,6698,23,16986,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Summer 2023,ENTR,6398,1,16987,Research,Wilbur,Stephen,2,1,0,0,0,0,0,3.557
+Summer 2023,COSC,8399,113,16989,Doctoral Dissertation,Johnsson,Lennart,0,0,0,0,0,1,0,
+Summer 2023,COSC,6398,112,16991,Special Problems,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Summer 2023,COSC,6398,101,16992,Special Problems,Alipour,Mohammad Amin,0,0,0,0,0,0,0,
+Summer 2023,PHAR,5297,2,16993,Selected Topics in Pharmacy,Garey,Kevin W,0,0,0,0,0,1,0,
+Summer 2023,PCEU,6398,1,17002,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Summer 2023,PCOL,6398,3,17003,Special Problems,Hussain,Tahir,0,0,0,0,0,1,0,
+Summer 2023,PCOL,6398,4,17004,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Summer 2023,MATH,6698,1,17005,Special Problems,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Summer 2023,PCOL,6398,5,17006,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Summer 2023,PCOL,6398,6,17007,Special Problems,Statsyuk,Alexander V,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,8698,12,17008,Doctoral Research,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Summer 2023,PHOP,6357,2,17009,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8398,6,17010,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Summer 2023,PHLS,8399,3,17012,Doctoral Dissertation,Fan,Weihua,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8399,7,17015,Doctoral Dissertation,Bodmann,Bernhard G,1,0,0,0,0,0,0,3.67
+Summer 2023,FINA,8399,1,17019,Doctoral Dissertation,Jacobs,Kris,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8199,5,17020,Doctoral Dissertation,Damian,Rodica Ioana,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,6698,5,17021,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6698,6,17024,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2023,PCOL,8398,1,17026,Doctoral Research,Cuny,Gregory D,0,0,0,0,0,1,0,
+Summer 2023,MATH,8399,8,17029,Doctoral Dissertation,Azencott,Robert Guy,1,0,0,0,0,0,0,4.0
+Summer 2023,COMM,4398,1,17033,Independent Study,Vaughn,Ginger Koto,1,0,0,0,0,0,0,4.0
+Summer 2023,PCOL,8398,2,17034,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6698,7,17038,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Summer 2023,MECE,8399,13,17040,Doctoral Dissertation,Cescon,Marzia,0,0,0,0,0,1,0,
+Summer 2023,PSYC,6399,4,17043,Masters Thesis,Alfano,Candice A,0,0,0,0,0,2,0,
+Summer 2023,SOCW,7397,8,17044,Selected Topics in Social Work,Dettlaff,Alan J,1,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7397,9,17045,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7397,10,17046,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7397,11,17047,Selected Topics in Social Work,Dettlaff,Alan J,1,0,0,0,0,0,0,4.0
+Summer 2023,SOCW,7397,12,17048,Selected Topics in Social Work,Lucas,Virginia,1,0,0,0,0,0,0,4.0
+Summer 2023,OPTO,5198,2,17049,Spec Prob Phys Optics,Bergmanson,Jan Pg,0,0,0,0,0,1,0,
+Summer 2023,MATH,8399,6,17051,Doctoral Dissertation,Labate,Demetrio,2,0,0,0,0,0,0,4.0
+Summer 2023,GHL,4298,1,17053,Independent Study,Maneethai,Dustin,1,0,0,0,0,0,0,4.0
+Summer 2023,BTEC,6399,30,17056,Thesis,Balan,Venkatesh,0,0,0,0,0,1,0,
+Summer 2023,ENTR,7337,1,17061,Entrepreneur Cap & Legal Forms,Wilbur,Stephen,0,1,0,0,0,0,0,3.33
+Summer 2023,ARTS,7398,1,17063,Independent Graduate Study,Politzer,David,2,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8398,5,17064,Doctoral Research,Sater,Amy,0,0,0,0,0,1,0,
+Summer 2023,ACCT,8399,1,17065,Doctoral Dissertation,Larson,Chad R,1,0,0,0,0,0,0,4.0
+Summer 2023,HON,4198,1,17067,Independent Study,Hallmark,Terrell L,0,0,1,0,0,0,0,2.0
+Summer 2023,FORE,6397,40,17070,Selected Topics in Foresight,Cowart,Adam David,1,0,0,0,0,0,0,4.0
+Summer 2023,PEP,7398,1,17071,Adv Special Problem Human Perf,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8398,11,17076,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Summer 2023,ECE,8399,13,17077,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,0,0,
+Summer 2023,PHOP,8199,4,17084,Doctoral Dissertation,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Summer 2023,HLT,1353,4,17086,Personal Health,Shamblin,Angel Ann,42,8,2,1,0,0,0,3.655
+Summer 2023,PHCA,6398,2,17090,Special Problems,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Summer 2023,PCEU,6398,2,17091,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2023,PCEU,8398,1,17092,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8398,12,17096,Doctoral Research,Labate,Demetrio,0,0,0,0,0,1,0,
+Summer 2023,ARLD,6198,1,17097,Special Prob in Arts Leadrshp,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Summer 2023,ACCT,7398,1,17099,Research,Newman,Michael Ray,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8399,10,17100,Doctoral Dissertation,Zheng,Yingcai,1,0,0,0,0,1,0,4.0
+Summer 2023,NURS,6330,1,17103,Adv Diagnostic Physicl Examntn,Kleinhans,Alicia Diane,2,3,0,0,0,0,0,3.4
+Summer 2023,GEOL,8698,19,17108,Doctoral Research,Zhang,Honghai,0,0,0,0,0,1,0,
+Summer 2023,PEP,7398,2,17111,Adv Special Problem Human Perf,Lee,Dong Hun,0,0,0,0,0,0,0,
+Summer 2023,PSYC,8399,25,17113,Doctoral Dissertation,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,6398,14,17115,Independent Studies,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Summer 2023,HIST,6393,1,17116,Rdgs Seminar in US History,Clavin,Matthew J,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8698,20,17119,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,1,0,
+Summer 2023,HIST,6383,1,17120,Topics in Public Hist,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8193,3,17121,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,1,0,
+Summer 2023,PHLS,8399,4,17122,Doctoral Dissertation,de Dios,Marcel A,0,0,0,0,0,1,0,
+Summer 2023,ELCS,8398,4,17124,Independent Study,Zou,Yali,1,0,0,0,0,0,0,4.0
+Summer 2023,DIGM,4398,30,17125,Independent Study,Lendasse,Amaury,1,0,0,0,0,0,0,4.0
+Summer 2023,PCEU,6398,3,17129,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Summer 2023,PCOL,6398,8,17130,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Summer 2023,ANTH,7399,2,17143,Masters Thesis,Brown,Kenneth L,2,0,0,0,0,1,0,4.0
+Summer 2023,MECE,7361,1,17147,System Identification,Franchek,Matthew,2,1,0,0,0,0,0,3.447
+Summer 2023,MECE,5397,1,17148,Selected Topics,Franchek,Matthew,1,0,0,0,0,0,0,4.0
+Summer 2023,ARCH,6393,1,17150,Master's Project Preparation,Wienert,Ross George,0,1,0,0,0,0,0,3.33
+Summer 2023,GEOL,8398,8,17152,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Summer 2023,GEOL,8398,9,17153,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Summer 2023,PHAR,5297,3,17154,Selected Topics in Pharmacy,Sansgiry,Sujit Sharad,0,0,0,0,0,23,0,
+Summer 2023,GEOL,8698,22,17156,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Summer 2023,ELCS,8195,1,17157,Doctoral Thesis,Snodgrass Rangel,Virginia Walker,0,0,0,0,0,1,0,
+Summer 2023,OPTO,5198,3,17159,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,3,0,
+Summer 2023,OPTO,5198,4,17160,Spec Prob Phys Optics,Martinez,Muriel L,0,0,0,0,0,2,0,
+Summer 2023,SOCW,7397,13,17163,Selected Topics in Social Work,Taylor,Patricia G,1,0,0,0,0,0,0,4.0
+Summer 2023,HON,4398,3,17164,Independent Study,Reynolds,Aaron E,2,0,0,0,0,0,0,4.0
+Summer 2023,ELCS,8355,2,17165,Policy Pol & Gov of Education,Causey,Ashley,5,1,0,0,0,0,0,3.668
+Summer 2023,PHLS,8398,2,17166,Special Problems,Gonzalez,Jorge E,2,0,0,0,0,0,0,4.0
+Summer 2023,PHLS,8396,2,17177,Doctoral Research,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2023,PHLS,7398,2,17178,Candidacy Research,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2023,GHL,8399,1,17182,Dissertation I in Hosp. Admin,Back,KiJoon,0,0,0,0,0,1,0,
+Summer 2023,PHAR,5297,4,17183,Selected Topics in Pharmacy,Trivedi,Meghana,0,0,0,0,0,1,0,
+Summer 2023,PHAR,5297,5,17184,Selected Topics in Pharmacy,Varisco,Tyler J,3,0,0,0,0,0,0,4.0
+Summer 2023,PHAR,5297,6,17185,Selected Topics in Pharmacy,Gee,Jodie Sue,0,0,0,0,0,1,0,
+Summer 2023,PHAR,5297,7,17186,Selected Topics in Pharmacy,De La Cruz,Austin Isaac,1,0,0,0,0,0,0,4.0
+Summer 2023,FINA,7A97,2,17187,Selected Topics in Finance,Caire,Matthew,5,0,0,0,0,0,0,4.0
+Summer 2023,POLC,4398,1,17189,Independent Study,Cross,Renee Danielle,2,0,0,0,0,0,0,3.835
+Summer 2023,BIOE,6303,6,17191,Biomaterials,Abidian,Mohammad Reza,1,0,0,0,0,0,0,3.67
+Summer 2023,MECE,6399,1,17194,Masters Thesis,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Summer 2023,CIVE,4333,2,17203,Water & Wastewater Treatment,Saladi,Krishna Rishi Vijay,1,1,0,0,1,0,0,2.333
+Summer 2023,ANTH,4398,1,17205,Independent Study,Azua,Anneleise,1,0,0,0,0,0,0,4.0
+Summer 2023,MATH,8398,3,17207,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Summer 2023,PHCA,8398,2,17212,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,8399,11,17213,Doctoral Dissertation,Sun,Jiajia,0,0,0,0,0,1,0,
+Summer 2023,PEP,7398,3,17214,Adv Special Problem Human Perf,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Summer 2023,ENTR,4397,3,17215,Sel Topics in Entrepreneurship,McCormick,Kelly,12,2,1,0,2,0,2,3.255
+Summer 2023,HDCS,4398,1,17217,Independent Study,Roberts,Phyllis Rayburn,0,0,1,0,0,0,0,1.67
+Summer 2023,POLS,6359,1,17219,Bibliographic Essay,Basinger,Scott J,1,0,0,0,0,0,0,4.0
+Summer 2023,HLT,2320,2,17227,Introduction to Public Health,Rafique,Kiran Sajid,22,7,1,0,1,0,0,3.485
+Summer 2023,SOC,7399,2,17232,Masters Thesis,Katz,Sheila,0,0,0,0,0,1,0,
+Summer 2023,SOC,7399,3,17233,Masters Thesis,Baumle,Amanda K,0,0,0,0,0,1,0,
+Summer 2023,SOC,7399,4,17234,Masters Thesis,Lee,Shayne,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,8198,21,17242,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Summer 2023,BIOE,8399,19,17243,Doctoral Dissertation,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Summer 2023,COMM,4398,2,17245,Independent Study,Houk,Keith R,2,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,8398,3,17248,Independent Study,Thomas,Dustine J,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,6230,2,17249,Grad Biochem Lab Rotation I,Widger,William R,0,0,0,0,0,0,0,
+Summer 2023,BIOL,6698,25,17253,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Summer 2023,BCHS,6231,1,17254,Grad Biochem Lab Rotation II,Widger,William R,1,0,0,0,0,0,0,3.67
+Summer 2023,BCHS,6298,2,17255,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Summer 2023,FINA,7397,5,17258,Selected Topics in Finance,Stewart,Marcus,2,1,0,0,0,0,0,3.557
+Summer 2023,FINA,4397,4,17259,Selected Topics in Finance,Stewart,Marcus,3,2,0,0,0,0,1,3.6
+Summer 2023,PHYS,8398,52,17260,Doctoral Research,Vovchenko,Volodymyr,0,0,0,0,0,1,0,
+Summer 2023,ENGL,6398,1,17262,Rd&Research in Lang&Lit,Gregory,Elizabeth,0,0,0,0,0,1,0,
+Summer 2023,KIN,4398,4,17263,Independent Study,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,8398,6,17264,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Summer 2023,ECON,8699,2,17266,Doctoral Dissertation,Sorensen,Bent E,1,0,0,0,0,0,0,4.0
+Summer 2023,ECON,8699,4,17267,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,1,0,
+Summer 2023,ECON,8699,7,17268,Doctoral Dissertation,Craig,Steven G,2,0,0,0,0,0,0,4.0
+Summer 2023,ECON,8699,8,17269,Doctoral Dissertation,Yi,Kei-Mu,1,0,0,0,0,0,0,4.0
+Summer 2023,ENGL,4375,1,17270,Literature & Popular Culture,Wingard,Jennifer L,5,1,1,0,0,0,3,3.524
+Summer 2023,PETR,7399,2,17271,Masters Thesis,Dindoruk,Birol,1,0,0,0,0,0,0,4.0
+Summer 2023,INDE,6365,1,17272,Engineering Economy II,Wiggins,Nathanial David,3,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,6698,26,17278,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Summer 2023,CUIN,8398,4,17281,Independent Study,Hausmann,Robert Carl,1,0,0,0,0,0,0,4.0
+Summer 2023,ENGL,7396,2,17283,Topics in Language & Literatre,Wingard,Jennifer L,9,0,0,0,1,0,0,3.6
+Summer 2023,ECE,7399,5,17285,Masters Thesis,Brankovic,Stanko R,1,0,0,0,0,0,0,4.0
+Summer 2023,ECE,7399,7,17287,Masters Thesis,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2023,ECE,8399,14,17289,Doctoral Dissertation,Fu,Xin,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,7399,9,17290,Masters Thesis,Wu,Jonathan En Lin,1,0,0,0,0,0,0,4.0
+Summer 2023,CUIN,1350,5,17292,Mathematics for Teachers 1,Burris,Justin T,0,1,0,0,0,0,0,3.33
+Summer 2023,COSC,4398,101,17301,Independent Study,Rizk,Nouhad J,0,0,0,0,0,1,0,
+Summer 2023,ECE,8399,15,17305,Doctoral Dissertation,Han,Zhu,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,6399,128,17308,Masters Thesis,Tsekos,Nikolaos V,0,0,0,0,0,0,0,
+Summer 2023,PHLS,6398,2,17310,Special Problems,Smith,Nathaniel Lewis,10,0,0,0,0,0,0,4.0
+Summer 2023,BIOE,8398,28,17311,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Summer 2023,BCHS,8398,7,17313,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2023,CIVE,8399,4,17316,Doctoral Dissertation,Li,Hongyi,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,7399,129,17317,Masters Thesis,Verma,Rakesh M,1,0,0,0,0,0,0,4.0
+Summer 2023,CIS,6398,2,17319,Special Problems,Conklin,William A,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,4398,2,17322,Independent Study,Yoshida,Hanako,0,0,0,0,0,0,0,
+Summer 2023,PHCA,6398,4,17324,Special Problems,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2023,COMD,7391,8,17325,Clinic in Speech Lang Disorder,BeCoats,Brandi Lailoni,0,1,0,0,0,0,0,3.33
+Summer 2023,PSYC,7399,19,17326,Masters Thesis,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Summer 2023,FINA,7397,6,17327,Selected Topics in Finance,Stewart,Marcus,2,1,0,0,0,0,0,3.777
+Summer 2023,PHLS,8193,4,17329,Internship in Psychology,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Summer 2023,CUIN,8398,7,17330,Independent Study,Hale,Margaret Ann,0,0,1,0,0,0,0,2.0
+Summer 2023,COMM,4398,3,17333,Independent Study,Uhrick,Jan,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,4398,102,17336,Independent Study,Cheng,Albert M K,0,0,0,0,0,0,0,
+Summer 2023,BIOL,8399,8,17337,Doctoral Dissertation,Peng,Weiyi,1,0,0,0,0,0,0,4.0
+Summer 2023,COSC,3396,101,17338,Senior Research Project,Cheng,Albert M K,0,0,0,0,0,0,0,
+Summer 2023,BIOL,6698,27,17339,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2023,PHLS,8199,8,17342,Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Summer 2023,GEOL,7399,10,17344,Masters Thesis,Sager,William W,0,0,0,0,0,1,0,
+Summer 2023,BCHS,8399,6,17346,Doctoral Dissertation,Briggs,James M,0,0,0,0,0,1,0,
+Summer 2023,CIS,6398,3,17348,Special Problems,Lendasse,Amaury,1,0,0,0,0,0,0,4.0
+Summer 2023,PSYC,8399,26,17350,Doctoral Dissertation,Alfano,Candice A,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,20,17351,Masters Thesis,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Summer 2023,PSYC,7399,21,17353,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,
+Summer 2023,GEOL,6399,2,17361,Masters Thesis,Mann,Paul,0,0,0,0,0,1,0,
+Summer 2023,THEA,4398,1,17362,Independent Study,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Summer 2023,HIST,8699,10,17368,Doctoral Dissertation,Clavin,Matthew J,0,0,0,0,0,1,0,
+Summer 2023,HIST,8699,11,17369,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,1,0,
+Summer 2023,HIST,8699,12,17370,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,1,0,
+Summer 2023,HIST,8699,13,17372,Doctoral Dissertation,Golubev,Alexey Valeryevich,0,0,0,0,0,1,0,
+Summer 2023,HIST,4398,2,17373,Independent Study,Howard,Philip,1,0,0,0,0,0,0,3.67
+Summer 2023,PSYC,6392,2,17374,Intervention Practicum,Babcock,Julia,0,0,0,0,0,2,0,
+Summer 2023,ELCS,8395,10,17382,Doctoral Thesis,Davis,Bradley,0,0,0,0,0,1,0,
+Summer 2023,HLT,3380,2,17392,Culture and Health,Solari Williams,Kayce D,8,2,0,1,0,0,0,3.515
+Summer 2023,COMM,4398,4,17394,Independent Study,Yamasaki,Jill S,1,0,0,0,0,0,0,4.0
+Summer 2023,BCHS,6698,8,17396,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2023,ACCT,8399,2,17399,Doctoral Dissertation,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Summer 2023,GEOL,7301,3,17405,Capstone Project,Khan,Shuhab D,1,0,0,0,0,0,0,4.0
+Summer 2023,MARK,4396,2,17415,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,1,0,
+Summer 2023,COMM,4398,5,17416,Independent Study,Olson,Beth M,1,0,0,0,0,0,0,3.67
+Summer 2023,ARTS,4398,10,17417,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Summer 2023,BIOL,8398,6,17418,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Summer 2023,ECON,6693,3,17421,Master's Research Project,Pozo,Amber Papuga,1,0,0,0,0,0,0,4.0

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2023-03 (Fall 2023).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2023-03 (Fall 2023).csv
@@ -1,0 +1,6833 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Fall 2023,PHYS,2325,1,10002,University Physics I (lecture),McElhenny,Brian Patrick,55,37,47,14,10,0,18,2.665
+Fall 2023,GENB,7A97,1,10005,Selected Topics,Haseley,Ken A.,15,3,0,0,0,0,0,3.833
+Fall 2023,GENB,7A97,2,10006,Selected Topics,Haseley,Ken A.,9,2,1,0,0,0,0,3.667
+Fall 2023,GENB,7A97,3,10007,Selected Topics,Williams,John M,18,0,0,0,0,0,0,4.0
+Fall 2023,GENB,7A97,4,10008,Selected Topics,Williams,John M,11,0,0,0,0,0,0,4.0
+Fall 2023,SCM,6301,1,10009,Supply Chain Mgt Foundations,Hosseinabadi Farahani,Mehdi,7,0,0,0,0,0,0,3.906
+Fall 2023,SCM,6301,2,10010,Supply Chain Mgt Foundations,Smith,Gordon D,8,3,1,0,0,0,0,3.611
+Fall 2023,MANA,6A25,1,10012,Ethical Leadrshp & Crit Reason,Krylova,Ksenia O,18,0,0,0,0,0,0,4.0
+Fall 2023,MANA,6332,1,10013,Organiztnl Behavior & Mangemnt,Werner,Steve,18,0,0,0,0,0,0,3.982
+Fall 2023,BZAN,6310,5,10014,Quant Analysis for Busn Dec,Johnson,Norman A,11,6,0,0,0,0,0,3.569
+Fall 2023,BZAN,6310,6,10015,Quant Analysis for Busn Dec,Johnson,Norman A,8,3,0,0,0,0,0,3.757
+Fall 2023,COMM,6399,1,10018,Masters Thesis,Camaj,Lindita,3,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8334,1,10019,Social Policy Analysis,Ali,Samira Bano,3,1,0,0,0,0,0,3.75
+Fall 2023,SOCW,8323,1,10020,Research Methods III,Walton,Quenette,5,1,0,0,0,0,0,3.833
+Fall 2023,PHIL,1301,3,10022,Intro To Philosophy,Haaga,Curtis W,30,12,4,2,0,0,0,3.445
+Fall 2023,PHIL,1301,4,10023,Intro To Philosophy,Haaga,Curtis W,35,14,1,0,0,0,2,3.654
+Fall 2023,PHIL,1305,1,10024,Intro To Ethics,Aiman,Edwin E,31,31,1,1,5,0,4,3.15
+Fall 2023,PHIL,1361,1,10025,Philosophy and the Arts,Drapela,Nick Gerard,20,13,8,2,1,0,7,3.106
+Fall 2023,ARCH,1500,1,10026,Design Studio I,Benjamin,Gregory,9,5,1,0,0,0,0,3.401
+Fall 2023,ARCH,1500,3,10028,Design Studio I,Murray,Cara,3,7,1,0,1,0,2,2.889
+Fall 2023,ARCH,1500,5,10030,Design Studio I,Perez Lopez,Elena Maria,8,5,2,0,0,0,0,3.356
+Fall 2023,ARCH,1500,7,10032,Design Studio I,Wells,Adam C,0,12,1,0,0,0,0,3.025
+Fall 2023,ARCH,1500,9,10034,Design Studio I,Wienert,Ross George,7,4,2,0,0,0,2,3.385
+Fall 2023,ARCH,1500,11,10036,Design Studio I,Kudless,Andrew Justin,12,3,0,0,0,0,0,3.822
+Fall 2023,ARCH,1500,13,10038,Design Studio I,Olwi,Asmaa,5,8,1,0,0,0,0,3.333
+Fall 2023,ARCH,2350,1,10040,Hist of the Built Environmt I,Ramaswamy,Deepa,91,59,15,3,5,0,7,3.203
+Fall 2023,ARCH,2500,1,10047,Arc/Int Arc Design Studio III,Gonzales,Michael A,10,5,1,1,0,0,0,3.334
+Fall 2023,ARCH,2500,5,10049,Arc/Int Arc Design Studio III,Lutz,Shawn M,10,4,2,0,0,0,0,3.459
+Fall 2023,ARCH,2500,11,10053,Arc/Int Arc Design Studio III,Murray,Cara,3,7,3,1,1,0,1,2.645
+Fall 2023,ARCH,4373,1,10057,Urban Environments,Rifaat,Shafik I,109,10,0,0,0,0,0,3.805
+Fall 2023,ARCH,5500,3,10058,Architecture Design Studio IX,Longoria,Rafael R,6,0,0,0,0,0,0,3.89
+Fall 2023,ARCH,6301,1,10060,Visual Studies I,Logan,Jason,7,2,2,0,0,0,0,3.365
+Fall 2023,ARCH,6340,1,10062,Architectural History Survey I,Ramaswamy,Deepa,5,5,1,0,0,0,0,3.244
+Fall 2023,ARCH,7600,1,10064,Architecture Design Studio V,Race,Bruce Alan,1,2,0,0,0,0,0,3.553
+Fall 2023,INDS,2340,1,10066,Visual Communication,Jamjoom,Zain Ahmed,4,5,4,1,0,0,0,2.951
+Fall 2023,INDS,2355,1,10068,Design History I,Ramirez,Enrique,18,9,2,0,0,0,1,3.461
+Fall 2023,INDS,3500,1,10069,Industrial Design Studio V,Feng,Jeff Feng,3,10,0,0,0,0,0,3.282
+Fall 2023,INDS,4500,1,10071,Industrial Design Studio VII,Morshedzadeh,Elham,2,6,0,0,0,0,0,3.168
+Fall 2023,ACCT,2301,1,10074,Prin of Financial Accounting,Goble,Samuel,19,35,10,4,2,0,9,3.051
+Fall 2023,ACCT,2301,2,10075,Prin of Financial Accounting,Goble,Samuel,15,36,7,2,5,0,1,2.927
+Fall 2023,ACCT,2301,3,10076,Prin of Financial Accounting,Goble,Samuel,37,62,33,9,9,0,23,2.845
+Fall 2023,ACCT,3377,1,10077,Cost Accounting,Lin,Haijin,13,13,9,5,0,0,2,2.85
+Fall 2023,ACCT,3377,2,10078,Cost Accounting,Lin,Haijin,19,22,12,3,0,0,3,2.983
+Fall 2023,ACCT,3368,1,10079,Intermediate Accounting II,Muslu,Volkan,0,11,11,1,0,0,1,2.349
+Fall 2023,ACCT,4335,1,10080,Financial Statement Auditing,Zhao,Yuping,25,32,5,0,1,0,0,3.27
+Fall 2023,ACCT,4375,1,10081,Internal Audit Entity Environ,Brant Jr,Robert Edward,5,8,5,0,0,0,0,3.055
+Fall 2023,ACCT,5367,1,10082,Intermediate Accounting I,Noland,Thomas R,5,4,4,0,0,0,0,3.229
+Fall 2023,ACCT,6331,1,10083,Financial Accounting,Larson,Chad R,10,7,1,0,0,0,1,3.482
+Fall 2023,ACCT,6331,2,10084,Financial Accounting,Kuruvilla,Mohan,12,9,3,1,0,0,0,3.306
+Fall 2023,ACCT,6331,4,10085,Financial Accounting,Larson,Chad R,18,11,0,1,1,0,4,3.409
+Fall 2023,ACCT,7330,1,10086,Advanced Accounting,Ramaswamy,Vinita,13,12,2,0,0,0,0,3.444
+Fall 2023,ACCT,7330,2,10087,Advanced Accounting,Ramaswamy,Vinita,9,5,0,0,0,0,0,3.69
+Fall 2023,ACCT,7340,2,10088,Financial Statement Analysis,Lu,Tong,17,1,1,0,1,0,0,3.634
+Fall 2023,ACCT,7375,1,10089,Taxation of Business Entities,Fernandez,Ramon,5,11,4,0,0,0,2,3.149
+Fall 2023,ACCT,8699,1,10090,Doctoral Dissertation,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,8999,1,10091,Doctoral Dissertation,Lu,Tong,0,0,0,0,0,1,0,
+Fall 2023,ENTR,3310,1,10092,Entrepreneurship,Ortega,Carlos Alberto,168,22,4,1,0,0,2,3.77
+Fall 2023,ENTR,3310,2,10093,Entrepreneurship,Wilbur,Stephen,116,135,18,3,0,0,4,3.319
+Fall 2023,ENTR,3312,1,10094,Corporate Entrepreneurship,Karonika,John R,25,22,1,0,0,0,2,3.459
+Fall 2023,ENTR,3312,2,10095,Corporate Entrepreneurship,Karonika,John R,21,14,5,0,0,0,8,3.342
+Fall 2023,ENTR,3312,3,10096,Corporate Entrepreneurship,Lish,Alan D,28,52,14,1,2,0,2,3.021
+Fall 2023,FINA,3332,3,10097,Prin of Financial Management,Chisholm,Darla,24,41,66,35,10,0,17,2.161
+Fall 2023,FINA,4354,1,10098,Risk Management,Kapatos,Nick Gus,16,19,19,7,0,0,1,2.77
+Fall 2023,FINA,4355,1,10099,International Risk Management,Kapatos,Nick Gus,15,40,4,0,0,0,1,3.125
+Fall 2023,FINA,4357,1,10100,Commercial Liability,Kapatos,Nick Gus,10,12,10,0,0,0,0,2.99
+Fall 2023,FINA,6387,2,10101,Managerial Analysis,Basu,Swati,16,6,0,0,0,0,0,3.727
+Fall 2023,FINA,8398,1,10103,Special Problems,George,Thomas J,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,8999,1,10106,Doctoral Dissertation,Yerramilli,Vijay,0,0,0,0,0,1,0,
+Fall 2023,BUSI,4396,1,10107,Business Internship,Wortzel,Zachary,0,0,0,0,0,42,0,
+Fall 2023,MANA,3335,1,10109,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,208,35,4,0,1,0,1,3.776
+Fall 2023,MANA,3335,4,10110,Intro Org Behavior and Mgmt,Currie,Daniel David,180,54,8,2,4,0,2,3.61
+Fall 2023,MANA,4330,1,10111,Intro to Strategic HR Mgt,Phillips,James S,102,99,15,4,2,0,2,3.269
+Fall 2023,MARK,4389,1,10118,Marketing Strategy & Planning,Agrawal,Arpit,29,1,0,0,0,0,0,3.934
+Fall 2023,MARK,4389,2,10119,Marketing Strategy & Planning,Koch,Steven F,31,0,0,0,0,0,0,3.979
+Fall 2023,MARK,4389,3,10120,Marketing Strategy & Planning,Randazzo,Gary W,27,4,0,0,0,0,0,3.733
+Fall 2023,MARK,4389,4,10121,Marketing Strategy & Planning,Beveridge,Ivana,31,1,0,0,0,0,0,3.938
+Fall 2023,MARK,4373,1,10122,Advanced Professional Selling,Bremer,Justin,16,10,0,0,0,0,0,3.628
+Fall 2023,MARK,4374,1,10123,Sales Management,Webb,James R,26,0,0,0,0,0,0,4.0
+Fall 2023,MARK,4374,2,10124,Sales Management,Webb,James R,26,0,0,0,0,0,0,4.0
+Fall 2023,MARK,4375,1,10125,Key Account Selling,Webb,James R,17,3,0,0,0,0,0,3.735
+Fall 2023,MARK,7374,1,10126,New Product Development,Kamal,Saiyid Zafar,12,1,0,0,0,0,0,3.847
+Fall 2023,MARK,8398,1,10127,Special Problems,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Fall 2023,MARK,8399,1,10128,Doctoral Dissertation,Ahearne,Michael,0,0,0,0,0,1,0,
+Fall 2023,ACCT,4330,1,10131,Advanced Accounting,Ramaswamy,Vinita,4,1,1,0,0,0,0,3.61
+Fall 2023,ACCT,4330,2,10132,Advanced Accounting,Ramaswamy,Vinita,1,2,0,0,0,0,0,3.443
+Fall 2023,ENTR,3312,4,10133,Corporate Entrepreneurship,Lish,Alan D,23,52,21,1,1,0,1,2.932
+Fall 2023,ACCT,7370,1,10134,Adv Fin Statement Auditing,Zhao,Yuping,13,3,1,0,0,0,0,3.725
+Fall 2023,ENTR,7336,1,10149,Entrepreneurship Overview,Wilbur,Stephen,16,7,0,0,0,0,0,3.667
+Fall 2023,ACCT,2301,4,10150,Prin of Financial Accounting,Goble,Samuel,33,29,8,2,1,0,4,3.342
+Fall 2023,STAT,3331,1,10151,Statistical Anal Bus Appl I,Wiley,Briceon C,127,106,72,52,3,0,42,2.792
+Fall 2023,SCM,3301,1,10152,SCM Fundamentals,Miller,Bradley D,358,169,18,2,0,0,1,3.584
+Fall 2023,BCIS,1305,1,10153,Business Computer Applications,Felvegi,Emese,25,0,0,0,0,0,0,3.987
+Fall 2023,BCIS,1305,2,10154,Business Computer Applications,Felvegi,Emese,198,39,10,0,2,0,1,3.719
+Fall 2023,MIS,3370,1,10155,Info Systems Development Tools,Hossain,Nahid,8,14,17,6,4,0,11,2.327
+Fall 2023,MIS,3371,1,10156,Transaction Processing Sys I,Messinger,Jacob Nelson,146,33,1,0,0,0,0,3.763
+Fall 2023,FINA,4370,1,10158,Energy Trading,Smith III,Edwin A,5,3,0,0,0,0,0,3.584
+Fall 2023,FINA,4371,1,10159,Energy Value Chain,Slaughter,Andrew Jeremy,1,8,1,0,0,0,0,3.0
+Fall 2023,MARK,4373,2,10160,Advanced Professional Selling,Pingel,John W,23,8,1,0,0,0,0,3.615
+Fall 2023,ARED,6365,1,10168,Integrative Art Teaching,Chung,Sheng Kuan,3,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,3310,1,10169,Bilingual Education,Leon,Maredil Josefina,16,3,0,0,0,0,0,3.842
+Fall 2023,CUIN,4375,2,10170,Classroom Management,Castillo,Bernadette Marie,21,5,1,0,0,0,0,3.631
+Fall 2023,CUIN,7336,1,10171,Popular Culture in Education,Brower,Samuel Richard,10,0,0,0,0,0,0,4.0
+Fall 2023,EDUC,4314,1,10173,Student Teaching Sec,Culpepper,Shea Mosley,14,0,0,0,0,0,1,3.953
+Fall 2023,EDUC,4315,1,10174,Student Teaching Sec,Thompson,Amber M,15,1,0,0,0,0,0,3.896
+Fall 2023,EDUC,4316,1,10175,Student Teach Art Elem,Culpepper,Shea Mosley,4,0,0,0,0,0,0,4.0
+Fall 2023,EDUC,4317,1,10176,Student Tch Art Sec,Thompson,Amber M,3,0,0,0,0,0,0,4.0
+Fall 2023,EDUC,4318,1,10177,Student Tch Music Elem,McGinnis,Emily Jane,15,1,0,0,0,0,0,3.938
+Fall 2023,EDUC,4319,1,10178,Student Tch Music Sec,McGinnis,Emily Jane,15,1,0,0,0,0,0,3.938
+Fall 2023,EDUC,4325,1,10179,Student Teaching 4-8 2Nd 7 Wks,Thompson,Amber M,22,0,0,0,0,0,0,3.955
+Fall 2023,PHLS,6325,1,10181,Theories of Counseling,Lee,Jungeun,8,0,0,0,0,0,0,3.876
+Fall 2023,PHLS,6330,1,10182,Human Growth-Developmnt,Whitaker,Rachael Gwin,11,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,1300,1,10183,Dev of Contemporary Families,Jordan,Erica F,63,49,14,2,1,0,1,3.315
+Fall 2023,HDFS,1300,7,10189,Dev of Contemporary Families,Jordan,Erica F,64,52,12,3,0,0,1,3.334
+Fall 2023,HDFS,4393,1,10193,Internship in HDFS,Conston,Toya,23,8,3,0,1,0,0,3.429
+Fall 2023,HLT,1353,1,10194,Personal Health,Rafique,Kiran Sajid,82,15,3,0,0,0,0,3.727
+Fall 2023,HLT,2320,1,10195,Introduction to Public Health,Solari Williams,Kayce D,56,31,4,2,1,0,1,3.437
+Fall 2023,HLT,3300,1,10196,Social Health and Wellness,Farmer,Jennifer,80,11,3,0,1,0,1,3.727
+Fall 2023,HLT,4306,1,10198,Women's Health Issues,Solari Williams,Kayce D,70,8,2,0,0,0,0,3.772
+Fall 2023,PHLS,6322,1,10201,Dimensions in Women's Health,Solari Williams,Kayce D,7,0,0,0,0,0,1,3.953
+Fall 2023,HDFS,4394,1,10202,Internship in HDFS,Conston,Toya,34,0,0,0,1,0,0,3.886
+Fall 2023,PHLS,6345,1,10203,Atypical Growth & Behavior,Hurt,Kara Marie,15,2,0,0,0,0,0,3.902
+Fall 2023,CUIN,4336,1,10204,Popular Culture in Education,Brower,Samuel Richard,13,0,1,0,0,0,0,3.834
+Fall 2023,HLT,3381,1,10207,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,83,14,3,0,1,0,0,3.713
+Fall 2023,PHLS,8319,1,10208,Infer Stats in Psych/Educ Res,Fan,Weihua,17,2,0,0,0,0,0,3.877
+Fall 2023,BIOE,6111,1,10209,Grad Bioengineering Seminar,Naash,Muna,0,0,0,0,0,67,1,
+Fall 2023,CHEE,2332,1,10210,Chem Engr Thermodyn I,Palmer,Jeremy,13,11,7,3,0,0,5,2.99
+Fall 2023,CHEE,3300,1,10211,Materials Science & Engr I,Robertson,Megan L,8,12,8,5,0,0,6,2.597
+Fall 2023,CHEE,3333,1,10212,Chem Engr Thermodyn II,Orman,Mehmet,16,19,3,6,0,0,8,3.045
+Fall 2023,CHEE,3334,1,10213,Stat/Num Tchqs for Chem Engrs,Nikolaou,Michael,26,9,6,1,1,0,2,3.211
+Fall 2023,CHEE,3363,1,10214,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,11,20,17,1,1,0,5,2.714
+Fall 2023,CHEE,4321,1,10215,Chemical Engineering Design I,Smith,Christopher Michael,74,3,0,0,0,0,0,3.828
+Fall 2023,CHEE,4361,1,10216,Chemical Engineering Practices,Cirino,Patrick C,33,6,1,0,0,0,0,3.784
+Fall 2023,CHEE,4367,1,10219,Chemical Reaction Engineering,Rimer,Jeffrey,34,25,18,0,0,0,0,3.191
+Fall 2023,CHEE,6111,1,10220,Graduate Seminar,Mountziaris,Triantafillos John,0,0,0,0,0,64,0,
+Fall 2023,CHEE,8298,2,10227,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,
+Fall 2023,CHEE,8298,3,10228,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8298,4,10229,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8298,6,10231,Doctoral Research,Economou,Demetre J,0,0,0,0,0,0,0,
+Fall 2023,CHEE,8298,7,10232,Doctoral Research,Grabow,Lars C,0,0,0,0,0,3,0,
+Fall 2023,CHEE,8298,8,10233,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8298,9,10234,Doctoral Research,Karim,Alamgir,0,0,0,0,0,8,0,
+Fall 2023,CHEE,8298,10,10235,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8398,7,10244,Doctoral Research,Grabow,Lars C,0,0,0,0,0,4,0,
+Fall 2023,CHEE,8398,9,10246,Doctoral Research,Karim,Alamgir,0,0,0,0,0,4,0,
+Fall 2023,CHEE,8398,10,10247,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8398,13,10250,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8399,2,10252,Doctoral Dissertation,Bollini,Praveen P,5,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8399,3,10253,Doctoral Dissertation,Cirino,Patrick C,1,0,0,0,0,1,0,4.0
+Fall 2023,CHEE,8399,4,10254,Doctoral Dissertation,Conrad,Jacinta C,2,0,0,0,0,3,0,4.0
+Fall 2023,CHEE,8399,5,10255,Doctoral Dissertation,Donnelly,Vincent M,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8399,7,10257,Doctoral Dissertation,Grabow,Lars C,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8399,8,10258,Doctoral Dissertation,Harold,Michael P,3,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8399,9,10259,Doctoral Dissertation,Karim,Alamgir,7,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8399,10,10260,Doctoral Dissertation,Krishnamoorti,Ramanan,1,0,0,0,0,1,0,4.0
+Fall 2023,CHEE,8399,11,10261,Doctoral Dissertation,Mountziaris,Triantafillos John,2,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8498,9,10270,Doctoral Research,Karim,Alamgir,0,0,0,0,0,3,0,
+Fall 2023,CHEE,8498,10,10271,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8598,1,10275,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,3,0,
+Fall 2023,CHEE,8598,2,10276,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8598,4,10278,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8598,5,10279,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8598,7,10281,Doctoral Research,Grabow,Lars C,0,0,0,0,0,3,0,
+Fall 2023,CHEE,8598,8,10282,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Fall 2023,ENGR,2301,1,10283,Mechanics I (Statics),Kalliontzis,Dimitrios,16,14,9,3,9,0,4,2.49
+Fall 2023,CIVE,3339,1,10284,Geotechnical Engineering,Vipulanandan,Cumaraswamy,6,22,11,0,0,0,0,2.88
+Fall 2023,CIVE,8198,1,10287,Doctoral Research,Shaffer,Devin,0,0,0,0,0,3,0,
+Fall 2023,CIVE,8298,1,10288,Doctoral Research,Milillo,Pietro,0,0,0,0,0,7,0,
+Fall 2023,CIVE,8398,1,10289,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Fall 2023,CIVE,8598,1,10292,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Fall 2023,ECE,3441,1,10301,Digital Logic Design,Sheth,Bhavin R,29,14,16,2,1,0,5,3.086
+Fall 2023,ECE,3436,1,10303,Microprocessor Systems,De La Rosa-Pohl,Diana,39,1,0,0,0,0,0,3.967
+Fall 2023,ECE,5317,1,10305,Microwave Engineering,Chen,Ji,2,4,0,0,0,0,0,3.498
+Fall 2023,ECE,6111,3,10307,Graduate Research Seminar,Shan,Xiaonan,0,0,0,0,0,2,0,
+Fall 2023,ECE,6198,2,10310,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2023,ECE,6198,12,10320,Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,6298,2,10338,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2023,ECE,6298,12,10348,Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,6298,17,10353,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2023,ECE,6351,1,10365,Microwave Engineering,Chen,Ji,8,1,0,0,0,0,0,3.926
+Fall 2023,ECE,6398,4,10369,Research,Chen,Ji,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,6,10371,Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,8,10373,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2023,ECE,6398,11,10376,Research,Han,Zhu,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,12,10377,Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,13,10378,Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,14,10379,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,17,10382,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,18,10383,Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,25,10390,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,27,10392,Research,Yao,Yan,0,0,0,0,0,3,0,
+Fall 2023,ECE,6399,7,10400,Masters Thesis,Chen,Yuhua,0,0,0,0,0,0,0,
+Fall 2023,ECE,6399,8,10401,Masters Thesis,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2023,ECE,8198,1,10427,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2023,ECE,8198,7,10433,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Fall 2023,ECE,8198,8,10434,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2023,ECE,8198,10,10436,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Fall 2023,ECE,8198,12,10438,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,8198,13,10439,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2023,ECE,8198,17,10443,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2023,ECE,8198,27,10453,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2023,ECE,8298,1,10456,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,
+Fall 2023,ECE,8298,2,10457,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2023,ECE,8298,3,10458,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,4,0,
+Fall 2023,ECE,8298,4,10459,Doctoral Research,Chen,Ji,0,0,0,0,0,3,0,
+Fall 2023,ECE,8298,5,10460,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Fall 2023,ECE,8298,7,10462,Doctoral Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Fall 2023,ECE,8298,10,10465,Doctoral Research,Fu,Xin,0,0,0,0,0,1,0,
+Fall 2023,ECE,8298,13,10468,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,
+Fall 2023,ECE,8298,14,10469,Doctoral Research,Li,Xingpeng,0,0,0,0,0,2,0,
+Fall 2023,ECE,8298,15,10470,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Fall 2023,ECE,8298,16,10471,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,3,0,
+Fall 2023,ECE,8298,20,10475,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Fall 2023,ECE,8298,23,10478,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,5,0,
+Fall 2023,ECE,8298,24,10479,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2023,ECE,8298,26,10481,Doctoral Research,Yao,Yan,0,0,0,0,0,3,0,
+Fall 2023,ECE,8298,28,10483,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Fall 2023,ECE,8398,2,10485,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2023,ECE,8398,3,10486,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,2,0,
+Fall 2023,ECE,8398,4,10487,Doctoral Research,Chen,Ji,0,0,0,0,0,3,0,
+Fall 2023,ECE,8398,5,10488,Doctoral Research,Chen,Jiefu,0,0,0,0,0,1,0,
+Fall 2023,ECE,8398,6,10489,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2023,ECE,8398,7,10490,Doctoral Research,Chen,Yuhua,0,0,0,0,0,3,0,
+Fall 2023,ECE,8398,9,10492,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2023,ECE,8398,11,10494,Doctoral Research,Fu,Xin,0,0,0,0,0,4,0,
+Fall 2023,ECE,8398,12,10495,Doctoral Research,Han,Zhu,0,0,0,0,0,4,0,
+Fall 2023,ECE,8398,13,10496,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,8398,14,10497,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,
+Fall 2023,ECE,8398,15,10498,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Fall 2023,ECE,8398,18,10501,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2023,ECE,8398,19,10502,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Fall 2023,ECE,8398,24,10505,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,3,0,
+Fall 2023,ECE,8398,25,10506,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,5,0,
+Fall 2023,ECE,8398,26,10507,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2023,ECE,8398,30,10511,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2023,ECE,8399,2,10515,Doctoral Dissertation,Becker,Aaron T,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,3,10516,Doctoral Dissertation,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Fall 2023,ECE,8399,5,10518,Doctoral Dissertation,Chen,Jiefu,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,6,10519,Doctoral Dissertation,Chen,Jinghong,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,7,10520,Doctoral Dissertation,Chen,Yuhua,0,0,0,0,0,0,0,
+Fall 2023,ECE,8399,8,10521,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Fall 2023,ECE,8399,12,10524,Doctoral Dissertation,Han,Zhu,3,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,13,10525,Doctoral Dissertation,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,8399,14,10526,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,2,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,15,10527,Doctoral Dissertation,Li,Xingpeng,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,16,10528,Doctoral Dissertation,Litvinov,Dmitri,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,17,10529,Doctoral Dissertation,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Fall 2023,ECE,8399,18,10530,Doctoral Dissertation,Nguyen,Hien V,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,23,10535,Doctoral Dissertation,Reddy,Rohith Krishna,1,0,0,0,0,1,0,4.0
+Fall 2023,ECE,8399,25,10536,Doctoral Dissertation,Roysam,Badrinath,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8399,26,10537,Doctoral Dissertation,Shan,Xiaonan,0,0,0,0,0,1,0,
+Fall 2023,ECE,8399,30,10541,Doctoral Dissertation,Shireen,Wajiha,3,0,0,0,0,0,0,3.78
+Fall 2023,ECE,8498,2,10544,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,3,10545,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,2,0,
+Fall 2023,ECE,8498,4,10546,Doctoral Research,Chen,Ji,0,0,0,0,0,6,0,
+Fall 2023,ECE,8498,5,10547,Doctoral Research,Chen,Jiefu,0,0,0,0,0,4,0,
+Fall 2023,ECE,8498,7,10549,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,10,10552,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Fall 2023,ECE,8498,11,10553,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Fall 2023,ECE,8498,12,10554,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,13,10555,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,5,0,
+Fall 2023,ECE,8498,14,10556,Doctoral Research,Li,Xingpeng,0,0,0,0,0,2,0,
+Fall 2023,ECE,8498,15,10557,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,16,10558,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Fall 2023,ECE,8498,17,10559,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,3,0,
+Fall 2023,ECE,8498,21,10563,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,22,10564,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,24,10566,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,5,0,
+Fall 2023,ECE,8498,25,10567,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2023,ECE,8498,29,10571,Doctoral Research,Le,Hung Quang,0,0,0,0,0,1,0,
+Fall 2023,ECE,8598,4,10575,Doctoral Research,Chen,Ji,0,0,0,0,0,3,0,
+Fall 2023,ECE,8598,5,10576,Doctoral Research,Chen,Jiefu,0,0,0,0,0,1,0,
+Fall 2023,ECE,8598,8,10579,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2023,ECE,8598,10,10581,Doctoral Research,Fu,Xin,0,0,0,0,0,3,0,
+Fall 2023,ECE,8598,11,10582,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Fall 2023,ECE,8598,12,10583,Doctoral Research,Jackson,David R,0,0,0,0,0,2,0,
+Fall 2023,ECE,8598,13,10584,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Fall 2023,ECE,8598,18,10589,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2023,ECE,8598,24,10595,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,1,0,
+Fall 2023,ECE,8598,30,10601,Doctoral Research,Le,Hung Quang,0,0,0,0,0,1,0,
+Fall 2023,ECE,8699,8,10609,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2023,ECE,8699,10,10611,Doctoral Dissertation,Fu,Xin,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8699,11,10612,Doctoral Dissertation,Han,Zhu,3,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8699,13,10614,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,2,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8699,14,10615,Doctoral Dissertation,Li,Xingpeng,2,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8699,18,10619,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8699,20,10621,Doctoral Dissertation,Prasad,Saurabh,0,0,0,0,0,0,0,
+Fall 2023,ECE,8699,21,10622,Doctoral Dissertation,Rajashekara,Kaushik,4,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8699,22,10623,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2023,ECE,8699,28,10629,Doctoral Dissertation,Yao,Yan,0,0,0,0,0,0,0,
+Fall 2023,ECE,8699,29,10630,Doctoral Dissertation,Shireen,Wajiha,1,0,0,0,0,0,0,4.0
+Fall 2023,INDE,2333,1,10631,Engineering Statistics I,Wiggins,Nathanial David,6,9,0,0,1,0,0,3.084
+Fall 2023,INDE,3330,1,10632,Financial and Cost Management,Wiggins,Nathanial David,48,8,0,0,0,0,1,3.775
+Fall 2023,INDE,3333,1,10633,Engineering Economy I,Schulze,Lawrence John Henry,3,4,1,1,0,0,0,2.963
+Fall 2023,INDE,3364,1,10634,Engineering Statistics II,Wang,Yaping,22,8,7,0,0,0,1,3.388
+Fall 2023,INDE,3382,1,10635,Stochastic Models,Xiang,Yisha,8,13,9,1,0,0,0,2.861
+Fall 2023,INDE,4111,1,10636,Industrial Engineering Seminar,Peng,Jiming Ouyang,29,0,0,0,0,0,0,3.977
+Fall 2023,INDE,6111,1,10637,Graduate Seminar,Peng,Jiming Ouyang,0,0,0,0,0,56,0,
+Fall 2023,INDE,6372,1,10638,Advanced Linear Optimization,Peng,Jiming Ouyang,12,6,7,8,3,0,1,2.426
+Fall 2023,INDE,8298,1,10643,Doctoral Research,Xiang,Yisha,0,0,0,0,0,3,0,
+Fall 2023,INDE,8398,1,10646,Doctoral Research,Xiang,Yisha,0,0,0,0,0,2,0,
+Fall 2023,INDE,8398,3,10648,Doctoral Research,Peng,Jiming Ouyang,0,0,0,0,0,0,0,
+Fall 2023,INDE,8399,1,10649,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Fall 2023,INDE,8399,5,10652,Doctoral Dissertation,Lin,Ying,1,0,0,0,0,0,0,4.0
+Fall 2023,INDE,8598,1,10655,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2023,INDE,8699,1,10656,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Fall 2023,MECE,2334,1,10660,Thermodynamics,Love,Holley Carole,6,16,15,2,0,0,2,2.641
+Fall 2023,MECE,2361,1,10661,Intro Mechanical Design,Chang,Christiana,21,48,20,1,0,0,2,3.007
+Fall 2023,MECE,3245,1,10663,Materials Science Laboratory,Chen,Xuemei,20,21,4,2,1,0,1,3.119
+Fall 2023,MECE,3360,1,10665,Experimental Methods,Chen,Xuemei,25,45,8,0,0,0,2,3.209
+Fall 2023,MECE,4371,1,10668,Thermal-Fluids Laboratory,Love,Holley Carole,68,0,0,0,0,0,0,3.99
+Fall 2023,MECE,4372,1,10671,Mechs-Cntrls-Vibrtn Lab,Song,Gangbing,10,46,7,0,0,0,1,3.027
+Fall 2023,MECE,8111,1,10674,Graduate Seminar,Sharma,Pradeep,0,0,0,0,0,51,0,
+Fall 2023,MECE,6384,1,10675,Methods of Applied Math I,Chen,Yi-Chao,13,20,4,1,1,0,1,3.077
+Fall 2023,CHEE,8298,13,10676,Doctoral Research,Orman,Mehmet,0,0,0,0,0,3,0,
+Fall 2023,INDE,6383,1,10679,Engr Design and Prototyping,Kamrani,Ali K,2,2,0,0,0,0,0,3.335
+Fall 2023,CHEE,8298,14,10681,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,
+Fall 2023,CHEE,8399,13,10682,Doctoral Dissertation,Orman,Mehmet,4,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8598,9,10684,Doctoral Research,Karim,Alamgir,0,0,0,0,0,3,0,
+Fall 2023,PETR,6350,1,10685,Natural Gas Engineering,Farouq-Ali,Syed,14,2,1,0,0,0,0,3.668
+Fall 2023,GHL,1337,1,10687,Intro To Hospitality Industry,Cheatham,Cathy A,49,13,1,0,2,0,0,3.611
+Fall 2023,GHL,1337,2,10688,Intro To Hospitality Industry,Doudna,Simone P,48,0,0,0,1,0,1,3.918
+Fall 2023,GHL,1345,1,10689,"Safety, Sanitation in Hosp Ind",Beiza,Alberto,35,13,6,0,0,0,0,3.482
+Fall 2023,GHL,2365,1,10690,Tourism,Draper,Jason A,21,13,3,0,1,0,0,3.369
+Fall 2023,GHL,3336,1,10692,Beverage Management,Rinck,Kristen Ann,9,1,0,0,0,0,0,3.834
+Fall 2023,GHL,2343,1,10693,Hospitality Cost Controls,Haskell,Rebecca Erin,20,4,1,0,0,0,0,3.654
+Fall 2023,GHL,2343,2,10694,Hospitality Cost Controls,Haskell,Rebecca Erin,15,8,1,1,1,0,0,3.207
+Fall 2023,GHL,3345,1,10695,Wine Appreciation,Taylor,David C,22,2,1,6,2,0,2,3.031
+Fall 2023,GHL,3352,1,10697,Human Resource Management,Guchait,Priyanko,14,7,4,2,2,0,0,2.954
+Fall 2023,GHL,3361,1,10698,Hospitality Marketing,Park,Yunna,27,6,0,0,0,0,0,3.788
+Fall 2023,GHL,3361,2,10699,Hospitality Marketing,Lee,Hyun Kyung,34,11,2,0,1,0,0,3.597
+Fall 2023,GHL,4343,1,10700,Financial Admin for Hosp.Ind.,Koh,Yoon,8,9,3,0,0,0,1,3.184
+Fall 2023,GHL,4353,1,10701,Leadership in Hospitality Ind,Barth,Stephen C,20,8,1,1,0,0,0,3.512
+Fall 2023,GHL,4353,2,10702,Leadership in Hospitality Ind,Maneethai,Dustin,30,16,4,0,2,0,0,3.366
+Fall 2023,GHL,6345,1,10703,Wine Appreciation,Taylor,David C,4,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6360,1,10705,Graduate Directed Practicum,Padilla,Magdalena Manzano,9,0,0,0,0,0,0,4.0
+Fall 2023,GHL,3358,2,10711,Hospitality Industry Law,Abbott,Jeanna L,30,12,5,0,0,0,3,3.511
+Fall 2023,GHL,2350,1,10712,Mgmt Principles in Hospitality,Liu,Wenfang,14,5,2,1,0,0,0,3.395
+Fall 2023,LAW,5103,1,10715,Health Law Journal,Mantel,Jessica,0,0,0,0,0,7,0,
+Fall 2023,LAW,5110,1,10717,Law Review,Sanders,Joseph,0,0,0,0,0,6,0,
+Fall 2023,LAW,5147,1,10718,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,2,1,
+Fall 2023,LAW,5151,1,10719,Tax Research,Dykes,Christopher,8,6,0,0,0,0,0,3.501
+Fall 2023,LAW,5198,1,10720,Special Rsch & Writing,Vetter,Greg R,2,1,0,0,0,0,0,3.777
+Fall 2023,LAW,5210,1,10721,Law Review,Sanders,Joseph,0,0,0,0,0,4,0,
+Fall 2023,LAW,5247,2,10722,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,7,0,
+Fall 2023,LAW,5288,1,10723,Tax Ethics,Arabi Katbi,Eman Patricia,2,2,1,0,0,0,0,3.332
+Fall 2023,LAW,5292,1,10724,Tax Procedure,Vasquez Jr,Juan F,3,2,0,0,0,0,0,3.468
+Fall 2023,LAW,5298,1,10725,Special Rsch & Writing,Vetter,Greg R,4,1,0,0,0,0,0,3.734
+Fall 2023,LAW,5319,1,10726,Intro To American Law,Kalu,Vivian O,20,12,3,0,0,0,0,3.486
+Fall 2023,LAW,5322,1,10727,Pretrial Litigation,Hawk,Amy Elizabeth,5,16,0,0,0,2,0,3.38
+Fall 2023,LAW,5328,1,10728,Judicial Externship I,Powers,William,0,0,0,0,0,8,0,
+Fall 2023,LAW,5355,1,10729,Oil and Gas,Mason,Jasper,15,24,0,0,0,0,0,3.478
+Fall 2023,LAW,5381,1,10730,Legal Negotiation,Aguirre,Cindy Mayela,20,38,0,0,0,2,0,3.396
+Fall 2023,LAW,5386,1,10731,Trial Advocacy,Baldassano,Steven L,11,22,0,0,0,2,0,3.293
+Fall 2023,LAW,5398,1,10732,Special Research and Writing,Vetter,Greg R,4,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5406,2,10735,Civil Procedure,Salib,Peter,30,48,0,0,0,0,0,3.402
+Fall 2023,LAW,5406,3,10736,Civil Procedure,Ragazzo,Robert A,29,44,1,0,0,0,1,3.365
+Fall 2023,LAW,5409,6,10737,Contracts,Guggenberger,Nikolas,12,28,2,0,0,0,0,3.38
+Fall 2023,LAW,5418,2,10739,Torts,Duncan,Meredith J,26,53,0,0,0,0,0,3.4
+Fall 2023,LAW,5459,1,10740,Federal Income Tax,Wilson,John Marshall,13,19,0,0,0,18,0,3.355
+Fall 2023,LAW,6209,1,10741,Health Law Journal,Mantel,Jessica,0,0,0,0,0,10,0,
+Fall 2023,LAW,6211,1,10742,Houston Buiness/Tax Journal,Wells,Douglas,0,0,0,0,0,4,0,
+Fall 2023,LAW,6300,1,10743,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,4,0,
+Fall 2023,LAW,6318,1,10746,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,10,0,
+Fall 2023,LAW,6354,1,10747,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,11,0,
+Fall 2023,LAW,6356,1,10748,Law Review,Sanders,Joseph,0,0,0,0,0,17,0,
+Fall 2023,LAW,6358,1,10749,Health Law Journal,Mantel,Jessica,0,0,0,0,0,6,0,
+Fall 2023,LAW,5406,5,10750,Civil Procedure,Stewart,Rebecca,30,50,0,0,0,0,0,3.4
+Fall 2023,LAW,5301,1,10753,Immigration Clinic II,Cabot,Jessica Anna,1,0,0,0,0,0,0,3.67
+Fall 2023,AAS,2320,1,10755,Intro To African American Stdy,Smith,Marlon Antoine,16,9,7,0,0,0,0,3.219
+Fall 2023,AFSC,1201,1,10756,Foundations of the USAF I,Bolarinwa,Feyisade,22,1,1,0,0,0,3,3.861
+Fall 2023,AFSC,1201,2,10757,Foundations of the USAF I,Bolarinwa,Feyisade,4,0,0,0,0,0,1,4.0
+Fall 2023,AFSC,2201,1,10759,Evolution of Air Power I,Bolarinwa,Feyisade,9,1,1,0,0,0,1,3.637
+Fall 2023,AFSC,2201,2,10760,Evolution of Air Power I,Bolarinwa,Feyisade,4,0,0,0,0,0,0,3.753
+Fall 2023,ANTH,6300,1,10763,Anthropological Theory,De Genova,Nicholas Paul,3,2,0,0,0,0,0,3.468
+Fall 2023,ANTH,6399,1,10764,Masters Thesis,De Genova,Nicholas Paul,0,0,0,0,0,0,0,
+Fall 2023,ANTH,6399,2,10765,Masters Thesis,Sen,Debarati,0,0,0,0,0,1,0,
+Fall 2023,ANTH,7399,1,10767,Masters Thesis,Sen,Debarati,0,0,0,0,0,1,0,
+Fall 2023,ARAB,2311,1,10771,Intermediate Arabic I,Sayyid,Huda,9,1,1,0,0,0,1,3.667
+Fall 2023,ARTS,1316,1,10772,Fundamentals of Drawing,Siddiq,Sajeela,11,6,0,0,0,0,2,3.55
+Fall 2023,ARTS,1316,3,10774,Fundamentals of Drawing,Griffin,Alvin Garrett,12,5,1,1,0,0,1,3.335
+Fall 2023,ARTS,1316,4,10775,Fundamentals of Drawing,Coulter,Crystal Lennette,18,2,0,0,0,0,0,3.884
+Fall 2023,ARTS,1316,5,10776,Fundamentals of Drawing,Willis,William H,19,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,2316,1,10778,Fundamentals of Painting,Foutz,Madelyn Mairie,13,2,2,1,0,0,1,3.427
+Fall 2023,ARTS,2316,2,10779,Fundamentals of Painting,Kidd,Julia A,11,1,3,1,0,0,2,3.416
+Fall 2023,ARTS,6380,1,10780,Seminar,Mayer,Anna W,15,0,0,0,0,0,1,4.0
+Fall 2023,ARTS,1304,1,10781,Art Hist II(15th C to Present),Buske,Zoie,113,36,7,4,12,0,3,3.37
+Fall 2023,ARTH,4383,1,10782,Contemporary Painting,Barrera,Debra,18,10,2,2,1,0,1,3.253
+Fall 2023,CHIN,1501,1,10783,Elementary Chinese I,Zhang,Jing,21,4,0,0,0,0,0,3.84
+Fall 2023,CHIN,1501,3,10785,Elementary Chinese I,Zhang,Jing,11,3,1,0,0,0,1,3.667
+Fall 2023,CHIN,2311,1,10787,Intermediate Chinese I,Zhang,Jing,10,5,2,0,0,0,0,3.354
+Fall 2023,CHIN,3301,1,10788,Advanced Mandarin Chinese I,Zhang,Jing,14,3,0,0,0,0,1,3.765
+Fall 2023,SGNL,1301,1,10789,Elementary Sign Language I,Brittain,Robyn Michelle,3,6,2,3,2,0,3,2.395
+Fall 2023,SGNL,2301,2,10790,Intermediate Sign Language I,Warmack,Chris Kiskinis,4,8,6,0,0,0,0,2.889
+Fall 2023,COMD,2338,1,10791,Phonetics,Bunta,Ferenc,14,14,4,0,0,0,0,3.343
+Fall 2023,COMD,6328,1,10792,Acquired Cognitive Disorders,Thiessen,Amber L,10,8,0,0,0,0,0,3.611
+Fall 2023,COMD,6387,1,10793,Voice Disorders,Joshi,Ashwini,12,14,0,0,0,0,0,3.411
+Fall 2023,COMD,7322,1,10794,Speech Sound Disorders,Cizek,Laura S,23,21,1,0,0,0,0,3.548
+Fall 2023,COMD,7391,2,10795,Clinic in Speech Lang Disorder,Devore,Danielle R,2,1,0,0,0,0,0,3.557
+Fall 2023,COMD,7391,3,10796,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,3,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7391,4,10797,Clinic in Speech Lang Disorder,Townsend,Alayna,3,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7391,5,10798,Clinic in Speech Lang Disorder,Townsend,Alayna,3,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7391,6,10799,Clinic in Speech Lang Disorder,Devore,Danielle R,3,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7391,7,10800,Clinic in Speech Lang Disorder,Trevino,Alexandra Hanson,3,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7392,1,10801,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,2,0,0,0,0,0,0,4.0
+Fall 2023,COMD,7392,2,10802,Adv Pract Sp & Lang Dis,Cadavid,Kelsey Lee,2,0,0,0,0,0,0,3.835
+Fall 2023,COMD,7392,3,10803,Adv Pract Sp & Lang Dis,Walker,Dionne A,2,0,0,0,0,0,0,4.0
+Fall 2023,SPCH,1318,1,10804,Interpersonal Communication,Uhrick,Jan,27,3,0,0,1,0,3,3.721
+Fall 2023,COMM,2300,1,10805,Communication Research Methods,Lyn,Robyn,26,7,1,1,4,0,2,3.274
+Fall 2023,COMM,4331,1,10810,Persuasion,Huang,Yan,23,6,2,0,0,0,1,3.614
+Fall 2023,COMM,6370,1,10812,Public Relations Management,Ni,Lan,6,3,0,0,0,0,0,3.703
+Fall 2023,DANC,1300,1,10815,Dance as a Fine Art,Prokop,Travis Cooper,23,4,0,0,0,0,0,3.901
+Fall 2023,DANC,2305,1,10816,Dance Composition I,Prokop,Travis Cooper,19,0,0,0,0,0,1,3.861
+Fall 2023,DANC,2303,1,10817,Introduction to Dance,Bobet,Jacqueline A,64,16,2,0,4,0,2,3.551
+Fall 2023,DANC,4110,1,10818,Dance Ensemble,Lockett,KeyAira,7,0,0,0,0,0,0,3.906
+Fall 2023,DANC,4302,1,10819,Advanced Technique and Theory,Estrada,Maria Gabriela,9,2,0,0,0,0,1,3.878
+Fall 2023,ECON,2302,1,10820,Principles of Microeconomics,Hossain,Md Shahadath,96,249,68,16,5,0,14,2.972
+Fall 2023,ECON,3334,2,10821,Intermediate Macroeconomics,Cubas Norando,German,9,21,7,2,1,0,8,2.859
+Fall 2023,ECON,3371,1,10822,Economics of Money & Banking,Peru Durayalage,Dhanushka Arunasiri,27,23,17,6,0,0,3,2.95
+Fall 2023,ECON,3370,1,10823,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,1,1,3,3,1,0,2,1.594
+Fall 2023,ECON,3370,2,10824,Introduction To Econometrics,Zhivan,Natalia A,10,6,4,1,1,0,2,2.97
+Fall 2023,ECON,4390,1,10825,Economics Internship,Thornton,Rebecca Achee,9,1,0,0,0,0,0,3.834
+Fall 2023,ECON,8399,1,10826,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,1,0,
+Fall 2023,ENGL,1301,1,10827,First Year Writing I,Kroger,Ann Gabriel,10,6,0,0,6,0,3,2.576
+Fall 2023,ENGL,1301,2,10828,First Year Writing I,Garcia,Serena Mari,18,4,1,0,1,0,0,3.515
+Fall 2023,ENGL,1301,3,10829,First Year Writing I,Garcia,Serena Mari,12,8,3,0,2,0,0,3.133
+Fall 2023,ENGL,1301,4,10830,First Year Writing I,Garcia,Serena Mari,18,5,2,0,0,0,0,3.534
+Fall 2023,ENGL,1301,5,10831,First Year Writing I,Bose,Godhuly,19,2,1,2,0,0,1,3.515
+Fall 2023,ENGL,1301,6,10832,First Year Writing I,Campese,Kathleen Ann,17,5,2,2,3,0,1,3.023
+Fall 2023,ENGL,1301,7,10833,First Year Writing I,Rajkumar,Nidhi,12,8,3,0,0,0,1,3.363
+Fall 2023,ENGL,1301,8,10834,First Year Writing I,Rajkumar,Nidhi,10,7,4,0,1,0,3,3.046
+Fall 2023,ENGL,1301,9,10835,First Year Writing I,Penzien,Eugene Norman,14,4,3,0,3,0,1,3.001
+Fall 2023,ENGL,1301,10,10836,First Year Writing I,Penzien,Eugene Norman,11,3,1,1,8,0,0,2.278
+Fall 2023,ENGL,1301,11,10837,First Year Writing I,Jones,Baylea,10,7,4,3,1,0,0,2.92
+Fall 2023,ENGL,1301,12,10838,First Year Writing I,Stratford,Marigold,9,4,4,1,1,0,6,2.965
+Fall 2023,ENGL,1301,15,10839,First Year Writing I,Worley,Sharon J,9,7,3,0,8,0,3,2.26
+Fall 2023,ENGL,1301,16,10840,First Year Writing I,Anderson,Claire F,27,1,0,1,1,0,0,3.7
+Fall 2023,ENGL,1301,18,10841,First Year Writing I,Barr,Anna Kate,15,3,0,0,1,0,0,3.684
+Fall 2023,ENGL,1301,19,10842,First Year Writing I,Abdelwahab,Maha Ahmed Ibraheem,15,1,1,0,1,0,1,3.629
+Fall 2023,ENGL,1301,28,10843,First Year Writing I,Downey,Carlton M,23,0,0,0,2,0,0,3.601
+Fall 2023,ENGL,1301,42,10846,First Year Writing I,Lowder,Will,10,5,2,0,1,0,1,3.314
+Fall 2023,ENGL,1301,48,10847,First Year Writing I,Lopez,Reese D,12,5,2,0,0,0,0,3.422
+Fall 2023,ENGL,1301,50,10848,First Year Writing I,Lopez,Reese D,13,5,0,0,1,0,0,3.474
+Fall 2023,ENGL,1301,54,10849,First Year Writing I,Hall,Laura Dianne,5,7,3,1,2,0,1,2.667
+Fall 2023,ENGL,1301,61,10850,First Year Writing I,Bellomy,Charlotte Seychelles,18,0,1,0,0,0,0,3.86
+Fall 2023,ENGL,1301,63,10851,First Year Writing I,Rolater,Sara C,8,3,4,3,2,0,3,2.501
+Fall 2023,ENGL,1301,70,10852,First Year Writing I,Weitman,Mathew,15,3,0,0,1,0,0,3.649
+Fall 2023,ENGL,1301,73,10853,First Year Writing I,Downey,Carlton M,21,2,0,0,0,0,1,3.899
+Fall 2023,ENGL,1302,2,10855,First Year Writing II,Long,Steven A.,11,3,0,0,4,0,0,2.944
+Fall 2023,ENGL,1302,4,10856,First Year Writing II,Rizzo,Kaitlin M,24,2,0,0,2,0,2,3.596
+Fall 2023,ENGL,1302,10,10857,First Year Writing II,Wingard,Jennifer L,17,5,0,0,2,0,0,3.445
+Fall 2023,ENGL,1302,13,10858,First Year Writing II,Sicinski,Michael J,11,7,0,0,4,0,3,2.91
+Fall 2023,ENGL,1302,16,10860,First Year Writing II,Kozma,Andrew,12,6,5,0,3,0,4,2.898
+Fall 2023,ENGL,1302,19,10861,First Year Writing II,Kozma,Andrew,10,7,3,0,2,0,3,3.015
+Fall 2023,ENGL,1302,34,10862,First Year Writing II,Mandia,Christopher Peter,13,0,3,0,1,0,2,3.237
+Fall 2023,ENGL,1370,1,10864,Composition II-Honors,Barnes,Michael,5,1,0,0,0,0,0,3.778
+Fall 2023,ENGL,1370,2,10865,Composition II-Honors,Barnes,Michael,8,4,0,0,0,0,0,3.749
+Fall 2023,ENGL,2305,3,10866,Intro To Fiction,Repass,Scott,23,4,0,0,1,0,1,3.691
+Fall 2023,ENGL,2307,1,10868,Intro To Drama,Khalil,Rand Omar,25,4,1,0,0,0,0,3.778
+Fall 2023,ENGL,3330,1,10870,Beg Creative Writing-Fiction,Stockwell,Patrick Edward,19,0,0,0,0,0,2,4.0
+Fall 2023,ENGL,4390,1,10871,Professional Internship,Zentz,Lauren R,0,0,0,0,0,1,0,
+Fall 2023,FREN,1501,1,10872,Elementary French I,Gnanwo Hounfodji,Raymond,3,8,3,1,0,0,3,2.889
+Fall 2023,FREN,1502,1,10874,Elementary French II,Chalhoub,Rania Maria,2,1,7,2,2,0,1,1.881
+Fall 2023,FREN,2311,1,10876,Intermediate French I,Green,Viola V,3,5,4,2,0,0,0,2.619
+Fall 2023,FREN,2312,1,10877,Intermediate French II,Vredenburgh,Amanda Jane,4,11,5,0,0,0,0,2.917
+Fall 2023,GERM,2311,1,10878,Intermediate German I,Kleinheider,Julia D,1,4,2,3,1,0,2,2.061
+Fall 2023,GERM,3333,1,10879,Ger Conversatn&Composit,Kleinheider,Julia D,1,2,0,0,0,0,0,3.113
+Fall 2023,HIST,1301,1,10880,The U.S. to 1877,Clavin,Matthew J,23,48,30,15,12,0,19,2.401
+Fall 2023,HIST,3378,1,10881,The Modern Middle East,Al-Sowayel,Dina,19,7,1,3,3,0,1,3.071
+Fall 2023,HIST,8699,1,10882,Doctoral Dissertation,Klieman,Kairn,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,8999,1,10884,Doctoral Dissertation,Takriti,Abdel Razzaq,0,0,0,0,0,2,0,
+Fall 2023,HIST,8999,8,10885,Doctoral Dissertation,Goldberg,Mark A,0,0,0,0,0,2,0,
+Fall 2023,HIST,8999,9,10886,Doctoral Dissertation,McNally,David Joseph,3,0,0,0,0,0,0,4.0
+Fall 2023,HON,2301,1,10887,The Human Situation: Antiquity,Sommers,Tamler S,221,59,14,2,1,0,9,3.615
+Fall 2023,HON,2301,2,10888,The Human Situation: Antiquity,Ferguson,Jamie H,182,87,7,1,2,0,7,3.548
+Fall 2023,ITAL,2311,2,10889,Intermediate Italian I,Ercolani,Monica,18,4,1,0,0,0,1,3.696
+Fall 2023,LATI,1301,1,10890,Elementary Latin I,Kidder,Kathleen,8,9,3,1,2,0,1,2.827
+Fall 2023,LATI,2311,1,10891,Intermediate Latin I,Armstrong,Richard H,7,3,1,0,0,0,1,3.455
+Fall 2023,MAS,2340,1,10892,Intro Mexican American Studies,Rodriguez,Andre,19,10,3,0,1,0,1,3.334
+Fall 2023,MSCI,1125,1,10893,Phys Readiness Training,Comiskey,Melissa C,12,3,0,0,0,0,0,3.822
+Fall 2023,MSCI,1210,1,10894,Introduction to the Army,Comiskey,Melissa C,9,1,0,0,0,0,1,3.9
+Fall 2023,MSCI,2210,1,10896,Leadership & Decision Making,Thomas,Roland,5,1,0,0,0,0,0,3.723
+Fall 2023,MSCI,2210,2,10897,Leadership & Decision Making,Thomas,Roland,2,1,0,0,0,0,0,3.557
+Fall 2023,MSCI,3310,1,10899,Training Management & WFF,Comiskey,Melissa C,19,0,1,0,0,0,0,3.9
+Fall 2023,MSCI,3310,2,10900,Training Management & WFF,Comiskey,Melissa C,2,0,0,0,0,0,0,4.0
+Fall 2023,MSCI,4310,1,10902,The Army Officer,Comiskey,Melissa C,7,0,0,0,0,0,0,4.0
+Fall 2023,MUED,4305,1,10904,General Music/Elem & Sec Schls,Derges,Julie D,10,4,0,0,0,0,0,3.667
+Fall 2023,MUSA,1300,1,10905,Applied Voice,Averyt,Zachary Benjamin,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1300,2,10906,Applied Voice,Clayton Vasquez,Cynthia L,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1310,2,10907,Applied Piano,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1320,2,10908,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1324,1,10909,Applied Violoncello,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1326,1,10910,Applied Double Bass,Larson,Eric Amery,5,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1330,1,10911,Applied Flute,Russell,Peggy,3,2,0,0,0,0,0,3.6
+Fall 2023,MUSA,1330,2,10912,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1334,2,10914,Applied Clarinet,Rowell,Chester D,2,0,1,0,0,0,0,3.223
+Fall 2023,MUSA,1336,1,10915,Applied Bassoon,Wagner,Elise L,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1342,2,10916,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1344,1,10917,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1346,1,10918,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1348,1,10919,Applied Euphonium,Fenske,Kevin,2,0,1,0,0,0,0,3.333
+Fall 2023,MUSA,2300,1,10920,Applied Voice,Clayton Vasquez,Cynthia L,3,1,0,0,0,0,0,3.75
+Fall 2023,MUSA,2300,2,10921,Applied Voice,Ceres,Emily Margaret,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2300,3,10922,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2300,4,10923,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2320,1,10924,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2326,1,10926,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2330,1,10927,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2330,2,10928,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,2334,1,10929,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,1,4.0
+Fall 2023,MUSA,2336,1,10930,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2342,2,10931,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2344,1,10932,Applied Trombone,Kauk,Brian Keith,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2346,1,10933,Applied Tuba,Barton,Mark,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2348,1,10934,Applied Euphonium,Fenske,Kevin,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3400,1,10936,Applied Voice,Averyt,Zachary Benjamin,3,0,0,0,0,0,0,3.89
+Fall 2023,MUSA,3400,2,10937,Applied Voice,Clayton Vasquez,Cynthia L,2,1,0,0,0,0,0,3.777
+Fall 2023,MUSA,3400,5,10938,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,1,4.0
+Fall 2023,MUSA,3400,6,10939,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,3.835
+Fall 2023,MUSA,3434,2,10941,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3436,1,10942,Applied Bassoon,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3442,2,10943,Applied French Horn,Reed,Gavin Davis,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3448,1,10944,Applied Euphonium,Fenske,Kevin,2,0,0,0,0,0,0,3.835
+Fall 2023,MUSA,4400,2,10945,Applied Voice,Clayton Vasquez,Cynthia L,4,0,0,0,0,0,0,3.918
+Fall 2023,MUSA,4402,1,10946,Applied Composition,Maroney,Marcus K,0,1,0,0,0,0,0,3.33
+Fall 2023,MUSA,4410,2,10947,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4420,1,10948,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,4430,2,10949,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4434,2,10950,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4436,1,10952,Applied Bassoon,Wagner,Elise L,4,0,0,0,0,0,0,3.918
+Fall 2023,MUSA,4442,2,10954,Applied French Horn,Reed,Gavin Davis,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4444,1,10955,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4446,1,10956,Applied Tuba,Barton,Mark,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4448,1,10957,Applied Euphonium,Fenske,Kevin,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8241,1,10960,Doctoral Recital II,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,1100,1,10961,Marching Band,Kubos,Cameron Kade,180,0,0,0,2,0,3,3.956
+Fall 2023,MUSI,1102,1,10962,Wind Ensemble,Bertman,David Garry,53,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,1102,2,10963,Wind Ensemble,Bertman,David Garry,76,0,0,0,0,0,1,4.0
+Fall 2023,MUSI,1110,1,10964,Jazz Orchestra,Marmolejo,Noe J,22,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,1120,1,10968,University Chorus,Basili,Franco,4,0,1,0,0,0,0,3.534
+Fall 2023,MUSI,1121,1,10969,Concert Chorus,Koppel,Alexander,28,3,1,0,1,0,1,3.707
+Fall 2023,MUSI,1140,1,10970,Orchestra,Krager,Franz A,64,0,0,0,0,0,0,3.99
+Fall 2023,MUSI,1181,2,10972,Group Piano I,Van Kekerix,Todd Evan,12,1,0,0,0,0,0,3.822
+Fall 2023,MUSI,1116,1,10973,Aural Skills I,Snyder,John L,7,6,4,1,4,0,3,2.575
+Fall 2023,MUSI,1311,1,10974,Music Theory I,Snyder,John L,8,2,4,3,4,0,4,2.27
+Fall 2023,MUSI,1160,1,10975,Italian and English Diction,Suits,Brian J,9,9,0,3,0,0,0,3.08
+Fall 2023,MUSI,2181,1,10976,Group Piano III,Van Kekerix,Todd Evan,8,6,0,0,0,0,0,3.571
+Fall 2023,MUSI,2181,2,10977,Group Piano III,Van Kekerix,Todd Evan,5,2,0,0,1,0,0,3.044
+Fall 2023,MUSI,2116,1,10978,Aural Skills III,Lee,Ji Yeon,8,4,5,2,0,0,0,2.999
+Fall 2023,MUSI,2210,1,10979,Theory III,Lee,Ji Yeon,8,7,3,0,0,0,0,3.314
+Fall 2023,MUED,2320,1,10980,Computers for Musicians,Welch,Carl Chapman,9,3,2,1,0,0,1,3.289
+Fall 2023,MUED,2320,2,10981,Computers for Musicians,Welch,Carl Chapman,13,1,0,0,1,0,1,3.645
+Fall 2023,MUSI,2361,1,10982,Music and Culture,Vansteenburg,Jessica N,19,32,11,2,4,0,1,2.824
+Fall 2023,MUED,3100,1,10983,Woodwinds,Bell,Priscilla Garrett,12,3,1,0,0,0,0,3.626
+Fall 2023,MUED,3101,1,10984,Woodwinds,Bell,Priscilla Garrett,13,2,0,0,0,0,0,3.889
+Fall 2023,MUED,3104,1,10985,Strings,Hansen,Erin Melissa,8,8,2,1,0,0,0,3.158
+Fall 2023,MUSI,3215,1,10986,Introduction To Large Forms,Guez,Jonathan Charles,7,8,3,0,0,0,1,3.204
+Fall 2023,MUSI,3215,2,10987,Introduction To Large Forms,Garza,Paul Victor,13,4,1,0,0,0,0,3.612
+Fall 2023,MUSI,3215,3,10988,Introduction To Large Forms,Garza,Paul Victor,4,5,6,0,1,0,0,2.605
+Fall 2023,MUSI,1307,1,10989,Listening to Classical Music,Engle,Nicholas Paul,30,5,4,0,0,0,1,3.633
+Fall 2023,MUSI,1307,2,10990,Listening to Classical Music,Dirst,Matthew C,31,8,0,0,0,0,0,3.778
+Fall 2023,MUSI,3301,1,10991,Listening To World Music,Hubley,Robert L,27,8,3,0,0,0,1,3.606
+Fall 2023,MUSI,3363,1,10992,History of Music II,Bertagnolli,Paul A,9,15,21,7,5,0,3,2.205
+Fall 2023,MUSI,4102,1,10993,Acting for Opera,Belcher,Kathleen,13,3,0,0,0,0,0,3.771
+Fall 2023,MUSI,4120,1,10994,Percussion Ensemble,Wilkins,Blake M,11,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4220,1,10995,Choral Conducting I,Weber,Mary E,9,5,0,0,0,0,1,3.572
+Fall 2023,MUSI,4230,1,10996,Instrumental Conducting I,Bertman,David Garry,19,0,0,0,0,0,0,4.0
+Fall 2023,MUED,4344,1,10997,MS/JS/HS Inst Admin&Ens Tech,Meals,Cory Dewitt,20,4,0,0,0,0,0,3.792
+Fall 2023,MUSI,6104,1,10998,New Music Ensemble,Smith,Robert Thomas,10,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8300,1,10999,Doct Research Seminar,Pollack,Howard J,5,3,0,0,0,0,0,3.46
+Fall 2023,POLS,4390,1,11001,Government Internship,Cross,Renee Danielle,31,5,1,0,0,0,0,3.829
+Fall 2023,PSYC,2305,1,11002,Intro to Methods in Psychology,Foss,Donald J,12,5,9,3,8,0,7,2.244
+Fall 2023,PSYC,4344,1,11004,Cultural Psychology,Kilani,Mohamed Hechmi,19,15,2,1,0,0,3,3.379
+Fall 2023,PSYC,3310,2,11005,Indstrl-Orgnztnl Psy,Ng,Vincent,27,6,1,2,1,0,2,3.54
+Fall 2023,PSYC,2316,1,11006,Psychology of Personality,Atherton,Olivia Emile,17,17,8,0,1,0,0,3.055
+Fall 2023,PSYC,2330,1,11007,Biological Psychology,Leasure,Jennifer Leigh,17,11,11,6,2,0,8,2.745
+Fall 2023,PSYC,6317,1,11008,Psychopathology I,Alfano,Candice A,6,6,0,0,0,0,0,3.39
+Fall 2023,SOCI,1301,3,11009,Introduction To Sociology,Nelson,Steven M,30,15,10,0,1,0,4,3.245
+Fall 2023,SOCI,1301,1,11010,Introduction To Sociology,Nelson,Steven M,27,19,10,3,1,0,2,3.1
+Fall 2023,SOCI,1301,5,11011,Introduction To Sociology,Dorsey,Patricia Lynne,14,26,9,3,7,0,0,2.61
+Fall 2023,SOC,3400,1,11012,Intro To Social Statistics,Hwang,Hyunseok,16,14,8,0,1,0,1,3.077
+Fall 2023,SOC,6300,1,11015,Sem-Sociological Theory,Lee,Shayne,14,0,0,0,0,0,0,4.0
+Fall 2023,SOC,6304,1,11016,Social Statistics,Anderson,Kathryn,8,4,0,0,0,0,1,3.639
+Fall 2023,SPAN,1501,1,11019,Elementary Spanish I,Pena Loyola,Jose Francisco,11,8,3,0,1,0,3,3.16
+Fall 2023,SPAN,1501,7,11021,Elementary Spanish I,Javierre Londono,Juliana,9,6,4,0,3,0,1,2.818
+Fall 2023,SPAN,1501,9,11023,Elementary Spanish I,Jouannet De La Jara,Sebastian Nicolas,8,9,7,2,1,0,0,2.717
+Fall 2023,SPAN,1501,11,11025,Elementary Spanish I,Falahasl,Hamideh,11,5,5,0,4,0,1,2.734
+Fall 2023,SPAN,1501,13,11027,Elementary Spanish I,Nieves Cabrera,Wendy,12,9,2,2,0,0,1,3.187
+Fall 2023,SPAN,1502,5,11029,Elementary Spanish II,del Castillo Garza,Alejandro,9,9,2,3,2,0,2,2.84
+Fall 2023,SPAN,1502,11,11031,Elementary Spanish II,Brave,Ivan,8,10,9,1,0,0,0,2.846
+Fall 2023,SPAN,1502,15,11033,Elementary Spanish II,Miranda Moreno,Sujaila Abigail,8,12,0,0,1,0,1,3.238
+Fall 2023,SPAN,2311,4,11037,Intermediate Spanish I,Torres,Cristina,12,13,2,0,1,0,0,3.238
+Fall 2023,SPAN,2311,7,11038,Intermediate Spanish I,Scalzo,Dillon S,10,11,5,0,0,0,2,3.218
+Fall 2023,SPAN,2312,1,11039,Intermediate Spanish II,Ruffino,Maythe,2,17,4,0,1,0,0,2.792
+Fall 2023,SPAN,2312,2,11040,Intermediate Spanish II,Morales Utria,Yordanis,8,18,1,0,0,0,1,3.259
+Fall 2023,SPAN,2307,1,11041,Span for Heritage Learners I,Fairclough,Marta A,8,10,2,0,0,0,0,3.366
+Fall 2023,SPAN,2308,2,11042,Span for Heritage Learners II,Martinez,Raquel,12,3,3,0,0,0,0,3.39
+Fall 2023,SPAN,3302,1,11044,Adv Span for Non-Heritage,Cuesta,Mabel,10,1,0,0,0,0,2,3.849
+Fall 2023,SPAN,3307,3,11046,Public Speaking in Spanish,Lopez Otero,Julio Cesar,15,2,2,0,1,0,0,3.533
+Fall 2023,SPAN,3308,2,11047,Written Com-Hisp Herit Learner,Hasbun,Rodrigo,11,3,1,0,0,0,1,3.667
+Fall 2023,SPAN,3384,2,11049,Intro To Hispanic Literature,Gutierrez,Pedro Revuelta,7,3,0,1,0,0,0,3.395
+Fall 2023,SPAN,6398,8,11051,Special Problems,Gutierrez,Manuel J,1,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,6398,10,11053,Special Problems,Fairclough,Marta A,2,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,8399,1,11058,Dissertation,Gutierrez,Manuel J,1,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,8399,4,11061,Dissertation,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,1,0,4.0
+Fall 2023,SPAN,8399,6,11062,Dissertation,Solino,Maria Elena,0,0,0,0,0,1,0,
+Fall 2023,SPAN,8699,1,11063,Dissertation,Solino,Maria Elena,0,0,0,0,0,1,0,
+Fall 2023,THEA,1332,1,11067,Fundamentals of Theatre,Bush,Rachel R,20,12,5,0,0,0,1,3.254
+Fall 2023,DRAM,1330,1,11068,Scenic Technology,Ramos,Emili,16,5,1,0,0,0,0,3.607
+Fall 2023,THEA,2373,1,11070,Costume Technology,Niederer,Barbara,7,9,1,1,0,0,1,3.186
+Fall 2023,THEA,3335,1,11072,History of the Theatre I,Romero,Gregory John,21,2,0,0,0,0,0,3.913
+Fall 2023,THEA,6301,1,11073,Acting,Young,John M,0,8,0,0,0,0,0,3.083
+Fall 2023,VIET,2301,1,11074,Intermediate Vietnamese I,Dang,Thong Q,18,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,2350,3,11075,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,3,0,0,0,0,1,3.858
+Fall 2023,MUSI,8106,2,11076,Doctoral Large Ensemble,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,3361,1,11078,Advertising Copywriting,Tinnel,Jason Wayne,13,15,3,0,1,0,0,3.167
+Fall 2023,SPAN,3305,1,11080,Spanish Grammar Review,Gutierrez,Manuel J,6,6,2,2,1,0,0,2.746
+Fall 2023,VIET,1501,1,11081,Elementary Vietnamese I,Dang,Thong Q,23,2,1,0,0,0,2,3.833
+Fall 2023,PSYC,2305,3,11083,Intro to Methods in Psychology,Foss,Donald J,12,9,6,4,9,0,3,2.283
+Fall 2023,ENGL,1301,101,11085,First Year Writing I,Stewart-Steele,Heather Marie,10,3,9,2,4,0,2,2.394
+Fall 2023,ENGL,1301,103,11086,First Year Writing I,Krajniak,Matthew J,14,6,2,0,4,0,4,2.911
+Fall 2023,ENGL,1301,109,11103,First Year Writing I,Hiers,Maria,15,2,0,1,0,0,0,3.667
+Fall 2023,HON,4398,3,11121,Independent Study,Cremins,Robert Paul,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,2316,3,11130,Fundamentals of Painting,Bender,Hannah,9,8,1,0,1,0,0,3.315
+Fall 2023,MUSI,2181,4,11135,Group Piano III,Van Kekerix,Todd Evan,5,5,3,1,0,0,0,2.929
+Fall 2023,MUSI,3303,1,11136,Pop Music of Americas Sn 1840,Garza,Paul Victor,24,2,6,1,1,0,0,3.314
+Fall 2023,SOC,3351,1,11137,Soc Class&Mobilty in Am,Lorence,Jon P,11,16,10,1,2,0,1,2.817
+Fall 2023,GERM,1501,1,11138,Beginning German I,Bandmann,Tanya,4,2,0,1,0,0,0,3.286
+Fall 2023,GERM,1501,3,11140,Beginning German I,Bandmann,Tanya,7,4,2,0,0,0,0,3.308
+Fall 2023,FREN,1502,3,11144,Elementary French II,Chalhoub,Rania Maria,3,6,5,2,1,0,0,2.529
+Fall 2023,CHIN,1501,5,11146,Elementary Chinese I,McArthur,Charles M,13,2,0,0,0,0,2,3.867
+Fall 2023,AFSC,4301,3,11151,National Security Affairs I,Curiel,Ernesto F,2,1,0,0,0,0,0,3.557
+Fall 2023,POLS,6380,1,11153,Quantitative Methods I,Basinger,Scott J,5,4,0,0,0,0,0,3.629
+Fall 2023,CHIN,3360,1,11154,A Look Into Modern China,McArthur,Charles M,9,14,1,0,0,0,2,3.361
+Fall 2023,WGSS,2350,4,11155,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,28,3,0,0,0,0,0,3.861
+Fall 2023,ENGL,6300,1,11157,College Tchg-Lang & Lit in Eng,Shepley,Nathan,14,2,0,0,0,0,0,3.896
+Fall 2023,THEA,7303,1,11158,Graduate Acting III,Young,John M,1,6,0,0,0,0,0,3.331
+Fall 2023,THEA,7313,1,11159,Graduate Movement III,Noble,Adam S,7,0,0,0,0,0,0,3.953
+Fall 2023,ENGL,1302,42,11160,First Year Writing II,Sicinski,Michael J,13,10,0,0,0,0,0,3.537
+Fall 2023,ENGL,1302,43,11161,First Year Writing II,Ornell,Colby,11,2,2,1,5,0,2,2.572
+Fall 2023,ENGL,1302,44,11162,First Year Writing II,Coleman,Quintin,15,2,0,1,0,0,1,3.649
+Fall 2023,ENGL,1301,111,11164,First Year Writing I,Rizzo,Kaitlin M,14,6,0,3,1,0,1,3.112
+Fall 2023,DANC,3310,1,11165,Dance History I,Estrada,Maria Gabriela,24,14,0,0,0,0,6,3.632
+Fall 2023,THEA,7323,1,11166,Graduate Voice/Speech III,Wetzel,Molly Elizabeth,6,1,0,0,0,0,0,3.81
+Fall 2023,MUSI,2188,1,11168,Keybd Skills & Collab Technqs,Hester,Timothy E,6,0,0,0,0,0,0,4.0
+Fall 2023,WCL,2352,2,11169,World Cinema,Centeno,Daniel,8,20,2,0,0,0,0,3.167
+Fall 2023,COMD,7391,10,11171,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,3,0,0,0,0,0,0,3.78
+Fall 2023,SOC,6399,3,11183,Masters Thesis,Lee,Shayne,0,0,0,0,0,2,0,
+Fall 2023,ENGL,1302,46,11184,First Year Writing II,Coleman,Quintin,12,5,1,0,0,0,1,3.501
+Fall 2023,SOCI,1301,11,11186,Introduction To Sociology,Davis,Mary A,46,7,1,0,4,0,2,3.518
+Fall 2023,ENGL,1301,120,11187,First Year Writing I,Khalil,Rand Omar,12,4,0,0,1,0,1,3.568
+Fall 2023,ENGL,1301,121,11188,First Year Writing I,Cervantes,Kimberly Ann,14,4,0,0,0,0,0,3.741
+Fall 2023,SGNL,1301,3,11189,Elementary Sign Language I,Brittain,Robyn Michelle,1,4,5,4,0,0,7,2.025
+Fall 2023,ENGL,1301,122,11190,First Year Writing I,Hiers,Maria,13,4,0,0,2,0,0,3.351
+Fall 2023,ENGL,1301,123,11191,First Year Writing I,Niaz,Zarlasht,8,9,1,0,1,0,0,3.245
+Fall 2023,MUSI,4120,2,11192,Percussion Ensemble,Warren,Paul Alexander,14,0,0,0,0,0,1,4.0
+Fall 2023,ENGL,1301,124,11193,First Year Writing I,Stratford,Marigold,10,3,1,1,6,0,4,2.445
+Fall 2023,ENGL,1301,125,11194,First Year Writing I,Dykes,Justin,6,11,5,0,2,0,0,2.778
+Fall 2023,BCHS,3304,1,11201,General Biochemistry I,Amaral Antunes,Dinler,45,27,21,1,1,0,2,3.311
+Fall 2023,BCHS,3304,2,11202,General Biochemistry I,Scott,Sean-Patrick,56,54,43,12,6,0,18,2.817
+Fall 2023,BCHS,3305,1,11203,General Biochemistry II,Yi,Ping,24,15,5,0,0,0,0,3.424
+Fall 2023,BCHS,4306,1,11204,Nucleic Acids,Gunaratne,Preethi H,31,17,6,2,0,0,0,3.351
+Fall 2023,BCHS,4313,1,11205,Cell Biochemistry,Rea,Michael A,9,4,3,1,0,0,2,3.255
+Fall 2023,BCHS,6113,1,11206,Graduate Biochemistry Seminar,Yeo,Hye-Jeong,0,0,0,0,0,23,0,
+Fall 2023,BCHS,6298,1,11207,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,2,0,
+Fall 2023,BCHS,6398,1,11208,Special Problems,Widger,William R,0,0,0,0,0,5,0,
+Fall 2023,BCHS,8698,1,11215,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2023,BIOL,2101,1,11218,Anatomy & Physiology Lab I,Gill,Tejendra,6,10,5,2,0,0,1,2.783
+Fall 2023,BIOL,2101,2,11219,Anatomy & Physiology Lab I,Gill,Tejendra,4,15,2,1,2,0,0,2.723
+Fall 2023,BIOL,2101,3,11220,Anatomy & Physiology Lab I,Gill,Tejendra,6,14,4,0,0,0,0,3.028
+Fall 2023,BIOL,2101,4,11221,Anatomy & Physiology Lab I,Gill,Tejendra,5,12,2,0,0,0,4,3.106
+Fall 2023,BIOL,2101,5,11222,Anatomy & Physiology Lab I,Gill,Tejendra,4,12,3,2,0,0,3,2.779
+Fall 2023,BIOL,2101,6,11223,Anatomy & Physiology Lab I,Gill,Tejendra,4,16,3,0,0,0,1,3.043
+Fall 2023,BIOL,2101,7,11224,Anatomy & Physiology Lab I,Gill,Tejendra,4,14,3,2,1,0,0,2.723
+Fall 2023,BIOL,2101,8,11225,Anatomy & Physiology Lab I,Gill,Tejendra,0,18,4,0,1,0,1,2.753
+Fall 2023,BIOL,2101,9,11226,Anatomy & Physiology Lab I,Gill,Tejendra,6,14,3,0,0,0,0,3.13
+Fall 2023,BIOL,2120,1,11227,Microbiology for Non-Science,Knapp,Richard D,10,8,4,0,0,0,0,3.228
+Fall 2023,BIOL,2120,2,11228,Microbiology for Non-Science,Knapp,Richard D,11,6,4,0,0,0,3,3.412
+Fall 2023,BIOL,1106,1,11229,Biol for Science Majors I(Lab),Medrano,Ana I,10,8,5,0,0,0,1,3.246
+Fall 2023,BIOL,1106,2,11230,Biol for Science Majors I(Lab),Medrano,Ana I,14,6,3,0,1,0,0,3.347
+Fall 2023,BIOL,1106,3,11231,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,1,0,0,0,1,3.681
+Fall 2023,BIOL,1106,4,11232,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,2,0,0,0,0,3.653
+Fall 2023,BIOL,1106,6,11233,Biol for Science Majors I(Lab),Medrano,Ana I,23,1,0,0,0,0,0,3.917
+Fall 2023,BIOL,1106,7,11234,Biol for Science Majors I(Lab),Medrano,Ana I,5,15,0,1,1,0,1,3.06
+Fall 2023,BIOL,1106,8,11235,Biol for Science Majors I(Lab),Medrano,Ana I,14,8,1,0,0,0,1,3.465
+Fall 2023,BIOL,1106,9,11236,Biol for Science Majors I(Lab),Medrano,Ana I,16,5,1,0,1,0,0,3.55
+Fall 2023,BIOL,1106,10,11237,Biol for Science Majors I(Lab),Medrano,Ana I,13,4,4,1,1,0,1,3.203
+Fall 2023,BIOL,1106,11,11238,Biol for Science Majors I(Lab),Medrano,Ana I,17,4,1,0,1,0,1,3.594
+Fall 2023,BIOL,1106,12,11239,Biol for Science Majors I(Lab),Medrano,Ana I,20,1,2,0,0,0,0,3.797
+Fall 2023,BIOL,1106,13,11240,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,0,0,0,0,1,3.758
+Fall 2023,BIOL,1106,14,11241,Biol for Science Majors I(Lab),Medrano,Ana I,23,0,1,0,0,0,0,3.917
+Fall 2023,BIOL,1106,15,11242,Biol for Science Majors I(Lab),Medrano,Ana I,19,4,0,1,0,0,0,3.695
+Fall 2023,BIOL,1106,16,11243,Biol for Science Majors I(Lab),Medrano,Ana I,19,5,0,0,0,0,0,3.805
+Fall 2023,BIOL,1106,17,11244,Biol for Science Majors I(Lab),Medrano,Ana I,16,6,1,0,0,0,1,3.609
+Fall 2023,BIOL,1106,18,11245,Biol for Science Majors I(Lab),Medrano,Ana I,20,2,2,0,0,0,0,3.709
+Fall 2023,BIOL,1106,19,11246,Biol for Science Majors I(Lab),Medrano,Ana I,17,3,2,2,0,0,0,3.431
+Fall 2023,BIOL,1106,20,11247,Biol for Science Majors I(Lab),Medrano,Ana I,11,8,4,0,1,0,0,3.18
+Fall 2023,BIOL,1106,21,11248,Biol for Science Majors I(Lab),Medrano,Ana I,22,1,0,0,0,0,1,3.942
+Fall 2023,BIOL,1106,22,11249,Biol for Science Majors I(Lab),Medrano,Ana I,13,6,3,1,1,0,0,3.153
+Fall 2023,BIOL,1308,1,11250,Biology for Non-Science Majors,Ibrahim,Abdalla Zanouny,63,71,31,11,7,0,4,2.891
+Fall 2023,BIOL,2301,1,11251,Anatomy & Physiology I (lect),Wayne,Chad M,40,99,126,38,25,0,68,2.252
+Fall 2023,BIOL,2320,1,11252,Microbiology for Non-Science,Knapp,Richard D,89,78,78,32,19,0,47,2.628
+Fall 2023,BIOL,1306,1,11253,Biology for Science Majors I,Farmer,Lisa M,56,86,73,41,17,0,10,2.425
+Fall 2023,BIOL,1306,2,11254,Biology for Science Majors I,Cheek,Ann Oliver,65,78,61,35,25,0,18,2.531
+Fall 2023,BIOL,1306,3,11255,Biology for Science Majors I,Cheek,Ann Oliver,45,62,91,39,26,0,20,2.297
+Fall 2023,BIOL,1306,4,11256,Biology for Science Majors I,Gifford,Jenifer,68,78,81,37,13,0,4,2.526
+Fall 2023,BIOL,3306,1,11257,Evolutionary Biology,Azevedo,Ricardo,16,39,31,3,1,0,2,2.73
+Fall 2023,BIOL,3324,1,11258,Human Physiology,Wayne,Chad M,15,26,43,0,5,0,12,2.498
+Fall 2023,BIOL,3341,1,11259,Human Genetics,Feng,Qin,71,22,4,0,0,0,2,3.667
+Fall 2023,BIOL,4320,1,11261,Molecular Biology,Chung,Sanghyuk,6,11,8,0,0,0,2,2.933
+Fall 2023,BIOL,6110,1,11262,Biology Seminar,Sater,Amy,0,0,0,0,0,28,0,
+Fall 2023,BIOL,7167,1,11267,Population Biology Seminar,Pennings,Steven C,0,0,0,0,0,7,0,
+Fall 2023,BIOL,8498,1,11271,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,
+Fall 2023,CHEM,1105,1,11273,Foundations of Chem Lab,Zaitsev,Vladimir G,6,9,1,0,0,0,1,3.313
+Fall 2023,CHEM,1105,2,11274,Foundations of Chem Lab,Zaitsev,Vladimir G,9,6,2,0,0,0,2,3.295
+Fall 2023,CHEM,1111,1,11275,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,2,0,0,0,2,2.981
+Fall 2023,CHEM,1111,2,11276,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,14,2,0,0,0,0,3.084
+Fall 2023,CHEM,1111,5,11277,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,10,2,0,0,0,2,3.155
+Fall 2023,CHEM,1111,4,11278,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,10,2,1,0,0,0,2.933
+Fall 2023,CHEM,1111,9,11279,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,1,0,0,0,0,3.211
+Fall 2023,CHEM,1111,12,11280,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,15,0,0,0,0,1,3.176
+Fall 2023,CHEM,1111,7,11281,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,7,2,2,0,0,1,2.903
+Fall 2023,CHEM,1111,10,11282,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,18,0,0,0,0,0,3.166
+Fall 2023,CHEM,1111,11,11283,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,6,3,1,0,0,0,3.167
+Fall 2023,CHEM,1111,13,11284,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,9,4,2,2,0,1,2.351
+Fall 2023,CHEM,1111,14,11285,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,3,0,0,0,0,3.092
+Fall 2023,CHEM,1111,15,11286,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,8,3,0,0,0,1,3.142
+Fall 2023,CHEM,1111,16,11287,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,3,0,0,0,6,3.0
+Fall 2023,CHEM,1111,17,11288,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,11,1,0,0,0,0,3.212
+Fall 2023,CHEM,1111,19,11289,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,0,1,0,0,0,3.059
+Fall 2023,CHEM,1111,20,11290,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,10,3,0,0,0,2,3.043
+Fall 2023,CHEM,1111,22,11291,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,4,1,2,2,0,0,2.548
+Fall 2023,CHEM,1111,23,11292,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,12,1,1,0,0,0,2.823
+Fall 2023,CHEM,1111,25,11293,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,6,0,0,0,0,2.824
+Fall 2023,CHEM,1111,26,11294,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,0,0,0,0,0,3.185
+Fall 2023,CHEM,1111,28,11295,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,2,2,0,0,1,2.944
+Fall 2023,CHEM,1111,29,11296,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,0,0,0,2,3.166
+Fall 2023,CHEM,1111,31,11297,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,1,2,0,0,0,3.0
+Fall 2023,CHEM,1111,32,11298,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,11,3,0,0,0,2,3.14
+Fall 2023,CHEM,1111,34,11299,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,3,1,0,0,0,2.964
+Fall 2023,CHEM,1111,35,11300,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,1,0,0,0,1,3.063
+Fall 2023,CHEM,1111,37,11301,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,1,1,0,0,0,3.185
+Fall 2023,CHEM,1111,40,11302,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,6,4,0,1,0,0,2.945
+Fall 2023,CHEM,1111,41,11303,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,11,1,0,0,0,1,3.264
+Fall 2023,CHEM,1111,43,11304,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,3,1,0,0,1,3.0
+Fall 2023,CHEM,1111,44,11305,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,8,2,1,0,0,1,3.211
+Fall 2023,CHEM,1111,46,11306,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,1,1,0,0,0,3.138
+Fall 2023,CHEM,1112,1,11307,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,5,0,0,0,1,3.082
+Fall 2023,CHEM,1112,2,11308,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,9,1,1,0,0,1,3.228
+Fall 2023,CHEM,1112,3,11309,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,4,0,0,0,0,2.999
+Fall 2023,CHEM,1112,5,11310,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,10,2,0,0,0,1,3.251
+Fall 2023,CHEM,1112,6,11311,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,5,0,0,0,0,3.018
+Fall 2023,CHEM,1112,7,11312,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,0,2,0,0,1,2.999
+Fall 2023,CHEM,1112,8,11313,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,0,0,1,0,1,3.105
+Fall 2023,CHEM,1112,9,11314,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,12,2,0,1,0,0,2.874
+Fall 2023,CHEM,1112,10,11315,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,1,0,0,0,3,3.2
+Fall 2023,CHEM,1112,12,11316,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,1,0,0,0,1,3.236
+Fall 2023,CHEM,1112,13,11317,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,3,1,0,3,0,4,2.667
+Fall 2023,CHEM,1305,1,11318,Foundations of Chemistry,Czernuszewicz,Roman S,34,69,89,19,48,0,46,2.068
+Fall 2023,CHEM,1311,1,11319,Fundamentals of Chemistry,Larsen,Russell Gene,121,146,139,33,33,0,69,2.603
+Fall 2023,CHEM,1311,2,11320,Fundamentals of Chemistry,Carrasquillo M,Edwin,27,32,50,12,13,0,16,2.299
+Fall 2023,CHEM,1312,1,11321,Fundamentals of Chemistry 2,Larsen,Russell Gene,56,81,96,25,35,0,62,2.302
+Fall 2023,CHEM,3133,1,11322,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,3,8,3,0,0,0,0,2.976
+Fall 2023,CHEM,3133,2,11323,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,4,6,1,0,0,0,1,3.213
+Fall 2023,CHEM,3119,1,11324,Anlytical Chemistry Lab,Czader,Arkadiusz,5,6,1,0,0,0,0,3.251
+Fall 2023,CHEM,3119,2,11325,Anlytical Chemistry Lab,Czader,Arkadiusz,7,7,0,0,0,0,1,3.453
+Fall 2023,CHEM,2123,1,11326,Organic Chemistry Lab I,Bean,Mary B,4,7,8,3,0,0,0,2.56
+Fall 2023,CHEM,2123,2,11327,Organic Chemistry Lab I,Bean,Mary B,4,10,8,2,0,0,0,2.653
+Fall 2023,CHEM,2123,3,11328,Organic Chemistry Lab I,Bean,Mary B,3,9,6,1,1,0,3,2.501
+Fall 2023,CHEM,2123,4,11329,Organic Chemistry Lab I,Bean,Mary B,1,14,6,1,0,0,2,2.697
+Fall 2023,CHEM,2123,5,11330,Organic Chemistry Lab I,Bean,Mary B,4,8,8,3,0,0,0,2.608
+Fall 2023,CHEM,2123,6,11331,Organic Chemistry Lab I,Bean,Mary B,4,8,11,0,0,0,1,2.724
+Fall 2023,CHEM,2123,7,11332,Organic Chemistry Lab I,Bean,Mary B,3,6,12,1,0,0,1,2.575
+Fall 2023,CHEM,2123,8,11333,Organic Chemistry Lab I,Bean,Mary B,1,11,7,1,0,0,1,2.633
+Fall 2023,CHEM,2123,9,11334,Organic Chemistry Lab I,Bean,Mary B,2,16,4,0,0,0,1,2.849
+Fall 2023,CHEM,2123,10,11335,Organic Chemistry Lab I,Bean,Mary B,2,18,4,0,0,0,0,2.848
+Fall 2023,CHEM,2123,11,11336,Organic Chemistry Lab I,Bean,Mary B,3,8,10,0,0,0,2,2.682
+Fall 2023,CHEM,2123,12,11337,Organic Chemistry Lab I,Bean,Mary B,4,9,8,2,0,0,1,2.623
+Fall 2023,CHEM,2123,17,11338,Organic Chemistry Lab I,Bean,Mary B,3,7,5,3,0,0,3,2.519
+Fall 2023,CHEM,2123,14,11339,Organic Chemistry Lab I,Bean,Mary B,3,9,7,2,0,0,2,2.603
+Fall 2023,CHEM,2123,15,11340,Organic Chemistry Lab I,Bean,Mary B,2,6,9,0,0,0,3,2.569
+Fall 2023,CHEM,2123,16,11341,Organic Chemistry Lab I,Bean,Mary B,5,8,5,2,2,0,2,2.53
+Fall 2023,CHEM,2123,21,11342,Organic Chemistry Lab I,Bean,Mary B,2,13,5,1,0,0,2,2.73
+Fall 2023,CHEM,2123,18,11343,Organic Chemistry Lab I,Bean,Mary B,3,10,8,1,1,0,1,2.551
+Fall 2023,CHEM,2123,19,11344,Organic Chemistry Lab I,Bean,Mary B,3,10,6,1,0,0,4,2.734
+Fall 2023,CHEM,2123,20,11345,Organic Chemistry Lab I,Bean,Mary B,6,14,3,0,1,0,0,3.028
+Fall 2023,CHEM,2123,25,11346,Organic Chemistry Lab I,Bean,Mary B,3,8,5,2,1,0,4,2.474
+Fall 2023,CHEM,2123,22,11347,Organic Chemistry Lab I,Bean,Mary B,1,9,6,0,1,0,5,2.51
+Fall 2023,CHEM,2123,24,11349,Organic Chemistry Lab I,Bean,Mary B,3,8,6,3,0,0,3,2.583
+Fall 2023,CHEM,2125,2,11350,Organic Chemistry Lab II,Bean,Mary B,4,10,5,1,0,0,3,2.85
+Fall 2023,CHEM,2125,3,11351,Organic Chemistry Lab II,Bean,Mary B,4,11,6,1,0,0,2,2.743
+Fall 2023,CHEM,2125,4,11352,Organic Chemistry Lab II,Bean,Mary B,4,7,7,1,0,0,1,2.772
+Fall 2023,CHEM,2125,7,11353,Organic Chemistry Lab II,Bean,Mary B,2,12,1,2,0,0,2,2.765
+Fall 2023,CHEM,2125,6,11354,Organic Chemistry Lab II,Bean,Mary B,4,9,6,1,0,0,3,2.8
+Fall 2023,CHEM,2323,1,11355,Organic Chemistry I,Bean,Mary B,61,73,77,33,29,0,34,2.379
+Fall 2023,CHEM,2323,3,11356,Organic Chemistry I,Miljanic,Ognjen S,10,31,28,29,22,0,22,1.797
+Fall 2023,CHEM,2323,4,11357,Organic Chemistry I,Do,Loi H,11,9,9,3,0,0,2,2.875
+Fall 2023,CHEM,2323,2,11358,Organic Chemistry I,Bean,Mary B,41,74,84,30,30,0,47,2.276
+Fall 2023,CHEM,2325,1,11359,Organic Chemistry II,Young,Crystal Ann,16,30,39,36,25,0,90,1.833
+Fall 2023,CHEM,3369,1,11360,Analytical Chemistry 1,Czader,Arkadiusz,4,10,17,4,0,0,5,2.419
+Fall 2023,CHEM,4229,1,11361,Instrmntl Mthd-Anly Lab,Czader,Arkadiusz,2,9,0,0,0,0,0,3.152
+Fall 2023,CHEM,4272,1,11362,Physical Chemistry Lab II,Czader,Arkadiusz,5,1,1,0,0,0,1,3.571
+Fall 2023,CHEM,4369,1,11363,Analytical Chemistry 2,Chiang,Naihao,5,8,1,0,0,0,0,3.144
+Fall 2023,CHEM,4372,1,11364,Physical Chemistry II,Xu,Shoujun,7,10,4,1,1,0,2,2.913
+Fall 2023,CHEM,4373,1,11365,Survey of Physical Chemistry,Lubchenko,Vassiliy,6,21,14,0,0,0,0,2.757
+Fall 2023,CHEM,6111,1,11366,Graduate Colloquium,Chiang,Naihao,0,0,0,0,0,24,0,
+Fall 2023,CHEM,6112,1,11367,Graduate Seminar,Gilbertson,Scott R,0,0,0,0,0,12,0,
+Fall 2023,CHEM,6112,2,11368,Graduate Seminar,Chiang,Naihao,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6112,3,11369,Graduate Seminar,Brgoch,Jakoah,0,0,0,0,0,10,0,
+Fall 2023,CHEM,6115,3,11370,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,6,0,
+Fall 2023,CHEM,6115,1,11371,Sem in Chm Lab Instruct,Zaitsev,Vladimir G,0,0,0,0,0,4,0,
+Fall 2023,CHEM,6198,5,11375,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6198,7,11377,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6198,8,11378,Special Problems,Carrow,Bradley,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6198,9,11379,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6313,1,11388,Thermodynamcs & Kinects,Chen,Tai-Yen,11,4,1,0,0,0,0,3.522
+Fall 2023,CHEM,6352,1,11390,Orgnc React & Synthesis,May,Jeremy A,2,14,10,0,0,0,1,2.705
+Fall 2023,CHEM,6374,1,11391,Physical Inorganic Chem I,Teets,Thomas,5,8,1,0,0,0,0,3.286
+Fall 2023,CHEM,6398,7,11392,Special Problems,Comito,Robert Joseph,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6398,9,11393,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6398,11,11394,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6399,16,11398,Masters Thesis,Guloy,Arnold M,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6698,4,11400,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6698,5,11401,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6698,7,11403,Special Problems,Gilbertson,Scott R,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6698,8,11404,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6698,10,11405,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,3,0,
+Fall 2023,CHEM,6698,19,11410,Special Problems,Teets,Thomas,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6998,1,11411,Special Problems,Lee,T Randall,0,0,0,0,0,5,0,
+Fall 2023,CHEM,6998,2,11412,Special Problems,Teets,Thomas,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6998,5,11414,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6998,7,11416,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6998,8,11417,Special Problems,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6998,9,11418,Special Problems,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6998,13,11421,Special Problems,Harth,Eva M,0,0,0,0,0,4,0,
+Fall 2023,CHEM,6998,15,11423,Special Problems,Chiang,Naihao,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6998,16,11424,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6998,18,11425,Special Problems,Carrow,Bradley,0,0,0,0,0,4,0,
+Fall 2023,CHEM,6998,19,11426,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2023,CHEM,8399,5,11432,Doctoral Dissertation,Guloy,Arnold M,0,0,0,0,0,1,0,
+Fall 2023,CHEM,8998,5,11459,Doctoral Research,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2023,CHEM,8998,7,11461,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2023,CHEM,8998,8,11462,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Fall 2023,CHEM,8998,10,11463,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Fall 2023,CHEM,8998,15,11467,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2023,CHEM,8998,19,11469,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Fall 2023,CHEM,8999,1,11470,Doctoral Dissertation,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,8999,6,11473,Doctoral Dissertation,Harth,Eva M,0,0,0,0,0,3,0,
+Fall 2023,CHEM,8999,13,11475,Doctoral Dissertation,Lee,T Randall,2,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,8999,15,11476,Doctoral Dissertation,Teets,Thomas,1,0,0,0,0,3,0,4.0
+Fall 2023,COSC,3340,1,11477,Intro. to Automata and Comp.,Singh,Raj Kumar,149,19,0,0,1,0,2,3.84
+Fall 2023,COSC,6110,1,11478,Graduate Colloquium,Leiss,Ernst L,0,0,0,0,0,2,0,
+Fall 2023,GEOL,1103,1,11479,Physical Geology Lab,Hauptvogel,Daniel William,17,4,0,0,3,0,0,3.292
+Fall 2023,GEOL,1103,2,11480,Physical Geology Lab,Hauptvogel,Daniel William,17,5,0,1,1,0,0,3.445
+Fall 2023,GEOL,1103,4,11481,Physical Geology Lab,Hauptvogel,Daniel William,18,2,2,0,0,0,1,3.697
+Fall 2023,GEOL,1103,5,11482,Physical Geology Lab,Hauptvogel,Daniel William,17,3,3,0,0,0,1,3.537
+Fall 2023,GEOL,1103,12,11483,Physical Geology Lab,Hauptvogel,Daniel William,21,0,0,0,0,0,2,4.0
+Fall 2023,GEOL,1340,1,11484,Earth Systems,Lytwyn,Jennifer N,16,31,11,2,3,0,3,2.873
+Fall 2023,MATH,1314,1,11485,College Algebra,Caglar,Atife,86,65,56,28,39,0,23,2.453
+Fall 2023,MATH,1314,2,11486,College Algebra,Caglar,Atife,109,55,56,24,37,0,15,2.603
+Fall 2023,MATH,1314,5,11487,College Algebra,West,James David,38,38,45,22,64,0,36,1.812
+Fall 2023,MATH,1332,2,11488,Contemporary Mathematics,Chern,Haley Nicole,45,49,27,11,14,0,4,2.604
+Fall 2023,MATH,2312,1,11489,Precalculus,May,Jennifer Ruhnow,212,102,100,34,48,0,68,2.739
+Fall 2023,MATH,2312,2,11490,Precalculus,Manavalan Varghese,Shyla,72,48,28,6,18,0,28,2.83
+Fall 2023,MATH,2312,3,11491,Precalculus,Perepelitsa,Irina,250,106,90,14,48,0,72,2.946
+Fall 2023,MATH,2312,5,11492,Precalculus,Almus,Melahat,234,114,100,22,34,0,72,2.92
+Fall 2023,MATH,2312,7,11493,Precalculus,Ansari,Haseeb E,60,36,22,6,20,0,16,2.768
+Fall 2023,MATH,2413,1,11494,Calculus I,Perepelitsa,Irina,218,84,64,44,44,0,24,2.847
+Fall 2023,MATH,2413,11,11498,Calculus I,Almus,Melahat,344,84,58,38,36,0,28,3.175
+Fall 2023,MATH,2413,21,11505,Calculus I,Perepelitsa,Irina,206,88,80,36,28,0,30,2.942
+Fall 2023,MATH,2413,31,11510,Calculus I,Sosa,Moses,170,90,64,32,58,0,42,2.648
+Fall 2023,MATH,2413,41,11513,Calculus I,May,Jennifer Ruhnow,136,62,64,50,82,0,62,2.31
+Fall 2023,MATH,2414,1,11515,Calculus II,May,Jennifer Ruhnow,91,68,45,34,30,0,38,2.564
+Fall 2023,MATH,2414,11,11518,Calculus II,Xhabli,Blerina,107,60,62,24,38,0,30,2.557
+Fall 2023,MATH,2414,21,11521,Calculus II,Xhabli,Blerina,72,54,34,13,34,0,38,2.525
+Fall 2023,MATH,1342,1,11523,Elementary Statistical Methods,Chern,Haley Nicole,76,60,74,30,54,0,40,2.18
+Fall 2023,MATH,1342,2,11524,Elementary Statistical Methods,Kim,Jae Youn,50,82,96,38,30,0,32,2.235
+Fall 2023,MATH,1342,4,11525,Elementary Statistical Methods,Caputo,Matthew G,186,170,116,50,42,0,30,2.666
+Fall 2023,MATH,1342,5,11526,Elementary Statistical Methods,Ryan,John M,80,110,108,50,62,0,64,2.234
+Fall 2023,MATH,2415,1,11527,Calculus III,West,James David,28,23,25,13,21,0,14,2.218
+Fall 2023,MATH,2415,11,11530,Calculus III,Pan,Tsorng-Whay,62,42,19,10,23,0,11,2.667
+Fall 2023,MATH,3303,1,11534,Elts Algebra & Numb Thy,George,Rebecca Ann,27,9,2,2,4,0,0,3.19
+Fall 2023,MATH,3321,2,11535,Engineering Mathematics,Etgen,Garret J,52,26,25,23,20,0,30,2.439
+Fall 2023,MATH,3321,3,11536,Engineering Mathematics,Ryan,John M,43,35,49,20,24,0,22,2.322
+Fall 2023,MATH,3331,1,11538,Intermediate Diff Equations,Sanders,Richard,4,8,7,3,8,0,2,1.9
+Fall 2023,MATH,3363,1,11540,Introduction To PDE,Caglar,Atife,11,21,13,9,5,0,5,2.323
+Fall 2023,MATH,3364,1,11541,Intro Complex Analysis,Wu,Yingying,15,10,0,0,1,0,6,3.5
+Fall 2023,MATH,4320,1,11542,Intro To Stochastic Processes,Timofeyev,Ilya,14,4,0,1,1,0,1,3.401
+Fall 2023,MATH,6302,1,11543,Modern Algebra,Kalantar,Mehrdad,6,2,2,0,0,0,0,3.4
+Fall 2023,MATH,6315,1,11544,Masters Tutorial,Jun,Mikyoung,3,0,0,0,0,0,0,4.0
+Fall 2023,MATH,6315,3,11546,Masters Tutorial,Etgen,Garret J,2,0,0,0,0,0,0,4.0
+Fall 2023,MATH,6320,1,11570,Func Real Variable,Climenhaga,Vaughn,8,6,2,0,0,0,0,3.313
+Fall 2023,MATH,6342,1,11571,Topology,Ott,William R,17,0,0,0,0,0,0,4.0
+Fall 2023,MATH,6366,1,11572,Optimization Theory,Mang,Andreas,22,2,1,0,0,0,0,3.708
+Fall 2023,MATH,6370,1,11573,Numerical Analysis,Cappanera,Loic,23,7,0,0,0,0,0,3.723
+Fall 2023,MATH,6398,2,11575,Special Problems,Ott,William R,0,0,0,0,0,1,0,
+Fall 2023,MATH,6398,9,11581,Special Problems,Ru,Min,0,0,0,0,0,2,0,
+Fall 2023,MATH,6398,10,11582,Special Problems,Climenhaga,Vaughn,0,0,0,0,0,2,0,
+Fall 2023,MATH,6398,11,11583,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Fall 2023,MATH,6398,12,11584,Special Problems,Papadakis,Emanuel Ioannis,0,0,0,0,0,1,0,
+Fall 2023,MATH,6398,13,11585,Special Problems,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Fall 2023,MATH,6398,14,11586,Special Problems,Nicol,Matthew J,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,3,11612,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,5,11614,Doctoral Research,Blecher,David P,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,8,11616,Doctoral Research,Haynes,Alan K,0,0,0,0,0,0,0,
+Fall 2023,MATH,8398,11,11619,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,12,11620,Doctoral Research,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,13,11621,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,15,11623,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Fall 2023,MATH,8398,16,11624,Doctoral Research,Ru,Min,0,0,0,0,0,2,0,
+Fall 2023,MATH,8398,17,11625,Doctoral Research,Cappanera,Loic,0,0,0,0,0,2,0,
+Fall 2023,MATH,8398,20,11628,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,2,0,
+Fall 2023,MATH,8398,22,11630,Doctoral Research,Labate,Demetrio,0,0,0,0,0,1,0,
+Fall 2023,MATH,8399,11,11632,Doctoral Dissertation,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Fall 2023,MATH,8699,2,11635,Doctoral Dissertation,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,1,0,
+Fall 2023,PHYS,1301,1,11637,College Physics I (lecture),Portillo Vazquez,Israel,15,10,17,9,2,0,13,2.509
+Fall 2023,PHYS,1302,1,11638,College Physics II (lecture),Maric,Sladjana,12,30,22,2,3,0,7,2.648
+Fall 2023,PHYS,1304,1,11639,Solar System,Li,Liming,91,52,12,1,0,0,4,3.434
+Fall 2023,PHYS,1303,1,11640,Stars and Galaxies,Pinsky,Lawrence S,23,27,2,2,6,0,9,2.983
+Fall 2023,PHYS,2326,3,11642,University Physics II(lecture),Curran,Seamus A,39,52,34,26,6,0,13,2.657
+Fall 2023,PHYS,8298,2,11652,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,1,11654,Doctoral Research,Cardoso Barato,Andre,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,3,11656,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,4,11657,Doctoral Research,Bering,Edgar A,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,5,11658,Doctoral Research,Chen,Shuo,0,0,0,0,0,3,0,
+Fall 2023,PHYS,8398,11,11664,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,23,11674,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8398,28,11678,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8398,30,11679,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,36,11682,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8399,8,11690,Doctoral Dissertation,Chu,Ching Wu,1,0,0,0,0,0,0,3.67
+Fall 2023,PHYS,8399,14,11695,Doctoral Dissertation,Stokes,Donna,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8399,26,11704,Doctoral Dissertation,Morrison,Gregory C,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,2306,1,11718,Intro To Poetry,Pan,Weijia,25,0,0,0,0,0,0,3.974
+Fall 2023,HIST,1301,2,11721,The U.S. to 1877,Hopkins,Kelly Y,126,91,43,15,8,0,15,3.078
+Fall 2023,PHYS,8699,35,11744,Doctoral Dissertation,Ren,Zhifeng,1,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,1102,1,11748,College Physics II (lab),Wood,Lowell T,5,7,8,1,0,0,3,2.825
+Fall 2023,PHYS,1101,1,11749,College Physics I (lab),Wood,Lowell T,1,11,11,0,0,0,0,2.666
+Fall 2023,PHYS,1101,2,11750,College Physics I (lab),Wood,Lowell T,1,9,6,0,0,0,0,2.646
+Fall 2023,PHYS,1101,3,11751,College Physics I (lab),Wood,Lowell T,1,16,4,0,0,0,1,2.81
+Fall 2023,PHYS,1101,4,11752,College Physics I (lab),Wood,Lowell T,1,9,5,0,0,0,1,2.799
+Fall 2023,PHYS,1101,5,11753,College Physics I (lab),Wood,Lowell T,4,10,5,0,0,0,3,2.826
+Fall 2023,PHYS,1101,6,11754,College Physics I (lab),Wood,Lowell T,0,10,2,1,0,0,3,2.667
+Fall 2023,PHYS,1101,7,11755,College Physics I (lab),Wood,Lowell T,1,12,10,0,0,0,0,2.637
+Fall 2023,PHYS,1101,8,11756,College Physics I (lab),Wood,Lowell T,2,8,4,0,0,0,2,2.763
+Fall 2023,PHYS,1101,9,11757,College Physics I (lab),Wood,Lowell T,4,7,9,0,1,0,2,2.603
+Fall 2023,PHYS,1101,10,11758,College Physics I (lab),Wood,Lowell T,2,6,6,0,0,0,2,2.761
+Fall 2023,PHYS,1102,2,11759,College Physics II (lab),Wood,Lowell T,5,8,9,1,0,0,1,2.696
+Fall 2023,PHYS,1102,3,11760,College Physics II (lab),Wood,Lowell T,2,12,4,0,0,0,3,2.816
+Fall 2023,PHYS,1102,4,11761,College Physics II (lab),Wood,Lowell T,3,9,10,0,1,0,0,2.608
+Fall 2023,PHYS,1102,5,11762,College Physics II (lab),Wood,Lowell T,4,11,9,0,0,0,0,2.778
+Fall 2023,PHYS,1102,6,11763,College Physics II (lab),Wood,Lowell T,1,14,5,0,0,0,2,2.751
+Fall 2023,PHYS,1102,7,11764,College Physics II (lab),Wood,Lowell T,1,14,5,0,1,0,0,2.588
+Fall 2023,PHYS,1102,8,11765,College Physics II (lab),Wood,Lowell T,4,12,7,1,0,0,0,2.682
+Fall 2023,COSC,3380,1,11766,Database Systems,Ordonez,Carlos,9,30,24,5,4,0,7,2.463
+Fall 2023,COSC,4393,1,11767,Digital Image Processing,Mantini,Pranav,69,49,12,2,1,0,4,3.346
+Fall 2023,COSC,6309,1,11770,Intro Automata & Computability,Singh,Raj Kumar,14,0,0,0,0,0,0,3.976
+Fall 2023,CHEM,4272,2,11771,Physical Chemistry Lab II,Czader,Arkadiusz,4,3,4,0,0,0,0,3.03
+Fall 2023,MATH,3340,1,11772,Intro To Fixed Income Math,Timofeyev,Ilya,7,6,8,1,0,0,1,2.879
+Fall 2023,BIOL,3306,2,11773,Evolutionary Biology,Azevedo,Ricardo,16,40,29,1,0,0,5,2.829
+Fall 2023,COSC,6358,1,11776,Interactive Game Development,Yun,Changhoon,3,4,0,0,0,0,0,3.334
+Fall 2023,COSC,4358,1,11777,Intro to Interactive Game Dev.,Yun,Changhoon,79,40,1,0,0,0,1,3.543
+Fall 2023,COSC,6355,1,11778,Ubiquitous Computing,Pavlidis,Ioannis T,9,0,0,0,0,0,0,3.963
+Fall 2023,COSC,4355,1,11779,Intro to Ubiquitous Computing,Pavlidis,Ioannis T,16,14,3,0,4,0,2,3.018
+Fall 2023,COSC,6380,1,11780,Digital Image Processing,Mantini,Pranav,14,8,0,0,0,0,0,3.741
+Fall 2023,BIOL,2120,3,11781,Microbiology for Non-Science,Knapp,Richard D,11,12,1,0,0,0,0,3.403
+Fall 2023,BIOL,2120,4,11782,Microbiology for Non-Science,Knapp,Richard D,11,5,3,2,0,0,3,3.033
+Fall 2023,MATH,2415,21,11788,Calculus III,West,James David,24,27,25,14,19,0,24,2.211
+Fall 2023,OPTO,5111,1,11791,Optics Lab I,Marsack,Jason,9,15,1,0,0,0,0,3.32
+Fall 2023,OPTO,5111,2,11792,Optics Lab I,Marsack,Jason,15,10,0,0,0,0,0,3.6
+Fall 2023,OPTO,5111,3,11793,Optics Lab I,Marsack,Jason,10,11,3,0,0,0,1,3.292
+Fall 2023,OPTO,5111,4,11794,Optics Lab I,Marsack,Jason,18,5,0,0,0,0,0,3.783
+Fall 2023,OPTO,5133,3,11795,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,11,10,3,1,0,0,1,3.24
+Fall 2023,OPTO,5133,4,11796,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,9,13,2,1,0,0,0,3.2
+Fall 2023,OPTO,5134,1,11797,Neuroanatomy Laboratory,Cheng,Han,23,0,0,0,0,0,0,4.0
+Fall 2023,OPTO,5134,2,11798,Neuroanatomy Laboratory,Cheng,Han,24,1,0,0,0,0,0,3.96
+Fall 2023,OPTO,5134,3,11799,Neuroanatomy Laboratory,Cheng,Han,23,0,1,0,0,0,1,3.917
+Fall 2023,OPTO,5134,4,11800,Neuroanatomy Laboratory,Cheng,Han,22,3,0,0,0,0,0,3.88
+Fall 2023,OPTO,5171,1,11801,Clinic Practicum I,Dempsey,Robert L,5,18,3,0,0,0,0,3.077
+Fall 2023,OPTO,5171,2,11802,Clinic Practicum I,Dempsey,Robert L,12,12,1,0,0,0,0,3.44
+Fall 2023,OPTO,5171,3,11803,Clinic Practicum I,Dempsey,Robert L,6,15,3,0,1,0,1,3.0
+Fall 2023,OPTO,5171,4,11804,Clinic Practicum I,Berntsen,David A,7,16,0,0,0,0,0,3.304
+Fall 2023,OPTO,5233,1,11805,Adv Human Anatomy and Hist,Coulson-Thomas,Vivien J,60,29,9,1,0,0,1,3.495
+Fall 2023,OPTO,5271,1,11806,Optometry I,Dempsey,Robert L,55,37,5,0,0,0,1,3.478
+Fall 2023,OPTO,5314,1,11807,Optics I,Marsack,Jason,71,21,6,0,1,0,1,3.626
+Fall 2023,OPTO,5320,1,11808,Vision Science I,Yoon,Geunyoung,28,50,18,1,0,0,1,3.082
+Fall 2023,OPTO,5334,1,11809,Neuroanat and Physio,Cheng,Han,55,25,17,0,0,0,1,3.392
+Fall 2023,OPTO,5344,1,11810,Adv Physiol and Molecular Biol,Frishman,Laura J,33,36,24,4,0,0,1,3.034
+Fall 2023,OPTO,6132,1,11811,Med Laboratory Proced,Dempsey,Robert L,24,0,0,0,0,0,0,4.0
+Fall 2023,OPTO,6132,2,11812,Med Laboratory Proced,Dempsey,Robert L,21,3,0,0,0,0,0,3.875
+Fall 2023,OPTO,6132,3,11813,Med Laboratory Proced,Dempsey,Robert L,17,6,0,0,0,0,0,3.739
+Fall 2023,OPTO,6132,4,11814,Med Laboratory Proced,Dempsey,Robert L,19,3,1,0,0,0,0,3.783
+Fall 2023,OPTO,6163,1,11815,Primary Opt Lab,Chandler,Moriah Adine,23,1,0,0,0,0,0,3.958
+Fall 2023,OPTO,6163,2,11816,Primary Opt Lab,Chandler,Moriah Adine,23,1,0,0,0,0,0,3.958
+Fall 2023,OPTO,6163,3,11817,Primary Opt Lab,Chandler,Moriah Adine,13,8,0,0,0,0,0,3.619
+Fall 2023,OPTO,6163,4,11818,Primary Opt Lab,Chandler,Moriah Adine,20,3,1,0,0,0,0,3.792
+Fall 2023,OPTO,6173,1,11819,Clinic Practicum III,Giannoni,Amber Gaume,12,11,1,0,0,0,0,3.458
+Fall 2023,OPTO,6173,2,11820,Clinic Practicum III,Giannoni,Amber Gaume,19,4,1,0,0,0,0,3.75
+Fall 2023,OPTO,6173,3,11821,Clinic Practicum III,Giannoni,Amber Gaume,15,5,1,0,0,0,0,3.667
+Fall 2023,OPTO,6173,4,11822,Clinic Practicum III,Giannoni,Amber Gaume,18,4,2,0,0,0,0,3.667
+Fall 2023,OPTO,6190,1,11823,Ophthalmic Optics Laboratory,Tucker,Ashley,24,1,0,0,0,0,0,3.96
+Fall 2023,OPTO,6190,2,11824,Ophthalmic Optics Laboratory,Tucker,Ashley,21,3,0,0,0,0,0,3.875
+Fall 2023,OPTO,6190,3,11825,Ophthalmic Optics Laboratory,Tucker,Ashley,21,0,0,0,0,0,0,4.0
+Fall 2023,OPTO,6190,4,11826,Ophthalmic Optics Laboratory,Tucker,Ashley,22,2,0,0,0,0,0,3.917
+Fall 2023,OPTO,6219,1,11827,Vision Science III,Das,Vallabh E,54,30,9,0,0,0,0,3.484
+Fall 2023,OPTO,6231,1,11828,Corneal Disease,Bergmanson,Jan Pg,0,0,0,0,0,24,0,
+Fall 2023,OPTO,6234,1,11829,Ocular Pathology I,Dempsey,Robert L,24,48,21,0,0,0,0,3.025
+Fall 2023,OPTO,6251,1,11830,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,27,0,
+Fall 2023,OPTO,6311,1,11831,Optics III,Ritchey,Eric R,64,25,5,0,0,0,0,3.628
+Fall 2023,OPTO,6363,1,11832,Primary Optometry,Stevenson,Scott Bailli,55,33,5,0,0,0,0,3.538
+Fall 2023,OPTO,6434,1,11833,General Pharmacology,Rump,Rachel,30,40,24,0,2,0,0,2.969
+Fall 2023,OPTO,7152,1,11834,Pediatric Optometry II Lab,Martinez,Muriel L,15,8,0,0,0,0,0,3.652
+Fall 2023,OPTO,7152,2,11835,Pediatric Optometry II Lab,Martinez,Muriel L,15,10,0,0,0,0,0,3.6
+Fall 2023,OPTO,7152,3,11836,Pediatric Optometry II Lab,Martinez,Muriel L,19,4,0,0,0,0,0,3.826
+Fall 2023,OPTO,7152,4,11837,Pediatric Optometry II Lab,Martinez,Muriel L,18,7,2,0,0,0,0,3.593
+Fall 2023,OPTO,7252,1,11838,Pediatric Optometry II,Dempsey,Robert L,49,43,5,0,0,0,0,3.454
+Fall 2023,OPTO,7361,1,11839,Geriatric Optometry,Dempsey,Robert L,59,39,2,0,0,0,0,3.57
+Fall 2023,OPTO,7494,1,11840,General Clinic IIIb,Dempsey,Robert L,0,0,0,0,0,95,0,
+Fall 2023,OPTO,8990,1,11841,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,31,0,
+Fall 2023,OPTO,8991,1,11842,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,31,0,
+Fall 2023,OPTO,8992,1,11843,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,27,0,
+Fall 2023,OPTO,8993,1,11844,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,27,0,
+Fall 2023,PHOP,6160,1,11845,Gen Sem Visual Sciences,Sapoznik,Kaitlyn Anne,0,0,0,0,0,27,0,
+Fall 2023,PHOP,6198,3,11846,Spec Prob-Physio Optics,Nurminen,Lauri Oskari,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6241,1,11848,Vision Science Core-Part 1,Frishman,Laura J,4,3,0,0,0,0,0,3.619
+Fall 2023,PHOP,6242,1,11849,Vision Science Core-Part 2,Frishman,Laura J,3,4,0,0,0,0,0,3.476
+Fall 2023,OPTO,5198,2,11852,Spec Prob - Clerkship,Dempsey,Robert L,0,0,0,0,0,2,0,
+Fall 2023,PCEU,6441,1,11853,Advanced Pharmacokinetics,Chow,Diana Shu-Lian,2,0,0,0,0,0,0,4.0
+Fall 2023,PCEU,6498,1,11854,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6370,1,11856,Advanced Pharmacology,Boini,Krishna M,0,2,0,0,0,0,0,3.0
+Fall 2023,PCOL,7180,1,11857,Pharmacology Seminar,McConnell,Bradley K,0,0,0,0,0,18,0,
+Fall 2023,PHAR,4270,1,11859,Communication Aspects of Pharm,Gee,Jodie Sue,54,47,6,0,0,0,1,3.449
+Fall 2023,PHAR,4320,1,11860,Physiology I,Salim,Samina,44,40,17,7,2,0,1,3.064
+Fall 2023,PHAR,4330,1,11861,Pharmaceutics I & Calculations,Guo,Bin,49,32,25,2,0,0,1,3.185
+Fall 2023,PHAR,5332,1,11862,Pharmacokinetics,Chow,Diana Shu-Lian,37,51,21,1,0,0,0,3.127
+Fall 2023,PHAR,5642,1,11863,Emergency Medicine,Truong,Mabel,7,2,0,0,0,0,0,3.778
+Fall 2023,PHAR,5643,1,11864,Neurology,Truong,Mabel,0,1,0,0,0,0,0,3.0
+Fall 2023,PHAR,5662,1,11865,Academic Scholarship,Surati,Dhara Divyang,1,1,0,0,0,0,0,3.5
+Fall 2023,PHAR,5663,1,11866,Pharmacy Management,Truong,Mabel,7,1,0,0,0,0,0,3.875
+Fall 2023,PHAR,5664,1,11867,Legal & Regulatory Affairs,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5670,1,11868,Community Pharmaceutical Care,Tolleson,Shane Russell,13,3,0,0,0,0,0,3.813
+Fall 2023,PHAR,5673,1,11869,Veterinary Pharmaceutical Care,Tolleson,Shane Russell,0,1,0,0,0,0,0,3.0
+Fall 2023,PHAR,5675,1,11870,Disease State Management,Tolleson,Shane Russell,22,5,0,0,0,0,0,3.815
+Fall 2023,PHAR,5678,1,11871,Transplant Therapeutics,Truong,Mabel,4,4,0,0,0,0,0,3.5
+Fall 2023,PHAR,5680,1,11873,Oncology,Truong,Mabel,5,1,1,0,0,0,0,3.571
+Fall 2023,PHAR,5685,1,11875,Critical Care,Truong,Mabel,13,4,2,0,0,0,0,3.579
+Fall 2023,PHAR,5686,1,11876,Psychiatry,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5690,1,11878,Internal Medicine,Sherer,Jeffrey T,1,1,0,0,0,0,0,3.5
+Fall 2023,PHAR,5690,2,11879,Internal Medicine,Truong,Mabel,28,13,0,0,1,0,0,3.595
+Fall 2023,PHAR,5691,1,11880,Drug Information,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5692,1,11881,Advanced Hospital Pharmacy,Truong,Mabel,43,5,0,0,0,0,0,3.896
+Fall 2023,PHAR,5693,1,11882,Advanced Community Pharmacy,Tolleson,Shane Russell,23,6,1,0,0,0,0,3.733
+Fall 2023,PHAR,5694,1,11883,Pediatrics,Truong,Mabel,6,3,0,0,0,0,0,3.667
+Fall 2023,PHAR,5695,1,11884,Geriatrics,Tolleson,Shane Russell,3,1,0,0,0,0,0,3.75
+Fall 2023,PHAR,5696,1,11885,Ambulatory Care - Primary Care,Gee,Jodie Sue,1,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5696,3,11886,Ambulatory Care - Primary Care,Tolleson,Shane Russell,5,2,0,0,0,0,0,3.714
+Fall 2023,PHCA,6398,4,11887,Special Problems,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,8398,13,11892,Doctoral Research,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,3354,1,11893,Nonprofit Management,Battle,Jennifer Alene,7,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,6354,1,11894,Managing Human Services Orgs,Battle,Jennifer Alene,6,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7356,1,11895,Groups: Adv Clinical Practice,Flores,Vanessa Marie,24,4,0,0,0,0,0,3.857
+Fall 2023,SOCW,7384,1,11896,SW Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,32,0,
+Fall 2023,SOCW,7385,1,11897,SW Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,4,0,
+Fall 2023,SOCW,7388,1,11898,SW Practicum III- Macro,Gonzales,Shelley A,0,0,0,0,0,6,0,
+Fall 2023,SOCW,7389,1,11899,SW Practicum IV- Macro,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Fall 2023,SOCW,8399,1,11901,Dissertation,Leung,Yuk-Hi Patrick,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8699,1,11902,Dissertation,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Fall 2023,CNST,1301,1,11903,Constructn Materials & Methods,Zaheri,Mohammad J,52,60,2,1,0,0,1,3.412
+Fall 2023,CNST,2341,1,11904,Construction Documents,Vecera,Robert Gerard,14,31,17,0,0,0,2,3.031
+Fall 2023,CNST,4331,1,11905,Construction Management II,Khan,Taimoor,9,5,0,0,0,0,1,3.525
+Fall 2023,ELET,2101,1,11906,Poly-Phase Circuits Laboratory,Fan,Lei,13,0,0,0,0,0,0,3.924
+Fall 2023,ELET,2101,2,11907,Poly-Phase Circuits Laboratory,Fan,Lei,8,0,0,0,0,0,0,4.0
+Fall 2023,ELET,2300,1,11908,Introductn To C++ Programming,Lent,Marino Ricardo,22,8,5,7,4,0,10,2.804
+Fall 2023,ELET,2303,1,11909,Digital Systems,Gallardo,Victor Jaime,28,9,3,0,0,0,1,3.518
+Fall 2023,ELET,2307,1,11910,Electrical-Electronic Circuits,Abraham,Yonas B,12,18,3,2,0,0,2,3.19
+Fall 2023,ELET,3107,1,11911,Electrical Mach & Control Lab,Fan,Lei,9,4,2,0,0,0,1,3.467
+Fall 2023,ELET,3107,2,11912,Electrical Mach & Control Lab,Fan,Lei,1,8,0,0,0,0,0,3.148
+Fall 2023,ELET,3307,1,11913,Electrical Machines & Controls,Fan,Lei,4,12,3,1,1,0,1,2.841
+Fall 2023,ELET,3405,1,11914,Microprocessor Architecture,Soneja,Chandrayee,6,8,2,1,2,0,0,2.789
+Fall 2023,ELET,3425,1,11915,Embedded Systems,Moges,Mequanint A,7,8,14,0,0,0,0,2.565
+Fall 2023,ELET,4208,1,11917,Senior Project Laboratory,Moges,Mequanint A,2,8,1,0,0,0,0,3.211
+Fall 2023,ELET,4308,1,11919,Senior Project,Moges,Mequanint A,13,17,0,0,0,0,0,3.411
+Fall 2023,ELET,4310,1,11920,Alternative Energy Sources,Shireen,Wajiha,11,14,1,0,0,0,1,3.461
+Fall 2023,ELET,4317,1,11921,Elec Sys Safety & Protection,Shi,Jian,20,6,0,0,0,0,0,3.655
+Fall 2023,ELET,4421,1,11922,Computer Networks,Small,Damon Jonathan,15,14,9,0,4,0,1,2.818
+Fall 2023,HDCS,1300,1,11924,Human Ecosystems & Tech Change,Mudd,Blake Stevens,42,7,2,0,1,0,6,3.705
+Fall 2023,HDCS,1300,2,11925,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,48,9,2,0,0,0,2,3.729
+Fall 2023,HDCS,1300,3,11926,Human Ecosystems & Tech Change,Mudd,Blake Stevens,42,13,4,0,1,0,0,3.572
+Fall 2023,HDCS,3300,1,11927,Org Decisions,Stewart,Quentin K,40,8,0,2,0,0,0,3.674
+Fall 2023,HDCS,2301,1,11928,Consumer Science,Stewart,Juliana Floriene,34,7,2,2,5,0,3,3.168
+Fall 2023,HDCS,3303,1,11929,Retailing and Consumer Science,Jacobs,Karen S,12,3,0,0,1,0,1,3.439
+Fall 2023,HDCS,3303,2,11930,Retailing and Consumer Science,Rifai,Rana Ihsan,38,5,3,1,2,0,1,3.497
+Fall 2023,HDCS,3304,1,11931,Visual Merchandising,Stewart,Barbara L,13,14,12,7,3,0,1,2.524
+Fall 2023,HDCS,4300,1,11932,Research Concepts in Hdcs,Gatterson,Beverly,15,15,5,1,0,0,0,3.195
+Fall 2023,HDCS,4302,1,11933,Apparel Analysis,Gatterson,Beverly,42,12,2,0,0,0,0,3.685
+Fall 2023,HDCS,4380,2,11934,Merchandising,Jacobs,Karen S,15,15,3,1,1,0,0,3.068
+Fall 2023,HDCS,4386,1,11935,Communication Strategies,Gatterson,Beverly,42,13,1,0,0,0,1,3.661
+Fall 2023,HDCS,4394,1,11936,Internship in RCS,Ezell,Shirley D,2,1,0,0,0,0,0,3.557
+Fall 2023,HRD,6304,30,11937,Research in Human Resource Dev,Kjerfve,Tania M,3,0,1,0,0,0,0,3.418
+Fall 2023,TECH,1301,1,11938,Intro to Data Analytics Tools,Schroeder,Susan L,36,5,1,0,1,0,5,3.737
+Fall 2023,MECT,3155,1,11939,Strength Materials Lab,Al Ibadi,Adnan,9,4,2,1,1,0,0,3.098
+Fall 2023,MECT,3331,1,11940,Applied Thermodynamics,El Nahas,Medhat A,1,4,12,2,8,0,8,1.507
+Fall 2023,MECT,4172,1,11941,Materials Tech Lab,Al Ibadi,Adnan,5,10,3,1,0,0,0,2.948
+Fall 2023,MECT,4372,1,11942,Materials Technology,Robles Hernandez,Francisco C,5,13,13,8,2,0,0,2.244
+Fall 2023,TECH,3365,1,11943,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,35,9,4,0,1,0,0,3.612
+Fall 2023,TECH,3365,2,11944,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,32,8,5,2,0,0,2,3.524
+Fall 2023,TLIM,4341,1,11946,Production & Service Operation,Cao,Shun,23,7,1,1,1,0,0,3.535
+Fall 2023,TMTH,3360,3,11947,Applied Technical Statistics,Dick,Deanna L,3,2,4,0,4,0,4,1.873
+Fall 2023,TMTH,3360,2,11948,Applied Technical Statistics,Schroeder,Susan L,10,17,12,8,1,0,0,2.583
+Fall 2023,CNST,1330,1,11949,Graphics I,Lyon,Eva Yaneth,21,27,1,0,0,0,1,3.422
+Fall 2023,MECT,4275,1,11953,Senior Design Project I,Zhu,Weihang,10,17,3,0,0,0,0,3.288
+Fall 2023,ELET,3402,1,11954,Communications Circuits,Velusamy,Gandhimathi,5,15,7,0,0,0,0,2.95
+Fall 2023,MECT,3118,2,11958,Fluid Mechanic Application Lab,Al Ibadi,Adnan,14,3,0,0,0,0,0,3.746
+Fall 2023,TEPM,6395,20,11960,Integration Project,Carden,Lila L,5,2,0,0,0,0,0,3.573
+Fall 2023,TEPM,6302,20,11961,Leadership and Team Building,Hopkins,Ronald K,8,0,0,0,0,0,1,3.876
+Fall 2023,CNST,1361,1,11962,Construction Management I,Beadle,Dwight D,146,22,8,1,3,0,3,3.706
+Fall 2023,CNST,2321,1,11963,Mechanical & Electrical System,Beadle,Dwight D,58,21,14,0,1,0,0,3.436
+Fall 2023,CNST,3155,1,11964,Const Materials & Testing,Meyer,Joseph Ray,78,18,3,0,0,0,1,3.728
+Fall 2023,CNST,3185,1,11965,Construction Experience,Eldin,Neil N,0,24,1,0,0,0,1,2.96
+Fall 2023,MECT,4276,1,11966,Senior Design Project II,Afrin,Samia,32,6,1,0,0,0,0,3.795
+Fall 2023,MECT,1330,1,11968,Engineering Graphics,Fan,Zheng,3,16,9,2,1,0,2,2.549
+Fall 2023,HRD,6305,1,11969,Organizational Learning,Greer,Tomika,17,3,0,0,0,0,0,3.784
+Fall 2023,HDCS,4372,1,11970,Forecasting for Tech Entrep.,Breaux,James William,26,2,1,0,3,0,0,3.469
+Fall 2023,BTEC,3200,30,11971,Biotech Research Methods,Ibrahim,Eman Refaat,17,2,1,0,0,0,0,3.784
+Fall 2023,GEOL,1103,6,11975,Physical Geology Lab,Hauptvogel,Daniel William,21,3,0,0,0,0,0,3.806
+Fall 2023,ACCT,5331,1,11976,Federal Income Tax,Fernandez,Ramon,3,7,3,0,0,0,5,3.076
+Fall 2023,MATH,3339,2,11977,Statistics for the Sciences,Niu,Yabo,98,60,24,5,5,0,6,3.229
+Fall 2023,MATH,3363,3,11978,Introduction To PDE,Wang,Min,4,3,5,2,1,0,7,2.357
+Fall 2023,PSYC,3350,1,11979,Intro to Cognitive Psychology,Perkovich,Elizabeth Susan,57,18,2,0,3,0,0,3.563
+Fall 2023,MATH,4389,1,11980,Survey of Undergraduate Math,Blecher,David P,9,9,7,4,0,0,0,2.748
+Fall 2023,MARK,4389,5,11981,Marketing Strategy & Planning,Agrawal,Arpit,29,3,0,0,0,0,0,3.917
+Fall 2023,ECE,5113,1,11982,Microwave Engineering Lab,Chen,Ji,1,0,0,0,0,0,0,4.0
+Fall 2023,HRD,3310,1,11983,Talent Management,Edwards,Malaika,34,13,1,0,1,0,0,3.504
+Fall 2023,HDCS,1300,4,11984,Human Ecosystems & Tech Change,Selzer,Lori Michele,15,33,8,2,0,0,1,3.029
+Fall 2023,COMM,3303,1,11985,Health Literacy,Xiao,Zhiwen,17,9,1,0,0,0,0,3.605
+Fall 2023,COMM,4366,1,11987,Advertising Account Planning,Tinnel,Jason Wayne,11,10,4,0,0,0,0,3.333
+Fall 2023,SOCW,6201,1,11988,Foundation of Social Work Prof,Gonzales,Shelley A,0,0,0,0,0,192,1,
+Fall 2023,GEOL,6396,1,11990,Graduate Seminar,Rappenglueck,Bernhard,0,0,0,0,0,8,0,
+Fall 2023,GHL,4336,1,11991,Beverage Marketing,Taylor,David C,5,3,1,2,4,0,0,2.156
+Fall 2023,GHL,6330,1,11992,Statistical Analysis in Hosp.,Shin,Min Jung,11,3,1,0,1,0,2,3.479
+Fall 2023,GHL,7353,1,11993,Services Management in Hosp.,Boger Jr,Carl A,11,1,2,0,0,0,0,3.643
+Fall 2023,MIS,3360,1,11994,Systems Analysis and Design,Harkness,Carol Louise,21,25,12,3,0,0,0,3.049
+Fall 2023,MIS,3360,2,11995,Systems Analysis and Design,Kniffen,Richard Chad,26,28,8,0,0,0,0,3.29
+Fall 2023,FREN,2311,2,11996,Intermediate French I,Green,Viola V,4,15,3,3,1,0,0,2.578
+Fall 2023,AFSC,3301,3,11997,Air Force Leadership I,Whitfield,David,6,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,3350,2,11998,Knowing/Learning Science-Math,Latiolais,Cheryl S,12,2,1,0,0,0,1,3.667
+Fall 2023,CUIN,3351,2,11999,Class Interact Science-Math,Latiolais,Cheryl S,4,0,1,0,0,0,0,3.534
+Fall 2023,BIOL,2101,10,12000,Anatomy & Physiology Lab I,Gill,Tejendra,12,11,1,0,0,0,0,3.403
+Fall 2023,BIOL,2101,11,12001,Anatomy & Physiology Lab I,Gill,Tejendra,8,15,1,0,0,0,0,3.264
+Fall 2023,ARCH,3354,1,12002,The Culture of Architecture,Turner,Drexel,9,5,0,0,0,0,0,3.549
+Fall 2023,ARCH,4351,1,12003,Readings & Criticism in Arch,Turner,Drexel,10,2,3,0,0,0,0,3.291
+Fall 2023,ARCH,6351,1,12004,Criticism in Architecture,Turner,Drexel,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,4355,1,12005,Houston Architecture,Fox,Stephen,10,2,0,0,0,0,0,3.751
+Fall 2023,ARCH,6355,1,12006,Houston Architecture,Fox,Stephen,2,0,0,0,0,0,0,3.835
+Fall 2023,LAW,5408,1,12007,Property,Fagundes,Dave,10,16,3,0,0,0,0,3.241
+Fall 2023,LAW,5371,1,12008,Int'l Petroleum Transaction,Wright,Denney L,8,10,0,0,0,1,0,3.408
+Fall 2023,SOCW,6306,1,12013,Social Work Practice Skills,Gonzales,Shelley A,25,2,0,0,0,0,1,3.926
+Fall 2023,LAW,5410,1,12014,Law Review,Sanders,Joseph,0,0,0,0,0,3,0,
+Fall 2023,PUBL,6310,1,12016,Administrative Theory,Sands,Sara,6,4,0,0,0,0,0,3.534
+Fall 2023,PHLS,8361,1,12017,Eco-Behavioral Interventions,Gonzalez,Jorge E,5,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8363,1,12018,Research in School Psych,Smith,Bradley,5,1,0,0,0,0,0,3.778
+Fall 2023,ELED,3320,2,12020,Survey Literature Child Adol,Black,Misty Paul,39,1,0,0,0,0,0,3.967
+Fall 2023,CUIN,4350,1,12021,Multiple Teaching Strategies,Segura,Perri F,13,3,0,0,0,0,0,3.648
+Fall 2023,PSYC,4344,2,12022,Cultural Psychology,Beltran-Najera,Ilex,36,33,5,0,5,0,0,3.257
+Fall 2023,SOCW,6306,2,12023,Social Work Practice Skills,Gonzales,Shelley A,28,0,0,0,0,0,1,4.0
+Fall 2023,SOCW,6306,3,12024,Social Work Practice Skills,Parker,Jamie Lynne,24,2,1,0,0,0,0,3.852
+Fall 2023,DRAM,2351,1,12025,Acting III,Pistorius,Allison Marie,11,1,0,0,0,0,0,3.862
+Fall 2023,THEA,2332,1,12026,Voice & Mvmnt for the Actor I,Bronfenbrenner,Skye,10,5,0,0,0,0,0,3.667
+Fall 2023,DRAM,2331,1,12027,Lighting and Sound Technology,Webb,Matthew Clark,23,0,0,0,0,0,0,4.0
+Fall 2023,DANC,4307,1,12030,Teaching Dance in Education,Orcutt,Tyler Brandon,8,1,0,1,0,0,1,3.567
+Fall 2023,ARCH,6354,1,12031,The Culture of Architecture,Turner,Drexel,1,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,3371,1,12033,Accounting Information Systems,Seijas,Nuria S,25,22,2,0,0,0,0,3.422
+Fall 2023,CUIN,8377,1,12034,Qualitative Inquiry in Educ I,Cole,Mikel Walker,5,4,0,0,0,0,0,3.592
+Fall 2023,CNST,6310,1,12035,Construction Contract Administ,Eldin,Neil N,16,0,0,0,0,0,0,4.0
+Fall 2023,TEPM,6303,2,12036,Risk Assessment in Project Mgm,Rypien,David V,7,3,1,0,0,0,0,3.605
+Fall 2023,COMD,2338,2,12037,Phonetics,Bunta,Ferenc,6,9,7,2,0,0,5,2.805
+Fall 2023,COMD,1333,1,12038,Intro to Comm Sci & Disorders,Ross,Byron L,10,15,6,2,1,0,1,2.921
+Fall 2023,PHCA,8198,3,12039,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2023,ENTR,3310,3,12043,Entrepreneurship,Ortega,Carlos Alberto,168,20,4,4,1,0,1,3.736
+Fall 2023,ENGL,1301,115,12044,First Year Writing I,Jones,Baylea,21,2,0,0,1,0,0,3.613
+Fall 2023,FREN,1501,3,12045,Elementary French I,Gnanwo Hounfodji,Raymond,3,9,0,2,1,0,0,2.733
+Fall 2023,FREN,1501,5,12047,Elementary French I,Chalhoub,Rania Maria,9,3,6,1,1,0,2,2.834
+Fall 2023,SOCW,6305,1,12049,Social Work Research,Leung,Yuk-Hi Patrick,27,1,0,0,0,0,1,3.964
+Fall 2023,SOCW,6305,2,12050,Social Work Research,Bhatt,Riya V,23,3,0,0,0,0,1,3.885
+Fall 2023,SOCW,6305,3,12051,Social Work Research,Sereno,Alba Donajhi,15,10,0,0,0,0,0,3.6
+Fall 2023,PSYC,3310,1,12053,Indstrl-Orgnztnl Psy,Ng,Vincent,28,4,4,1,2,0,2,3.427
+Fall 2023,HDFS,3300,2,12054,Educational Psychology,Kamdar-Sharif,Amber,127,27,3,1,2,0,3,3.649
+Fall 2023,DRAM,1310,2,12055,Introduction to Theatre,Ostrow,Stuart,24,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,6331,3,12058,Financial Accounting,Larson,Chad R,3,7,1,0,0,0,0,3.152
+Fall 2023,BIOL,2120,5,12064,Microbiology for Non-Science,Knapp,Richard D,14,7,3,0,0,0,0,3.39
+Fall 2023,MATH,2318,3,12069,Linear Algebra,Gao,Li,20,25,22,3,4,0,6,2.694
+Fall 2023,ENTR,3310,5,12073,Entrepreneurship,Ortega,Carlos Alberto,155,30,5,2,1,0,4,3.671
+Fall 2023,ARCH,5500,7,12074,Architecture Design Studio IX,Friedman,Nathan Carlson,12,0,0,0,0,0,0,3.89
+Fall 2023,PHLS,7393,1,12076,Internship and Practicum,Margulis,Milena A,0,0,0,0,0,5,0,
+Fall 2023,MUSI,6102,1,12092,Acting for Opera,Belcher,Kathleen,13,1,0,0,0,0,0,3.952
+Fall 2023,CUIN,8398,8,12094,Independent Study,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8398,9,12101,Independent Study,Zhang,Jie,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,1311,4,12102,Music Theory I,Snyder,John L,9,7,2,0,2,0,2,3.017
+Fall 2023,MUSI,1116,4,12103,Aural Skills I,Snyder,John L,11,6,2,1,0,0,2,3.383
+Fall 2023,MUSI,2210,2,12104,Theory III,Lee,Ji Yeon,14,2,0,0,0,0,1,3.875
+Fall 2023,MUSI,2210,4,12105,Theory III,Lee,Ji Yeon,6,10,1,0,0,0,1,3.352
+Fall 2023,MUSI,2116,2,12106,Aural Skills III,Lee,Ji Yeon,11,3,1,0,0,0,1,3.579
+Fall 2023,MUSI,2116,4,12107,Aural Skills III,Lee,Ji Yeon,7,7,2,0,0,0,1,3.292
+Fall 2023,ENGL,1302,52,12108,First Year Writing II,Denton,Amy,8,6,1,1,2,0,1,2.889
+Fall 2023,GEOL,1103,3,12127,Physical Geology Lab,Hauptvogel,Daniel William,16,6,0,0,0,0,2,3.607
+Fall 2023,GEOL,1347,1,12128,Introduction To Meteorology,Zheng,Youtong,99,84,2,0,5,0,17,3.407
+Fall 2023,ECON,2301,1,12129,Principles of Macroeconomics,Rivera,Javier Amilkar,7,29,17,10,0,0,4,2.519
+Fall 2023,FINA,4320,1,12130,Investment Management,Doshi,Hitesh B,36,15,1,0,0,0,1,3.648
+Fall 2023,ARTS,2348,1,12131,Digital Tools,Scott,Caitlin,13,2,0,1,0,0,1,3.688
+Fall 2023,MIS,3370,2,12132,Info Systems Development Tools,Oladeji,Oyebisi Olufoyeke,18,13,13,4,6,0,9,2.611
+Fall 2023,ITAL,1501,1,12133,Elementary Italian I,Ercolani,Monica,12,3,1,0,1,0,0,3.393
+Fall 2023,ITAL,1501,5,12135,Elementary Italian I,Ercolani,Monica,11,4,0,0,1,0,2,3.438
+Fall 2023,ECON,6475,1,12137,Macroeconomic Analysis,Thornton,Rebecca Achee,10,2,0,0,0,0,0,3.696
+Fall 2023,ECON,6485,1,12138,Microeconomic Analysis,Craig,Steven G,7,7,0,0,0,0,0,3.524
+Fall 2023,ECON,6465,1,12139,Econometrics,Chin,Aimee,11,6,1,0,0,0,0,3.574
+Fall 2023,ARTS,2356,1,12141,Fundamentals of Photo/DM,Krouba,Blya Ange Ernestine,14,4,0,0,0,0,0,3.668
+Fall 2023,ARTS,2356,2,12142,Fundamentals of Photo/DM,Sudhoff,Sarah Antonia,10,3,0,2,0,0,2,3.18
+Fall 2023,ARTS,2356,3,12143,Fundamentals of Photo/DM,Marion,Jennifer L,12,2,1,1,1,0,1,3.334
+Fall 2023,FINA,4341,1,12144,Commercial Bank Management,Lara,Alexander J,21,3,0,0,1,0,0,3.68
+Fall 2023,CUIN,3351,3,12145,Class Interact Science-Math,Mateer,Ramona Caravella,9,1,0,0,0,0,1,3.834
+Fall 2023,MUSA,1176,1,12146,Applied Jazz Percussion,Hubley,Robert L,6,2,0,0,0,0,0,3.544
+Fall 2023,MANA,3335,2,12147,Intro Org Behavior and Mgmt,Currie,Daniel David,196,45,6,1,1,0,0,3.703
+Fall 2023,EDUC,4314,3,12148,Student Teaching Sec,Evans,Paige K,13,1,0,0,0,0,0,3.929
+Fall 2023,EDUC,4315,3,12149,Student Teaching Sec,Evans,Paige K,14,0,0,0,0,0,0,4.0
+Fall 2023,ELED,3322,2,12150,Elem Reading Phonics Instructn,Alba,Celeste,38,0,0,0,0,0,0,3.913
+Fall 2023,EDUC,4324,1,12151,Student Teaching Tech Middle,Culpepper,Shea Mosley,28,1,0,0,0,0,0,3.966
+Fall 2023,MUSI,3215,4,12152,Introduction To Large Forms,Snyder,John L,2,7,6,0,2,0,1,2.315
+Fall 2023,MUED,4343,1,12153,Choral Materials Grades 4-12,Koppel,Alexander,9,0,0,0,0,0,0,3.963
+Fall 2023,GHL,6355,1,12155,Event Administration,Draper,Jason A,5,0,0,0,1,0,0,3.278
+Fall 2023,LAW,5488,1,12156,Constitutional Law,Chandler,Seth J,19,19,5,0,1,0,0,3.22
+Fall 2023,PHYS,4321,1,12157,Int Electromagnetic Theory I,Cherdack,Daniel David,8,5,5,5,1,0,0,2.638
+Fall 2023,LAW,5357,3,12158,Evidence,Janicke,Paul,38,40,2,0,0,0,0,3.384
+Fall 2023,HON,3310,1,12159,Creativity at Work,Rayneard,Max James Anthony,36,8,0,0,0,0,0,3.728
+Fall 2023,BIOL,1106,5,12162,Biol for Science Majors I(Lab),Medrano,Ana I,13,6,3,1,0,0,0,3.305
+Fall 2023,COSC,6370,1,12163,Fundamental of Medical Imaging,Tsekos,Nikolaos V,22,1,0,0,0,0,0,3.856
+Fall 2023,ELET,4326,1,12165,Power Converter Circuits,Shireen,Wajiha,3,5,2,0,0,0,1,3.199
+Fall 2023,CNST,2351,1,12167,Construction Estimating I,Liggin,Gregory G,32,20,8,0,0,0,0,3.4
+Fall 2023,FINA,7371,1,12168,Energy Value Chain,Slaughter,Andrew Jeremy,8,4,0,0,0,0,0,3.667
+Fall 2023,CNST,6310,2,12169,Construction Contract Administ,Eldin,Neil N,28,0,0,0,2,0,0,3.733
+Fall 2023,COSC,4372,1,12170,Fundamental of Medical Imaging,Tsekos,Nikolaos V,39,15,1,0,1,0,4,3.596
+Fall 2023,CNST,6350,1,12171,Decision Making and Risk Mgmt,Gao,Lu,75,0,0,0,1,0,0,3.947
+Fall 2023,THEA,3320,1,12172,Acting V,Pistorius,Allison Marie,4,4,3,0,0,0,0,3.061
+Fall 2023,THEA,3350,1,12173,Movement for the Actor III,Bronfenbrenner,Skye,9,2,0,0,0,0,0,3.638
+Fall 2023,THEA,3380,1,12174,Voice for the Actor III,Johnson,James B,10,1,0,0,0,0,0,3.699
+Fall 2023,POLS,3390,1,12175,Women in Politics,Sims,Nancy Lou,28,6,4,0,1,0,1,3.488
+Fall 2023,THEA,1111,1,12176,Production,Davis,Lauren E,19,1,0,0,0,0,0,3.901
+Fall 2023,THEA,1111,2,12177,Production,Whittenton,Laura Lynn,18,6,0,0,0,0,0,3.764
+Fall 2023,THEA,1112,1,12178,Production,Vlahos,Kalliope,12,0,0,0,0,0,0,3.808
+Fall 2023,THEA,2390,1,12179,Technical Drawing,Giannelli,Christina Rose,4,2,4,0,0,0,0,2.802
+Fall 2023,THEA,3387,1,12180,Lighting Design,Webb,Matthew Clark,8,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,2350,5,12181,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,24,3,2,1,0,0,0,3.645
+Fall 2023,MECE,4340,1,12182,Mechanical Engr Capstone I,Chen,Yi-Chao,49,77,4,0,0,0,0,3.43
+Fall 2023,MIS,7376,1,12183,Systems Analysis and Design,Johnson,Glynn L,26,6,0,0,1,0,0,3.557
+Fall 2023,CUIN,4361,1,12184,Second Language Methodology,Burgess,Miguel,25,1,0,1,1,0,1,3.703
+Fall 2023,WGSS,2350,7,12185,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,24,3,2,0,0,0,2,3.781
+Fall 2023,GEOL,1104,1,12186,Historical Geology Lab,Hauptvogel,Daniel William,6,6,1,0,0,0,0,3.258
+Fall 2023,ANTH,2351,1,12187,Intro to Cultural Anthropology,Small,Ivan Victor,54,35,10,0,1,0,4,3.387
+Fall 2023,MUSA,4400,5,12188,Applied Voice,Jones,Timothy J,2,0,0,0,0,0,0,3.835
+Fall 2023,PUBL,6410,1,12189,Quantitative Methods I,Buttorff,Gail J,5,10,3,0,0,0,0,3.148
+Fall 2023,PHAR,5668,1,12190,Managed Care Pharmacy,Tolleson,Shane Russell,6,1,0,0,0,0,0,3.857
+Fall 2023,ENGL,1301,127,12194,First Year Writing I,Dykes,Justin,6,4,4,3,3,0,5,2.416
+Fall 2023,ELET,4126,1,12195,Power Converter Circuits Lab,Shireen,Wajiha,6,4,0,0,0,0,0,3.567
+Fall 2023,BIOL,2101,12,12196,Anatomy & Physiology Lab I,Gill,Tejendra,6,12,1,3,2,0,0,2.681
+Fall 2023,BIOL,2101,13,12197,Anatomy & Physiology Lab I,Gill,Tejendra,5,10,4,0,2,0,2,2.73
+Fall 2023,CNST,1315,1,12200,Project Drawings and Graphics,Clark,Peter J,23,21,10,2,2,0,1,3.04
+Fall 2023,CNST,1325,1,12201,Process & Industrial Construct,Ponnusamy,Ravi Chandran,6,8,1,0,0,0,0,3.333
+Fall 2023,CNST,4341,1,12202,Project Controls,Bouhou,Nour-El Imane,8,20,18,4,1,0,0,2.666
+Fall 2023,ENGL,1301,128,12203,First Year Writing I,Dykes,Justin,6,8,6,0,4,0,0,2.486
+Fall 2023,ENGL,1302,1,12204,First Year Writing II,Pogue,Donovan A,12,5,0,1,0,0,2,3.556
+Fall 2023,MANA,6332,2,12207,Organiztnl Behavior & Mangemnt,Werner,Steve,11,0,0,0,0,0,0,3.94
+Fall 2023,MUSA,4400,6,12208,Applied Voice,Sonnenberg,Melanie,3,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2320,1,12209,Abnormal Psychology,Ridgely,Natalie,39,22,8,4,3,0,3,3.176
+Fall 2023,ENGL,1301,129,12210,First Year Writing I,Braniger,Leslie,6,8,2,2,5,0,1,2.219
+Fall 2023,ENGL,1301,130,12211,First Year Writing I,Garcia,Serena Mari,19,5,1,0,0,0,0,3.654
+Fall 2023,COMD,7392,4,12212,Adv Pract Sp & Lang Dis,Walker,Dionne A,3,0,0,0,0,0,0,3.78
+Fall 2023,MATH,3331,2,12225,Intermediate Diff Equations,Climenhaga,Vaughn,15,10,16,4,0,0,5,2.793
+Fall 2023,MUSI,6106,1,12226,Grad Large Ensemble,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1302,40,12228,First Year Writing II,Sicinski,Michael J,11,7,1,0,4,0,1,2.942
+Fall 2023,PHAR,5660,1,12231,Pharmaceutical Industry,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Fall 2023,SOC,7399,2,12235,Masters Thesis,Anderson,Kathryn,1,0,0,0,0,0,0,4.0
+Fall 2023,SOC,6399,8,12236,Masters Thesis,Tuthill,Zelma,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1301,26,12253,First Year Writing I,Abdelwahab,Maha Ahmed Ibraheem,17,0,0,0,2,0,0,3.509
+Fall 2023,ECON,3332,3,12261,Intermediate Microeconomics,Saboury,Piruz,8,10,9,4,1,0,2,2.594
+Fall 2023,MUSI,6300,1,12262,Intro Res Method in Musicology,Caton,Kathryn L.,8,2,0,0,1,0,0,3.425
+Fall 2023,MUSI,6300,2,12263,Intro Res Method in Musicology,Vansteenburg,Jessica N,5,2,0,0,0,0,0,3.714
+Fall 2023,BIOL,2321,1,12264,Microbiology for Science Major,Knapp,Richard D,120,106,73,34,10,0,51,2.813
+Fall 2023,BCHS,4304,1,12265,Biophysics,Fox,Robert O,18,16,10,0,0,0,2,3.182
+Fall 2023,SCM,4330,1,12269,Bus Modeling and Dec Analysis,Cossick,Kathy L,17,14,11,4,0,0,3,2.921
+Fall 2023,SCM,4301,1,12270,Logistics Management,Tibodeau,Dale,28,42,7,2,1,0,0,3.142
+Fall 2023,SCM,4330,2,12271,Bus Modeling and Dec Analysis,Cossick,Kathy L,25,11,8,2,2,0,2,3.153
+Fall 2023,INDE,2331,1,12272,Computer Applications for IE,Chung,Christopher,6,8,3,0,0,0,0,3.196
+Fall 2023,INDE,6339,1,12273,Materials Handling,Keedy,Elias,16,35,5,0,0,0,0,3.244
+Fall 2023,CHEE,3321,1,12274,Analytical Methods Chem Engr,Grabow,Lars C,5,5,10,0,0,0,6,2.701
+Fall 2023,KIN,1304,1,12275,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,311,16,4,3,4,0,1,3.869
+Fall 2023,KIN,3304,1,12276,Human Structure & Phys Perform,LaVoy,Emily Claire-Pyle,31,56,35,18,4,0,4,2.618
+Fall 2023,KIN,3305,1,12277,Sport Sociology,Graham,Marilynn Hadassah,163,19,10,0,2,0,2,3.712
+Fall 2023,KIN,3350,1,12278,Psych Aspects Sport Exercise,Ferrara,Morgan Paige,106,38,19,1,3,0,4,3.439
+Fall 2023,KIN,3360,1,12279,Professional Prep for Sp Admin,Pearson,Demetrius W,7,11,17,8,3,0,8,2.282
+Fall 2023,KIN,3370,1,12280,Sport Facility Management,Cho,Minseok,29,16,1,2,0,0,1,3.452
+Fall 2023,KIN,4190,1,12281,Sport Administration Seminar,Walsh,David W,22,8,2,1,3,0,1,3.213
+Fall 2023,KIN,4355,1,12283,Adm of Sport & Phys Activity,Walsh,David W,15,36,3,0,2,0,0,3.072
+Fall 2023,KIN,4390,1,12284,Internship in PE,Betts,Randi Jill,2,0,0,0,0,0,0,4.0
+Fall 2023,KIN,4690,1,12285,Internship in Sport Admin 1,Walsh,David W,21,2,1,2,1,0,0,3.445
+Fall 2023,NUTR,2133,1,12286,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,6,5,2,0,1,0,0,3.024
+Fall 2023,NUTR,2133,2,12287,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,7,8,2,0,0,0,0,3.391
+Fall 2023,NUTR,2333,1,12289,Comm Food Prod I,Svendsen-Sanchez,Ann Carol,23,6,0,0,4,0,0,3.193
+Fall 2023,NUTR,3101,1,12290,Dietetics As a Profession,Scott,Claudia W,27,1,0,0,0,0,1,3.894
+Fall 2023,NUTR,3330,1,12291,Mgmt in Food & Nutr Systems,Haubrick,Kevin,6,8,4,1,0,0,0,2.913
+Fall 2023,LAW,5406,6,12292,Civil Procedure,Hoffman,Lonny,9,20,0,0,0,0,0,3.379
+Fall 2023,ARTS,3371,1,12293,Photo-Dig Media Portfolio Dev,Molina,Lorena Guadalupe,13,2,0,0,0,0,0,3.801
+Fall 2023,ARTS,3372,1,12294,Intermediate Video Art,Kokoladze,Salome,10,6,0,0,0,0,0,3.522
+Fall 2023,NUTR,3334,1,12295,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,95,72,12,6,7,0,5,3.174
+Fall 2023,NUTR,4312,1,12296,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,14,21,6,6,0,0,1,2.859
+Fall 2023,NUTR,4333,1,12297,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,12,11,6,4,0,0,1,2.949
+Fall 2023,NUTR,4334,1,12298,Community Nutrition,Hughes,Lindsay,106,30,7,2,1,0,0,3.594
+Fall 2023,NUTR,4346,1,12299,Research in Nutrition,Ledoux,Tracey A,12,9,3,2,0,0,1,3.116
+Fall 2023,NUTR,4348,1,12300,Intro to NUTR Counseling,Honig,Caryn A,13,9,2,1,0,0,1,3.32
+Fall 2023,PEP,6305,1,12301,Measurmnt Hlt & Phys Educ,Lee,Dong Hun,12,4,1,0,0,0,0,3.569
+Fall 2023,PEP,7306,1,12302,Adm Princs of Sprts/Exer Prgms,Pearson,Demetrius W,2,11,5,0,0,0,0,2.76
+Fall 2023,PEP,7393,1,12303,Internship & Practicum,Walsh,David W,5,1,0,0,0,0,0,3.723
+Fall 2023,GEOL,7324,1,12304,Rock Physics,Castagna,John P,14,2,0,0,0,0,0,3.834
+Fall 2023,SPAN,1502,3,12305,Elementary Spanish II,Reyes Ferrufino,Diana Eufemia,5,7,6,1,2,0,3,2.571
+Fall 2023,BUSI,1301,1,12307,Business Principles,Thompson,Joseph Lee,24,0,0,0,0,0,0,4.0
+Fall 2023,SCM,4350,1,12308,Strategic Supply Management,Wayhan,Victor Brian,62,34,11,0,0,0,2,3.467
+Fall 2023,FREN,2312,2,12309,Intermediate French II,Vredenburgh,Amanda Jane,6,6,3,1,0,0,1,3.063
+Fall 2023,CHEM,4340,1,12310,Research Methods,Ekeoba,Jacqueline Njideka,0,2,0,0,0,0,0,3.33
+Fall 2023,BIOL,4340,1,12312,Research Methods,Ekeoba,Jacqueline Njideka,4,2,0,0,0,0,0,3.612
+Fall 2023,BIOE,6198,1,12315,Research,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8198,1,12317,Doctoral Research,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8298,1,12318,Doctoral Research,Akay,Metin,0,0,0,0,0,3,0,
+Fall 2023,BIOE,8298,2,12319,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,4,12320,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,2,12321,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8598,1,12322,Doctoral Research,Akay,Metin,0,0,0,0,0,5,0,
+Fall 2023,ECE,3355,1,12324,Electronics,Litvinov,Dmitri,6,30,24,11,6,0,1,2.212
+Fall 2023,ITAL,3303,1,12325,Italian Convers&Compos,Nicosia,Alda,5,0,0,0,0,0,0,3.868
+Fall 2023,MARK,4362,1,12326,Applied Buyer Behavior,Rudd,Melanie R,19,16,2,1,1,0,0,3.316
+Fall 2023,CUIN,3321,1,12327,Intro to Teaching Middle Grade,McDonough,Michael Joseph,24,1,1,0,0,0,0,3.796
+Fall 2023,MATH,4388,1,12329,History of Mathematics,Ji,Shanyu,20,10,2,0,1,0,1,3.415
+Fall 2023,HLT,3301,2,12330,Health Behavior Theories,Drenner,Kelli Linn,32,24,7,2,0,0,4,3.323
+Fall 2023,PHYS,1102,9,12331,College Physics II (lab),Wood,Lowell T,1,13,10,0,0,0,0,2.68
+Fall 2023,TEPM,6301,4,12332,Project Management Principles,Sherman,Dennis Louis,56,3,1,0,0,0,0,3.9
+Fall 2023,TEPM,6301,20,12333,Project Management Principles,Sherman,Dennis Louis,51,5,1,0,0,0,0,3.877
+Fall 2023,ARTS,3301,1,12334,Life Drawing,Barrera,Debra,17,1,0,0,1,0,0,3.754
+Fall 2023,ARTS,2333,1,12335,Fundamentals of Printmaking,Alderson,Saran,15,0,0,0,0,0,0,4.0
+Fall 2023,TEPM,6302,1,12336,Leadership and Team Building,Hopkins,Ronald K,12,1,0,0,0,0,0,3.822
+Fall 2023,ARTS,1311,1,12337,Fundamentals of Graphic Design,Williams,Celeste,10,9,1,0,0,0,3,3.417
+Fall 2023,ARTS,1311,3,12338,Fundamentals of Graphic Design,Boran,John David,11,9,1,1,0,0,2,3.289
+Fall 2023,PSYC,2317,1,12339,Intro to Psychology Statistics,Steinberg,Lynne,7,7,7,2,4,0,14,2.395
+Fall 2023,PSYC,2317,3,12340,Intro to Psychology Statistics,Mehta,Paras D,9,7,3,0,5,0,3,2.584
+Fall 2023,BIOE,8498,1,12341,Doctoral Research,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2023,ARTS,2326,2,12342,Fundamentals of Sculpture,De Leon,Laura,10,0,0,1,0,0,1,3.697
+Fall 2023,BIOL,2121,1,12343,Microbiol for Science Maj(lab),Knapp,Richard D,16,6,1,0,0,0,1,3.623
+Fall 2023,BIOL,2121,2,12344,Microbiol for Science Maj(lab),Knapp,Richard D,13,8,2,1,0,0,0,3.375
+Fall 2023,BIOL,2121,3,12345,Microbiol for Science Maj(lab),Knapp,Richard D,14,10,0,0,0,0,0,3.556
+Fall 2023,BIOL,2121,4,12346,Microbiol for Science Maj(lab),Knapp,Richard D,9,7,5,0,0,0,2,3.206
+Fall 2023,BIOL,2121,5,12347,Microbiol for Science Maj(lab),Knapp,Richard D,15,6,1,0,0,0,1,3.606
+Fall 2023,ARTS,2311,1,12348,"Color, Materials and Methods",Bootwala,Jennifer Elizabeth,11,9,3,0,0,0,2,3.29
+Fall 2023,ARTS,2311,2,12349,"Color, Materials and Methods",Williams,Celeste,18,7,0,0,0,0,1,3.667
+Fall 2023,ARTS,3313,1,12350,Silkscreen,Masterson,Patrick D,11,1,0,0,0,0,0,3.889
+Fall 2023,ARTS,3314,1,12351,Lithography,Masterson,Patrick D,11,1,0,0,0,0,0,3.889
+Fall 2023,ARTS,3334,1,12355,Introduction to Typography,Hagmann,Sibylle,4,11,6,0,0,0,2,2.873
+Fall 2023,ARCH,5500,5,12356,Architecture Design Studio IX,Quinones Torrero,Francisco Jose,7,4,0,0,0,0,1,3.636
+Fall 2023,ARCH,5500,9,12358,Architecture Design Studio IX,Handanovic,Dijana,7,2,0,0,0,0,0,3.704
+Fall 2023,ARCH,4327,1,12360,Technology 5,Taylor,Rives,73,37,2,0,0,0,1,3.634
+Fall 2023,FINA,4330,2,12361,Corporate Finance,Medina Palma,Paolina del Carmen,5,3,1,0,0,0,0,3.224
+Fall 2023,FINA,4330,4,12362,Corporate Finance,Berger,Elizabeth,24,14,13,2,0,0,1,3.12
+Fall 2023,CIS,1332,30,12364,Intro Information Technology,Ratner,Edward,104,19,2,0,2,0,3,3.714
+Fall 2023,CIS,2336,30,12365,Web Application Development,Faiyaz,Sajida,7,20,15,0,2,0,0,2.682
+Fall 2023,CIS,3343,1,12367,Info Systems Analysis & Design,Faiyaz,Sajida,20,22,15,0,1,0,1,3.063
+Fall 2023,CIS,3351,1,12368,Intrusion Detect & Incid Resp,Nsoh,Jovita T,65,14,0,1,3,0,6,3.627
+Fall 2023,CIS,4338,1,12370,Advanced Database Concepts,Miertschin,Susan L,28,31,9,0,0,0,2,3.284
+Fall 2023,CIS,4375,1,12371,Project Management & Practice,Martinez,Jose C,7,23,0,2,1,0,0,2.96
+Fall 2023,CIS,6321,1,12372,Principles of Cybersecurity,Lee,Kyu In,38,2,0,0,0,0,0,3.942
+Fall 2023,CIS,6323,1,12373,Applied Cryptography,Zhang,Yunpeng,45,1,0,0,1,0,0,3.88
+Fall 2023,SCLT,4312,30,12374,Inventory & Materials Handling,Kennedy,Elizabeth Heyn,53,6,0,0,0,0,0,3.854
+Fall 2023,SCLT,4375,30,12375,Global Supply Chain,Dong,Zhijie,9,19,4,1,1,0,0,3.01
+Fall 2023,SCLT,4380,31,12376,Quality Systems,Singh,Gulshan,38,18,2,1,1,0,1,3.489
+Fall 2023,ELET,2103,1,12377,Digital Systems Laboratory,Gallardo,Victor Jaime,19,7,0,1,0,0,1,3.544
+Fall 2023,ELET,3403,1,12378,Sensor Applications,Yuan,Xiaojing,11,9,0,1,0,0,0,3.224
+Fall 2023,NUTR,4347,1,12380,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,3,6,2,0,0,0,0,2.971
+Fall 2023,TEPM,6307,1,12381,Advanced Project Management,Sherman,Dennis Louis,9,0,0,0,0,0,0,3.927
+Fall 2023,TEPM,6307,20,12382,Advanced Project Management,Sherman,Dennis Louis,3,0,0,0,0,0,0,4.0
+Fall 2023,MIS,4374,1,12384,Info Technology Project Mgmt,Scott,Carl P,27,14,1,0,0,0,0,3.548
+Fall 2023,MIS,4374,2,12385,Info Technology Project Mgmt,Scott,Carl P,30,9,1,0,0,0,0,3.643
+Fall 2023,BIOL,1308,2,12386,Biology for Non-Science Majors,Gifford,Jenifer,40,73,54,15,13,0,15,2.544
+Fall 2023,ARCH,3393,1,12387,Thesis Preparation,Johnson,Matthew W,8,0,0,0,0,0,0,3.918
+Fall 2023,THEA,3332,1,12388,Directing I,Holm,Eric Powell,6,0,0,0,0,0,0,4.0
+Fall 2023,THEA,4320,1,12389,Acting VII,Pistorius,Allison Marie,8,4,0,0,0,0,0,3.667
+Fall 2023,PHYS,1101,11,12390,College Physics I (lab),Wood,Lowell T,2,12,10,0,0,0,0,2.57
+Fall 2023,MATH,3321,5,12391,Engineering Mathematics,Torok,Andrei S,6,19,16,6,23,0,4,1.686
+Fall 2023,PHYS,1101,12,12392,College Physics I (lab),Wood,Lowell T,0,10,5,0,0,0,1,2.755
+Fall 2023,HLT,4317,1,12393,Found of Epi in Public Health,Drenner,Kelli Linn,17,28,14,1,1,0,2,2.87
+Fall 2023,FINA,4320,2,12394,Investment Management,Doshi,Hitesh B,27,24,1,1,0,0,0,3.509
+Fall 2023,MUSI,8106,4,12395,Doctoral Large Ensemble,Krager,Franz A,16,0,0,0,0,0,0,3.979
+Fall 2023,MUSI,6106,4,12397,Grad Large Ensemble,Krager,Franz A,23,1,0,0,0,0,0,3.972
+Fall 2023,CNST,2325,1,12399,Process and Industrial Subsyst,Zayas,Frederick A,3,13,0,0,0,0,0,3.126
+Fall 2023,CNST,2345,1,12400,Contract Doc Capital Projects,Beadle,Dwight D,21,11,3,0,1,0,0,3.417
+Fall 2023,PSYC,2317,2,12402,Intro to Psychology Statistics,Steinberg,Lynne,5,3,12,4,6,0,15,1.889
+Fall 2023,THEA,4693,1,12403,Stage Management Internship,Bush,Rachel R,0,0,0,0,0,4,0,
+Fall 2023,PHAR,5662,3,12404,Academic Scholarship,Wallace,David A,2,0,0,0,0,0,0,4.0
+Fall 2023,FINA,4320,3,12413,Investment Management,Mateen,Haaris,11,7,2,0,0,0,0,3.434
+Fall 2023,SOCW,7319,1,12421,SW Practice in Organizations,Foster,Charday D,21,0,0,0,0,0,0,4.0
+Fall 2023,INDE,6365,1,12428,Engineering Economy II,Schulze,Lawrence John Henry,6,14,9,0,1,0,0,2.789
+Fall 2023,BIOL,1106,23,12429,Biol for Science Majors I(Lab),Medrano,Ana I,18,3,1,0,0,0,2,3.713
+Fall 2023,BIOL,1106,24,12430,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,1,0,1,0,0,3.455
+Fall 2023,BIOL,1106,25,12431,Biol for Science Majors I(Lab),Medrano,Ana I,8,12,1,0,1,0,1,3.257
+Fall 2023,BIOL,1106,26,12432,Biol for Science Majors I(Lab),Medrano,Ana I,19,3,1,1,0,0,0,3.598
+Fall 2023,PSYC,2317,4,12436,Intro to Psychology Statistics,Mehta,Paras D,17,3,3,1,1,0,4,3.281
+Fall 2023,ELET,2300,2,12437,Introductn To C++ Programming,Hu,Bin,14,18,11,4,2,0,10,2.789
+Fall 2023,ECON,8362,1,12438,Workshop Research Methods IV,Liu,Elaine Meichen,8,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,8180,1,12445,Advanced Seminar,Aparasu,Rajender R,4,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,1106,27,12446,Biol for Science Majors I(Lab),Medrano,Ana I,14,4,3,2,1,0,0,3.139
+Fall 2023,BIOL,1106,28,12447,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,2,0,1,0,1,3.377
+Fall 2023,BIOL,2101,14,12456,Anatomy & Physiology Lab I,Gill,Tejendra,4,11,5,1,0,0,3,2.92
+Fall 2023,BIOL,1106,29,12458,Biol for Science Majors I(Lab),Medrano,Ana I,18,5,0,0,1,0,0,3.625
+Fall 2023,BIOL,1106,30,12459,Biol for Science Majors I(Lab),Medrano,Ana I,15,4,1,2,1,0,1,3.333
+Fall 2023,BIOL,1106,31,12461,Biol for Science Majors I(Lab),Medrano,Ana I,14,3,3,1,1,0,1,3.258
+Fall 2023,BIOL,1106,32,12462,Biol for Science Majors I(Lab),Medrano,Ana I,17,3,2,1,0,0,1,3.537
+Fall 2023,BIOL,1306,5,12463,Biology for Science Majors I,Medrano,Ana I,63,96,57,15,22,0,27,2.663
+Fall 2023,COMD,7391,8,12464,Clinic in Speech Lang Disorder,Devore,Danielle R,2,0,0,0,0,0,0,3.835
+Fall 2023,ENGL,1301,119,12466,First Year Writing I,Jones,Baylea,14,6,1,2,1,0,0,3.14
+Fall 2023,DRAM,1310,7,12467,Introduction to Theatre,Young,Courtney Leigh,45,1,3,0,1,0,0,3.78
+Fall 2023,SPAN,8399,8,12471,Dissertation,Ventura,Gabriela Baeza,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1301,30,12472,First Year Writing I,Zachow,Alix V,11,4,2,1,0,0,1,3.389
+Fall 2023,ENTR,4340,1,12473,Entrepreneurial Capital,Blair,Edward A,19,9,0,0,0,0,0,3.537
+Fall 2023,BTEC,1322,30,12483,Introduction to Biotechnology,Ibrahim,Eman Refaat,9,5,0,0,0,0,0,3.69
+Fall 2023,BTEC,3200,31,12484,Biotech Research Methods,Ibrahim,Eman Refaat,23,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2305,5,12487,Intro to Methods in Psychology,Tamber-Rosenau,Benjamin J,8,11,6,1,2,0,1,2.739
+Fall 2023,ECON,2301,2,12488,Principles of Macroeconomics,Maden,Bitaran Jang,89,191,95,20,15,0,12,2.768
+Fall 2023,GEOL,1103,7,12490,Physical Geology Lab,Hauptvogel,Daniel William,19,3,0,0,1,0,0,3.667
+Fall 2023,GEOL,1103,8,12491,Physical Geology Lab,Hauptvogel,Daniel William,17,4,1,0,1,0,1,3.493
+Fall 2023,GEOL,1103,9,12492,Physical Geology Lab,Hauptvogel,Daniel William,14,6,1,0,0,0,2,3.603
+Fall 2023,CHEM,1111,49,12493,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,10,0,0,0,0,0,3.334
+Fall 2023,CHEM,1112,14,12494,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,6,0,0,0,3,2.941
+Fall 2023,CHEM,1112,15,12495,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,5,5,1,1,0,1,2.807
+Fall 2023,CHEM,1112,17,12497,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,5,1,1,0,2,2.745
+Fall 2023,CHEM,1105,4,12498,Foundations of Chem Lab,Zaitsev,Vladimir G,1,9,5,2,0,0,0,2.646
+Fall 2023,CHEM,1105,3,12499,Foundations of Chem Lab,Zaitsev,Vladimir G,6,11,2,0,0,0,0,3.211
+Fall 2023,MARK,3365,2,12500,Intro to Digital Marketing,Tirunillai,Seshadri N,97,60,8,2,1,0,2,3.459
+Fall 2023,CHEM,2125,5,12501,Organic Chemistry Lab II,Bean,Mary B,5,6,7,3,0,0,1,2.635
+Fall 2023,BIOL,2302,1,12502,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,59,78,72,34,14,0,37,2.497
+Fall 2023,MUSI,6350,1,12503,Applied Music Pedagogy,Averyt,Zachary Benjamin,3,1,0,0,0,0,0,3.668
+Fall 2023,PHAR,5663,2,12504,Pharmacy Management,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5683,2,12505,Cardiology,Truong,Mabel,1,1,1,0,0,0,0,3.0
+Fall 2023,GEOL,3378,1,12506,Principles of Atmospheric Sci.,Jiang,Xun,19,5,0,0,0,0,0,3.682
+Fall 2023,ELED,4310,3,12508,Reading/Language in Elementary,Tyson,Eleanore S,36,3,0,0,0,0,0,3.94
+Fall 2023,ELED,4310,4,12509,Reading/Language in Elementary,Tyson,Eleanore S,28,2,2,0,0,0,1,3.823
+Fall 2023,EDUC,1301,1,12510,Intro to Teaching Profession,Snead,Lauren Oropeza,16,5,1,0,0,0,0,3.682
+Fall 2023,RELS,2310,1,12511,Bible and Western Culture I,Dawson,Cindy,21,14,10,2,1,0,1,3.042
+Fall 2023,PETR,6368,1,12512,Well Drilling and Completion I,Samuel,Robello,3,5,2,0,0,0,0,3.1
+Fall 2023,ARAB,3301,1,12513,Adv Modern Standard Arabic I,Hefter,Thomas H,3,0,0,0,0,0,1,3.89
+Fall 2023,PETR,5350,1,12514,Natural Gas Engineering,Farouq-Ali,Syed,0,3,0,0,0,0,0,3.0
+Fall 2023,PETR,6328,1,12515,Petro Fluid Prop & Phase Equil,Dindoruk,Birol,4,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,4354,1,12516,Endocrinology,Warner,Margaret,36,14,0,0,0,0,0,3.72
+Fall 2023,BIOL,4374,1,12517,Cell Biology,Rea,Michael A,26,24,14,8,4,0,9,2.798
+Fall 2023,BCHS,4313,2,12518,Cell Biochemistry,Rea,Michael A,4,1,2,1,0,0,0,3.0
+Fall 2023,BIOL,6374,1,12519,Cell Biology,Rea,Michael A,1,0,1,0,0,0,0,3.0
+Fall 2023,AAS,2320,3,12520,Intro To African American Stdy,Wiggins,Gretchen Flowers,8,15,0,0,2,0,5,3.133
+Fall 2023,ECE,4119,1,12521,Solid State Devices Lab,Pei,Shin-Shem Steven,14,0,0,0,0,0,0,3.67
+Fall 2023,SOCW,7367,1,12524,Social Policy Analysis,Pang,Melanie Espinosa,29,0,0,0,0,0,1,4.0
+Fall 2023,ECE,5356,1,12525,Cmos Analog Integrated Circuit,Chen,Jinghong,2,1,0,0,0,0,0,3.777
+Fall 2023,ECE,6328,1,12526,Cmos Analog Integrated Circuit,Chen,Jinghong,6,9,1,0,0,0,0,3.395
+Fall 2023,ASLI,2233,1,12527,History of Interpreting,Hill,Sharon Grigsby,7,5,0,0,1,0,1,3.257
+Fall 2023,CUIN,4350,2,12528,Multiple Teaching Strategies,Latiolais,Cheryl S,11,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4348,1,12529,Global Leadership,Walker,William A,38,4,1,2,0,0,1,3.763
+Fall 2023,SCM,4380,1,12530,Enterprise Resource Planning,Pendyala,Raja,44,19,0,0,0,0,0,3.662
+Fall 2023,MUSI,6200,1,12531,Accompanying Seminar,Hester,Timothy E,8,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4346,1,12532,Leadership Development,Evans,Klavdia Markelova,49,8,1,0,1,0,0,3.718
+Fall 2023,FINA,4358,1,12533,Commercial Property,Kapatos,Nick Gus,16,11,8,6,0,0,4,2.878
+Fall 2023,SOCW,7367,2,12534,Social Policy Analysis,Johnson,Kenya Rene,29,1,0,0,0,0,0,3.945
+Fall 2023,CIS,2348,30,12535,Info Systems Appl Development,Ratner,Edward,19,20,33,0,13,0,5,2.33
+Fall 2023,ELET,2103,2,12537,Digital Systems Laboratory,Gallardo,Victor Jaime,7,3,4,0,0,0,0,3.285
+Fall 2023,ELET,2105,1,12538,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,20,0,1,0,0,0,0,3.889
+Fall 2023,MUSI,2302,1,12539,Listening to Jazz,Hubley,Robert L,24,27,16,9,14,0,8,2.4
+Fall 2023,HLT,2320,2,12540,Introduction to Public Health,Proctor,Robin Ann,79,14,1,0,1,0,1,3.703
+Fall 2023,SOCI,1301,15,12541,Introduction To Sociology,Cooper,Chelsey Wells,48,12,2,0,0,0,0,3.726
+Fall 2023,ARTS,1372,1,12542,Fundamentals of Video Art,Hillerbrand,Stephan C,8,3,2,0,2,0,2,3.044
+Fall 2023,ARTS,3309,1,12543,Jr Painting Major,Hecker,Rachel G,11,4,1,0,0,0,0,3.625
+Fall 2023,ARTS,3310,1,12544,Jr Painting Major,Maxen,William,12,3,1,0,0,0,0,3.646
+Fall 2023,ARTS,3311,1,12545,Jr Painting Major,Hecker,Rachel G,11,4,1,0,0,0,0,3.625
+Fall 2023,ARTS,3335,1,12546,Junior Graphic Design Major,Kim,Yoonkyung,10,13,1,0,0,0,0,3.444
+Fall 2023,ARTS,3336,1,12547,Junior Graphic Design Major,Beckett,Cheryl A,16,7,1,0,0,0,0,3.584
+Fall 2023,ARTS,3337,1,12548,Junior Graphic Design Major,Unikel,Joshua,21,2,1,0,0,0,0,3.82
+Fall 2023,ARTS,3365,1,12549,Jr Sculpture Major,Kittelson,Paul A,3,1,0,0,0,0,0,3.585
+Fall 2023,ARTS,3366,1,12550,Jr Sculpture Major,Conrad,Jillian,3,1,0,0,0,0,0,3.585
+Fall 2023,ARTS,3367,1,12551,Jr Sculpture Major,Conrad,Jillian,4,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4300,1,12552,Senior Painting Major I,Suber,Anthony,8,6,0,0,0,0,0,3.501
+Fall 2023,ARTS,4301,1,12553,Senior Painting Major I,Suber,Anthony,8,6,0,0,0,0,0,3.501
+Fall 2023,ARTS,4302,1,12554,Senior Painting Major I,Parazette,Aaron,8,6,0,0,0,0,0,3.501
+Fall 2023,ARTS,4303,1,12555,Senior Painting Major II,Suber,Anthony,6,3,0,0,0,0,0,3.703
+Fall 2023,ARTS,4304,1,12556,Senior Painting Major II,Suber,Anthony,6,3,0,0,0,0,0,3.703
+Fall 2023,ARTS,4305,1,12557,Senior Painting Major II,Parazette,Aaron,6,3,0,0,0,0,0,3.703
+Fall 2023,ARTS,4330,1,12558,Senior Graphic Design Major I,Beckett,Cheryl A,10,10,2,0,0,0,0,3.304
+Fall 2023,ARTS,4331,1,12559,Senior Graphic Design Major I,Unikel,Joshua,19,3,0,0,0,0,0,3.864
+Fall 2023,ARTS,4332,1,12560,Senior Graphic Design Major I,Hagmann,Sibylle,12,9,1,0,0,0,0,3.395
+Fall 2023,ARTS,4360,1,12561,Senior Sculpture Major I,Kittelson,Paul A,5,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4361,1,12562,Senior Sculpture Major I,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4362,1,12563,Senior Sculpture Major I,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4363,1,12564,Senior Sculpture Major II,Kittelson,Paul A,5,0,0,0,0,0,0,3.934
+Fall 2023,ARTS,4364,1,12565,Senior Sculpture Major II,Conrad,Jillian,5,0,0,0,0,0,0,3.934
+Fall 2023,ARTS,4365,1,12566,Senior Sculpture Major II,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Fall 2023,GOVT,2306,3,12567,US and Texas Const/Politics,McDonald,John Terrence George,72,82,63,16,11,0,6,2.748
+Fall 2023,GOVT,2306,1,12568,US and Texas Const/Politics,Cole,Jeffrey Bryan,104,75,32,13,16,0,7,2.989
+Fall 2023,INDE,4370,1,12569,Discrete Event Simulation,Khator,Suresh K,10,8,14,1,0,0,2,2.838
+Fall 2023,INDE,4320,1,12571,Computer-Integrated Manufactur,Lin,Ying,8,16,4,0,0,0,0,3.108
+Fall 2023,MIS,4390,1,12572,Energy Trading Systems,Pena,Juan F,174,29,5,3,0,0,3,3.758
+Fall 2023,MIS,4386,1,12573,Busn Appls Database Mgmt II,Scamell,Richard W,15,9,7,1,1,0,7,3.001
+Fall 2023,ELET,1400,1,12574,Circuit Theory and Lab I,Barbieri,Enrique,4,9,15,8,0,0,15,2.223
+Fall 2023,PETR,1111,1,12575,Intro to Petroleum Engineering,Hathon,Lori A,3,9,3,0,0,0,0,2.824
+Fall 2023,HRD,6353,1,12576,Methods of Adult Learning,Shirmohammadi,Melika,20,0,0,0,0,0,0,3.934
+Fall 2023,ASLI,3430,1,12577,Consecutive Interpreting,Sheneman,Naomi,5,5,0,0,0,0,0,3.368
+Fall 2023,MUSI,6330,1,12578,Adv Instrumental Conducting,Krager,Franz A,5,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,6300,1,12579,Drawing Studio,Parazette,Aaron,8,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,6305,1,12580,Painting Studio,Suber,Anthony,13,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,6330,1,12581,Graphic Design Studio,Kim,Yoonkyung,3,0,0,0,0,0,1,3.78
+Fall 2023,ARTS,6360,1,12582,Sculpture Studio,Mayer,Anna W,7,0,1,0,0,0,0,3.75
+Fall 2023,ARTS,6370,1,12583,Photography Studio,Ho,Jamie C,5,0,0,0,0,0,0,3.934
+Fall 2023,ARTS,6385,1,12584,IPEF Studio,Lowe,Rick,9,0,0,0,0,0,0,4.0
+Fall 2023,PETR,3362,1,12585,Reservoir Engineering I,Sakhaee Pour,Ahmad,6,2,1,0,0,0,0,3.556
+Fall 2023,FINA,7376,1,12586,Energy Trading,Smith III,Edwin A,11,0,0,0,0,0,0,3.88
+Fall 2023,ARTS,4370,1,12587,Sr Photo/Digital Media Major I,Kirages,Anastasia Francisca,12,5,1,0,0,0,0,3.593
+Fall 2023,ARTS,4371,1,12588,Sr Photo/Digital Media Major I,Molina,Lorena Guadalupe,9,6,3,0,0,0,0,3.297
+Fall 2023,ARTS,4372,1,12589,Sr Photo/Digital Media Major I,Ho,Jamie C,9,9,0,0,0,0,0,3.537
+Fall 2023,SPAN,3306,1,12590,Intro Study Span Language,Lopez Otero,Julio Cesar,6,9,4,0,0,0,0,3.244
+Fall 2023,PHAR,5672,3,12591,Clinical Pharmaceutical Resch,Gonzales-Luna,Anne J,2,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5675,3,12593,Disease State Management,De La Cruz,Austin Isaac,3,0,0,0,0,0,0,4.0
+Fall 2023,HIST,3327,1,12594,Houston Since 1836,Harwell,Debbie Z,17,2,4,0,1,0,2,3.403
+Fall 2023,ENGL,1301,31,12599,First Year Writing I,Anderson,Claire F,16,6,0,0,0,0,2,3.697
+Fall 2023,ENGL,1301,32,12600,First Year Writing I,Anderson,Claire F,17,4,0,2,1,0,0,3.334
+Fall 2023,ENGL,1301,36,12601,First Year Writing I,Pachuca,Adrian,6,9,2,0,2,0,0,2.825
+Fall 2023,ENGL,1301,41,12602,First Year Writing I,Weitman,Mathew,18,0,0,1,0,0,0,3.825
+Fall 2023,MUSI,3303,2,12603,Pop Music of Americas Sn 1840,Garza,Paul Victor,27,6,3,0,0,0,0,3.63
+Fall 2023,IDNS,1101,1,12604,Physics 1301 Workshop,Pattison,Donna,25,5,1,0,1,0,5,3.646
+Fall 2023,CHEM,2132,1,12605,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,6,1,
+Fall 2023,CHEM,2131,1,12606,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,9,1,
+Fall 2023,CHEM,2131,2,12607,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,5,1,
+Fall 2023,ARTS,3361,1,12608,Wood and Metal Fabrication,Giampietro,Francis A,14,0,0,0,0,0,1,3.953
+Fall 2023,COMD,2376,2,12609,Anatomy for Communication,Daniels,Stephanie K,7,15,10,5,1,0,11,2.536
+Fall 2023,BIOL,2120,6,12610,Microbiology for Non-Science,Knapp,Richard D,18,5,1,0,0,0,0,3.695
+Fall 2023,BIOL,2121,6,12611,Microbiol for Science Maj(lab),Knapp,Richard D,8,10,5,1,0,0,0,2.959
+Fall 2023,ELCS,8399,1,12612,Doctoral Dissertation,Horn,Catherine Lynn,5,0,0,0,0,2,0,4.0
+Fall 2023,MTLS,6111,1,12613,Materials Engineering Seminar,Shan,Xiaonan,0,0,0,0,0,27,0,
+Fall 2023,BIOL,1106,33,12614,Biol for Science Majors I(Lab),Medrano,Ana I,20,3,0,0,0,0,1,3.841
+Fall 2023,BIOL,1106,34,12615,Biol for Science Majors I(Lab),Medrano,Ana I,21,1,0,0,0,0,2,3.94
+Fall 2023,BIOL,1106,35,12616,Biol for Science Majors I(Lab),Medrano,Ana I,21,0,0,1,0,0,1,3.849
+Fall 2023,BIOL,1106,36,12617,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,0,0,0,0,1,3.833
+Fall 2023,HON,3361,1,12618,Global Engagement and Research,Miljanic,Andra Olivia,4,1,0,0,0,0,0,3.734
+Fall 2023,PHAR,5644,1,12619,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,4,0,1,0,0,0,0,3.6
+Fall 2023,PHAR,5645,1,12620,Pharmacy Informatics,Truong,Mabel,4,0,0,0,0,0,0,4.0
+Fall 2023,SCM,4351,1,12621,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,50,13,4,2,0,0,2,3.585
+Fall 2023,BIOL,1106,37,12622,Biol for Science Majors I(Lab),Medrano,Ana I,20,2,2,0,0,0,0,3.736
+Fall 2023,BIOL,1106,38,12623,Biol for Science Majors I(Lab),Medrano,Ana I,16,3,1,0,2,0,2,3.394
+Fall 2023,BIOL,1106,39,12624,Biol for Science Majors I(Lab),Medrano,Ana I,15,7,1,0,0,0,1,3.594
+Fall 2023,BIOL,1106,40,12625,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,0,1,1,0,0,3.514
+Fall 2023,CUIN,8398,3,12626,Independent Study,Hutchison,Laveria F,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,2120,7,12634,Microbiology for Non-Science,Knapp,Richard D,10,8,3,2,1,0,0,3.055
+Fall 2023,BIOL,2121,7,12635,Microbiol for Science Maj(lab),Knapp,Richard D,8,13,2,0,0,0,1,3.247
+Fall 2023,BIOL,2101,15,12636,Anatomy & Physiology Lab I,Gill,Tejendra,8,12,2,1,0,0,1,3.16
+Fall 2023,BIOL,2101,16,12637,Anatomy & Physiology Lab I,Gill,Tejendra,6,11,5,1,0,0,0,2.756
+Fall 2023,BIOL,1106,41,12638,Biol for Science Majors I(Lab),Medrano,Ana I,19,1,2,0,0,0,1,3.758
+Fall 2023,BIOL,1106,42,12639,Biol for Science Majors I(Lab),Medrano,Ana I,22,1,0,1,0,0,0,3.82
+Fall 2023,HDFS,4316,1,12640,Dynamics of Family Relations,Schoger,Kimberly,35,2,0,1,0,0,1,3.868
+Fall 2023,COMD,1333,3,12646,Intro to Comm Sci & Disorders,Ross,Byron L,13,8,9,0,0,0,5,3.1
+Fall 2023,BIOL,1106,43,12648,Biol for Science Majors I(Lab),Medrano,Ana I,12,6,3,1,1,0,0,3.174
+Fall 2023,CHEM,1111,3,12649,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,8,2,1,0,0,0,3.228
+Fall 2023,CHEM,1111,8,12650,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,14,1,0,0,0,1,3.193
+Fall 2023,CHEM,1111,21,12651,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,1,0,0,0,2,3.333
+Fall 2023,CHEM,1111,33,12652,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,2,0,0,0,3,3.125
+Fall 2023,CHEM,1111,42,12653,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,15,3,0,0,0,1,2.999
+Fall 2023,CHEM,1112,4,12657,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,5,0,0,0,0,2.933
+Fall 2023,CHEM,1112,11,12658,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,7,2,0,2,0,2,2.882
+Fall 2023,MATH,2450,1,12659,Accelerated Calculus I,Nicol,Matthew J,32,10,20,0,2,0,4,3.073
+Fall 2023,BIOL,1106,46,12660,Biol for Science Majors I(Lab),Medrano,Ana I,19,1,1,0,0,0,1,3.826
+Fall 2023,CHEE,8398,14,12664,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8398,15,12665,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8298,15,12666,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,2,0,
+Fall 2023,BTEC,1322,1,12667,Introduction to Biotechnology,Ibrahim,Eman Refaat,55,10,3,0,1,0,5,3.701
+Fall 2023,DANC,3302,1,12684,Int. Technique and Theory,Prokop,Travis Cooper,14,2,0,0,0,0,0,3.813
+Fall 2023,CHEM,2123,13,12685,Organic Chemistry Lab I,Bean,Mary B,4,8,10,0,0,0,2,2.622
+Fall 2023,ENGL,2360,1,12687,Western World Lit I--Honors,Barnes,Michael,11,1,0,0,1,0,0,3.539
+Fall 2023,ENGL,2360,2,12688,Western World Lit I--Honors,Barnes,Michael,5,1,1,0,0,0,0,3.477
+Fall 2023,ACCT,8398,1,12694,Special Problems,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Fall 2023,ECON,7301,1,12701,Seminar in Microecon Research,Chin,Aimee,0,0,0,0,0,9,0,
+Fall 2023,ECON,7302,1,12702,Seminar in Macroecon Research,Cubas Norando,German,0,0,0,0,0,9,0,
+Fall 2023,MATH,2318,4,12703,Linear Algebra,Sanders,Richard,17,12,21,7,9,0,10,2.363
+Fall 2023,MATH,3333,3,12704,Intermediate Analysis,Kalantar,Mehrdad,10,3,3,2,1,0,7,2.896
+Fall 2023,MATH,3339,4,12705,Statistics for the Sciences,Wang,Wenshuang,193,52,18,15,6,0,14,3.438
+Fall 2023,GEOL,1103,10,12706,Physical Geology Lab,Hauptvogel,Daniel William,17,4,3,0,0,0,0,3.57
+Fall 2023,GEOL,1304,1,12707,Historical Geology,Copeland,Peter,30,19,5,4,0,0,2,3.27
+Fall 2023,SPAN,3343,1,12710,Span for the Health Profession,Zubiate,Maria Laura,9,1,0,0,0,0,0,3.801
+Fall 2023,CHEM,6311,1,12711,Mechanisms,Comito,Robert Joseph,9,13,6,0,0,0,1,3.048
+Fall 2023,HDFS,4318,2,12713,Parent-Child Relationships,Frankel,Leslie Ann,18,12,5,0,0,0,2,3.315
+Fall 2023,PHYS,2326,5,12715,University Physics II(lecture),Timmins,Anthony Robert,17,11,6,0,0,0,0,3.285
+Fall 2023,ECE,4335,1,12716,Electrical Comp Engr Design I,Contreras-Vidal,Jose Luis,29,28,3,0,0,0,0,3.461
+Fall 2023,HLT,1353,2,12718,Personal Health,Rafique,Kiran Sajid,95,16,4,1,1,0,1,3.69
+Fall 2023,HLT,3381,2,12720,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,78,16,4,0,0,0,0,3.688
+Fall 2023,HLT,4307,1,12721,Research and Eval in Health,Correa-Fernandez,Virmarie,27,6,1,1,1,0,1,3.547
+Fall 2023,PHAR,5681,3,12722,Infectious Diseases,Truong,Mabel,16,3,0,0,0,0,0,3.842
+Fall 2023,PSYC,4344,3,12723,Cultural Psychology,Hernandez Ortiz,Jessica G,54,13,7,1,3,0,1,3.512
+Fall 2023,ENGL,1301,20,12725,First Year Writing I,Colchado,Lea,8,4,3,1,3,0,0,2.511
+Fall 2023,MANA,3335,3,12726,Intro Org Behavior and Mgmt,Carlin,Barbara A,69,123,43,9,2,0,1,2.997
+Fall 2023,MANA,4338,1,12727,Performance Management Systems,Sullivan,David Walter,48,8,3,0,1,0,0,3.744
+Fall 2023,ENGL,1302,14,12728,First Year Writing II,Long,Steven A.,5,6,2,1,2,0,3,2.688
+Fall 2023,ENGL,1302,20,12729,First Year Writing II,Presswood,Phillip Hilliard,22,2,0,2,4,0,0,3.189
+Fall 2023,ENGL,1302,22,12730,First Year Writing II,Cowan,Joshua Jared,7,4,2,1,7,0,4,2.049
+Fall 2023,ENGL,2305,2,12731,Intro To Fiction,Seelen,William,25,2,1,0,0,0,0,3.857
+Fall 2023,INTB,3355,1,12732,Global Environment of Business,Thompson,Joseph Lee,232,9,4,1,1,0,2,3.901
+Fall 2023,INTB,3355,2,12733,Global Environment of Business,Carvalho,Emilia Barreto,192,40,12,4,1,0,1,3.689
+Fall 2023,CNST,4385,1,12734,Field Operations Capital Proj,Molina,Mariel,8,2,0,0,0,0,0,3.8
+Fall 2023,BUSI,1301,2,12735,Business Principles,Thompson,Joseph Lee,24,0,0,0,0,0,0,4.0
+Fall 2023,BUSI,1301,3,12736,Business Principles,Thompson,Joseph Lee,260,7,4,0,2,0,1,3.915
+Fall 2023,TMTH,3360,4,12737,Applied Technical Statistics,Daniel,Patrick Nathanial,7,11,6,0,1,0,1,2.88
+Fall 2023,PSYC,6303,1,12738,Foundation-Clinical Interven I,Babcock,Julia,12,0,0,0,0,0,0,3.945
+Fall 2023,EDUC,1301,2,12739,Intro to Teaching Profession,Ronduen,Lionnel Ganir,19,2,5,1,1,0,2,3.298
+Fall 2023,CIS,4365,2,12740,Database Management,Hu,Renjie,29,25,7,0,0,0,0,3.344
+Fall 2023,CIS,4338,2,12741,Advanced Database Concepts,Miertschin,Susan L,0,1,0,0,0,0,0,3.0
+Fall 2023,CIS,4339,1,12742,Enterprise Appls Development,Lindner,Peggy,46,17,2,0,1,0,2,3.596
+Fall 2023,HDCS,3300,2,12743,Org Decisions,Hitchman Sr,Cal M,37,7,0,1,3,0,1,3.487
+Fall 2023,GEOL,6324,1,12744,Sat. Positioning & Geodesy,Wang,Guoquan,14,1,0,0,0,0,0,3.757
+Fall 2023,FINA,7372,1,12745,Upstream Economics,Berta,Dominique,4,1,0,0,0,0,0,3.668
+Fall 2023,FINA,4372,1,12746,Upstream Economics,Berta,Dominique,6,0,1,0,0,0,0,3.526
+Fall 2023,FINA,4352,1,12747,Fin Planning for Professionals,Lopez,John C,6,5,8,1,3,0,0,2.435
+Fall 2023,LAW,5409,1,12748,Contracts,Bush,Darren,17,21,0,0,0,0,1,3.404
+Fall 2023,ENRG,3310,1,12749,Intro to Energy & Sustainblty,Jacobsen,Nicolas Fisher,14,6,1,1,0,0,0,3.455
+Fall 2023,ACCT,5375,1,12750,Internl Audit-Entity Ctrl Env,Brant Jr,Robert Edward,2,1,1,0,0,0,0,3.333
+Fall 2023,HLT,4320,1,12751,Admin of Health Services,Markowitz,Eliz,26,12,1,2,0,0,1,3.424
+Fall 2023,ELED,4314,2,12752,Mathematics in Elem School I,Cutler,Carrie Sybil,28,5,0,0,0,0,0,3.868
+Fall 2023,BTEC,3320,30,12753,Intro to QA/QC in BTEC,Flavier,Albert B,7,18,5,0,0,0,0,2.99
+Fall 2023,ARCH,4510,1,12755,Integrated Arch Solutions,Peters,Patrick A,6,14,0,0,0,0,0,3.218
+Fall 2023,ARCH,4510,3,12757,Integrated Arch Solutions,Lutz,Shawn M,15,2,2,0,0,0,0,3.597
+Fall 2023,ARCH,4510,5,12759,Integrated Arch Solutions,Story,Jon Kevin,11,4,3,0,0,0,1,3.316
+Fall 2023,INAR,3500,1,12761,Interior Arch Design Studio V,Mantz,Ophelia,4,15,0,0,0,0,0,3.245
+Fall 2023,ASLI,4346,1,12763,ASL Translit & Educ Interpret,Gietz,Merrilee Ruth,5,5,0,0,0,0,0,3.269
+Fall 2023,ASLI,3434,1,12764,Simultaneous Interpreting II,Hill,Sharon Grigsby,4,4,0,0,0,0,0,3.5
+Fall 2023,SGNL,2302,1,12765,Intermediate Sign Language II,Gietz,Merrilee Ruth,4,6,7,0,1,0,1,2.593
+Fall 2023,HON,3330,1,12766,Leadership Theory and Practice,Rhoden,Brenda,5,1,0,0,0,0,0,3.833
+Fall 2023,ECE,3337,1,12767,Signals and Systems Analysis,Roysam,Badrinath,10,17,7,2,2,0,2,2.755
+Fall 2023,ECE,3364,1,12768,Circuits and Systems,Hebert,Thomas James,5,10,6,1,0,0,2,2.984
+Fall 2023,ENGL,3306,1,12769,Shakespeare-Major Works,Christensen,Ann C,12,8,5,0,1,0,4,3.09
+Fall 2023,TECH,6360,1,12770,Exp Design & Data Analysis,Schroeder,Susan L,26,1,0,0,0,0,0,3.963
+Fall 2023,MATH,3325,1,12771,Transition to Advanced Math,Ott,William R,19,6,4,2,1,0,1,3.229
+Fall 2023,COMD,6334,1,12772,Aphasia & Related Com Disorder,Maher,Lynn M,32,19,1,0,0,0,3,3.545
+Fall 2023,ACCT,4105,1,12774,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,1,0,
+Fall 2023,NUTR,3336,1,12775,Nutritional Pathophysiology,Vollrath,Kirstin,31,12,4,0,0,0,1,3.539
+Fall 2023,ARCH,1360,1,12777,Architectural Sketching I,Williams,Celeste,18,5,0,1,0,0,1,3.57
+Fall 2023,BCIS,1305,3,12778,Business Computer Applications,Felvegi,Emese,200,33,6,4,5,0,2,3.664
+Fall 2023,MUSA,4440,2,12779,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2023,MIS,4378,1,12780,Admin of Computer-Based MIS,Kniffen,Richard Chad,21,27,3,0,0,0,0,3.353
+Fall 2023,MIS,4378,2,12781,Admin of Computer-Based MIS,Kniffen,Richard Chad,2,21,4,0,0,0,0,2.926
+Fall 2023,SCM,4367,1,12782,Process and Quality Management,Miller,Bradley D,13,11,9,3,0,0,0,2.917
+Fall 2023,SCM,4367,2,12783,Process and Quality Management,Miller,Bradley D,30,30,8,1,0,0,0,3.276
+Fall 2023,MUSI,6370,1,12784,Art Song Repertoire,Sonnenberg,Melanie,4,1,0,0,0,0,0,3.668
+Fall 2023,ARED,4365,1,12787,Integrative Art Teaching,Chung,Sheng Kuan,7,0,0,0,0,0,0,3.906
+Fall 2023,SEDE,4312,1,12788,Teaching English in Sec School,Pauloski,Gwendolyn Jordan,11,3,0,0,0,0,0,3.739
+Fall 2023,MARK,4362,2,12789,Applied Buyer Behavior,Rudd,Melanie R,12,22,4,0,0,0,1,3.124
+Fall 2023,MARK,4362,3,12790,Applied Buyer Behavior,Rudd,Melanie R,19,16,2,1,0,0,0,3.334
+Fall 2023,CUIN,7303,1,12791,Professional Seminar I,Gist,Conra D,16,3,1,0,0,0,0,3.75
+Fall 2023,CUIN,7303,3,12792,Professional Seminar I,Brower,Samuel Richard,20,5,0,0,0,0,0,3.826
+Fall 2023,CUIN,7303,2,12793,Professional Seminar I,Leon,Maredil Josefina,15,0,1,0,1,0,1,3.608
+Fall 2023,PHYS,1101,13,12795,College Physics I (lab),Wood,Lowell T,1,11,10,0,0,0,1,2.651
+Fall 2023,PHYS,1101,14,12796,College Physics I (lab),Wood,Lowell T,1,7,6,0,0,0,1,2.666
+Fall 2023,SCM,7380,1,12797,Analytics & Enterprise Opertns,Murray,Michael J,17,5,0,0,0,0,0,3.758
+Fall 2023,COSC,4315,901,12798,Programming Languages and Para,Subramaniam,Venkat,15,4,5,0,0,0,3,3.375
+Fall 2023,COSC,6345,901,12799,Programming Languages,Subramaniam,Venkat,2,0,0,0,0,0,0,3.835
+Fall 2023,LAW,5314,1,12802,Lawyering Skills & Strategy I,Gomez,Alissa R,6,9,0,0,0,0,0,3.4
+Fall 2023,LAW,5314,2,12803,Lawyering Skills & Strategy I,Gomez,Alissa R,6,10,0,0,0,0,0,3.396
+Fall 2023,LAW,5314,4,12804,Lawyering Skills & Strategy I,Brantley,Maikieta Antoinette,6,7,0,0,0,0,1,3.385
+Fall 2023,LAW,5314,5,12805,Lawyering Skills & Strategy I,Swift,Kenneth Richard,6,8,1,0,0,0,0,3.399
+Fall 2023,LAW,5314,6,12806,Lawyering Skills & Strategy I,Heard,Whitney W,6,9,0,0,0,0,0,3.378
+Fall 2023,LAW,5314,8,12807,Lawyering Skills & Strategy I,Heard,Whitney W,6,11,0,0,0,0,0,3.334
+Fall 2023,LAW,5314,9,12808,Lawyering Skills & Strategy I,Brantley,Maikieta Antoinette,6,9,1,0,0,0,0,3.292
+Fall 2023,LAW,5314,10,12809,Lawyering Skills & Strategy I,Reed,Hilary S,7,8,0,0,0,0,0,3.401
+Fall 2023,LAW,5314,12,12810,Lawyering Skills & Strategy I,Swift,Kenneth Richard,8,7,0,0,0,0,0,3.401
+Fall 2023,LAW,5314,13,12811,Lawyering Skills & Strategy I,Reed,Hilary S,8,6,1,0,0,0,0,3.401
+Fall 2023,LAW,5314,14,12812,Lawyering Skills & Strategy I,Thornton,Nicole Kumari,6,9,0,0,0,0,0,3.334
+Fall 2023,LAW,5314,16,12813,Lawyering Skills & Strategy I,Brem,Katherine B,9,6,2,0,0,0,0,3.392
+Fall 2023,GRET,6336,1,12815,Global Retail Analysis,Robinson,Ebony M,3,2,1,0,0,0,0,3.333
+Fall 2023,GRET,6332,1,12816,Consumer Issues and Apps.,Johnson,Olivia,4,2,0,0,0,0,0,3.667
+Fall 2023,GRET,6334,1,12817,Global E-Tailing Systems,Ezell,Shirley D,4,1,0,0,0,0,0,3.734
+Fall 2023,ARLD,6310,1,12818,Fundraising for the Arts,Hays,Carolyn Jane,4,5,0,0,1,0,0,3.034
+Fall 2023,FORE,6331,20,12819,Social Change,Mudge,James Thomas,12,0,0,0,1,0,1,3.667
+Fall 2023,FORE,6351,20,12820,Futures Research,Hines,Andrew Lewis,11,0,0,0,0,0,0,3.91
+Fall 2023,ENGL,1301,131,12821,First Year Writing I,Yates,Kaitlyn,9,10,3,0,2,0,1,2.945
+Fall 2023,ENGI,1100,2,12822,Introduction To Engineering,Landon,Alexandra Maley,20,1,0,0,0,0,0,3.89
+Fall 2023,ENGI,1100,3,12823,Introduction To Engineering,Kowal,Marsha Christine,14,6,1,0,0,0,0,3.682
+Fall 2023,KIN,1352,1,12824,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,234,5,7,2,0,0,0,3.895
+Fall 2023,KIN,1352,2,12825,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,223,10,7,3,2,0,3,3.819
+Fall 2023,KIN,1352,3,12826,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,225,13,6,3,5,0,1,3.775
+Fall 2023,PHYS,8399,40,12834,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,1,0,
+Fall 2023,MUSI,8296,4,12840,Doctoral Essay,Pollack,Howard J,1,0,0,0,0,1,0,4.0
+Fall 2023,MUSI,6106,3,12841,Grad Large Ensemble,Weber,Mary E,2,0,0,0,0,0,0,4.0
+Fall 2023,SOC,6399,9,12842,Masters Thesis,Katz,Sheila,3,0,0,0,0,0,0,4.0
+Fall 2023,SOC,6302,1,12843,Research and Writing,Kwan,Samantha S,8,3,1,0,0,0,0,3.556
+Fall 2023,PHYS,6315,1,12845,Quantum Mechanics I,Hosur,Pavan R,10,9,0,0,0,0,0,3.405
+Fall 2023,FINA,4326,1,12847,Private Equity & Inv. Banking,Stewart,Marcus,18,11,0,0,0,0,2,3.575
+Fall 2023,MUSI,8296,5,12848,Doctoral Essay,Bertagnolli,Paul A,2,0,0,0,0,1,0,4.0
+Fall 2023,HRD,4344,1,12849,Designing E-Learning,Bennett,LaTasha,30,8,1,0,0,0,0,3.701
+Fall 2023,POLS,8999,19,12850,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,4,0,
+Fall 2023,COMD,6261,1,12851,Research and Critical Thinking,Dial,Heather Raye,34,16,1,0,0,0,3,3.563
+Fall 2023,ENGL,1301,132,12854,First Year Writing I,Yates,Kaitlyn,10,5,3,2,2,0,3,2.744
+Fall 2023,ENGL,1301,133,12855,First Year Writing I,Bradley,Jari,4,6,4,5,3,0,3,2.136
+Fall 2023,ENGL,1302,32,12856,First Year Writing II,Presswood,Phillip Hilliard,22,0,0,1,2,0,0,3.534
+Fall 2023,MARK,4396,1,12857,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,12,0,
+Fall 2023,POLS,8999,25,12869,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,3,0,
+Fall 2023,HIST,8999,5,12870,Doctoral Dissertation,Clavin,Matthew J,0,0,0,0,0,1,0,
+Fall 2023,HIST,8999,6,12871,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,1,0,
+Fall 2023,GOVT,2305,3,12872,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,96,81,44,19,2,0,7,3.013
+Fall 2023,POLS,8399,20,12874,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,1,0,
+Fall 2023,SPAN,8699,6,12877,Dissertation,Kanellos,Nicolas,0,0,0,0,0,2,0,
+Fall 2023,THEA,7221,1,12881,Graduate Voice I,Johnson,James B,8,0,0,0,0,0,0,3.876
+Fall 2023,THEA,7251,1,12882,Graduate Speech I,Wetzel,Molly Elizabeth,5,3,0,0,0,0,0,3.666
+Fall 2023,THEA,7211,1,12883,Graduate Movement I,Noble,Adam S,8,0,0,0,0,0,0,3.67
+Fall 2023,CHEE,8598,10,12889,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2023,POLS,8399,23,12891,Doctoral Dissertation,Clark,Jennifer H,0,0,0,0,0,0,0,
+Fall 2023,MANA,4396,1,12892,Management Internship,Carlin,Barbara A,0,0,0,0,0,5,0,
+Fall 2023,SPAN,8699,7,12894,Dissertation,Ventura,Gabriela Baeza,2,0,0,0,0,0,0,4.0
+Fall 2023,FINA,4396,1,12895,Finance Internship,Kumar,Praveen,0,0,0,0,0,15,0,
+Fall 2023,BIOE,8298,4,12896,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,3,0,
+Fall 2023,GEOL,1340,2,12899,Earth Systems,Lytwyn,Jennifer N,66,76,48,9,7,0,14,2.879
+Fall 2023,CHEE,8298,16,12901,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8399,8,12905,Doctoral Dissertation,Chung,Sheng Kuan,1,0,0,0,0,0,0,4.0
+Fall 2023,MANA,8399,3,12906,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,6,12909,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,3,0,
+Fall 2023,BIOE,8298,5,12910,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,
+Fall 2023,BIOE,6398,8,12915,Research,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Fall 2023,GOVT,2306,4,12916,US and Texas Const/Politics,Jefferies,Kevin E,141,69,17,9,11,0,1,3.281
+Fall 2023,KIN,3303,1,12918,Sports Communication,Walsh,David W,6,31,10,1,1,0,0,2.81
+Fall 2023,KIN,4302,1,12919,Fitness and Human Sexuality,Alastuey,Lisa L,47,34,23,6,6,0,4,2.891
+Fall 2023,SPAN,3312,1,12920,English/Spanish Translation,Arboleda,Paola,17,3,0,1,1,0,0,3.485
+Fall 2023,MUSI,8106,3,12921,Doctoral Large Ensemble,Weber,Mary E,3,0,0,0,0,0,0,4.0
+Fall 2023,MATH,2318,5,12922,Linear Algebra,Perepelitsa,Mikhail Antolyevic,25,38,30,13,1,0,11,2.63
+Fall 2023,MATH,4331,2,12923,Intro to Real Analysis I,Bodmann,Bernhard G,5,2,0,1,0,0,3,3.293
+Fall 2023,MATH,6312,2,12924,Introduction to Real Analysis,Bodmann,Bernhard G,1,3,0,0,0,0,2,3.25
+Fall 2023,MATH,4377,4,12925,Advanced Linear Algebra I,Mamonov,Alexander V,4,2,8,2,3,0,6,1.984
+Fall 2023,MATH,6308,4,12926,Advanced Linear Algebra I,Mamonov,Alexander V,4,6,0,1,0,0,0,3.182
+Fall 2023,BIOE,6398,13,12931,Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2023,CNST,4315,1,12935,Steel Construction,Chang,Chi Chung,18,38,0,0,0,0,1,3.28
+Fall 2023,BIOE,8298,9,12938,Doctoral Research,Larin,Kirill,0,0,0,0,0,6,0,
+Fall 2023,BIOE,8298,12,12941,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2023,FINA,3332,4,12943,Prin of Financial Management,Chisholm,Darla,16,29,34,26,11,0,27,2.044
+Fall 2023,NUTR,4349,1,12944,Public Policy in Nutrition,Vollrath,Kirstin,43,27,8,0,2,0,0,3.301
+Fall 2023,BIOE,8398,5,12945,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,3,0,
+Fall 2023,BIOE,8398,8,12947,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,
+Fall 2023,BIOE,8398,9,12948,Doctoral Research,Larin,Kirill,0,0,0,0,0,3,0,
+Fall 2023,BIOE,8398,10,12949,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,13,12952,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,0,1,
+Fall 2023,PSYC,3339,1,12953,Intro To Clinical Psychology,Szafranski,Derek D,65,9,3,0,2,0,1,3.68
+Fall 2023,PSYC,2301,1,12954,Introduction to Psychology,Agan,Herb W,178,82,10,2,3,0,0,3.534
+Fall 2023,PSYC,2301,2,12955,Introduction to Psychology,Agan,Herb W,152,92,15,5,7,0,5,3.366
+Fall 2023,PSYC,2301,3,12956,Introduction to Psychology,Gehm,Kevan H,19,16,3,1,0,0,1,3.334
+Fall 2023,GEOL,1340,3,12957,Earth Systems,Lytwyn,Jennifer N,48,64,40,13,8,0,21,2.776
+Fall 2023,SCM,4301,2,12958,Logistics Management,Tibodeau,Dale,18,18,11,3,0,0,0,3.033
+Fall 2023,BIOL,4374,2,12959,Cell Biology,Rea,Michael A,52,35,24,8,3,0,7,3.03
+Fall 2023,FORE,6395,1,12960,Master's Project in Foresight,Hines,Andrew Lewis,7,1,0,0,0,0,0,3.834
+Fall 2023,FORE,6398,1,12961,Special Problems in Foresight,Hines,Andrew Lewis,2,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7329,1,12962,Behavioral Finance,Rude,Dale,1,2,0,0,0,0,0,3.553
+Fall 2023,BIOE,8498,11,12967,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,7,12970,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,8,12971,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,0,0,
+Fall 2023,BIOE,8598,10,12973,Doctoral Research,Larin,Kirill,0,0,0,0,0,5,0,
+Fall 2023,BIOE,8598,11,12974,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,13,12976,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2023,COMM,6310,1,12977,Mass Comm Theory and Research,Bhat,Nandikoor R Prashanth,11,0,0,0,2,0,0,3.385
+Fall 2023,FINA,7329,1,12978,Behavioral Finance,Rude,Dale,6,4,0,0,0,0,0,3.468
+Fall 2023,GEOL,3383,1,12979,Remote Sensing,Khan,Shuhab D,9,7,0,0,0,0,4,3.48
+Fall 2023,GEOL,6325,1,12981,Remote Sensing,Khan,Shuhab D,9,5,0,0,0,0,0,3.525
+Fall 2023,ACCT,3367,1,12983,Intermediate Accounting I,Gamble,George O,2,2,3,0,0,0,0,2.81
+Fall 2023,PHYS,1302,2,12985,College Physics II (lecture),Portillo Vazquez,Israel,33,44,50,25,9,0,23,2.39
+Fall 2023,PETR,6399,2,12991,Masters Thesis,Dindoruk,Birol,0,0,0,0,0,2,0,
+Fall 2023,PETR,6399,3,12992,Masters Thesis,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2023,PHYS,3315,1,12994,Modern Physics,Forrest,Rebecca L,6,3,5,0,1,0,4,2.867
+Fall 2023,PETR,6362,1,12995,Reservoir Engineering I,Lee,Kyung Jae,5,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,3309,1,12996,Intermediate Mechanics,Bellwied,Rene,3,7,1,0,2,0,2,2.642
+Fall 2023,MIS,4477,3,12999,Network & Security Infrastruct,Khan,Hina F,23,12,3,1,0,0,0,3.411
+Fall 2023,ELED,4312,2,13004,Science in the Elem School II,Khalidi,Rana,21,2,0,0,0,0,0,3.856
+Fall 2023,ECE,4336,1,13005,Electrical Comp Engr Design II,Pei,Shin-Shem Steven,35,15,0,0,0,0,0,3.687
+Fall 2023,MECE,3345,1,13007,Materials Science,Ardebili,Haleh,13,22,15,0,1,0,4,2.889
+Fall 2023,MIS,3370,3,13008,Info Systems Development Tools,Zamarripa,Ivan,22,13,15,6,1,0,6,2.86
+Fall 2023,MECT,3331,2,13009,Applied Thermodynamics,Mohan,Gowtham,0,8,15,3,1,0,2,2.05
+Fall 2023,LAW,5383,1,13011,Family Law,Oldham,J Thomas,24,35,3,0,0,7,0,3.27
+Fall 2023,LAW,5418,7,13012,Torts,Mantel,Jessica,26,46,2,0,0,0,1,3.324
+Fall 2023,LAW,5332,1,13013,Patent Law,Michaels,Andrew Charles,13,15,0,0,0,0,0,3.394
+Fall 2023,FINA,4320,4,13014,Investment Management,Mateen,Haaris,9,4,2,0,0,0,1,3.401
+Fall 2023,ENGL,2330,1,13015,Writing Discipline English,Coleman,Quintin,11,5,0,1,1,0,1,3.297
+Fall 2023,POLS,3312,1,13017,"Arguments, Data, Politics",Karimov,Samad,15,11,4,3,2,0,5,2.924
+Fall 2023,CHEM,1311,4,13019,Fundamentals of Chemistry,Guloy,Arnold M,55,95,74,19,21,0,39,2.517
+Fall 2023,SPEC,3361,1,13021,Behavior: Interventions,Carp,Charlotte Lynn,8,3,0,0,0,0,0,3.637
+Fall 2023,SPEC,4363,2,13022,Instructional Interventions,Rigby-Wills,Hope,15,1,2,0,0,0,1,3.631
+Fall 2023,PSYC,2301,51,13023,Introduction to Psychology,Saiyed,Amna Shabbir,32,1,0,0,1,0,0,3.843
+Fall 2023,PSYC,2301,50,13024,Introduction to Psychology,Saiyed,Amna Shabbir,29,1,0,0,1,0,0,3.785
+Fall 2023,CUIN,3111,4,13025,Educational Tech Elem Teachers,Davis,Kelly M,38,2,0,0,0,0,0,3.892
+Fall 2023,PHYS,1101,15,13026,College Physics I (lab),Wood,Lowell T,4,10,10,0,0,0,0,2.668
+Fall 2023,PHYS,1101,16,13027,College Physics I (lab),Wood,Lowell T,0,13,1,0,0,0,1,2.834
+Fall 2023,PHYS,1102,10,13028,College Physics II (lab),Wood,Lowell T,0,19,5,0,0,0,0,2.847
+Fall 2023,INAR,4500,1,13030,Interior Arch Studio VII,Tucker de Vazquez,Sheryl,3,7,2,0,0,0,0,3.056
+Fall 2023,ARCH,3327,1,13032,Technology 3,Smith,Joshua S,71,45,7,2,4,0,0,3.372
+Fall 2023,LAW,5401,1,13035,Entrpr Community Dev Clinic II,Heard,Christopher D,0,0,0,0,0,1,0,
+Fall 2023,GHL,2350,2,13036,Mgmt Principles in Hospitality,Boger Jr,Carl A,27,6,5,0,1,0,1,3.436
+Fall 2023,GHL,3341,1,13037,Hospitality Managerial Acct,Johnson,Tucker A,14,14,0,0,0,0,0,3.441
+Fall 2023,PETR,4301,1,13039,Resvr Character and Modeling,Lee,Kyung Jae,14,4,0,0,0,0,0,3.686
+Fall 2023,PHAR,5690,3,13040,Internal Medicine,Fernandez,Julianna M,2,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5683,3,13041,Cardiology,Wanat,Matthew A,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,2340,1,13042,System of Accts in Hospitality,DeFranco,Agnes L,15,6,4,1,0,0,1,3.372
+Fall 2023,GHL,2340,2,13043,System of Accts in Hospitality,Ramirez,Arlene D,9,5,5,1,0,0,1,3.051
+Fall 2023,PHYS,1302,3,13044,College Physics II (lecture),Portillo Vazquez,Israel,27,38,53,19,12,0,18,2.338
+Fall 2023,MARK,7362,1,13045,Mgmt of Marketing Information,Hui,Kachuen Sam,19,0,0,0,0,0,0,3.983
+Fall 2023,MARK,4338,1,13046,Marketing Research,Hui,Kachuen Sam,12,6,1,0,0,0,1,3.579
+Fall 2023,MECE,4331,1,13047,Design of Machine Elements,Chen,Zheng,34,60,40,1,2,0,0,2.857
+Fall 2023,MUED,2342,1,13048,Music for Children,Schlosser,Emily Elizabeth,22,0,0,1,0,0,1,3.884
+Fall 2023,MUED,2342,2,13049,Music for Children,Schlosser,Emily Elizabeth,24,0,0,0,0,0,0,3.986
+Fall 2023,DANC,2304,1,13050,Dance Kinesiology,Chapman,Teresa Lynn,7,9,2,0,0,0,0,3.278
+Fall 2023,HDFS,3300,1,13051,Educational Psychology,Conston,Toya,134,15,5,1,2,0,0,3.756
+Fall 2023,TLIM,3340,30,13052,Org Leadership & Supervision,Evans,Gerald S,232,10,7,2,4,0,3,3.777
+Fall 2023,HLT,3325,1,13054,Medical Terminology,Bloom,Joel A,141,9,3,0,0,0,0,3.859
+Fall 2023,BIOE,4115,1,13056,Intro Bioinstrumentation Lab,An,Ran,22,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,4315,1,13057,Bioinstrumentation,An,Ran,45,10,0,0,0,0,0,3.77
+Fall 2023,BIOE,4335,1,13058,Capstone Design I,Akay,Metin,52,0,0,0,0,0,0,3.778
+Fall 2023,MECT,4188,1,13059,Ethics in Engineering Tech,Bose,Anima B,31,17,1,0,0,0,1,3.531
+Fall 2023,MECT,4188,2,13060,Ethics in Engineering Tech,Bose,Anima B,25,17,0,0,0,0,0,3.532
+Fall 2023,TLIM,4341,2,13061,Production & Service Operation,Chance,Michael Dean,16,13,0,0,0,0,0,3.529
+Fall 2023,TLIM,4342,32,13062,Quality Improvement Methods,O'Kelley,Donna K,22,20,8,2,0,0,0,3.116
+Fall 2023,TLIM,4372,30,13063,Proposal and Project Writing,Thomas,Jamie M,4,5,1,0,1,0,0,3.03
+Fall 2023,BIOE,6399,6,13064,Masters Thesis,Akay,Metin,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,7600,3,13068,Architecture Design Studio V,Longoria,Rafael R,3,2,0,0,0,0,0,3.534
+Fall 2023,ARLD,6320,1,13070,Financial Management for Arts,Townsend,Justine M,14,0,0,0,0,0,0,3.953
+Fall 2023,ENGL,1301,13,13071,First Year Writing I,Bradley,Jari,10,2,5,3,3,0,2,2.565
+Fall 2023,ENGL,1301,105,13072,First Year Writing I,Krajniak,Matthew J,11,4,3,1,9,0,1,2.179
+Fall 2023,COSC,6344,1,13073,Visualization,Chen,Guoning,35,25,0,0,0,0,0,3.523
+Fall 2023,CNST,4335,1,13074,Capital Projects Development,Weintraub,Marvin Stanley,11,0,0,0,0,0,2,4.0
+Fall 2023,ACCT,3367,2,13075,Intermediate Accounting I,Gamble,George O,1,2,2,0,0,0,1,2.8
+Fall 2023,ARTS,3313,2,13078,Silkscreen,Masterson,Patrick D,12,0,1,0,0,0,2,3.846
+Fall 2023,BIOE,6347,1,13080,Intro Opt Sense & Biophotonics,Larin,Kirill,3,1,2,0,0,0,0,3.112
+Fall 2023,INDE,6333,2,13082,Probability Stat For Engineers,Feng,Qianmei,28,28,15,3,3,0,1,2.944
+Fall 2023,ARTH,7380,1,13083,Graduate Art History Methods I,Harren,Natilee O,4,1,0,0,0,0,0,3.866
+Fall 2023,FORE,6311,20,13084,Introduction to Foresight,Schultz,Wendy L,9,1,1,0,1,0,0,3.417
+Fall 2023,COMM,3320,1,13085,Audio Production,Newlin,Julye G,13,12,2,1,2,0,0,3.067
+Fall 2023,BZAN,6310,2,13087,Quant Analysis for Busn Dec,Wiley,Briceon C,4,2,5,0,0,0,0,2.849
+Fall 2023,WGSS,2350,6,13088,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,4,1,0,0,0,0,3.8
+Fall 2023,CHEE,8398,16,13089,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8398,17,13091,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8398,18,13092,Doctoral Research,Vekilov,Peter,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8598,11,13093,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,2,0,
+Fall 2023,MATH,8698,2,13094,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Fall 2023,FINA,4380,1,13095,R E Fin & Investment,Adams,James S,7,25,7,0,0,0,0,2.966
+Fall 2023,CUIN,3350,3,13096,Knowing/Learning Science-Math,Segura,Perri F,16,2,0,0,0,0,0,3.816
+Fall 2023,ARTS,3383,1,13097,Digital Fabrication,Scott,Caitlin,11,3,0,1,0,0,0,3.556
+Fall 2023,ENGL,3351,1,13098,Am Lit Since 1865,Ellis,Amanda,16,3,3,1,1,0,5,3.265
+Fall 2023,MUSI,6101,1,13099,Opera Role Performance,Belcher,Kathleen,20,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6140,1,13101,Graduate Recital I,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6140,2,13102,Graduate Recital I,Yon,Kirsten A,0,0,0,0,0,0,0,
+Fall 2023,MUSI,4370,1,13104,Art Song Repertoire,Sonnenberg,Melanie,8,0,1,0,0,0,0,3.778
+Fall 2023,MUSI,6340,1,13105,Graduate Music History Review,Caton,Kathryn L.,8,3,1,0,0,0,0,3.583
+Fall 2023,MUSI,6341,1,13106,Graduate Music Theory Review,Guez,Jonathan Charles,7,9,2,0,1,0,0,3.105
+Fall 2023,SOC,6398,2,13111,Special Problems,Anderson,Kathryn,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3400,4,13112,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2023,ECON,3370,3,13113,Introduction To Econometrics,Zhivan,Natalia A,7,8,6,1,2,0,0,2.681
+Fall 2023,ATP,6311,1,13114,Research in Athletic Training,Knoblauch,Mark Alan,7,7,1,0,0,0,0,3.4
+Fall 2023,ATP,6312,1,13115,Therapeutic Intervention 1,Gililland,Darrell Jon,11,3,0,0,0,0,0,3.786
+Fall 2023,ATP,6192,1,13116,Clinical Experience II,Harrison,Layci,11,4,0,0,0,0,0,3.733
+Fall 2023,PHOP,6275,1,13117,Professional Development,Porter,Jason,7,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5314,18,13119,Lawyering Skills & Strategy I,Simpson,Lauren J,7,7,0,0,0,0,0,3.476
+Fall 2023,LAW,5314,22,13120,Lawyering Skills & Strategy I,Simpson,Lauren J,2,13,0,0,0,0,0,3.309
+Fall 2023,MECT,4172,2,13123,Materials Tech Lab,Al Ibadi,Adnan,2,14,2,0,1,0,0,2.842
+Fall 2023,CHEE,8398,19,13125,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2023,THEA,7141,1,13126,Grad Direct/Design Collaboratn,Niederer,Barbara,3,0,0,0,0,0,0,4.0
+Fall 2023,ARLD,6691,1,13127,Internship in Arts Organizatn,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8303,1,13128,Seminar in Music Theory,Koozin,Timothy,8,1,0,0,0,0,0,3.889
+Fall 2023,CHEM,8998,20,13129,Doctoral Research,Baldelli,Steve,0,0,0,0,0,1,0,
+Fall 2023,WGSS,2350,8,13134,Intro To Women's Studies,Pegoda,Andrew Joseph,5,14,4,1,0,0,6,3.0
+Fall 2023,CHEM,6698,24,13143,Special Problems,Carrow,Bradley,0,0,0,0,0,2,0,
+Fall 2023,PHYS,1102,13,13144,College Physics II (lab),Wood,Lowell T,1,9,11,1,0,0,0,2.605
+Fall 2023,PHLS,7393,2,13145,Internship and Practicum,Margulis,Milena A,4,0,1,0,0,0,0,3.6
+Fall 2023,BIOL,1106,47,13148,Biol for Science Majors I(Lab),Medrano,Ana I,22,1,0,1,0,0,0,3.82
+Fall 2023,BIOL,1106,48,13149,Biol for Science Majors I(Lab),Medrano,Ana I,21,1,0,1,0,0,1,3.812
+Fall 2023,CHEM,1111,52,13150,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,1,0,0,0,2,3.177
+Fall 2023,CHEM,1111,55,13151,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,1,0,0,0,0,3.157
+Fall 2023,CHEM,1112,18,13152,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,0,1,0,0,1,3.098
+Fall 2023,CHEM,1112,19,13153,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,2,0,0,0,3,3.155
+Fall 2023,ARCH,1500,17,13154,Design Studio I,Gonzales,Michael A,10,2,1,0,0,0,0,3.642
+Fall 2023,MECT,3118,3,13157,Fluid Mechanic Application Lab,Al Ibadi,Adnan,3,0,0,0,0,0,0,3.89
+Fall 2023,MECT,3155,3,13158,Strength Materials Lab,Al Ibadi,Adnan,7,4,0,0,0,0,0,3.606
+Fall 2023,MATH,8698,3,13164,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Fall 2023,SPAN,6305,1,13166,Teaching Span. for Acquisition,Gellon,Sofia,8,1,0,0,0,0,0,3.926
+Fall 2023,ECON,8363,1,13167,Workshop in Research Methods V,Cubas Norando,German,11,0,0,0,0,0,0,4.0
+Fall 2023,PHIL,1321,2,13168,Logic I,Haaga,Curtis W,37,16,12,12,5,0,14,2.789
+Fall 2023,ECON,8399,3,13169,Doctoral Dissertation,Sorensen,Bent E,1,0,0,0,0,3,0,4.0
+Fall 2023,PHOP,6257,5,13170,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,HRD,3340,1,13171,Principles of HRD,Greer,Tomika,7,17,3,0,0,0,1,3.221
+Fall 2023,ENGL,1301,22,13177,First Year Writing I,Rolater,Sara C,12,6,1,2,3,0,0,2.862
+Fall 2023,ENGL,1301,25,13178,First Year Writing I,Rolater,Sara C,7,5,6,3,3,0,1,2.417
+Fall 2023,BIOL,2101,17,13179,Anatomy & Physiology Lab I,Gill,Tejendra,6,11,6,0,0,0,0,3.0
+Fall 2023,BIOL,2101,18,13180,Anatomy & Physiology Lab I,Gill,Tejendra,0,14,7,0,1,0,1,2.47
+Fall 2023,BIOL,2101,19,13181,Anatomy & Physiology Lab I,Gill,Tejendra,6,13,3,1,1,0,0,2.779
+Fall 2023,ECON,8399,2,13186,Doctoral Dissertation,Papell,David H,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,14,13187,Doctoral Research,Romero Ortega,Mario Ignacio,0,0,0,0,0,0,1,
+Fall 2023,THEA,6294,3,13188,Design and Production Studio,Willson,Paige A,1,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6294,5,13189,Design and Production Studio,Niederer,Barbara,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,8699,2,13192,Doctoral Dissertation,Johnston,Craig Allen,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8298,17,13193,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Fall 2023,HIST,8399,4,13197,Doctoral Dissertation,Takriti,Abdel Razzaq,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6301,1,13209,Leadership for Equity,Johnson,Detra DeVerne,10,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,3304,3,13212,General Biochemistry I,Scott,Sean-Patrick,33,58,42,6,1,0,12,2.796
+Fall 2023,BIOE,6351,1,13213,Diseases and Biomarkers,Mohan,Chandra,10,3,0,0,0,0,0,3.769
+Fall 2023,BIOE,6350,1,13214,Genomic and Proteomic Engr,Wu,Tianfu,22,1,0,0,0,0,0,3.942
+Fall 2023,SCM,4390,1,13215,Supply Chain Strategy,Smith,Gordon D,34,29,2,0,0,0,0,3.497
+Fall 2023,PETR,4311,1,13216,Petroleum Capstone Project I,Zargar,Zeinab,3,9,0,0,0,0,0,3.498
+Fall 2023,SPAN,3339,1,13217,Span for Global Professions,Zubiate,Maria Laura,10,6,1,0,0,0,0,3.588
+Fall 2023,ARTS,3374,3,13218,Computer Imaging,Chen,Shang-Yee Mark,13,1,1,0,1,0,0,3.48
+Fall 2023,PETR,8298,1,13225,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,4,0,
+Fall 2023,PETR,8699,1,13229,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,2,0,
+Fall 2023,CHEM,4365,1,13230,Inorganic Chemistry II,Hoffman,David M,2,8,8,1,1,0,0,2.467
+Fall 2023,PSYC,3350,2,13231,Intro to Cognitive Psychology,Racioppo,Keith,31,41,5,1,0,0,0,3.342
+Fall 2023,BIOE,4115,2,13232,Intro Bioinstrumentation Lab,An,Ran,12,0,1,0,0,0,0,3.846
+Fall 2023,GEOL,1147,1,13233,Introductory Meteorology Lab,Zheng,Youtong,11,3,1,0,3,0,0,3.019
+Fall 2023,CUIN,8341,1,13234,Crit Issues & Research Urb Ed,Batt,Joanna,9,3,0,0,0,0,0,3.778
+Fall 2023,COSC,4351,2,13236,Fundamentals of Software Engr,Hilford,Victoria,49,19,14,1,0,0,1,3.334
+Fall 2023,ECE,2100,1,13237,Circuit Analysis Laboratory,Pan,Miao,18,1,2,0,0,0,0,3.793
+Fall 2023,ECE,2201,1,13238,Circuit Analysis I,Ramachandran,Deepa,8,13,11,11,3,0,9,2.196
+Fall 2023,ECE,3340,1,13239,Numerical Methods for ECE,Mayerich,David Matthew,17,8,4,0,0,0,0,3.448
+Fall 2023,ECE,3155,1,13240,Electronics Laboratory,Wolfe,John C,76,10,0,0,0,0,2,3.865
+Fall 2023,COMM,2320,1,13241,Fundamentals Media Production,Crowe,Craig Warren,59,10,2,0,0,0,3,3.807
+Fall 2023,COMM,2322,1,13242,Television Production I,Crowe,Craig Warren,9,10,0,0,0,0,1,3.387
+Fall 2023,ECE,6340,1,13243,Interm Electromag Waves,Chen,Jiefu,6,1,0,0,0,0,0,3.81
+Fall 2023,GEOL,3370,1,13244,Mineralogy,Fu,Qi,18,16,5,3,2,0,1,2.948
+Fall 2023,ACCT,2302,6,13247,Prin of Managerial Accounting,Weber,Catherine K,20,30,19,9,3,0,3,2.724
+Fall 2023,ACCT,5379,1,13248,Enterprise Risk Management,Neely,Gregory Wayne,1,1,0,0,0,0,0,3.665
+Fall 2023,ENGI,1100,8,13250,Introduction To Engineering,Burleson,Daniel W,42,13,2,2,1,0,0,3.523
+Fall 2023,PHLS,8393,1,13251,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,7,1,
+Fall 2023,AAMS,2300,1,13253,Intro Asian American Studies,Nguyen,An,8,7,6,2,0,0,1,2.999
+Fall 2023,PETR,8198,4,13256,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2023,PETR,8298,4,13258,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,4,0,
+Fall 2023,PETR,8398,2,13259,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Fall 2023,PETR,8498,4,13263,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2023,MUSI,4198,2,13264,Research in Chamber Music,Lo,Mann-Wen,2,0,0,0,0,0,0,3.67
+Fall 2023,MUSI,4198,3,13265,Research in Chamber Music,Cho,Eunghee,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,5,13266,Research in Chamber Music,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Fall 2023,SOC,4394,1,13267,Internship in Sociology,Karner,Tracy Xavia,2,3,1,0,0,0,1,3.167
+Fall 2023,ELET,1401,1,13268,Circuit Theory and Lab II,Barbieri,Enrique,5,9,15,3,0,0,2,2.335
+Fall 2023,FINA,4329,1,13271,Life Insurance and Annuities,Hong,James,23,35,6,0,0,0,0,3.281
+Fall 2023,PETR,8598,2,13273,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,4,0,
+Fall 2023,PETR,8598,3,13274,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,2,0,
+Fall 2023,PETR,8399,2,13277,Doctoral Dissertation,Dindoruk,Birol,0,0,0,0,0,3,0,
+Fall 2023,PETR,8399,3,13278,Doctoral Dissertation,Ehlig-Economides,Christine A,0,0,0,0,0,3,0,
+Fall 2023,BCHS,3201,1,13281,Biochemistry I Laboratory,Pattison,Donna,8,11,0,0,0,0,2,3.438
+Fall 2023,BCHS,3201,2,13282,Biochemistry I Laboratory,Pattison,Donna,11,7,0,1,0,0,1,3.439
+Fall 2023,BCHS,3201,3,13283,Biochemistry I Laboratory,Pattison,Donna,1,8,2,2,1,0,1,2.499
+Fall 2023,BCHS,3201,4,13284,Biochemistry I Laboratory,Pattison,Donna,8,7,0,0,0,0,1,3.511
+Fall 2023,BCHS,3201,5,13285,Biochemistry I Laboratory,Pattison,Donna,14,10,0,0,0,0,0,3.597
+Fall 2023,BCHS,3201,6,13286,Biochemistry I Laboratory,Pattison,Donna,11,5,3,0,1,0,1,3.234
+Fall 2023,BCHS,3201,7,13287,Biochemistry I Laboratory,Pattison,Donna,5,8,3,0,0,0,1,3.187
+Fall 2023,BCHS,3201,8,13288,Biochemistry I Laboratory,Pattison,Donna,13,8,2,0,0,0,0,3.464
+Fall 2023,BCHS,3201,9,13289,Biochemistry I Laboratory,Pattison,Donna,9,9,0,1,0,0,4,3.386
+Fall 2023,BIOL,4103,1,13291,Integration Biol Knowledge,Wayne,Chad M,46,26,8,0,2,0,1,3.41
+Fall 2023,BIOL,4103,2,13292,Integration Biol Knowledge,Wayne,Chad M,71,15,7,0,1,0,1,3.67
+Fall 2023,COSC,4353,901,13293,Software Design,Subramaniam,Venkat,8,6,3,0,0,0,0,3.255
+Fall 2023,COMM,4360,2,13300,Media Planning & Placement,Jin,Eunjoo,10,12,8,0,0,0,1,2.968
+Fall 2023,COMM,4368,1,13301,Public Relations Campaigns,Vardeman,Jennifer E,23,0,0,0,0,0,0,3.943
+Fall 2023,POLS,3348,1,13302,"Left, Right, and Center",Hawley,Michael C,5,27,3,0,2,0,3,2.999
+Fall 2023,COSC,3360,1,13303,Operating Systems,Long,Kevin B,24,14,1,0,0,0,0,3.59
+Fall 2023,HDCS,3300,3,13304,Org Decisions,Stewart,Quentin K,17,10,2,1,0,0,0,3.411
+Fall 2023,MECE,3363,1,13305,Intro To Fluid Mechanics,Floryan,Daniel,16,30,9,1,1,0,7,3.006
+Fall 2023,ARCH,6359,1,13306,Modern Architecture & Urbanism,Bassi Cendra,Giovanna Maria,12,15,2,0,0,0,0,3.345
+Fall 2023,ECE,3317,2,13307,Applied Electromagnetic Waves,Long,Stuart A,6,8,7,0,0,0,0,2.89
+Fall 2023,COMD,4489,1,13308,Clinical Procedures,Ivey,Michelle L,22,2,0,0,0,0,1,3.862
+Fall 2023,MARK,3336,1,13309,Introduction to Marketing,Koch,Steven F,18,5,1,0,0,0,0,3.612
+Fall 2023,MARK,3336,2,13310,Introduction to Marketing,Kraemer,Martin,240,231,52,13,4,0,6,3.256
+Fall 2023,MARK,3336,3,13311,Introduction to Marketing,Koch,Steven F,149,181,81,12,1,0,3,3.103
+Fall 2023,MARK,3336,4,13312,Introduction to Marketing,Kraemer,Martin,61,89,19,2,2,0,3,3.164
+Fall 2023,HON,3301,3,13313,Readings in Medicine & Society,Liddell,Robert B,22,0,2,0,0,0,0,3.806
+Fall 2023,MATH,1324,1,13314,Finite Math with Applications,Sosa,Moses,196,134,74,28,90,0,72,2.56
+Fall 2023,MATH,1324,2,13315,Finite Math with Applications,Kim,Jae Youn,66,58,50,12,12,0,14,2.738
+Fall 2023,MATH,1324,3,13316,Finite Math with Applications,Caglar,Atife,166,156,70,16,80,0,58,2.631
+Fall 2023,MATH,1324,5,13317,Finite Math with Applications,Constante,Beatrice,286,128,58,24,58,0,48,2.976
+Fall 2023,MATH,1324,6,13318,Finite Math with Applications,Sosa,Moses,278,120,74,18,52,0,54,2.999
+Fall 2023,MATH,1325,2,13319,Calc for Bus & Social Sciences,Constante,Beatrice,86,92,20,10,20,0,56,2.886
+Fall 2023,MATH,4364,1,13320,Intro to Numerical Analysis,Pan,Tsorng-Whay,20,22,10,0,1,0,1,3.163
+Fall 2023,BUSI,3302,1,13321,Connecting Bauer to Business,Belinne,Jamie King,358,51,7,2,3,0,2,3.803
+Fall 2023,BUSI,3302,2,13322,Connecting Bauer to Business,Belinne,Jamie King,351,56,15,2,3,0,0,3.756
+Fall 2023,COSC,4353,902,13323,Software Design,Singh,Raj Kumar,60,5,0,0,0,0,2,3.923
+Fall 2023,COSC,6353,901,13324,Software Design,Subramaniam,Venkat,8,2,0,0,0,0,0,3.866
+Fall 2023,BIOL,4272,1,13325,Cell and Develop Biol Lab,Gifford,Jenifer,13,8,1,0,0,0,1,3.62
+Fall 2023,COMM,3314,1,13326,Intermediate Reporting,Roth,Geoffrey,22,1,0,1,0,0,0,3.765
+Fall 2023,THEA,4305,1,13329,Theatre in Elem & Sec Schools,Hickman,Margo Louise,5,1,0,0,0,0,0,3.778
+Fall 2023,SOCW,8311,1,13331,Research Methods I,Narendorf,Sarah C,6,1,0,0,0,0,0,3.857
+Fall 2023,MSCI,4398,1,13332,Independent Study,Thomas,Roland,2,1,0,0,0,0,0,3.557
+Fall 2023,BIOL,4272,2,13333,Cell and Develop Biol Lab,Gifford,Jenifer,15,6,1,0,0,0,1,3.501
+Fall 2023,SOCW,8424,1,13334,Statistics and Data Analysis I,Leung,Yuk-Hi Patrick,6,3,0,0,0,0,0,3.667
+Fall 2023,DIGM,3353,32,13335,Visual Communications Tech,Dozier,Devin K,30,13,7,4,8,0,2,2.818
+Fall 2023,COMM,6305,1,13336,Qualitative Research Methods,Yamasaki,Jill S,10,2,0,0,3,0,0,3.089
+Fall 2023,PSYC,2319,1,13337,Intro to Social Psychology,Fetterman,Adam Kent,15,20,6,1,2,0,1,3.105
+Fall 2023,GHL,1301,1,13338,Hospitality Technology,Morosan,Cristian,28,16,8,0,2,0,1,3.216
+Fall 2023,GHL,1301,2,13339,Hospitality Technology,Hernandez Calderon,Araceli,14,6,0,0,1,0,0,3.477
+Fall 2023,GHL,2160,1,13340,Hospitality Internship,Shepherd,Ashley,18,2,1,0,1,0,1,3.561
+Fall 2023,GHL,8303,1,13342,Multivariate Anal. in Hosp. Ad,Guchait,Priyanko,2,1,0,0,0,0,0,3.777
+Fall 2023,GHL,3348,1,13343,Principles of Hosp Revenue Mgt,Kazemi Zarkouei,Mohammad Sadegh,19,9,8,2,5,0,3,2.814
+Fall 2023,COMD,4489,3,13345,Clinical Procedures,Ermgodts,Katherine Natalie,24,1,1,0,0,0,0,3.834
+Fall 2023,FINA,4351,1,13346,"Derivs II: Frwds, Futrs&Swaps",Rabinovitch,Ramon,7,7,2,1,1,0,0,3.018
+Fall 2023,LAW,5314,23,13347,Lawyering Skills & Strategy I,Thornton,Nicole Kumari,5,9,0,0,0,0,0,3.357
+Fall 2023,LAW,5108,1,13348,Advanced Health Law,Ewer,Michael S,6,2,0,0,0,0,0,3.585
+Fall 2023,LAW,5407,1,13349,Judicial Externship I,Powers,William,0,0,0,0,0,3,0,
+Fall 2023,THEA,2383,1,13351,Stage Management II,Bush,Rachel R,5,1,0,0,0,0,0,3.833
+Fall 2023,THEA,3283,1,13352,Stage Management III,Bush,Rachel R,2,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5500,1,13353,Government and Nonprofit Exter,Powers,William,0,0,0,0,0,1,0,
+Fall 2023,COMM,4392,1,13360,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,25,0,
+Fall 2023,TLIM,3355,31,13361,Project Management Principles,Moore,George P,65,17,4,1,2,0,1,3.536
+Fall 2023,CIVE,6111,1,13362,Graduate Seminar,Ferdowsi,Behrooz,0,0,0,0,0,36,0,
+Fall 2023,MECT,3367,1,13363,Quality Control Technology,Afrin,Samia,8,12,4,1,1,0,0,2.911
+Fall 2023,MECT,3342,1,13364,Elements of Plant Design,El Nahas,Medhat A,1,9,7,0,1,0,1,2.518
+Fall 2023,MECT,3358,1,13366,Dynamics of Mechanisms,Basaran,Burak,3,7,18,4,5,0,2,1.937
+Fall 2023,MECT,3365,1,13368,Computer-Aided Design I,El Nahas,Medhat A,0,9,21,2,2,0,0,2.03
+Fall 2023,PHYS,2326,1,13370,University Physics II(lecture),Su,Wu-Pei,7,11,12,8,4,0,4,2.238
+Fall 2023,PHYS,1101,17,13371,College Physics I (lab),Wood,Lowell T,2,19,2,0,0,0,0,2.813
+Fall 2023,PHYS,1101,18,13372,College Physics I (lab),Wood,Lowell T,1,12,8,0,0,0,2,2.667
+Fall 2023,ENGL,3322,1,13373,Contemporary Novel,Majumder,Auritro,13,14,0,0,2,0,0,3.298
+Fall 2023,PHYS,1102,14,13374,College Physics II (lab),Wood,Lowell T,2,10,2,1,1,0,0,2.688
+Fall 2023,ACCT,2301,6,13375,Prin of Financial Accounting,Goble,Samuel,50,69,29,7,1,0,18,3.129
+Fall 2023,ACCT,3366,1,13376,Financial Reporting Frameworks,Harris,Kathleen L,31,20,9,4,0,0,9,3.255
+Fall 2023,ECE,3457,1,13377,Digital Electronics,Bao,Jiming,71,8,0,0,0,0,0,3.849
+Fall 2023,PETR,2111,1,13379,Petroleum Petrophysics Lab,Hathon,Lori A,11,1,0,0,0,0,0,3.889
+Fall 2023,MECE,3400,1,13380,Intro To Mechanics,Agrawal,Ashutosh,7,22,10,0,2,0,5,2.764
+Fall 2023,SPAC,6201,1,13384,Man Systems Integration,Toups,Larry David,18,0,0,0,0,0,1,4.0
+Fall 2023,SPAC,6401,1,13385,Space Systems Tech Studio,Bannova,Olga,16,3,0,0,0,0,1,3.616
+Fall 2023,BIOE,8298,16,13387,Doctoral Research,Wu,Tianfu,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8298,17,13388,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,14,13389,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,16,13390,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,15,13395,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,3,0,
+Fall 2023,BIOE,8598,17,13396,Doctoral Research,Zhang,Yingchun,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8399,1,13402,Doctoral Dissertation,Akay,Metin,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8399,10,13409,Doctoral Dissertation,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8399,14,13412,Doctoral Dissertation,Roh,Jinsook,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8699,1,13414,Doctoral Dissertation,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8699,6,13417,Doctoral Dissertation,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8399,14,13420,Doctoral Dissertation,Palmer,Jeremy,3,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,6398,17,13422,Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Fall 2023,PETR,8598,7,13424,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2023,INDE,3310,1,13425,Quality Control & Improvement,Wang,Yaping,19,16,8,0,0,0,0,3.271
+Fall 2023,ENGI,1331,2,13429,Computing for Engineers,Kota,Venkata Krishna Tulasi,18,13,10,6,3,0,8,2.694
+Fall 2023,ENGI,1331,6,13430,Computing for Engineers,Burleson,Daniel W,14,24,12,2,2,0,8,2.864
+Fall 2023,ENGI,1100,9,13431,Introduction To Engineering,Aksu,Gulin Tulunay,26,26,9,0,0,0,8,3.17
+Fall 2023,ENGI,1100,12,13433,Introduction To Engineering,Luna Singh,Jennifer Austin,32,23,10,2,1,0,2,3.298
+Fall 2023,ENGI,1100,13,13434,Introduction To Engineering,Luna Singh,Jennifer Austin,28,22,5,1,0,0,1,3.428
+Fall 2023,PETR,8298,7,13435,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Fall 2023,PETR,8399,7,13438,Doctoral Dissertation,Lee,Kyung Jae,1,0,0,0,0,1,0,4.0
+Fall 2023,PETR,8699,7,13439,Doctoral Dissertation,Lee,Kyung Jae,0,0,0,0,0,1,1,
+Fall 2023,ENGR,2301,2,13440,Mechanics I (Statics),Zamiran,Siavash,12,16,15,9,0,0,1,2.596
+Fall 2023,PETR,4312,1,13441,Petroleum Capstone Project II,Zargar,Zeinab,3,0,0,0,0,0,0,4.0
+Fall 2023,MECE,2334,2,13442,Thermodynamics,Love,Holley Carole,13,30,47,4,0,0,3,2.532
+Fall 2023,MECE,3336,1,13443,Mechanics II,Cescon,Marzia,3,7,15,7,3,0,4,2.038
+Fall 2023,MECE,3369,1,13444,Solid Mechanics,Joshi,Shailendra Pramod,10,66,40,0,1,0,4,2.741
+Fall 2023,MECE,3381,1,13445,Finite Elements for Mech Engr,Baxevanis,Theocharis,11,31,8,0,1,0,4,2.935
+Fall 2023,ECE,3436,3,13446,Microprocessor Systems,Le,Hung Quang,9,15,8,0,2,0,2,2.717
+Fall 2023,BIOE,3351,1,13448,Introduction to Diseases,Mohan,Chandra,26,3,0,0,0,0,0,3.897
+Fall 2023,CIVE,6355,2,13450,Intro-Dynamics of Structures,Mo,Larry Yi-Lung,1,3,0,0,0,0,0,3.333
+Fall 2023,CIVE,6362,1,13451,Water Quality Engineering,Fiorenza,Stephanie,5,2,0,0,0,0,0,3.714
+Fall 2023,ECE,4339,2,13452,Phy Prin of Solid State Device,Pei,Shin-Shem Steven,10,4,0,0,0,0,0,3.596
+Fall 2023,MECE,3338,1,13453,Dynamic & Control of Mech Syst,Grigoriadis,Karolos,24,41,31,10,3,0,8,2.636
+Fall 2023,MECE,4343,1,13454,Thermal Design,Ghasemi,Hadi,14,13,26,0,6,0,29,2.469
+Fall 2023,CHEE,6335,1,13455,Classicl-Statist Thermo,Vekilov,Peter,14,18,1,0,1,0,3,3.304
+Fall 2023,CHEE,6333,1,13456,Transport Processes,Conrad,Jacinta C,21,14,0,0,1,0,0,3.418
+Fall 2023,INDE,3432,1,13457,Manufacturing Processes,Kamrani,Ali K,9,11,7,0,0,0,0,2.976
+Fall 2023,SPAC,6405,1,13459,Advanced Design and Analysis,Bannova,Olga,2,1,0,0,0,0,0,3.557
+Fall 2023,SPAC,7410,1,13460,Master's Project: Space Arch,Bell,Larry S,6,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8298,20,13463,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8298,22,13465,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,21,13467,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8399,16,13470,Doctoral Dissertation,Shevkoplyas,Sergey,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8399,17,13471,Doctoral Dissertation,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8399,22,13476,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8598,18,13483,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,19,13484,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,20,13485,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,23,13488,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8699,10,13491,Doctoral Dissertation,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8699,16,13497,Doctoral Dissertation,Wu,Tianfu,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8699,20,13500,Doctoral Dissertation,Das,Mini,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8399,15,13503,Doctoral Dissertation,Rimer,Jeffrey,0,0,0,0,0,9,0,
+Fall 2023,CHEE,8399,16,13504,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,4,0,
+Fall 2023,CHEE,8399,17,13505,Doctoral Dissertation,Varadarajan,Navin,6,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8399,18,13506,Doctoral Dissertation,Vekilov,Peter,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,8399,19,13507,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2023,PETR,3315,1,13508,Introduction to Well Logging,Hathon,Lori A,3,4,2,0,0,0,1,3.148
+Fall 2023,PETR,7399,8,13510,Masters Thesis,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2023,PETR,6399,9,13516,Masters Thesis,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2023,ENGI,1100,15,13519,Introduction To Engineering,Aksu,Gulin Tulunay,30,15,12,0,2,0,0,3.052
+Fall 2023,ENGI,1331,3,13520,Computing for Engineers,Kowal,Marsha Christine,23,17,13,0,1,0,5,3.062
+Fall 2023,ENGI,1331,7,13521,Computing for Engineers,Aksu,Gulin Tulunay,21,7,11,4,4,0,13,2.703
+Fall 2023,BIOE,4307,1,13522,Optical Imaging,Larin,Kirill,2,2,0,0,0,0,0,3.583
+Fall 2023,BIOE,6303,1,13523,Biomaterials,Abidian,Mohammad Reza,6,4,0,0,0,0,0,3.6
+Fall 2023,BIOE,6305,1,13524,Brain Machine Interfacing,Francis,Joseph Thachil,3,0,0,0,0,0,0,3.89
+Fall 2023,ENGI,2304,5,13525,Technical Communications,Wilson,Chad A,16,5,1,0,2,0,1,3.334
+Fall 2023,CHEE,3367,1,13526,Process Modeling and Control,Kaspar,Michael,10,22,6,0,0,0,1,3.053
+Fall 2023,CHEE,3369,1,13527,Chemical Engr Transport Proc,Bollini,Praveen P,6,13,0,0,0,0,3,3.455
+Fall 2023,CHEE,3466,1,13528,Bio & Physical Chemistry,Varadarajan,Navin,4,14,6,0,0,0,1,2.862
+Fall 2023,MECE,4341,1,13530,Mechanical Engr Capstone II,Chang,Christiana,33,23,7,0,0,0,0,3.355
+Fall 2023,ECE,2100,2,13531,Circuit Analysis Laboratory,Ramachandran,Deepa,11,1,0,0,0,0,1,3.834
+Fall 2023,ECE,2202,1,13532,Circuit Analysis II,Trombetta,Leonard P,10,10,13,5,4,0,18,2.468
+Fall 2023,ECE,4115,1,13534,Control Systems Laboratory I,Provence,Robert S,5,10,11,0,0,0,0,2.706
+Fall 2023,ECE,4375,1,13535,Automatic Control Systems,Provence,Robert S,3,15,12,1,1,0,1,2.49
+Fall 2023,ECE,4437,2,13537,Embedded Microcomputer Systems,Le,Hung Quang,7,6,3,0,0,0,0,3.168
+Fall 2023,PETR,6332,1,13538,Deterministic Reserves Estimat,Zargar,Zeinab,4,4,1,0,0,0,0,3.297
+Fall 2023,ECE,5335,2,13539,State-Space Control Systems,Ortiz,James Norman,1,7,1,0,0,0,0,3.073
+Fall 2023,ECE,6325,2,13540,State-Space Control Systems,Ortiz,James Norman,7,7,3,3,1,0,0,2.778
+Fall 2023,MECE,2336,1,13541,Mechanics I,Hammami,Farah,5,9,2,2,0,0,1,2.853
+Fall 2023,CHEE,6331,1,13542,Math Mtds in Chem Engr,Mountziaris,Triantafillos John,19,14,0,0,1,0,0,3.509
+Fall 2023,PETR,8398,9,13548,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2023,POLC,6313,1,13555,Policy Analysis I: Microecon,Wong,Man Chiu,14,12,1,0,0,0,0,3.494
+Fall 2023,POLC,6316,1,13556,Pol Res III: Adv Quant Mod,Atsusaka,Yuki,12,3,2,0,0,0,0,3.588
+Fall 2023,POLC,6331,1,13557,Philosophy and Pub Policy II,Engster,Daniel A,14,6,3,0,0,0,0,3.45
+Fall 2023,POLC,6314,1,13559,Pol Res I: Intro to Statistics,Buttorff,Gail J,17,8,5,1,0,0,1,3.259
+Fall 2023,POLC,6311,2,13560,Leader and Prof Development,Witt,Lawrence A,18,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,2314,8,13566,Human Dev and Interventions,Dunsmore,Julie C,16,9,4,3,1,0,2,2.901
+Fall 2023,PHLS,8699,2,13572,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Fall 2023,CUIN,7358,1,13574,Educ Uses Digital Storytelling,Dogan,Bulent,20,0,0,0,1,0,0,3.81
+Fall 2023,PHLS,8193,1,13575,Internship in Psychology,Arbona,Consuelo,0,0,0,0,0,9,0,
+Fall 2023,CUIN,8399,9,13577,Doctoral Dissertation,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8301,1,13579,Leadership Theory School Admin,Shockley,Gerald,5,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,3111,1,13580,Educational Tech Elem Teachers,Davis,Kelly M,30,2,0,0,0,0,1,3.917
+Fall 2023,CUIN,3302,4,13581,Social Education,Thomas,Dustine J,37,2,0,0,0,0,0,3.949
+Fall 2023,CUIN,4375,5,13582,Classroom Management,Castillo,Bernadette Marie,25,1,0,0,0,0,0,3.873
+Fall 2023,ELED,3320,1,13583,Survey Literature Child Adol,Tyson,Eleanore S,28,4,0,0,0,0,0,3.885
+Fall 2023,ELED,4312,1,13586,Science in the Elem School II,Domjan,Heather N,22,1,0,0,0,0,0,3.971
+Fall 2023,EDUC,2301,1,13589,Intro to Special Populations,Christensen,Caroline,94,56,18,2,11,0,5,3.143
+Fall 2023,ARED,3305,1,13590,Art in Elementary Schools,Boyaki Wilson,Amanda R,26,2,0,0,1,0,1,3.77
+Fall 2023,ELED,4314,5,13591,Mathematics in Elem School I,Burris,Justin T,21,2,0,1,0,0,0,3.723
+Fall 2023,SEDE,7335,1,13592,Literature for Adolescents,Russell IV,Glen Curtis,5,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8302,1,13593,Research Meth in Psych/Educ,Matta,Michael,9,5,0,0,0,0,0,3.596
+Fall 2023,CUIN,8371,1,13594,Introduction to Quant Research,Weiland,Travis,5,2,0,1,0,0,0,3.375
+Fall 2023,HLT,4307,2,13595,Research and Eval in Health,Correa-Fernandez,Virmarie,15,18,2,0,0,0,0,3.296
+Fall 2023,PHLS,8241,1,13596,Prof Seminar in School Psych,Margulis,Milena A,3,2,0,0,0,0,0,3.666
+Fall 2023,PHLS,8341,1,13597,Professional Seminar,Allan,Blake A,6,1,0,0,0,0,0,3.81
+Fall 2023,ELED,6301,1,13599,Tch Soc Studies/Ele Sch,Ford,Haley Michelle Grimland,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8345,1,13600,CUIN Seminar,Hutchison,Laveria F,10,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,2314,10,13604,Human Dev and Interventions,Schoger,Kimberly,43,10,3,2,6,0,0,3.276
+Fall 2023,HLT,3301,3,13606,Health Behavior Theories,Fedor Amador,Theresa Marie,44,18,2,1,0,0,0,3.575
+Fall 2023,HLT,3325,2,13607,Medical Terminology,Bloom,Joel A,137,6,1,0,0,0,1,3.905
+Fall 2023,HDFS,3350,1,13608,Observation and Assessment,Schroder,Kathleen Anne,33,4,2,0,2,0,3,3.553
+Fall 2023,HDFS,4316,2,13609,Dynamics of Family Relations,Schroder,Kathleen Anne,26,11,0,0,1,0,1,3.536
+Fall 2023,HDFS,3318,1,13612,Human Ecol of Adult Developmt,Schoger,Kimberly,54,5,1,0,0,0,0,3.872
+Fall 2023,HLT,3325,3,13613,Medical Terminology,Burk,Kelly Ann,144,2,3,0,0,0,1,3.902
+Fall 2023,PHLS,8324,2,13614,Multivar Analy in Psy/Educ Res,Fan,Weihua,14,0,0,0,0,0,0,3.976
+Fall 2023,ELED,4312,3,13616,Science in the Elem School II,Khalidi,Rana,23,2,0,0,0,0,0,3.88
+Fall 2023,AAMS,2300,2,13617,Intro Asian American Studies,Nguyen,An,7,4,3,0,1,0,2,2.847
+Fall 2023,ELCS,8191,1,13618,Special Field Projects,Davis,Bradley,6,3,0,0,0,0,0,3.63
+Fall 2023,HDFS,4317,1,13619,Intro to Early Child Dev,Jelsma,Elizabeth,11,7,8,1,1,0,3,2.976
+Fall 2023,CUIN,4303,1,13621,Sec Language Acq,Leon,Maredil Josefina,28,5,1,0,0,0,1,3.804
+Fall 2023,HLT,4310,1,13625,Program Planning for Hlt Prof,Bennett,Kristin C,22,6,2,2,0,0,2,3.479
+Fall 2023,HLT,4310,2,13626,Program Planning for Hlt Prof,Bennett,Kristin C,22,7,4,0,1,0,1,3.364
+Fall 2023,ELED,7320,1,13633,Foundations of Literacy Instru,Alba,Celeste,7,0,0,0,0,0,0,3.953
+Fall 2023,CUIN,8399,1,13637,Doctoral Dissertation,Zhang,Jie,0,0,0,0,0,1,0,
+Fall 2023,SPEC,6361,1,13638,Behavior: Interventions,Carp,Charlotte Lynn,15,3,0,1,0,0,0,3.615
+Fall 2023,SPEC,6363,1,13639,Instructional Interventions,Rigby-Wills,Hope,14,4,2,0,0,0,0,3.551
+Fall 2023,SPEC,6360,1,13640,Individuals with Disabilities,Dulas,Heather,7,0,0,0,0,0,0,4.0
+Fall 2023,SPEC,7340,1,13641,Assessment of Acad Achievement,Cole,Jana Belinda,18,2,0,0,0,0,0,3.884
+Fall 2023,HLT,4320,2,13643,Admin of Health Services,Markowitz,Eliz,26,9,4,1,0,0,3,3.426
+Fall 2023,CUIN,1350,1,13644,Mathematics for Teachers 1,Burris,Justin T,25,5,3,1,1,0,0,3.42
+Fall 2023,ELED,4314,1,13645,Mathematics in Elem School I,Cutler,Carrie Sybil,32,2,0,0,0,0,0,3.912
+Fall 2023,SEDE,4311,2,13646,Teaching Social Studie Sec Sch,Ford,Haley Michelle Grimland,10,0,1,0,0,0,0,3.848
+Fall 2023,CUIN,4375,4,13648,Classroom Management,Castillo,Bernadette Marie,22,1,0,0,0,0,1,3.87
+Fall 2023,ELED,3322,5,13649,Elem Reading Phonics Instructn,Alba,Celeste,25,0,0,0,0,0,0,3.947
+Fall 2023,PHLS,6330,2,13651,Human Growth-Developmnt,Whitaker,Rachael Gwin,9,1,0,0,0,0,0,3.933
+Fall 2023,CUIN,3312,1,13652,Educational Technology,Hebert,Waneta Suzanne,23,2,1,0,0,0,0,3.821
+Fall 2023,PHLS,8321,1,13653,Struct Equ Mod in Psy/Educ Res,Wiesner,Margit F,8,1,0,0,0,0,0,3.889
+Fall 2023,CUIN,4101,3,13656,Content for Teaching,Ford,Haley Michelle Grimland,48,2,0,0,0,0,0,3.967
+Fall 2023,CUIN,1103,1,13657,Educator Dispositions,Culpepper,Shea Mosley,109,15,1,0,1,0,1,3.802
+Fall 2023,PHLS,7193,2,13659,Internship and Practicum,Margulis,Milena A,4,1,0,0,0,0,0,3.8
+Fall 2023,ELCS,8312,1,13660,Lab of Practice-Res Meth Devel,Hawkins,Jacqueline McLean,0,0,0,0,0,0,0,
+Fall 2023,ELCS,8312,3,13661,Lab of Practice-Res Meth Devel,Santi,Kristi L,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8340,1,13663,Organizatn & Admin Curriculum,Gillman-Rich,Lynn,12,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8393,2,13664,Adv Internship & Prac,Gronseth,Susie L B,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,3312,2,13665,Educational Technology,Hebert,Waneta Suzanne,26,2,0,0,0,0,0,3.929
+Fall 2023,CUIN,4331,2,13666,Adolescent Literature,Hale,Margaret Ann,24,3,0,0,0,0,0,3.877
+Fall 2023,CUIN,3302,1,13667,Social Education,Thomas,Dustine J,29,1,0,0,0,0,0,3.967
+Fall 2023,CUIN,4375,6,13668,Classroom Management,Alarcon,Jeannette Driscoll,26,1,1,0,0,0,0,3.893
+Fall 2023,CUIN,3111,2,13669,Educational Tech Elem Teachers,Davis,Kelly M,33,0,0,0,0,0,0,3.96
+Fall 2023,CUIN,8393,3,13670,Adv Internship & Prac,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,3317,2,13671,Prenatal and Infant Developmt,Storch,Jill Frenchman,28,14,6,1,0,0,1,3.28
+Fall 2023,CUIN,8393,6,13674,Adv Internship & Prac,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8199,1,13676,Dissertation,Smith,Bradley,0,0,0,0,0,2,0,
+Fall 2023,CUIN,8398,10,13677,Independent Study,Hausmann,Robert Carl,1,0,0,0,0,0,0,4.0
+Fall 2023,HLT,4307,3,13678,Research and Eval in Health,Dao,Tam K,35,0,0,0,0,0,0,3.991
+Fall 2023,CUIN,8393,7,13679,Adv Internship & Prac,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8399,5,13681,Doctoral Dissertation,Alarcon,Jeannette Driscoll,0,0,0,0,0,1,0,
+Fall 2023,CUIN,4350,3,13682,Multiple Teaching Strategies,Ekeoba,Jacqueline Njideka,8,1,1,0,0,0,1,3.667
+Fall 2023,CUIN,3351,1,13683,Class Interact Science-Math,Manuel,Mariam A,9,1,0,0,0,0,0,3.933
+Fall 2023,CUST,8375,1,13684,Hist & Phil of Higher Educ,Louis,Dave A,14,1,0,0,0,0,0,3.955
+Fall 2023,ELED,4312,4,13685,Science in the Elem School II,Domjan,Heather N,18,0,0,0,0,0,0,4.0
+Fall 2023,ELED,4315,1,13686,Mathematics in Elem School II,Cutler,Carrie Sybil,23,0,0,0,0,0,0,3.9
+Fall 2023,ELED,4315,3,13687,Mathematics in Elem School II,Cutler,Carrie Sybil,21,1,1,0,0,0,0,3.87
+Fall 2023,ELED,4315,4,13688,Mathematics in Elem School II,Burris,Justin T,14,4,0,0,0,0,0,3.668
+Fall 2023,ELED,4320,1,13689,Social Studies Ele Sch,Ford,Haley Michelle Grimland,38,0,0,0,0,0,0,4.0
+Fall 2023,ELED,4320,2,13690,Social Studies Ele Sch,Ford,Haley Michelle Grimland,33,0,0,0,0,0,0,4.0
+Fall 2023,ELED,4320,3,13691,Social Studies Ele Sch,Ford,Haley Michelle Grimland,6,0,0,0,0,0,0,4.0
+Fall 2023,SPEC,4364,1,13694,Ed Students Giifts and Talents,Govan,Kordney J,27,5,2,0,1,0,0,3.572
+Fall 2023,SPEC,7341,1,13695,Assessment of Learning Diff,Cole,Jana Belinda,6,1,0,0,0,0,0,3.857
+Fall 2023,SPEC,7394,1,13696,Diagnostician Practicum I,Hassett,Kristen Spring,0,0,0,0,0,12,0,
+Fall 2023,SPEC,7395,1,13697,Diagnostician Practicum II,Hassett,Kristen Spring,0,0,0,0,0,2,0,
+Fall 2023,SPEC,8375,2,13698,Research for Special Pops,Santi,Kristi L,5,0,0,0,0,0,0,3.802
+Fall 2023,HDFS,4325,1,13699,Theory to Practice in HDFS,Jordan,Erica F,20,4,0,0,0,0,0,3.751
+Fall 2023,CUIN,4344,1,13700,Teaching Math in Grades 4-8,Cutler,Carrie Sybil,32,0,1,0,0,0,0,3.909
+Fall 2023,ELCS,8310,1,13701,The Superintendency,Butcher,Keith,2,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,7392,1,13702,Internship in Superintendent,Klussmann,Duncan Foster,5,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6350,1,13703,School Leadership-Principalshp,Butcher,Keith,4,1,0,1,0,0,0,3.388
+Fall 2023,ELCS,6350,2,13704,School Leadership-Principalshp,Brosnahan,Carla,11,1,0,0,0,0,0,3.917
+Fall 2023,ELCS,6304,1,13705,Law & Policy for School Leader,Klussmann,Duncan Foster,23,0,0,0,0,0,0,4.0
+Fall 2023,HLT,3380,1,13707,Culture and Health,Fedor Amador,Theresa Marie,51,10,0,1,1,0,0,3.641
+Fall 2023,HDFS,3350,3,13708,Observation and Assessment,Schroder,Kathleen Anne,29,8,3,0,5,0,0,3.222
+Fall 2023,HDFS,3320,1,13710,Careers in HDFS,Jordan,Erica F,18,6,2,2,1,0,0,3.288
+Fall 2023,PHLS,8306,1,13711,Health Psych Res Prev Interv,Carmack,Chakema,6,0,0,0,0,0,1,4.0
+Fall 2023,EDUC,4511,1,13716,Student Teaching - Elementary,Culpepper,Shea Mosley,98,1,0,1,0,0,1,3.927
+Fall 2023,CUIN,7347,1,13720,"Sem in Learning, Design & Tech",Ahlf,Michael,19,2,0,1,0,0,1,3.758
+Fall 2023,CUIN,8398,5,13723,Independent Study,Lee,Mimi Miyoung,2,0,0,0,0,0,0,4.0
+Fall 2023,EDUC,4512,1,13724,Student Teaching - Elementary,Thompson,Amber M,84,5,0,0,0,0,0,3.907
+Fall 2023,CUIN,4331,1,13725,Adolescent Literature,Hale,Margaret Ann,21,0,0,0,0,0,0,3.953
+Fall 2023,CUIN,3311,1,13726,Methods/Tech in Bilingual Educ,Leon,Maredil Josefina,9,0,0,0,0,0,0,4.0
+Fall 2023,EDUC,3101,1,13727,Practicum for Preservice Tchrs,Thompson,Amber M,91,5,0,0,0,0,0,3.934
+Fall 2023,CUIN,3333,1,13728,Differentiating Diverse Learn,Henderson,Linda Fay,19,2,0,0,0,0,0,3.889
+Fall 2023,CUIN,6375,2,13729,Classroom Mgt,Castillo,Bernadette Marie,3,1,0,0,0,0,0,3.668
+Fall 2023,CUIN,6375,3,13730,Classroom Mgt,Alarcon,Jeannette Driscoll,0,0,1,0,0,0,0,2.33
+Fall 2023,PHLS,6343,1,13732,Ethical Legal Issues in Counsl,Hurt,Kara Marie,15,2,0,0,0,0,0,3.902
+Fall 2023,PHLS,6311,1,13734,Introduction to Counseling,Hurt,Kara Marie,17,0,0,0,0,0,0,4.0
+Fall 2023,HLT,4303,1,13736,The Obesity Epidemic,Olvera,Norma E,23,28,6,1,2,0,0,3.051
+Fall 2023,EDRS,8381,1,13737,Rsch Mthds in Educ,Hawkins,Jacqueline McLean,6,0,0,0,0,0,0,3.89
+Fall 2023,CUIN,4332,4,13738,Literacy Assess Rdg Writing,Reis,Nancy,17,3,0,0,0,0,0,3.834
+Fall 2023,ELED,4315,2,13739,Mathematics in Elem School II,Burris,Justin T,24,1,0,0,0,0,0,3.934
+Fall 2023,PHLS,8337,2,13741,Multicul Iss Coun Psych,McCain,Morgan,21,1,0,0,0,0,0,3.925
+Fall 2023,CUIN,4375,10,13742,Classroom Management,Mateer,Ramona Caravella,5,0,0,0,0,0,0,3.868
+Fall 2023,HLT,3301,4,13745,Health Behavior Theories,Hudson-Gillan,Gail,53,11,1,0,0,0,0,3.77
+Fall 2023,CUIN,4304,3,13746,La/Read Meth in Span,Burgess,Miguel,14,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,6324,1,13757,Addictions Counseling,Lukingbeal,Patrick Livingston,17,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6301,2,13759,Leadership for Equity,Johnson,Detra DeVerne,12,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8399,4,13761,Doctoral Dissertation,Zou,Yali,2,0,0,0,0,0,0,4.0
+Fall 2023,SPEC,6340,1,13764,Learning & Education Sciences,Santi,Kristi L,17,1,0,0,0,0,0,3.871
+Fall 2023,EDRS,8380,1,13765,Rsch Mthds in Educ,Johnson,Detra DeVerne,5,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8699,1,13766,Doctoral Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Fall 2023,CUIN,3317,1,13768,Kindergarten/Elem Curr & Instr,Katz,Denise Annette,30,3,1,0,0,0,0,3.804
+Fall 2023,CUIN,4315,1,13769,Assessment of Children,Siller Escudero,Patricia,27,5,2,0,0,0,0,3.599
+Fall 2023,CUIN,4315,5,13771,Assessment of Children,Wilson,Jahnette,5,1,1,0,0,0,0,3.571
+Fall 2023,PHED,1306,1,13773,Emergency Care & First Aid,Brown,Korey J,31,3,0,0,1,0,0,3.791
+Fall 2023,PHED,1306,3,13774,Emergency Care & First Aid,Monreal,Daniel Joseph,33,0,1,0,0,0,1,3.941
+Fall 2023,PHLS,7193,1,13775,Internship and Practicum,Gonzalez,Jorge E,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8303,1,13776,Seminal Thinkers,Santi,Kristi L,7,2,0,0,0,0,0,3.594
+Fall 2023,CUIN,8399,6,13783,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,1,0,
+Fall 2023,PHLS,8999,1,13785,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2023,CUIN,6380,1,13789,Teaching Young Children,Siller Escudero,Patricia,8,1,1,0,0,0,1,3.502
+Fall 2023,CUIN,1350,2,13790,Mathematics for Teachers 1,Burris,Justin T,21,6,3,0,1,0,2,3.441
+Fall 2023,CUIN,7366,1,13793,Sci instruct in Middle Grades,Varnado,Jakarda Wiltz,2,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,2300,1,13794,Introduction to STEM Teaching,Ekeoba,Jacqueline Njideka,7,1,1,0,0,0,1,3.667
+Fall 2023,CUIN,2300,2,13795,Introduction to STEM Teaching,Manuel,Mariam A,32,0,1,0,0,0,0,3.939
+Fall 2023,CUIN,2300,4,13797,Introduction to STEM Teaching,Campos,Amanda Renee,24,3,0,0,0,0,0,3.889
+Fall 2023,CUIN,4332,9,13798,Literacy Assess Rdg Writing,Reis,Nancy,5,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,4332,5,13799,Literacy Assess Rdg Writing,Reis,Nancy,34,0,0,0,0,0,0,3.981
+Fall 2023,CUIN,4332,7,13800,Literacy Assess Rdg Writing,Reis,Nancy,28,0,1,0,0,0,0,3.908
+Fall 2023,CUIN,3302,2,13801,Social Education,Thomas,Dustine J,38,1,1,0,0,0,0,3.933
+Fall 2023,CUIN,3316,2,13802,Prekindergarten Curr & Instr,Katz,Denise Annette,33,2,0,0,0,0,0,3.849
+Fall 2023,CUIN,3316,3,13803,Prekindergarten Curr & Instr,Siller Escudero,Patricia,29,4,0,0,0,0,0,3.829
+Fall 2023,CUIN,3317,3,13806,Kindergarten/Elem Curr & Instr,Katz,Denise Annette,26,6,1,0,0,0,0,3.658
+Fall 2023,CUIN,3317,4,13807,Kindergarten/Elem Curr & Instr,Wilson,Jahnette,5,1,1,0,0,0,0,3.383
+Fall 2023,CUIN,3347,2,13808,Reading in the Content Area,Morris,Alana,24,3,2,0,0,0,1,3.77
+Fall 2023,CUIN,4315,3,13810,Assessment of Children,Siller Escudero,Patricia,17,12,4,0,0,0,0,3.354
+Fall 2023,CUIN,4361,3,13811,Second Language Methodology,Li,Miao,25,3,0,0,1,0,0,3.713
+Fall 2023,CUIN,4375,1,13813,Classroom Management,Thompson,Alan M,14,3,0,0,0,0,0,3.843
+Fall 2023,ARED,2310,1,13814,Intro Critical Visual Culture,Chung,Sheng Kuan,25,2,0,0,1,0,2,3.727
+Fall 2023,SPEC,2350,1,13815,RBT Training,Richardson,Amy Renee,8,1,0,0,1,0,0,3.401
+Fall 2023,EDRS,8382,1,13817,Statistical Analyses in Eductn,Templeton,Toni,8,0,0,0,0,0,0,3.918
+Fall 2023,ELCS,8356,1,13818,Program Policy Evaluation,Davis,Bradley,7,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,1,13819,Research in Chamber Music,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,3366,2,13821,Financial Reporting Frameworks,Harris,Kathleen L,20,11,12,7,2,0,8,2.801
+Fall 2023,ACCT,4331,1,13822,Federal Income Tax,Meade,Janet,0,6,13,13,1,0,7,1.707
+Fall 2023,MARK,4389,6,13823,Marketing Strategy & Planning,Muschalik,Monica Harper,25,3,1,0,0,0,0,3.748
+Fall 2023,TLIM,3363,1,13824,Technical Communications,Piercy,Penelope Junker,17,17,3,0,1,0,2,3.229
+Fall 2023,TLIM,3363,2,13825,Technical Communications,Piercy,Penelope Junker,27,6,1,0,2,0,1,3.464
+Fall 2023,BTEC,3317,30,13826,Biotech Regulatory Environment,Flavier,Albert B,6,28,17,1,3,0,0,2.6
+Fall 2023,BTEC,3301,30,13827,Genomics/Proteomics & Bioinfo.,Flavier,Albert B,5,11,18,5,0,0,1,2.41
+Fall 2023,BTEC,3321,30,13828,Good Manufacturing Practices,Aghoghovbia-Pugh,Alero,6,8,9,1,3,0,2,2.408
+Fall 2023,ELET,2301,1,13830,Poly-Phase Circuits & Trans,Fan,Lei,6,12,2,1,0,0,0,3.19
+Fall 2023,ELET,2305,1,13831,Semicond Devices & Circuits,Talusani,Pratap Reddy,25,14,6,0,0,0,0,3.466
+Fall 2023,ENTR,7339,1,13832,Venture Fund,Rassin,Keith David,6,0,0,0,0,0,0,3.78
+Fall 2023,MARK,4376,1,13833,Sales CRM,Herman,Carl,49,9,0,0,0,0,0,3.799
+Fall 2023,ELET,3301,1,13835,Linear Systems Analysis,Barbieri,Enrique,5,9,34,0,1,0,1,2.273
+Fall 2023,PHAR,5646,1,13838,Medication Safety,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2023,SGNL,1301,6,13839,Elementary Sign Language I,Brittain,Terrell,4,9,3,4,0,0,2,2.667
+Fall 2023,BUSI,4335,1,13840,Brainstorming to Bankrolling,Khumawala,Saleha B,12,0,0,0,1,0,1,3.642
+Fall 2023,GENB,7334,1,13841,Brainstorming to Bankrolling,Khumawala,Saleha B,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,2318,1,13842,Linear Algebra,Alexander,Amanda M,18,24,11,4,6,0,14,2.677
+Fall 2023,MECT,3318,1,13843,Fluid Mechanics Applications,Alba,Kamran,5,13,12,5,5,0,4,2.192
+Fall 2023,MECT,3355,1,13844,Strength of Materials,Basaran,Burak,2,5,24,14,6,0,1,1.686
+Fall 2023,LAW,5339,1,13847,Trusts and Wills,Tamborello,Gus Gerard,20,32,7,0,0,0,0,3.204
+Fall 2023,ENGL,3327,1,13848,Masterpieces of British Lit I,Mazella,David S,13,9,1,0,5,0,1,2.893
+Fall 2023,MECT,1330,4,13849,Engineering Graphics,Fan,Zheng,3,5,4,0,1,0,2,2.616
+Fall 2023,ARCH,2500,3,13852,Arc/Int Arc Design Studio III,Lee,Seo Hee,2,4,2,0,0,0,2,3.041
+Fall 2023,CNST,3265,1,13854,Construction Layout & Site Dvp,Moghaddam,Hassan,1,15,24,0,0,0,3,2.458
+Fall 2023,ACCT,5376,1,13855,Adv Fin Statement Auditing,Zhao,Yuping,1,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,3350,1,13856,Feminist Theory,Gregory,Elizabeth,15,1,3,0,0,0,2,3.649
+Fall 2023,HDCS,4393,1,13857,Internship in RCS,Ezell,Shirley D,19,3,1,0,3,0,1,3.283
+Fall 2023,CNST,3205,1,13859,Construction Safety Management,Hart,Lee J,38,2,0,0,0,0,0,3.95
+Fall 2023,CNST,3331,1,13860,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,21,20,6,0,0,0,1,3.319
+Fall 2023,CNST,3355,1,13861,Strength of Construction Mtrls,Hossain,Sk Amjad,36,31,17,11,3,0,0,2.878
+Fall 2023,CNST,3351,1,13862,Construction Estimating II,Siddiqui,Muhammad Ali,26,22,0,1,0,0,1,3.449
+Fall 2023,CNST,3365,1,13863,Cost Estimating Capital Projec,Glumac,Carmel,6,9,7,0,0,0,1,3.06
+Fall 2023,CNST,3372,1,13864,Soil Mechanics & Foundations,Meyer,Joseph Ray,35,24,6,1,0,0,0,3.424
+Fall 2023,ATP,7311,1,13865,Human Performance,Knoblauch,Mark Alan,12,3,0,0,0,0,0,3.8
+Fall 2023,DANC,2303,2,13866,Introduction to Dance,Bobet,Jacqueline A,54,16,6,0,6,0,8,3.342
+Fall 2023,RELS,3370,1,13867,The Bible and Modern Science,Ott,Aaron Frederick,22,8,1,1,5,0,2,3.046
+Fall 2023,TECH,3365,3,13869,Appl of Discrete Mthds in Tech,Telles,John E,13,7,3,0,4,0,4,2.889
+Fall 2023,GHL,8310,1,13870,Teaching Methods in Hosp. Adm.,DeFranco,Agnes L,3,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6A48,1,13871,Environmental Technology 3,Kyropoulou,Amygdalia,23,8,0,0,0,0,0,3.71
+Fall 2023,ARCH,6A20,1,13872,Environmental Technology 1,Kyropoulou,Amygdalia,7,4,0,0,0,0,0,3.666
+Fall 2023,ARCH,6A50,1,13873,Construction Technology 3,Thaddeus,David J,12,10,9,0,0,0,0,3.054
+Fall 2023,ARCH,6A22,1,13874,Construction Technology I,Thaddeus,David J,5,6,0,0,0,0,0,3.425
+Fall 2023,NAVY,1301,1,13875,Naval Orientation,Davis,Danyelle,1,3,1,0,0,0,0,2.934
+Fall 2023,LATI,1301,2,13878,Elementary Latin I,Behr,Francesca D,9,3,0,0,0,0,1,3.75
+Fall 2023,DRAM,1310,20,13879,Introduction to Theatre,Brincks,Alan,34,9,3,1,2,0,1,3.469
+Fall 2023,SPAN,2610,1,13880,Intensive Intermediate Spanish,Pueyo Castan,Josefa,2,10,5,1,1,0,0,2.562
+Fall 2023,SPAN,2610,2,13881,Intensive Intermediate Spanish,Said,Erika,3,7,7,1,1,0,2,2.613
+Fall 2023,CHEM,6698,25,13886,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Fall 2023,BTEC,6304,30,13888,Computational Methods in BTEC,Chitrala,Kumaraswamy Naidu,6,3,0,0,0,0,0,3.703
+Fall 2023,BTEC,6302,30,13889,Intro to Regulatory Affairs,Flavier,Albert B,4,2,1,0,0,0,0,3.476
+Fall 2023,DANC,1309,1,13890,Dance Production,Valle,Toni Leago,15,1,0,1,0,0,0,3.687
+Fall 2023,ATP,7295,1,13891,Clinical Experience 5,Gililland,Darrell Jon,13,1,0,0,0,0,0,3.929
+Fall 2023,ATP,7312,1,13892,Therapeutic Intervention 2,Gililland,Darrell Jon,15,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,3304,2,13894,Intermediate Painting,Meza,Edgar,20,0,0,0,0,0,0,4.0
+Fall 2023,COMM,7399,1,13896,Masters Thesis,Camaj,Lindita,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6338,1,13897,Fndtns of Social Psyc,Derrick,Jaye L,28,6,0,0,0,0,0,3.736
+Fall 2023,ENGL,1302,6,13911,First Year Writing II,Denton,Amy,14,5,2,0,1,0,1,3.244
+Fall 2023,ENGL,1302,7,13912,First Year Writing II,Spencer,Jaxson Matthew,14,2,2,0,1,0,0,3.439
+Fall 2023,ENGL,1302,8,13913,First Year Writing II,Rizzo,Kaitlin M,24,1,1,1,3,0,0,3.411
+Fall 2023,ENGL,1302,9,13914,First Year Writing II,Wingard,Jennifer L,16,4,4,0,1,0,1,3.386
+Fall 2023,CHEM,8998,22,13917,Doctoral Research,May,Jeremy A,0,0,0,0,0,3,0,
+Fall 2023,MATH,8698,6,13918,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Fall 2023,MATH,8698,7,13920,Doctoral Research,Josic,Kresimir,0,0,0,0,0,1,0,
+Fall 2023,ENGL,1301,112,13922,First Year Writing I,Woodward,Marshall B,14,3,2,0,0,0,0,3.597
+Fall 2023,ENGL,1301,113,13923,First Year Writing I,Niaz,Zarlasht,5,7,6,0,0,0,1,2.999
+Fall 2023,ENGL,3301,1,13924,Intro To Literary Studies,Singh,Kavita Ashana,12,5,1,1,1,0,0,3.218
+Fall 2023,CHEM,1111,61,13925,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,18,0,0,0,0,1,3.122
+Fall 2023,CHEM,1111,62,13926,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,2,0,0,0,1,2.942
+Fall 2023,CHEM,1111,63,13927,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,13,1,0,0,0,0,3.283
+Fall 2023,CHEM,1111,64,13928,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,0,0,0,0,4,3.288
+Fall 2023,CHEM,1111,65,13929,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,5,2,1,2,0,2,2.711
+Fall 2023,CHEM,1111,67,13930,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,7,4,0,0,0,0,3.245
+Fall 2023,CHEM,1111,69,13931,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,1,0,0,0,1,3.13
+Fall 2023,CHEM,1111,70,13932,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,1,1,1,0,1,2.959
+Fall 2023,CHEM,1111,71,13933,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,2,1,0,0,0,2.999
+Fall 2023,PSYC,4344,4,13935,Cultural Psychology,Murphy,Elijah Rayvon,51,21,3,2,1,0,2,3.568
+Fall 2023,BIOL,1306,50,13936,Biology for Science Majors I,Cheek,Ann Oliver,7,11,5,4,0,0,4,2.827
+Fall 2023,AAS,3348,1,13937,African Americans and the Law,Putman,Eronn A,10,6,0,0,0,0,0,3.584
+Fall 2023,PHOP,6243,1,13940,Vision Science Core-Part 3,Frishman,Laura J,7,0,0,0,0,0,0,4.0
+Fall 2023,HON,4298,1,13941,Independent Study,LeVeaux,Christine,2,0,0,0,0,0,0,3.835
+Fall 2023,PSYC,2319,2,13949,Intro to Social Psychology,Fetterman,Adam Kent,21,18,3,1,2,0,0,3.244
+Fall 2023,PHLA,6100,1,13950,Leadership Seminar,Varkey,Divya A,13,1,0,0,0,0,0,3.929
+Fall 2023,PHOP,6257,10,13952,Research Practicum B,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,2101,20,13957,Anatomy & Physiology Lab I,Gill,Tejendra,5,10,2,1,2,0,4,2.816
+Fall 2023,POLS,8699,8,13958,Doctoral Dissertation,Scarrow,Susan E,0,0,0,0,0,1,0,
+Fall 2023,ELET,2300,4,13959,Introductn To C++ Programming,Malki,Heidar A,1,9,5,0,1,0,1,2.521
+Fall 2023,CHEM,1111,73,13960,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,3,0,0,0,3,3.156
+Fall 2023,CHEM,1111,74,13961,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,2,0,0,0,2,3.119
+Fall 2023,CHEM,1111,75,13962,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,14,3,0,0,0,0,3.11
+Fall 2023,CHEM,1111,76,13963,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,11,0,0,0,0,0,3.209
+Fall 2023,MATH,8698,8,13965,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Fall 2023,CHEM,2123,26,13967,Organic Chemistry Lab I,Bean,Mary B,3,7,11,0,0,0,0,2.682
+Fall 2023,CHEM,2123,27,13968,Organic Chemistry Lab I,Bean,Mary B,1,11,8,2,0,0,0,2.65
+Fall 2023,CIS,3343,3,13971,Info Systems Analysis & Design,Faiyaz,Sajida,39,19,13,0,1,0,1,3.347
+Fall 2023,TLIM,4341,32,13972,Production & Service Operation,Chance,Michael Dean,22,12,3,0,0,0,0,3.469
+Fall 2023,ENGL,1302,11,13975,First Year Writing II,Presswood,Phillip Hilliard,26,2,0,0,2,0,0,3.645
+Fall 2023,MATH,8698,9,13976,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Fall 2023,MATH,8698,10,13977,Doctoral Research,Cappanera,Loic,0,0,0,0,0,2,0,
+Fall 2023,CNST,3301,1,13978,Constructn Equipment & Methods,Al-Nahhas,Amer Faisal,20,55,34,9,3,0,2,2.661
+Fall 2023,MUSA,1300,8,13981,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8698,11,13985,Doctoral Research,Mang,Andreas,0,0,0,0,0,2,0,
+Fall 2023,CHEM,6398,26,13988,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2023,PHAR,5681,5,13990,Infectious Diseases,Tam,Vincent H,0,1,1,0,0,0,0,2.5
+Fall 2023,MAS,2340,2,13993,Intro Mexican American Studies,Pino,Diana,7,21,6,3,4,0,0,2.537
+Fall 2023,ARTS,2326,3,13994,Fundamentals of Sculpture,Long,Randi Rochelle,12,0,0,0,0,0,0,4.0
+Fall 2023,PHIL,1305,2,13996,Intro To Ethics,Coates,Daniel J,70,66,20,8,1,0,11,3.23
+Fall 2023,DIGM,3354,30,13997,Visual Production,Snyder,Philip Charles,65,26,8,2,4,0,4,3.318
+Fall 2023,COMM,3316,1,14002,Electronic News,Platenburg,Gheni Nicole,4,13,2,0,0,0,0,3.105
+Fall 2023,COMM,3316,2,14003,Electronic News,Perez,Felicia Russell,13,4,0,0,0,0,1,3.59
+Fall 2023,COMM,3353,1,14004,Information & Comm Tech I,Liu,Youmei,43,3,1,2,0,0,1,3.776
+Fall 2023,COMM,4378,1,14006,Social Impact of Info Tech,Ashley,Laura B,50,4,5,0,1,0,0,3.684
+Fall 2023,DIGM,4372,30,14007,DIGM Production Management,Hargrove,Mark Stephen,63,20,1,1,0,0,1,3.644
+Fall 2023,DIGM,3351,30,14010,Individ Comm Processes,Dawson,Michael John,48,25,5,4,2,0,0,3.318
+Fall 2023,PSYC,2307,1,14013,Psychology of Adolescence,Martin,Rebecca B,59,11,4,2,2,0,2,3.547
+Fall 2023,HRD,3351,30,14014,Instructional Design for HRD,Pereira-Leon,Maura Josefina,10,27,2,1,1,0,0,3.121
+Fall 2023,PSYC,2319,3,14015,Intro to Social Psychology,Ravey,Eriksen,21,12,4,1,0,0,2,3.386
+Fall 2023,GHL,4355,1,14016,Event Administration,Kenyan,Erin Oeser,14,3,2,0,0,0,0,3.597
+Fall 2023,MATH,2312,6,14017,Precalculus,Douglas,Casey,94,114,106,36,82,0,130,2.183
+Fall 2023,SOC,3342,1,14018,Sociology of Work,Lorence,Jon P,9,26,9,0,2,0,1,2.87
+Fall 2023,NURS,3735,1,14019,Clinical Nursing Practice III,McWilliams,Lenora A,44,3,0,0,0,0,9,3.936
+Fall 2023,NURS,3737,1,14020,Nurs Proc Collabrtive Prac II,McWilliams,Lenora A,6,41,0,0,0,0,9,3.128
+Fall 2023,POLS,3357,1,14021,Constitutnl Law-Civ Lib,Wall,Kenneth S,5,4,4,6,0,0,3,2.334
+Fall 2023,SCLT,3389,31,14022,Transportation Law,Henson,Alfred Bernard,52,8,0,0,0,0,1,3.795
+Fall 2023,SCLT,4387,30,14023,Financial Evaluation For SCM,Reyes,Jorge,36,15,8,1,3,0,1,3.259
+Fall 2023,SCLT,4389,30,14024,Practicum in Supply Chain,Kidd,Margaret A,7,5,0,0,0,0,0,3.611
+Fall 2023,SCLT,3387,30,14025,Procurement,Velarde,Jose Manuel,36,16,8,0,0,0,5,3.406
+Fall 2023,MATH,3339,3,14026,Statistics for the Sciences,Papadakis,Emanuel Ioannis,12,8,6,6,0,0,11,2.751
+Fall 2023,PSYC,3350,3,14027,Intro to Cognitive Psychology,Yoshida,Hanako,17,23,5,11,0,0,1,2.821
+Fall 2023,BCHS,3304,4,14028,General Biochemistry I,Liu,Yu,10,15,8,1,0,0,3,3.0
+Fall 2023,COMM,3369,2,14030,Strategic Comm. Writing,Williams,Uniqua Janae,24,3,1,0,1,0,0,3.587
+Fall 2023,COMM,3383,1,14031,Non-linear Editing,Newlin,Julye G,45,7,8,1,2,0,2,3.377
+Fall 2023,COMM,4303,3,14033,Communication Law and Ethics,Payne,Latosha Lewis Terrell,63,31,4,0,2,0,1,3.441
+Fall 2023,MATH,2131,2,14034,Linear Alg Labs w/MATLAB,Vu,An Thuy,31,2,0,0,1,0,6,3.794
+Fall 2023,COMM,4370,1,14035,Social Aspects of Film,Carter,Nestor Gregory,12,8,3,0,0,0,1,3.391
+Fall 2023,BIOL,3304,1,14036,The Biology of Social Behavior,Cole,Blaine J,15,19,18,4,3,0,2,2.594
+Fall 2023,GOVT,2305,2,14037,"US Govt: Congress,Pres & Crts",Contractor,Cyrus Ali,5,10,5,1,1,0,2,2.788
+Fall 2023,POLS,3316,1,14039,Stats for Political Scientists,Hanna,Tom Leard,25,9,1,1,0,0,3,3.629
+Fall 2023,CHEM,4364,1,14040,Advanced Organic Chem,Wu,Judy,7,9,0,0,0,0,0,3.396
+Fall 2023,PHYS,1301,2,14041,College Physics I (lecture),McElhenny,Brian Patrick,53,53,55,7,11,0,18,2.728
+Fall 2023,PHYS,3313,1,14042,Advanced Laboratory I,Forrest,Rebecca L,4,5,1,0,0,0,0,3.267
+Fall 2023,RELS,3366,1,14043,Magic and Occult,Ullrey,Aaron Michael,9,14,4,1,4,0,2,2.688
+Fall 2023,PSYC,7306,1,14044,Adv. Stats: Multilevel Model.,Francis,David J,5,4,0,0,0,0,1,3.482
+Fall 2023,COSC,1336,1,14045,Computer Science & Program,Hilford,Victoria,29,34,25,18,4,0,7,2.573
+Fall 2023,COSC,2436,1,14047,Programming and Data Structure,Mukherjee,Arjun,37,10,13,8,2,0,16,3.005
+Fall 2023,SOCW,8335,1,14049,Teaching in Higher Education,Lucas,Virginia,4,1,0,0,0,0,0,3.8
+Fall 2023,ENTR,3311,1,14051,Technology Entrepreneurship,Chatterji,Tanushree,13,0,1,0,0,0,1,3.763
+Fall 2023,MARK,4332,1,14052,Social Media Marketing,Zahn,William J,38,19,0,1,1,0,1,3.559
+Fall 2023,SCM,3301,2,14054,SCM Fundamentals,Miller,Bradley D,249,135,26,5,3,0,3,3.448
+Fall 2023,SCM,4385,1,14055,Supply Chain Analytics,Murray,Michael J,1,4,3,0,0,0,0,2.668
+Fall 2023,BIOL,6374,2,14056,Cell Biology,Rea,Michael A,2,1,0,0,0,0,0,3.557
+Fall 2023,MANA,3335,9,14057,Intro Org Behavior and Mgmt,Miljanic,Andra Olivia,72,30,16,6,5,0,3,3.202
+Fall 2023,POLS,6344,1,14058,Dissertation Prospectus,Scarrow,Susan E,13,0,0,0,0,0,0,4.0
+Fall 2023,POLS,3322,1,14059,Intro Latin-Am Politics,Aleman,Eduardo,15,17,7,0,0,0,1,3.18
+Fall 2023,MARK,7333,1,14060,Search Engine Marketing,Gavin,Daniel Yaakov,22,4,0,1,0,0,0,3.741
+Fall 2023,HON,3303,1,14061,Mental Health & Society,Macdonald,Arlene,16,7,0,1,0,0,0,3.597
+Fall 2023,HON,3301,4,14062,Readings in Medicine & Society,Macdonald,Arlene,11,7,0,1,0,0,1,3.561
+Fall 2023,GHL,1345,2,14063,"Safety, Sanitation in Hosp Ind",Sirsat,Sujata Ashok,13,18,8,1,2,0,0,2.913
+Fall 2023,GHL,3348,2,14064,Principles of Hosp Revenue Mgt,Kazemi Zarkouei,Mohammad Sadegh,13,8,7,9,6,0,7,2.318
+Fall 2023,HRD,4396,2,14065,Internship in HRD,Owens-Shepard,Toya,12,1,0,0,0,0,0,3.771
+Fall 2023,GHL,6368,1,14066,Career Capstone Project,Shin,Min Jung,0,1,0,0,0,0,0,2.67
+Fall 2023,GHL,7361,1,14067,Hospitality Marketing Analysis,Shin,Min Jung,22,1,0,0,0,0,1,3.885
+Fall 2023,MIS,4378,3,14068,Admin of Computer-Based MIS,Knighton,William B,43,6,0,0,0,0,0,3.878
+Fall 2023,GOVT,2306,9,14070,US and Texas Const/Politics,Hanna,Tom Leard,185,43,9,0,5,0,8,3.653
+Fall 2023,SPAN,1507,1,14071,Intns Elem Span Heritage Learn,Ruiz,Eugenia Maria,9,7,2,0,1,0,2,3.089
+Fall 2023,LAW,5203,1,14074,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,7,0,
+Fall 2023,LAW,5206,1,14075,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,2,0,
+Fall 2023,LAW,5228,1,14076,Judicial Externship I,Powers,William,0,0,0,0,0,7,0,
+Fall 2023,LAW,5229,1,14077,Judicial Externship II,Powers,William,0,0,0,0,0,1,0,
+Fall 2023,LAW,7334,1,14078,WRS: Int'l Law & Use of Force,Foteh,Samir Jabra,3,8,0,0,0,0,0,3.423
+Fall 2023,HRD,3351,1,14079,Instructional Design for HRD,Pereira-Leon,Maura Josefina,12,19,6,2,0,0,1,2.992
+Fall 2023,COMM,3377,1,14080,Strategic PR Planning,Uhrick,Jan,25,3,1,0,0,0,0,3.748
+Fall 2023,KIN,1304,2,14081,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,258,20,12,2,3,0,5,3.804
+Fall 2023,KIN,3301,1,14082,Design/Eval Phys Activity Prog,Alastuey,Lisa L,21,20,4,1,2,0,1,3.167
+Fall 2023,LAW,5361,1,14083,Financial Statement Analysis,Brennan,Daniel,11,15,0,0,0,0,0,3.41
+Fall 2023,PSYC,2316,4,14084,Psychology of Personality,Inman,Tonya N,54,31,9,3,12,0,8,3.003
+Fall 2023,IDNS,2115,1,14085,Physics 2325 SEP Workshop,Pattison,Donna,8,7,1,1,0,0,1,3.178
+Fall 2023,IDNS,2116,1,14086,Physics 2326 SEP Workshop,Pattison,Donna,9,3,1,1,0,0,0,3.476
+Fall 2023,WGSS,4360,1,14087,Capstone Internship Course,Gregory,Elizabeth,6,0,1,0,0,0,0,3.714
+Fall 2023,ACCT,3368,2,14088,Intermediate Accounting II,Muslu,Volkan,13,24,12,0,0,0,1,2.973
+Fall 2023,KIN,3306,1,14089,Physiology-Human Performance,Park,Yoonjung,43,56,39,9,1,0,1,2.852
+Fall 2023,KIN,3309,2,14090,Biomechanics,Gorniak,Stacey,33,35,35,12,3,0,1,2.656
+Fall 2023,KIN,4301,1,14091,Workplace Wellness,Alastuey,Lisa L,17,11,6,2,1,0,0,2.983
+Fall 2023,KIN,4310,1,14092,Measurement Tech Human Perf,Thrasher,Timothy Adam,11,35,36,8,5,0,4,2.452
+Fall 2023,MARK,3337,3,14093,Professional Selling,Vandaveer,Amy L,248,42,4,0,0,0,2,3.809
+Fall 2023,BTEC,6101,30,14094,Biotechnology Techniques Metho,Khan,Abdul Latif,5,0,0,0,0,0,0,4.0
+Fall 2023,SCLT,6396,1,14095,Internship in Logistics,Wang,Kailai,6,0,0,0,0,0,0,4.0
+Fall 2023,BTEC,3302,30,14096,Molecular Genetics and Biotech,Lin,Yuheng,25,14,4,1,1,0,0,3.304
+Fall 2023,TLIM,3363,31,14099,Technical Communications,Tangeman,Anthony C,18,13,5,0,4,0,0,3.083
+Fall 2023,TLIM,3363,32,14100,Technical Communications,Tangeman,Anthony C,20,12,4,1,3,0,0,3.133
+Fall 2023,TLIM,3363,33,14101,Technical Communications,Tangeman,Anthony C,19,10,5,3,2,0,2,3.102
+Fall 2023,TLIM,3365,30,14102,Team Leadership,Feriante,Chris,31,8,4,0,0,0,1,3.628
+Fall 2023,TLIM,4341,31,14103,Production & Service Operation,Cao,Shun,26,5,1,1,0,0,0,3.687
+Fall 2023,TLIM,4342,30,14104,Quality Improvement Methods,Chance,Michael Dean,16,18,7,2,1,0,1,2.985
+Fall 2023,TLIM,4390,30,14105,Current Issues Ldshp & Innov,Mehring,Brian George,18,6,4,1,0,0,0,3.3
+Fall 2023,MATH,3363,4,14106,Introduction To PDE,Onofrei,Daniel T,19,17,8,1,2,0,0,3.071
+Fall 2023,ENGL,7390,1,14108,Intro to Doctoral Studies,Ehlers,Sarah E,11,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3350,1,14109,Am Lit To 1865,Berger,Jason,20,6,1,0,0,0,2,3.581
+Fall 2023,ENTR,4110,1,14110,Entrepren Values & Leadership,Cook,David B,11,12,5,0,0,0,0,3.179
+Fall 2023,SCLT,3376,30,14111,Global Trade Intermediaries,Crockett,Brianne,32,12,1,1,1,0,0,3.427
+Fall 2023,SCLT,6318,1,14112,Supply Chain Strategies,Bian,Zheyong,37,5,0,0,0,0,0,3.897
+Fall 2023,MARK,4333,1,14113,Search Engine Marketing,Buffaloe,Bonnie Lora-Lee,30,6,0,0,0,0,0,3.806
+Fall 2023,MATH,1332,1,14116,Contemporary Mathematics,Hafeez,Shahinda,23,27,24,21,23,0,20,1.989
+Fall 2023,MATH,1351,1,14117,Intro to Geometric Reasoning,Douglas,Casey,70,98,70,24,48,0,68,2.355
+Fall 2023,HRD,3346,30,14118,Performance Assessment & Eval,Edwards,Malaika,7,1,2,0,0,0,0,3.434
+Fall 2023,PHYS,3110,1,14119,Sem-Adv Lab Analysis,Forrest,Rebecca L,9,0,1,0,0,0,0,3.767
+Fall 2023,SCM,7350,1,14124,Strategic Supply Management,Wayhan,Victor Brian,23,5,0,0,0,0,0,3.833
+Fall 2023,PSYC,6392,1,14125,Intervention Practicum,Vincent,John P,0,0,0,0,0,14,0,
+Fall 2023,PSYC,8321,1,14126,Clinical Psyc Internship,Vincent,John P,0,0,0,0,0,5,0,
+Fall 2023,PSYC,8399,1,14127,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,1,0,
+Fall 2023,GHL,3341,2,14128,Hospitality Managerial Acct,Johnson,Tucker A,10,14,2,0,0,0,0,3.32
+Fall 2023,GHL,3358,1,14129,Hospitality Industry Law,Abbott,Jeanna L,37,6,2,1,0,0,0,3.717
+Fall 2023,MARK,4379,1,14130,Personal Branding,Suki,Yara D,54,4,0,0,0,0,0,3.914
+Fall 2023,MATH,3305,2,14131,Formal & Informal Geometry,George,Rebecca Ann,22,7,5,1,2,0,2,3.181
+Fall 2023,PSYC,6399,1,14132,Masters Thesis,Reyes,Denise Lucia,1,0,0,0,0,1,0,4.0
+Fall 2023,PSYC,8399,2,14133,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,2,0,
+Fall 2023,ENGL,8322,1,14134,Master Workshop: Poetry,Belieu,Erin Colleen,9,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6399,2,14136,Masters Thesis,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2023,COMM,4328,1,14138,Broadcast & Film Writing,Vaughan,Thomas Michael,14,2,2,0,0,0,1,3.63
+Fall 2023,PSYC,8399,3,14140,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,3,0,
+Fall 2023,PSYC,6352,1,14142,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,4,0,
+Fall 2023,ENGL,6322,1,14143,Poetry Workshop,Prufer,Kevin D,10,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6362,1,14144,Dramatic Thry&Criticism,Romero,Gregory John,12,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,8699,9,14146,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,2,0,
+Fall 2023,PSYC,2306,1,14147,Psychology of Human Sexuality,Keo-Meier,Colton Lawrence,32,20,7,5,5,0,6,2.981
+Fall 2023,CHEM,1112,20,14149,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,5,2,1,0,0,6,3.083
+Fall 2023,CHEM,1112,21,14150,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,7,4,0,0,0,3,3.118
+Fall 2023,CHEM,1112,22,14151,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,4,1,0,0,4,2.854
+Fall 2023,PHAR,5681,6,14153,Infectious Diseases,Garey,Kevin W,2,0,0,0,0,0,0,4.0
+Fall 2023,COMM,1307,1,14154,Media and Society,Olson,Beth M,32,105,81,42,25,0,10,2.247
+Fall 2023,PSYC,7393,1,14155,Field Practicum in Psychology,Vincent,John P,0,0,0,0,0,30,0,
+Fall 2023,COMM,3311,1,14156,Editing Print & Digital Media,Crixell,Charles A,13,8,2,0,0,0,1,3.493
+Fall 2023,COMM,3311,2,14157,Editing Print & Digital Media,Crixell,Charles A,6,6,2,0,0,0,1,3.262
+Fall 2023,COMM,3311,3,14158,Editing Print & Digital Media,Crixell,Charles A,12,6,5,1,1,0,0,3.04
+Fall 2023,PSYC,7399,3,14159,Masters Thesis,Cirino,Paul,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,6399,1,14161,Master's Thesis,Koontz,Rex A,0,0,0,0,0,3,0,
+Fall 2023,PSYC,6298,1,14163,Special Problems,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6336,1,14164,Directed Rsch in Social Psyc,Damian,Rodica Ioana,0,0,0,0,0,3,0,
+Fall 2023,PSYC,3399,2,14165,Senior Honors Thesis,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1302,55,14166,First Year Writing II,Ornell,Colby,6,5,4,2,4,0,1,2.349
+Fall 2023,ENGL,1302,56,14167,First Year Writing II,Ornell,Colby,6,7,4,2,6,0,0,2.147
+Fall 2023,ENGL,1302,57,14168,First Year Writing II,Koulen,Marisa Theresa,15,1,0,1,2,0,0,3.299
+Fall 2023,SOCW,6201,2,14169,Foundation of Social Work Prof,Lucas,Virginia,0,0,0,0,0,81,1,
+Fall 2023,ARTH,3332,1,14173,20th Century Design,Orto,Luisa,20,2,0,0,0,0,0,3.834
+Fall 2023,ARTH,6332,1,14174,20th Century Design,Orto,Luisa,5,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8399,4,14175,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,3,0,
+Fall 2023,CHIN,3360,2,14176,A Look Into Modern China,McArthur,Charles M,10,11,3,0,1,0,3,3.2
+Fall 2023,MUSA,6140,3,14177,Graduate Recital I,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,4391,1,14178,Internships in Intl Affairs,Sisman,Ozlem,3,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8121,1,14179,Clinical Psychology Internship,Vincent,John P,0,0,0,0,0,4,0,
+Fall 2023,GEOL,3330,1,14180,Paleobiology,Maddocks,Rosalie F,5,4,6,2,0,0,0,2.725
+Fall 2023,PSYC,6393,1,14182,Clinical Research Practicum,Alfano,Candice A,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6200,2,14184,Accompanying Seminar,Suits,Brian J,9,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,2312,4,14186,Intermediate Spanish II,Ruffino,Maythe,7,18,2,0,0,0,1,3.087
+Fall 2023,AAS,2320,4,14198,Intro To African American Stdy,Shakir,Ameenah,19,5,2,1,2,0,4,3.197
+Fall 2023,MUSI,1181,3,14209,Group Piano I,Van Kekerix,Todd Evan,10,3,0,0,0,0,1,3.693
+Fall 2023,PSYC,8399,5,14213,Doctoral Dissertation,Alfano,Candice A,2,0,0,0,0,1,0,4.0
+Fall 2023,PSYC,7399,6,14214,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2023,PSYC,8390,1,14215,Clinical Neuropsyc Internship,Vincent,John P,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7399,7,14216,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Fall 2023,PSYC,6398,3,14217,Independent Studies,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6257,14,14220,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,1306,54,14222,Biology for Science Majors I,Sharp,Rita Evelyn,8,9,5,1,0,0,6,3.072
+Fall 2023,PSYC,7390,1,14223,Clin Neuropsychology Practicum,Woods,Steven Paul,0,0,0,0,0,11,0,
+Fall 2023,PSYC,8399,6,14225,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2023,MUSI,6352,1,14226,Group Piano Pedagogy,Van Kekerix,Todd Evan,5,1,0,0,0,0,0,3.833
+Fall 2023,MUSI,6260,1,14227,Internship in Piano Teaching I,Van Kekerix,Todd Evan,2,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,8399,11,14232,Dissertation,Kanellos,Nicolas,0,0,0,0,0,3,0,
+Fall 2023,SPAN,8699,10,14233,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6498,4,14234,Special Problems,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,8999,15,14235,Doctoral Dissertation,Basinger,Scott J,0,0,0,0,0,1,0,
+Fall 2023,ENGL,1301,92,14236,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,11,5,2,0,0,0,1,3.427
+Fall 2023,PSYC,6393,3,14237,Clinical Research Practicum,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2023,PEP,8399,1,14238,Doctoral Dissertation,O'Connor,Daniel Patrick,0,0,0,0,0,1,0,
+Fall 2023,MATH,8698,12,14240,Doctoral Research,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Fall 2023,PSYC,8399,7,14243,Doctoral Dissertation,Walker,Rheeda L,0,0,0,0,0,1,0,
+Fall 2023,MATH,8698,13,14249,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7399,9,14250,Masters Thesis,Sharp,Carla,0,0,0,0,0,1,0,
+Fall 2023,PSYC,8190,1,14251,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6352,2,14253,Directed Rsch in I/O Psyc,Ng,Vincent,0,0,0,0,0,3,0,
+Fall 2023,PSYC,8399,8,14254,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8399,9,14256,Doctoral Dissertation,Medina,Luis Daniel,0,0,0,0,0,2,0,
+Fall 2023,MATH,8698,14,14257,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6352,3,14258,Directed Rsch in I/O Psyc,Brummel,Bradley James,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1302,59,14263,First Year Writing II,Ornell,Colby,16,2,3,0,2,0,1,3.261
+Fall 2023,WGSS,2350,9,14264,Intro To Women's Studies,Al-Sowayel,Dina,18,2,5,2,0,0,2,3.248
+Fall 2023,COSC,1336,3,14266,Computer Science & Program,Subhlok,Jaspal,63,23,12,7,2,0,12,3.274
+Fall 2023,CHEM,2123,28,14276,Organic Chemistry Lab I,Bean,Mary B,3,9,9,1,0,0,1,2.636
+Fall 2023,CHEM,2125,8,14277,Organic Chemistry Lab II,Bean,Mary B,7,9,5,1,0,0,0,2.925
+Fall 2023,ECON,8399,4,14278,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,5,0,
+Fall 2023,PSYC,8399,10,14279,Doctoral Dissertation,Williams,Michael W,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6398,5,14280,Independent Studies,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6352,4,14281,Directed Rsch in I/O Psyc,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8399,12,14282,Doctoral Dissertation,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,2360,3,14284,Introduction to LGBT Studies,Stone,Lauren Michelle,23,5,2,0,0,0,0,3.645
+Fall 2023,CHEM,1111,77,14285,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,1,0,0,0,1,3.271
+Fall 2023,PSYC,6398,9,14288,Independent Studies,Yoshida,Hanako,0,0,0,0,0,1,0,
+Fall 2023,PSYC,8399,14,14289,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6399,7,14290,Masters Thesis,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Fall 2023,DRAM,1310,9,14292,Introduction to Theatre,Young,Courtney Leigh,39,9,1,0,1,0,0,3.667
+Fall 2023,ENGL,1301,93,14293,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,8,7,0,1,2,0,0,2.982
+Fall 2023,PSYC,6398,10,14299,Independent Studies,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Fall 2023,CHEM,1111,78,14300,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,0,0,0,0,2,3.314
+Fall 2023,GEOL,3150,2,14302,Prin-Stratigraphy Lab,Carlson,Brandee Nicole,9,3,0,0,0,0,0,3.668
+Fall 2023,PSYC,8399,15,14303,Doctoral Dissertation,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,8399,21,14306,Doctoral Dissertation,Cuny,Gregory D,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6398,12,14309,Independent Studies,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2023,INDS,6398,1,14310,Independent Study,Morshedzadeh,Elham,1,0,0,0,0,0,0,3.67
+Fall 2023,PSYC,6393,4,14312,Clinical Research Practicum,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6393,6,14313,Clinical Research Practicum,Woods,Steven Paul,0,0,0,0,0,2,0,
+Fall 2023,PSYC,6393,5,14314,Clinical Research Practicum,Woods,Steven Paul,3,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6393,7,14315,Clinical Research Practicum,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,6998,21,14316,Special Problems,Xu,Shoujun,0,0,0,0,0,1,0,
+Fall 2023,CHEM,6998,22,14317,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Fall 2023,BIOL,4399,1,14321,Senior Honors Thesis,Azevedo,Ricardo,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8698,16,14322,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,2,0,
+Fall 2023,ECON,8361,1,14331,Workshop Research Methods III,Ujhelyi,Gergely,0,0,0,0,0,5,0,
+Fall 2023,ECON,3332,4,14332,Intermediate Microeconomics,Chin,Aimee,19,16,2,0,1,0,2,3.342
+Fall 2023,PHIL,1301,1,14334,Intro To Philosophy,Hattab,Helen,3,11,13,10,8,0,52,1.778
+Fall 2023,PHIL,1301,2,14335,Intro To Philosophy,Oliveira,Luis RG,73,32,6,2,2,0,4,3.453
+Fall 2023,WCL,3366,1,14336,Latin American and Latino Film,Centeno,Daniel,12,11,7,0,0,0,0,3.068
+Fall 2023,GEOL,1102,1,14338,Intro to Climate Change Lab,Zhang,Honghai,1,8,1,0,1,0,1,2.817
+Fall 2023,GEOL,1103,11,14339,Physical Geology Lab,Hauptvogel,Daniel William,19,4,1,0,0,0,0,3.75
+Fall 2023,MATH,1314,6,14340,College Algebra,Caglar,Atife,96,68,54,19,42,0,18,2.538
+Fall 2023,MATH,2131,1,14345,Linear Alg Labs w/MATLAB,Goligerdian,Arash,18,4,2,0,4,0,5,3.096
+Fall 2023,POLS,3312,2,14346,"Arguments, Data, Politics",Raychaudhuri,Tanika,16,11,11,0,1,0,1,2.992
+Fall 2023,MATH,2305,4,14348,Discrete Mathematics,Leger,Nicholas M,5,10,7,3,7,0,12,2.094
+Fall 2023,BIOL,3345,1,14349,Plant Physiology,Farmer,Lisa M,34,19,3,0,0,0,0,3.512
+Fall 2023,COSC,3380,2,14351,Database Systems,Ramamurthy,Uma,17,23,20,0,4,0,8,2.657
+Fall 2023,POLS,3310,1,14352,Intro to Political Theory,Church,Jeffrey,147,32,9,5,5,0,2,3.547
+Fall 2023,FINA,4381,1,14353,Essentials of Real Estate,Jacobus,Charles J,8,13,10,5,1,0,0,2.577
+Fall 2023,PSYC,2307,2,14354,Psychology of Adolescence,Anderson,Jill Annette,14,17,8,1,3,0,0,2.914
+Fall 2023,PSYC,4344,5,14355,Cultural Psychology,Jewell,Rebecca D,59,16,2,2,1,0,0,3.654
+Fall 2023,PSYC,2308,1,14356,Child Development,Yoshida,Hanako,33,8,2,1,0,0,1,3.659
+Fall 2023,PSYC,2330,2,14357,Biological Psychology,Alward,Beau Andrew,29,16,0,1,0,0,0,3.58
+Fall 2023,PSYC,2330,3,14358,Biological Psychology,Gehm,Kevan H,9,18,7,1,3,0,0,2.824
+Fall 2023,MANA,4385,1,14359,Intro to Strategic Management,Chiu,Shih-chi,10,5,1,0,0,0,0,3.521
+Fall 2023,CNST,4302,2,14360,Construction Law and Ethics,Ducran,Denis George,6,37,28,3,1,0,0,2.595
+Fall 2023,CNST,4331,2,14361,Construction Management II,Menendez,Daniel,12,7,5,0,0,0,0,3.36
+Fall 2023,MATH,4335,1,14363,Partial Diff  Equations I,Jaramillo,Gabriela T,4,2,4,2,2,0,3,2.309
+Fall 2023,BCIS,1305,4,14364,Business Computer Applications,Felvegi,Emese,194,32,16,0,6,0,1,3.628
+Fall 2023,MARK,3337,4,14365,Professional Selling,Vandaveer,Amy L,207,78,4,1,3,0,6,3.628
+Fall 2023,PSYC,4343,1,14367,Perception,Tamber-Rosenau,Benjamin J,12,20,12,0,0,0,3,2.993
+Fall 2023,COMD,3381,1,14368,Audiology,Andrews,Chereece N,48,4,0,0,0,0,1,3.904
+Fall 2023,FINA,4328,1,14369,Principles of Personal Finance,Coleman,Alfred G,32,3,0,0,0,0,0,3.905
+Fall 2023,TEPM,6305,20,14370,Project Manager Tools,Sherman,Dennis Louis,3,1,0,0,0,0,0,3.833
+Fall 2023,KIN,4360,1,14371,Adaptive Athletics Management,Cottingham,Michael,14,1,0,0,0,0,0,3.889
+Fall 2023,TEPM,6304,20,14372,Quality Improvemnt in Proj Mgt,Kovach,Jamison,2,0,0,0,0,0,1,4.0
+Fall 2023,HRD,6352,1,14373,Inst Design for Training Envir,Waight,Consuelo L,20,0,0,0,0,0,0,3.967
+Fall 2023,HRD,6356,1,14374,Consulting & Prof. Practice,Salomon,Lauren Manning,10,2,0,0,0,0,0,3.668
+Fall 2023,ACCT,2301,10,14375,Prin of Financial Accounting,Sykes,Mary Reeves,36,23,2,2,3,0,3,3.398
+Fall 2023,HIST,3316,1,14376,Race & Racism in Amer Sci/Med,Mizelle Jr,Richard M,14,14,0,0,1,0,0,3.448
+Fall 2023,WGSS,2360,4,14377,Introduction to LGBT Studies,Pegoda,Andrew Joseph,6,8,8,2,2,0,4,2.475
+Fall 2023,NUTR,4353,1,14380,Cultural Comp for Nutr Prof,Yoon,Cynthia Yursun,43,25,5,1,0,0,0,3.433
+Fall 2023,SCLT,3340,30,14381,Geography for GSC,Henson,Alfred Bernard,26,18,1,2,2,0,0,3.259
+Fall 2023,SCLT,3375,30,14382,Maritime Operations,Chopra,Anuj,21,9,6,0,1,0,0,3.244
+Fall 2023,SCLT,3384,31,14383,Logistics Tech and Processes,Wang,Kailai,36,25,4,0,0,0,2,3.436
+Fall 2023,GEOL,1102,2,14384,Intro to Climate Change Lab,Zhang,Honghai,16,7,0,0,0,0,1,3.624
+Fall 2023,HON,4130,1,14387,E-Portfolio,Rayder,Benjamin Taylor,8,1,0,0,0,0,1,3.889
+Fall 2023,GHL,3352,2,14388,Human Resource Management,Madera,Juan Manuel,34,1,3,1,1,0,1,3.658
+Fall 2023,GHL,3357,1,14389,Gaming and Casino Managment,Kim,Jaewook,8,2,1,0,0,0,0,3.696
+Fall 2023,GHL,6357,1,14390,Gaming and Casino Mgmt,Kim,Jaewook,3,1,0,0,0,0,0,3.75
+Fall 2023,ARCH,3230,1,14391,Programming & Bldg Regulations,Lander,Lawrence Farnham,150,2,1,0,0,0,1,3.942
+Fall 2023,ANTH,6399,5,14392,Masters Thesis,Rasmussen,Susan J,1,0,0,0,0,0,0,4.0
+Fall 2023,ANTH,7399,3,14393,Masters Thesis,Rasmussen,Susan J,0,0,0,0,0,1,0,
+Fall 2023,PSYC,4344,6,14394,Cultural Psychology,Kilani,Mohamed Hechmi,15,9,4,0,6,0,5,2.765
+Fall 2023,DANC,1241,1,14395,Beginning Ballet,Estrada,Maria Gabriela,12,1,0,0,0,0,0,3.847
+Fall 2023,LAW,5199,1,14397,Special Problems,Vetter,Greg R,0,0,0,0,0,18,0,
+Fall 2023,LAW,5199,2,14398,Special Problems,Alderman,Richard M,0,0,0,0,0,4,0,
+Fall 2023,LAW,5299,1,14399,Special Problems,Vetter,Greg R,0,0,0,0,0,32,0,
+Fall 2023,LAW,5299,2,14400,Special Problems,Alderman,Richard M,0,0,0,0,0,5,0,
+Fall 2023,LAW,6238,1,14401,International Risk Management,Rivero,Francisco,6,8,0,0,0,0,0,3.476
+Fall 2023,LAW,5363,1,14402,Securities Regulation,Ragazzo,Robert A,9,16,0,0,0,0,0,3.334
+Fall 2023,LAW,5403,1,14403,Street Law,Cohen,Lisa Elaine,2,3,0,0,0,0,0,3.4
+Fall 2023,LAW,5418,11,14404,Torts,Sanders,Joseph,30,45,3,0,0,0,0,3.388
+Fall 2023,LAW,6360,1,14405,Trial Advocy for NonLitigators,Lukin,Karen B,3,6,0,0,0,1,0,3.37
+Fall 2023,ENGL,3331,1,14406,Beg Creative Writing-Poetry,Nee,Kelan,18,2,0,0,0,0,0,3.834
+Fall 2023,LAW,6321,2,14408,Professional Responsibility,Murphy,Mary Ellen,19,39,1,0,0,0,0,3.367
+Fall 2023,COMM,3360,3,14409,Principles of Strategic Comm,Ashley,Laura B,90,28,13,0,0,0,2,3.58
+Fall 2023,COMM,3331,1,14410,Communication in the Family,Hudson-Gillan,Gail,25,8,1,1,0,0,0,3.638
+Fall 2023,PETR,8399,8,14411,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,5,0,
+Fall 2023,PETR,8399,10,14413,Doctoral Dissertation,Sakhaee Pour,Ahmad,2,0,0,0,0,0,0,4.0
+Fall 2023,PETR,8598,8,14419,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,3,0,
+Fall 2023,PETR,8699,8,14420,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2023,PETR,8699,10,14422,Doctoral Dissertation,Sakhaee Pour,Ahmad,3,0,0,0,0,0,0,4.0
+Fall 2023,ENTR,7390,1,14423,Technology Entrepreneurship,Chatterji,Tanushree,11,0,0,0,0,0,0,3.94
+Fall 2023,ENGL,1301,135,14424,First Year Writing I,Marino,Peter,4,5,5,1,6,0,3,1.969
+Fall 2023,PHYS,3316,1,14425,Quantum Mechanics,Miller,John H,3,1,1,0,0,0,1,3.4
+Fall 2023,ENGL,1301,136,14426,First Year Writing I,Hall,Laura Dianne,10,7,1,0,0,0,0,3.408
+Fall 2023,ENGL,1301,137,14427,First Year Writing I,Cunningham,Sara Kaplan,13,5,1,0,0,0,0,3.545
+Fall 2023,ENGL,1301,138,14428,First Year Writing I,Berg,Caleb J.,15,4,0,0,0,0,0,3.755
+Fall 2023,ENGL,1301,139,14429,First Year Writing I,Lee,Nathanael D,9,3,3,2,1,0,0,2.871
+Fall 2023,ENGL,1301,140,14430,First Year Writing I,Marino,Peter,6,9,6,0,3,0,2,2.625
+Fall 2023,CIVE,3434,1,14431,Fluid Mech and Hydraulic Engr,Wang,Keh-Han,4,4,7,0,1,0,9,2.646
+Fall 2023,MATH,6382,2,14433,Probability,Azencott,Robert Guy,8,6,3,0,0,0,3,3.314
+Fall 2023,TLIM,3345,1,14434,Human Resources in Technology,Evans,Ruth Ann,49,12,5,1,3,0,1,3.471
+Fall 2023,CIS,3368,1,14435,Adv Info Systems Development,Dobretsberger,Otto,27,18,5,0,1,0,5,3.373
+Fall 2023,TLIM,4350,30,14436,Occup Safety & Envir Health,Freedkin,Aaron Samuel,43,19,0,1,1,0,0,3.516
+Fall 2023,TLIM,4371,30,14437,Leading Change in the Wrkplace,Mehring,Brian George,9,8,6,2,2,0,0,2.704
+Fall 2023,KIN,4691,1,14438,Internship in Sport Admin 2,Walsh,David W,20,3,0,0,0,0,0,3.827
+Fall 2023,KIN,4391,1,14439,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Fall 2023,KIN,4398,1,14440,Independent Study,Cottingham,Michael,3,0,0,0,0,0,0,4.0
+Fall 2023,KIN,1304,3,14441,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,167,18,3,5,6,0,1,3.703
+Fall 2023,LAW,6365,1,14442,Health Law Finance Transactns,Mantel,Jessica,7,12,1,0,0,4,0,3.317
+Fall 2023,MUED,2342,3,14443,Music for Children,Chapa,Julissa Y,13,6,1,2,1,0,1,3.217
+Fall 2023,NUTR,2332,3,14446,Intro To Human Nutrition,Hughes,Lindsay,30,31,11,0,1,0,1,3.201
+Fall 2023,BTEC,4319,30,14448,Microbial Biotechnology,Flavier,Albert B,6,8,9,4,4,0,1,2.29
+Fall 2023,PSYC,2316,5,14449,Psychology of Personality,Stroud,Scott Allen,57,13,6,1,0,0,2,3.666
+Fall 2023,DRAM,1341,1,14450,Make up for Actors,Gardecki,Samantha Lauren,5,1,1,0,0,0,1,3.477
+Fall 2023,THEA,3388,1,14453,Advanced Stagecraft,Webb,Matthew Clark,5,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5370,1,14454,International Law,Jackson,Craig Leonard,13,11,1,0,0,2,0,3.361
+Fall 2023,ECE,4398,1,14455,Independent Study,Bering,Edgar A,1,1,0,0,0,0,0,3.665
+Fall 2023,ARTS,3360,1,14456,Intermediate Sculpture,Kittelson,Paul A,9,10,1,0,0,0,0,3.384
+Fall 2023,MUED,3102,1,14457,Brasses,Bell,Priscilla Garrett,9,6,3,0,0,0,0,3.278
+Fall 2023,MUSA,3420,2,14459,Applied Violin,Lo,Mann-Wen,2,1,0,0,0,0,0,3.337
+Fall 2023,ARCH,1500,19,14460,Design Studio I,Handanovic,Dijana,6,4,1,0,0,0,3,3.485
+Fall 2023,PHYS,1101,19,14464,College Physics I (lab),Wood,Lowell T,2,12,6,0,0,0,0,2.718
+Fall 2023,CHEM,6698,29,14466,Special Problems,Comito,Robert Joseph,0,0,0,0,0,3,0,
+Fall 2023,INAR,3300,1,14467,Hist of Interior Architecture,Thomas,James B,26,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3438,1,14469,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,8999,2,14470,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,1,0,
+Fall 2023,BTEC,4300,31,14474,Principles of Bioinformatics,Balan,Venkatesh,5,7,1,0,0,0,0,3.257
+Fall 2023,CHEM,8998,26,14482,Doctoral Research,Xu,Shoujun,0,0,0,0,0,2,0,
+Fall 2023,MUSA,6324,1,14483,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,1,14484,Doctoral Applied Music,Dorough,Aralee,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,3,14485,Doctoral Applied Music,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,8,14486,Doctoral Applied Music,Morgulis,Tali,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,9,14487,Doctoral Applied Music,Robinson,Daryl Allen,4,0,0,0,0,0,0,3.918
+Fall 2023,MUSA,8320,16,14488,Doctoral Applied Music,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,6381,1,14489,Writing Seminar,Williams,Matthew Joseph,11,0,0,0,1,0,0,3.584
+Fall 2023,MUSI,7399,1,14491,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,1,0,
+Fall 2023,PHIL,1321,1,14495,Logic I,Loewenstein,Yael R,26,17,21,17,17,0,21,2.096
+Fall 2023,POLS,8699,3,14497,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,1,0,
+Fall 2023,ENGL,2315,1,14498,Literature and Film,Julian,Jennifer La'Vonne,27,1,1,1,0,0,0,3.789
+Fall 2023,ARTS,4398,1,14499,Independent Study,Parazette,Aaron,3,0,0,0,0,0,0,4.0
+Fall 2023,COSC,4351,1,14513,Fundamentals of Software Engr,Hilford,Victoria,53,33,3,2,0,0,0,3.455
+Fall 2023,HON,4399,1,14519,Senior Honors Thesis,Anderson Fletcher,Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8395,2,14530,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Fall 2023,ARTS,4398,2,14532,Independent Study,Lowe,Rick,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4398,3,14533,Independent Study,Hecker,Rachel G,1,0,0,0,0,0,0,3.67
+Fall 2023,PSYC,6399,11,14534,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6399,12,14543,Masters Thesis,Fetterman,Adam Kent,0,0,0,0,0,2,0,
+Fall 2023,LACP,2111,1,14549,Liberal Arts Career Planning,Thompson,Monica,0,0,0,0,0,21,0,
+Fall 2023,ACCT,4331,2,14550,Federal Income Tax,Fernandez,Ramon,3,23,10,2,3,0,3,2.577
+Fall 2023,HDCS,1300,5,14552,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,40,6,1,1,4,0,7,3.43
+Fall 2023,ENGL,4319,1,14557,English in Secondary Schools,Bachmann,Abbey Marie,21,2,0,0,1,0,1,3.723
+Fall 2023,MATH,6358,2,14558,Probability & Stat. Computing,Poliak,Cathy Dawn,24,0,0,0,0,0,1,3.945
+Fall 2023,BIOE,7399,6,14561,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Fall 2023,HON,4398,1,14567,Independent Study,LeVeaux,Christine,4,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2317,6,14569,Intro to Psychology Statistics,Griep,Christina Diaz,31,32,13,1,2,0,1,3.152
+Fall 2023,HON,3399,1,14580,Senior Honors Thesis,Ventura,Gabriela Baeza,0,0,0,0,0,0,0,
+Fall 2023,HON,4399,2,14581,Senior Honors Thesis,Morrison,Iain P D,1,0,0,0,0,0,0,3.67
+Fall 2023,MARK,4389,7,14586,Marketing Strategy & Planning,Randazzo,Gary W,25,6,1,0,0,0,0,3.575
+Fall 2023,PSYC,6393,8,14592,Clinical Research Practicum,Sharp,Carla,2,0,0,0,0,0,0,4.0
+Fall 2023,NURS,3315,1,14593,Pathophysiology,Edwards-Maddox,Shermel Vinese,4,26,0,3,0,0,5,2.939
+Fall 2023,POLS,3313,2,14594,Intro Internatl Relatns,Soules,Michael,19,10,9,0,2,0,0,3.075
+Fall 2023,PHAR,5686,2,14601,Psychiatry,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8399,16,14605,Doctoral Dissertation,Gallagher,Matthew Ward,0,0,0,0,0,1,0,
+Fall 2023,COSC,2425,1,14607,Computer Org & Architecture,Long,Kevin B,37,39,1,1,0,0,2,3.436
+Fall 2023,PHOP,6257,2,14608,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,3316,2,14612,Stats for Political Scientists,Basinger,Scott J,32,5,2,0,1,0,0,3.626
+Fall 2023,PSYC,7392,1,14613,Psychology Practicum,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2023,ASLI,3460,1,14614,Advanced ASL,Gietz,Merrilee Ruth,1,8,1,0,0,0,0,3.0
+Fall 2023,PSYC,7392,3,14615,Psychology Practicum,Fetterman,Adam Kent,2,0,0,0,0,0,0,4.0
+Fall 2023,POLS,8399,28,14627,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Fall 2023,PHLA,6221,1,14628,Adv Health System Mgmt,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,1106,45,14629,Biol for Science Majors I(Lab),Medrano,Ana I,14,6,1,0,1,0,1,3.365
+Fall 2023,BIOL,1106,44,14630,Biol for Science Majors I(Lab),Medrano,Ana I,17,1,2,0,1,0,2,3.571
+Fall 2023,MUSA,8320,24,14631,Doctoral Applied Music,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8399,2,14638,Doctoral Dissertation,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8598,2,14639,Doctoral Research,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8399,5,14654,Doctoral Dissertation,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLA,7299,1,14660,Masters Thesis,Varkey,Divya A,0,0,0,0,0,2,0,
+Fall 2023,MUSA,8320,25,14661,Doctoral Applied Music,Staupe,Andrew Paul,3,0,0,0,0,0,0,4.0
+Fall 2023,ECON,3332,1,14662,Intermediate Microeconomics,Troncoso,Pablo A,15,9,4,1,3,0,6,3.062
+Fall 2023,MANA,4356,1,14665,Managing Diversity,Fernandez,Alejandro,25,3,1,0,0,0,0,3.828
+Fall 2023,SGNL,1301,8,14666,Elementary Sign Language I,Brittain,Terrell,4,9,4,4,0,0,1,2.509
+Fall 2023,PSYC,6336,2,14668,Directed Rsch in Social Psyc,Derrick,Jaye L,2,0,0,0,0,0,0,4.0
+Fall 2023,HON,3399,3,14671,Senior Honors Thesis,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3426,1,14676,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,4.0
+Fall 2023,MSCI,1210,2,14679,Introduction to the Army,Comiskey,Melissa C,4,1,0,0,0,0,0,3.866
+Fall 2023,ARCH,2500,17,14680,Arc/Int Arc Design Studio III,LaRose,Katherine Gail,8,7,2,0,0,0,0,3.334
+Fall 2023,PSYC,7392,4,14689,Psychology Practicum,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6358,1,14696,Directed Rsch in Neuropsyc,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6336,4,14697,Directed Rsch in Social Psyc,Knee,Clifford R,3,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6365,1,14699,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,7399,9,14702,Masters Thesis,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6598,6,14703,Special Problems,Neighbors,Clayton T,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7392,5,14704,Psychology Practicum,Tamber-Rosenau,Benjamin J,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,7399,10,14705,Masters Thesis,Zhang,Yingchun,1,0,0,0,0,0,0,4.0
+Fall 2023,PETR,8298,11,14709,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2023,PETR,8298,12,14710,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Fall 2023,PETR,8398,11,14711,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Fall 2023,PETR,8398,12,14712,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2023,PETR,8399,11,14713,Doctoral Dissertation,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2023,PETR,8598,11,14717,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,3,0,
+Fall 2023,PETR,8598,12,14718,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Fall 2023,MUSA,2202,1,14721,Applied Composition,Maroney,Marcus K,1,1,0,0,1,0,0,2.223
+Fall 2023,MUSA,2202,2,14723,Applied Composition,Smith,Robert Thomas,4,2,3,0,0,0,0,3.001
+Fall 2023,MUSA,1276,1,14725,Applied Jazz Percussion,Hubley,Robert L,0,0,0,0,0,0,0,
+Fall 2023,PSYC,6365,2,14726,Dir Rsch in Dev Cog Beh Neuro,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8698,20,14731,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,2,0,
+Fall 2023,BIOL,3396,3,14732,Senior Research Project,Zhang,Shaun Xiaoliu,1,0,0,0,0,0,0,4.0
+Fall 2023,SOC,7395,2,14735,Internship in Sociology,Baumle,Amanda K,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6298,1,14739,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2023,PEP,8699,10,14743,Doctoral Dissertation,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6198,4,14744,Research in Chamber Music,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8399,18,14746,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2023,PHIL,1361,2,14753,Philosophy and the Arts,Drapela,Nick Gerard,16,11,6,2,3,0,6,2.904
+Fall 2023,PHIL,1361,3,14754,Philosophy and the Arts,Drapela,Nick Gerard,11,14,8,2,3,0,12,2.711
+Fall 2023,ECON,2302,4,14755,Principles of Microeconomics,Gonzaga Dos Santos,Angelo Fernando,8,25,22,7,2,0,5,2.422
+Fall 2023,ECON,3334,4,14756,Intermediate Macroeconomics,Vollrath,Dietrich E,4,7,8,18,2,0,9,1.761
+Fall 2023,MATH,1314,4,14757,College Algebra,Caputo,Matthew G,111,63,45,18,47,0,17,2.557
+Fall 2023,ECON,6390,1,14760,Workshop Research Methods I,Prokopovych,Pavlo,3,1,0,0,0,0,0,3.833
+Fall 2023,MUSA,4410,4,14766,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,2615,1,14767,Intsve Inter Span Heritg Lrnrs,Monarrez Martinez,Sendy Patricia,15,7,3,1,0,0,1,3.296
+Fall 2023,HRD,6305,30,14768,Organizational Learning,Waight,Consuelo L,4,1,0,0,0,0,0,3.734
+Fall 2023,MIS,4477,1,14769,Network & Security Infrastruct,Messinger,Jacob Nelson,26,10,4,0,0,0,0,3.517
+Fall 2023,ENGL,1302,60,14771,First Year Writing II,Denton,Amy,21,3,0,0,0,0,0,3.82
+Fall 2023,ENGL,1301,141,14772,First Year Writing I,Pan,Weijia,22,0,0,0,1,0,2,3.797
+Fall 2023,MANA,4330,3,14773,Intro to Strategic HR Mgt,Reinoso,Gaston,13,10,1,0,1,0,0,3.281
+Fall 2023,ENGL,3331,2,14774,Beg Creative Writing-Poetry,Williams,Adele E,18,1,0,0,0,0,0,3.843
+Fall 2023,ENGL,3301,3,14775,Intro To Literary Studies,Guajardo,Paul,12,6,0,0,0,0,2,3.63
+Fall 2023,ENGL,3365,1,14776,Postcolonial Literature,Singh,Kavita Ashana,15,8,3,1,1,0,2,3.144
+Fall 2023,SOCW,7318,1,14777,Cognitive Behavioral Interven,Cheung,Monit,23,5,0,0,0,0,0,3.821
+Fall 2023,ENGL,4315,1,14778,Sociolinguistics,Lee,Eunjeong,18,3,1,0,0,0,0,3.728
+Fall 2023,MANA,4310,1,14780,Behavioral Finance,Rude,Dale,6,1,0,0,0,0,0,3.763
+Fall 2023,HON,3301,1,14781,Readings in Medicine & Society,Reynolds,Aaron E,24,1,0,0,0,0,0,3.934
+Fall 2023,POLS,3311,2,14782,Intro Compar Politics,Aleman,Eduardo,14,13,8,2,1,0,1,2.982
+Fall 2023,POLS,3312,3,14783,"Arguments, Data, Politics",Karimov,Samad,14,7,5,3,3,0,8,2.771
+Fall 2023,PSYC,3350,4,14784,Intro to Cognitive Psychology,Xu,Yinan,33,24,8,5,7,0,1,2.909
+Fall 2023,GEOL,1102,3,14785,Intro to Climate Change Lab,Zhang,Honghai,10,11,3,0,0,0,0,3.278
+Fall 2023,TEPM,6306,20,14786,Project Management Office,Rypien,David V,5,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2316,7,14787,Psychology of Personality,Babalola,Olusegun,52,19,6,0,2,0,1,3.544
+Fall 2023,PSYC,2330,4,14789,Biological Psychology,Leonard,Samuel J,51,21,5,1,0,0,0,3.619
+Fall 2023,ACCT,2301,11,14791,Prin of Financial Accounting,Sykes,Mary Reeves,19,35,7,1,4,0,3,3.105
+Fall 2023,ACCT,2301,12,14792,Prin of Financial Accounting,Sykes,Mary Reeves,29,29,3,3,1,0,5,3.363
+Fall 2023,KIN,4315,1,14793,Motor Learning and Control,Layne,Charles S,16,50,24,9,0,0,1,2.731
+Fall 2023,COSC,3360,2,14794,Operating Systems,Rincon Castro,Carlos Alberto,34,31,21,7,9,0,22,2.716
+Fall 2023,ENTR,3312,5,14795,Corporate Entrepreneurship,Karonika,John R,24,14,7,0,0,0,2,3.29
+Fall 2023,ENTR,3312,6,14796,Corporate Entrepreneurship,Karonika,John R,24,15,3,0,0,0,7,3.39
+Fall 2023,CHIN,3350,1,14797,Chinese Culture Through Films,McArthur,Charles M,18,6,1,0,3,0,1,3.298
+Fall 2023,PSYC,4354,1,14798,Brain and Behavior,Leasure,Jennifer Leigh,10,14,6,6,1,0,0,2.605
+Fall 2023,COMM,3321,1,14799,Single Camera Studio Productn,Houk,Keith R,29,0,0,0,0,0,0,3.943
+Fall 2023,AAS,2320,2,14802,Intro To African American Stdy,Gary,Lindsay Cecilia,24,3,5,2,0,0,1,3.451
+Fall 2023,BIOL,6120,1,14803,Responsible Conduct Bio Rsrch,Sater,Amy,24,0,0,0,0,0,0,3.959
+Fall 2023,PETR,6111,1,14804,Petroleum Graduate Seminar,Qin,Guan,0,0,0,0,0,37,0,
+Fall 2023,COMM,3377,2,14805,Strategic PR Planning,Ni,Lan,11,5,0,0,0,0,0,3.667
+Fall 2023,BIOL,7124,1,14808,Cell Biology Seminar,Lekven,Arne,0,0,0,0,0,6,0,
+Fall 2023,PSYC,4344,7,14810,Cultural Psychology,Haddad,Sana,78,13,6,2,5,0,1,3.472
+Fall 2023,HRD,3350,1,14811,Workforce Diversity and Global,Lopez,Johana,12,20,3,0,2,0,1,3.099
+Fall 2023,ENGL,1301,142,14813,First Year Writing I,Cunningham,Sara Kaplan,11,5,1,0,0,0,2,3.549
+Fall 2023,ENGL,1301,143,14814,First Year Writing I,Bellomy,Charlotte Seychelles,13,1,1,1,1,0,1,3.334
+Fall 2023,ENGL,1301,144,14815,First Year Writing I,O'Bryan,Ann Patricia,19,3,1,1,1,0,0,3.454
+Fall 2023,ENGL,1301,145,14816,First Year Writing I,O'Bryan,Ann Patricia,16,5,1,1,2,0,0,3.214
+Fall 2023,ENGL,1301,146,14817,First Year Writing I,Julian,Jennifer La'Vonne,23,0,0,1,0,0,1,3.875
+Fall 2023,ENGL,1301,147,14818,First Year Writing I,Cooper,Jacquelyn Ruth,15,1,0,0,3,0,0,3.316
+Fall 2023,INTB,3355,3,14819,Global Environment of Business,Miljanic,Andra Olivia,156,70,14,1,5,0,2,3.449
+Fall 2023,FINA,6387,3,14820,Managerial Analysis,Berta,Dominique,3,9,0,0,0,0,0,3.47
+Fall 2023,ECE,6311,1,14821,Introduction to Robotics,Becker,Aaron T,11,10,1,0,0,0,3,3.32
+Fall 2023,BIOL,2315,1,14823,Biology of Food,Zufall,Rebecca A,26,13,1,0,0,0,0,3.584
+Fall 2023,MARK,3337,2,14824,Professional Selling,Boehm-Miller,Elizabeth A,219,51,5,2,0,0,2,3.722
+Fall 2023,ENTR,3310,4,14825,Entrepreneurship,Ortega,Carlos Alberto,152,26,13,2,0,0,4,3.655
+Fall 2023,IDNS,1101,2,14826,Physics 1301 Workshop,Pattison,Donna,15,5,2,1,0,0,7,3.45
+Fall 2023,IDNS,1102,1,14827,Physics 1302 Workshop,Pattison,Donna,19,4,1,0,0,0,1,3.709
+Fall 2023,COMD,3301,1,14828,History and Culture of Deaf,Brittain,Terrell,11,16,8,0,2,0,0,2.749
+Fall 2023,ASLI,4210,1,14829,ASL Literature,Gietz,Merrilee Ruth,8,0,0,0,0,0,0,3.959
+Fall 2023,FINA,4320,5,14830,Investment Management,Mateen,Haaris,2,6,1,2,0,0,2,2.757
+Fall 2023,BIOE,2331,1,14831,Biomedical Processes,Shevkoplyas,Sergey,15,6,1,0,0,0,1,3.591
+Fall 2023,BIOE,3340,1,14832,Quantitative Physiology,Roh,Jinsook,7,2,3,1,1,0,0,2.881
+Fall 2023,PSYC,2301,6,14833,Introduction to Psychology,Henderson,Perla R,43,21,11,3,0,0,0,3.35
+Fall 2023,GOVT,2306,50,14834,US and Texas Const/Politics,Belco,Michelle Helene,22,2,0,0,1,0,0,3.76
+Fall 2023,GOVT,2306,51,14835,US and Texas Const/Politics,Belco,Michelle Helene,25,0,0,0,0,0,0,4.0
+Fall 2023,GOVT,2306,52,14836,US and Texas Const/Politics,Leland,Alison W,6,16,2,1,0,0,0,3.146
+Fall 2023,GOVT,2306,53,14837,US and Texas Const/Politics,LeVeaux,Christine,16,9,0,0,0,0,0,3.6
+Fall 2023,GOVT,2306,54,14838,US and Texas Const/Politics,LeVeaux,Christine,21,6,0,0,0,0,0,3.741
+Fall 2023,GOVT,2306,55,14839,US and Texas Const/Politics,Lawler,Janet Marie,11,11,3,0,0,0,0,3.333
+Fall 2023,GOVT,2305,50,14840,"US Govt: Congress,Pres & Crts",Belco,Michelle Helene,24,0,0,0,0,0,1,3.986
+Fall 2023,GHL,6380,1,14841,Business Analytics,Lee,Minwoo,7,2,0,0,0,0,0,3.814
+Fall 2023,CHEM,1312,2,14843,Fundamentals of Chemistry 2,Yang,Ding-Shyue,6,31,44,11,27,0,31,1.779
+Fall 2023,CHEM,1311,3,14844,Fundamentals of Chemistry,Carrasquillo M,Edwin,43,45,63,12,17,0,31,2.428
+Fall 2023,FINA,4310,1,14846,Behavioral Finance,Rude,Dale,16,18,1,0,0,0,0,3.41
+Fall 2023,ECE,6373,1,14847,Adv Computer Arch,Fu,Xin,25,33,7,1,0,0,0,3.242
+Fall 2023,DIGM,2353,30,14848,Page Layout and Design,De Vega,Jaime M,104,20,9,1,6,0,4,3.498
+Fall 2023,HON,4198,1,14851,Independent Study,Rayder,Benjamin Taylor,7,1,0,0,0,0,1,3.834
+Fall 2023,THEA,1340,1,14853,Fundamentals of Acting,Matlock,Robert Patrick,12,1,0,0,0,0,2,3.872
+Fall 2023,THEA,4306,1,14854,Edu Thea & Prg Mngt in Schools,Hickman,Margo Louise,2,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5262,1,14856,Healthcare Compliance,Ingraham,Ryan,5,7,0,0,0,0,0,3.362
+Fall 2023,CHEM,6351,1,14858,Organic Structure Detrm,Carrow,Bradley,4,19,4,0,0,0,1,2.976
+Fall 2023,SOC,3395,1,14859,Careers in Sociology,Katz,Sheila,37,7,0,1,2,0,1,3.582
+Fall 2023,LAW,5357,7,14860,Evidence,Thompson,Sandra Guerra,28,52,0,0,0,0,0,3.395
+Fall 2023,LAW,5330,1,14862,Anti-Trust Law,Bush,Darren,12,21,0,0,0,5,0,3.404
+Fall 2023,LAW,5300,1,14863,Criminal Defense Clinic,Locascio,Erik Matthew,0,3,0,0,0,0,0,3.33
+Fall 2023,LAW,6366,1,14864,Int'l Arbitration Advocacy,Neufeld,Paul James,2,4,0,0,0,0,0,3.223
+Fall 2023,LAW,5221,1,14865,Int'l Commercial Arbitration,Dimitroff,Sashe Dimanin,3,4,7,0,0,3,0,2.714
+Fall 2023,FINA,4382,1,14868,Developing R E Project,Henning,Erica,16,7,4,0,0,0,0,3.444
+Fall 2023,FINA,4383,1,14869,R E Mkt Research & Valuation,Wright,Larry Thomas,21,4,1,0,0,0,0,3.744
+Fall 2023,CIVE,3337,1,14870,Structural Analysis,Zhang,Ruda,13,17,9,3,2,0,3,2.796
+Fall 2023,CIVE,4311,1,14871,Prof Practice in Civil Engr,Herman,Reagan,9,22,3,0,0,0,0,3.07
+Fall 2023,CIVE,4312,1,14873,Civil Engineering Capstone,Mo,Larry Yi-Lung,23,4,0,0,0,0,0,3.803
+Fall 2023,PETR,8298,13,14884,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,3,0,
+Fall 2023,PETR,8398,13,14885,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Fall 2023,MUSI,1301,1,14887,Rudiments of Theory,Brake,Austin S,10,2,3,1,0,0,0,3.168
+Fall 2023,PHYS,2126,2,14889,University Physics Lab II,Wood,Lowell T,2,12,6,0,0,0,0,2.668
+Fall 2023,PHYS,2126,3,14890,University Physics Lab II,Wood,Lowell T,2,11,6,0,0,0,0,2.668
+Fall 2023,PHYS,2126,4,14891,University Physics Lab II,Wood,Lowell T,1,14,5,0,0,0,0,2.734
+Fall 2023,PHYS,2126,5,14892,University Physics Lab II,Wood,Lowell T,0,11,7,0,0,0,0,2.648
+Fall 2023,PHYS,2126,6,14893,University Physics Lab II,Wood,Lowell T,2,10,8,0,0,0,0,2.684
+Fall 2023,COMM,1307,3,14894,Media and Society,Ashley,Laura B,39,38,12,6,4,0,1,3.024
+Fall 2023,PHYS,2126,7,14895,University Physics Lab II,Wood,Lowell T,2,11,5,1,0,0,0,2.789
+Fall 2023,PHYS,2125,1,14896,University Physics Lab I,Wood,Lowell T,4,5,10,0,0,0,1,2.788
+Fall 2023,PHYS,2125,2,14897,University Physics Lab I,Wood,Lowell T,0,14,4,1,0,0,1,2.667
+Fall 2023,PHYS,2125,3,14898,University Physics Lab I,Wood,Lowell T,0,11,7,0,0,0,2,2.684
+Fall 2023,PHYS,2125,4,14899,University Physics Lab I,Wood,Lowell T,3,7,8,0,0,0,0,2.704
+Fall 2023,PHYS,2125,5,14900,University Physics Lab I,Wood,Lowell T,0,11,6,0,0,0,1,2.725
+Fall 2023,PHYS,2125,6,14901,University Physics Lab I,Wood,Lowell T,1,13,5,0,0,0,2,2.703
+Fall 2023,POLS,3385,1,14902,Introduction to Law,Jackson,Jerald W,15,16,9,0,0,0,2,3.134
+Fall 2023,MUSI,3160,1,14903,Adv Sightrding for Kybrd Plyrs,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4104,1,14904,New Music Ensemble,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2023,MSCI,1131,1,14905,Intermediate Physical Fitness,Thomas,Roland,4,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,1311,2,14906,Fundamentals of Graphic Design,Williams,Celeste,19,4,0,0,0,0,1,3.697
+Fall 2023,ARTS,2356,4,14907,Fundamentals of Photo/DM,Hillerbrand,Stephan C,12,6,0,0,2,0,0,3.284
+Fall 2023,INDE,6337,1,14908,Human Factors Syst Dsgn,Schulze,Lawrence John Henry,0,2,0,0,1,0,2,2.11
+Fall 2023,ARTS,3384,1,14909,Sound Art,Meza,Abinadi,22,2,1,0,1,0,1,3.692
+Fall 2023,LACP,2111,2,14910,Liberal Arts Career Planning,Hayes,Olivia Kaye,0,0,0,0,0,24,2,
+Fall 2023,ARTH,3334,1,14911,History of Graphic Design,Orto,Luisa,21,19,0,0,0,0,0,3.542
+Fall 2023,ARTH,6331,1,14912,Contemporary Painting,Barrera,Debra,2,0,1,1,0,0,0,2.585
+Fall 2023,ARTH,6334,1,14913,History of Graphic Design,Orto,Luisa,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,6301,1,14914,Life Drawing Studio,Barrera,Debra,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,4305,1,14915,Brain Machine Interfacing,Francis,Joseph Thachil,13,1,0,0,0,0,1,3.834
+Fall 2023,MUSI,4298,1,14921,Special Problems in Pedagogy,Reed,Gavin Davis,10,0,0,0,0,0,0,3.967
+Fall 2023,MECE,6388,1,14923,Optimal Control Theory,Chen,Zheng,10,3,4,1,0,0,0,3.241
+Fall 2023,FINA,4330,1,14924,Corporate Finance,Medina Palma,Paolina del Carmen,4,3,3,0,0,0,0,3.133
+Fall 2023,TLIM,4342,31,14925,Quality Improvement Methods,O'Kelley,Donna K,16,21,8,0,2,0,2,2.972
+Fall 2023,TLIM,4342,2,14926,Quality Improvement Methods,Chance,Michael Dean,25,20,1,2,1,0,0,3.266
+Fall 2023,COMM,4335,1,14927,Crisis Communication,Hudson-Gillan,Gail,30,10,7,0,0,0,1,3.489
+Fall 2023,NAVY,2301,1,14928,Leadership Management,Kroeger,Eric J,0,1,1,0,0,0,0,2.665
+Fall 2023,PHYS,1301,3,14930,College Physics I (lecture),McElhenny,Brian Patrick,49,60,41,10,7,0,27,2.812
+Fall 2023,MUSA,4432,1,14932,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,6307,1,14933,Cell Biology for BME,Al-Ubaidi,Muayyad,0,3,0,0,0,0,0,3.0
+Fall 2023,THEA,2334,1,14934,Fundamentals of Design,Willson,Paige A,16,4,0,0,0,0,0,3.734
+Fall 2023,PHAR,4300,1,14935,Biochemistry I,Hussain,Tahir,36,44,22,7,1,0,1,2.973
+Fall 2023,PHAR,4260,1,14936,Intro to the Healthcare System,Essien,Ekere James,69,33,5,0,0,0,1,3.598
+Fall 2023,PHAR,4250,1,14937,Pharmacy Skills Program I,Wollen,Joshua T,46,50,10,1,0,0,1,3.318
+Fall 2023,CHEE,2331,1,14938,Chemical Processes,Henderson,Jerrod A,9,9,12,1,1,0,5,2.616
+Fall 2023,CHEE,2331,2,14939,Chemical Processes,Henderson,Jerrod A,1,3,2,0,1,0,0,2.287
+Fall 2023,MUSA,3430,1,14941,Applied Flute,Russell,Peggy,3,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,3140,2,14943,Quantitative Physiology Lab,Roh,Jinsook,10,1,0,0,2,0,0,3.308
+Fall 2023,WGSS,2360,2,14945,Introduction to LGBT Studies,Stone,Lauren Michelle,21,6,1,1,1,0,0,3.467
+Fall 2023,MUSA,4424,2,14946,Applied Violoncello,Cho,Eunghee,1,1,0,0,0,0,0,3.665
+Fall 2023,NUTR,2332,4,14948,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,28,14,6,1,0,0,0,3.314
+Fall 2023,ARTS,2333,2,14949,Fundamentals of Printmaking,Sawhney,Ashita,16,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,3316,1,14950,Relief Printmaking,Alderson,Saran,13,0,0,0,0,0,0,3.949
+Fall 2023,ARTS,6310,1,14951,Printmaking Studio,Alderson,Saran,2,0,0,0,0,0,0,4.0
+Fall 2023,CNST,6340,1,14955,Best Practices in Construction,Kim,Kinam,60,5,1,0,0,0,1,3.889
+Fall 2023,CNST,6340,2,14956,Best Practices in Construction,Kim,Kinam,35,0,0,0,0,0,0,3.981
+Fall 2023,ARTS,1372,2,14957,Fundamentals of Video Art,Ho,Jamie C,7,3,2,1,2,0,2,2.8
+Fall 2023,ARTS,3374,1,14958,Computer Imaging,Ranjbarcheshmehsorkhi,Mandana,6,6,4,0,0,0,2,3.043
+Fall 2023,ARTS,3304,1,14959,Intermediate Painting,Maxen,William,10,8,0,1,0,0,1,3.456
+Fall 2023,ARTS,3334,2,14960,Introduction to Typography,Gamble,Travis Hunter,13,5,3,0,0,0,1,3.476
+Fall 2023,ARTS,3330,1,14961,Intermediate Graphic Design,Jamaluddin,Mohd Ikhram,7,3,2,1,0,0,4,3.18
+Fall 2023,KIN,3304,2,14962,Human Structure & Phys Perform,Hunt,Rebekah,11,13,15,3,3,0,2,2.563
+Fall 2023,PSYC,7342,1,14965,Bio Bases of Behav,Williams,Michael W,23,0,0,0,0,0,0,3.928
+Fall 2023,MUSA,1340,1,14966,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,2326,5,14968,Fundamentals of Sculpture,Conrad,Jillian,10,1,0,0,0,0,1,3.849
+Fall 2023,ARTS,6310,2,14970,Printmaking Studio,Masterson,Patrick D,2,0,0,0,0,0,0,4.0
+Fall 2023,THEA,2100,1,14971,Theatre Education Internship,Hickman,Margo Louise,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1342,1,14973,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2023,NUTR,2332,2,14974,Intro To Human Nutrition,Hughes,Lindsay,30,38,6,1,0,0,0,3.267
+Fall 2023,CHEM,8998,27,14976,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2023,ARTS,3330,2,14978,Intermediate Graphic Design,Lopez,Jonathan Christopher,8,9,2,0,0,0,2,3.246
+Fall 2023,SOC,3313,1,14980,Criminology,Nelson,Steven M,22,23,8,1,1,0,0,3.116
+Fall 2023,COMD,1333,4,14983,Intro to Comm Sci & Disorders,Ross,Byron L,12,20,4,0,0,0,1,3.204
+Fall 2023,INDE,8398,5,14984,Doctoral Research,Lin,Ying,0,0,0,0,0,3,0,
+Fall 2023,PHIL,1361,4,14985,Philosophy and the Arts,Drapela,Nick Gerard,21,13,5,2,1,0,8,3.167
+Fall 2023,ECON,4399,1,14992,Senior Honors Thesis,Friedman,Willa H,2,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,3347,1,14996,Problems of Normal Life,Anderson,Jill Annette,36,36,6,0,2,0,0,3.284
+Fall 2023,MUSA,8320,11,14997,Doctoral Applied Music,Yon,Kirsten A,5,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6304,1,15002,Conducting,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1340,2,15005,Applied Trumpet,Vassallo,Jim Cates,5,0,0,0,0,0,1,3.934
+Fall 2023,MECE,6377,1,15006,Continuum Mechs I,Kulkarni,Yashashree,3,7,2,0,0,0,2,3.111
+Fall 2023,ECE,6337,1,15007,Stochastic Processes,Prasad,Saurabh,17,2,0,0,0,0,2,3.773
+Fall 2023,DRAM,1310,8,15010,Introduction to Theatre,Young,Courtney Leigh,45,3,0,0,0,0,1,3.951
+Fall 2023,MECT,1365,1,15013,Elements Materials & Processes,Hussain,Muhammad Muzamil,26,19,7,2,3,0,1,3.105
+Fall 2023,DIGM,4371,30,15018,3D Modeling and Animation,Snyder,Philip Charles,20,7,3,1,0,0,1,3.495
+Fall 2023,MUSA,6340,1,15021,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8698,21,15027,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,1,0,
+Fall 2023,PHCA,8298,2,15028,Doctoral Dissertation Research,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Fall 2023,HRD,6301,30,15030,Leadership Development in HRD,Hausmann,Robert Carl,6,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4331,1,15031,Current Issues Human Res Mgmt,Walker,William A,23,3,1,1,0,0,1,3.703
+Fall 2023,WGSS,2350,10,15032,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,28,0,1,0,0,0,0,3.908
+Fall 2023,COSC,3337,1,15034,Data Science I,Eick,Christoph F,19,31,26,2,1,0,4,2.848
+Fall 2023,PCOL,6398,4,15035,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2023,NUTR,6308,1,15037,Clinical Nutrition Practice I,Haubrick,Kevin,0,0,0,0,0,3,0,
+Fall 2023,SCM,4330,3,15042,Bus Modeling and Dec Analysis,Cossick,Kathy L,14,17,9,3,1,0,5,2.902
+Fall 2023,MARK,4363,1,15043,International Marketing,Beveridge,Ivana,38,0,0,0,0,0,0,3.939
+Fall 2023,ECON,8399,5,15046,Doctoral Dissertation,Liu,Elaine Meichen,0,0,0,0,0,2,0,
+Fall 2023,PCEU,6498,3,15047,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,2,0,
+Fall 2023,PHOP,6757,2,15053,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,1501,21,15068,Elementary Spanish I,Mejia Lara,Airy Sindik,4,9,3,2,4,0,2,2.288
+Fall 2023,SPAN,1502,9,15070,Elementary Spanish II,Perez Vigil De Mostaccero,Sylvia Rossana,8,6,7,1,3,0,2,2.574
+Fall 2023,PCOL,6198,5,15072,Special Problems,Garey,Kevin W,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,3396,5,15073,Senior Research Project,Cheek,Ann Oliver,1,0,0,0,0,0,0,4.0
+Fall 2023,ECON,8399,6,15075,Doctoral Dissertation,Cubas Norando,German,2,0,0,0,0,0,0,4.0
+Fall 2023,GOVT,2306,7,15078,US and Texas Const/Politics,McDonald,John Terrence George,39,73,63,38,23,0,12,2.305
+Fall 2023,PSYC,6352,5,15082,Directed Rsch in I/O Psyc,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2023,PCEU,6498,4,15084,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2023,PCEU,6398,2,15086,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2023,DRAM,1310,1,15087,Introduction to Theatre,Ostrow,Stuart,25,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,1101,20,15089,College Physics I (lab),Wood,Lowell T,1,14,6,0,0,0,3,2.746
+Fall 2023,PHYS,1101,21,15091,College Physics I (lab),Wood,Lowell T,1,20,3,0,0,0,0,2.807
+Fall 2023,PHCA,8698,3,15092,Doctoral Dissertation Research,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6257,4,15099,Research Practicum B,Ostrin,Lisa,4,0,0,0,0,0,0,4.0
+Fall 2023,PHLA,7299,3,15103,Masters Thesis,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2023,SOCI,1301,8,15104,Introduction To Sociology,Dorsey,Patricia Lynne,20,21,12,2,1,0,3,2.929
+Fall 2023,PEP,8699,12,15105,Doctoral Dissertation,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2300,5,15110,Applied Voice,Vasquez,Hector A,4,1,0,0,0,0,0,3.8
+Fall 2023,COMM,6398,2,15112,Special Problems,Vardeman,Jennifer E,1,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,2350,1,15113,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,2,1,1,0,0,0,3.745
+Fall 2023,ARCH,2500,21,15114,Arc/Int Arc Design Studio III,Olwi,Asmaa,4,7,1,0,0,0,3,3.223
+Fall 2023,PCEU,8998,2,15116,Doctoral Research,Hu,Ming,0,0,0,0,0,1,0,
+Fall 2023,WGSS,2350,11,15117,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,3,1,0,0,0,0,3.844
+Fall 2023,PCEU,6398,5,15121,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6398,6,15131,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2023,ARCH,3500,19,15139,Architecture Design Studio V,Story,Jon Kevin,2,14,1,0,0,0,0,3.156
+Fall 2023,POLS,4398,12,15142,Independent Study,Cross,Renee Danielle,4,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6365,3,15144,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,1,0,
+Fall 2023,BIOL,3399,3,15145,Senior Honors Thesis,Sen,Mehmet,0,0,0,0,0,0,0,
+Fall 2023,PCEU,8998,3,15181,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2023,CIS,3368,2,15182,Adv Info Systems Development,Dobretsberger,Otto,20,24,7,1,0,0,2,3.231
+Fall 2023,PCEU,6698,2,15183,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Fall 2023,PCEU,6398,1,15184,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6365,4,15187,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6398,16,15191,Independent Studies,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6398,18,15192,Independent Studies,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6365,5,15193,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Fall 2023,ENGI,2304,9,15194,Technical Communications,Anderson,Roshawnda M,13,9,2,0,1,0,0,3.32
+Fall 2023,PSYC,6365,6,15196,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,8399,12,15200,Dissertation,Rivera Garza,Cristina,0,0,0,0,0,1,0,
+Fall 2023,SPAN,8699,12,15201,Dissertation,Rivera Garza,Cristina,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2300,6,15202,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3400,8,15203,Applied Voice,Vasquez,Hector A,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,4399,2,15209,Senior Honors Thesis,McKeon,Frank D,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,2100,2,15215,Intro To Biomedical Engr,Akay,Yasemin M,43,1,2,0,1,0,3,3.801
+Fall 2023,TLIM,3363,30,15218,Technical Communications,Piercy,Penelope Junker,26,14,0,0,1,0,0,3.472
+Fall 2023,PHIL,1334,1,15219,Minds and Machines,Weisberg,Joshua,20,50,35,6,2,0,3,2.685
+Fall 2023,BIOE,4303,1,15220,Biomaterials,Abidian,Mohammad Reza,3,0,0,0,0,0,0,3.89
+Fall 2023,MATH,3339,5,15223,Statistics for the Sciences,Cao,Jian,23,11,15,6,6,0,6,2.639
+Fall 2023,GEOL,1102,4,15224,Intro to Climate Change Lab,Zhang,Honghai,12,11,0,0,0,0,0,3.493
+Fall 2023,GEOL,1147,2,15225,Introductory Meteorology Lab,Zheng,Youtong,8,5,4,1,2,0,1,2.833
+Fall 2023,HDCS,6331,20,15226,Adv Strat For Futures Planning,Hines,Andrew Lewis,15,1,0,0,0,0,0,3.876
+Fall 2023,WCL,2351,1,15227,World Cultures Thru Lit & Arts,Nguyen,Duy,6,8,5,1,3,0,5,2.551
+Fall 2023,ARCH,6301,3,15230,Visual Studies I,Olwi,Asmaa,13,5,0,0,0,0,0,3.667
+Fall 2023,ARCH,6361,1,15234,Integrated Practice,Hager,Jesse,6,7,4,0,0,0,0,3.059
+Fall 2023,MAS,3343,1,15236,Latino Psychology,Pino,Diana,18,14,9,0,1,0,3,3.033
+Fall 2023,SPAN,4357,1,15237,Spanish Phonetics,Goodin-Mayeda,Carrie Elizabeth,5,11,0,0,1,0,2,3.021
+Fall 2023,AAS,3350,1,15238,Slavery and Race Relations,Raynor,Autumn Fawn,15,2,1,1,1,0,0,3.467
+Fall 2023,ARCH,6393,3,15239,Master's Project Preparation,Borden,Gail,7,1,0,0,0,0,0,3.751
+Fall 2023,HDCS,3376,2,15240,Resources in Technology Entrep,Robinson,Ebony M,9,16,11,8,3,0,2,2.426
+Fall 2023,BIOL,2301,2,15241,Anatomy & Physiology I (lect),Gill,Tejendra,76,207,95,13,14,0,18,2.754
+Fall 2023,INDS,1360,1,15243,Visual Thinking,Kimbrough,Mark S,10,8,1,1,0,0,2,3.367
+Fall 2023,CHEE,3321,2,15244,Analytical Methods Chem Engr,Grabow,Lars C,0,0,1,0,0,0,1,1.67
+Fall 2023,BIOL,6315,2,15245,Neuroscience,Ziburkus,Jokubas,16,1,1,0,0,0,0,3.815
+Fall 2023,INDS,6310,1,15246,Visual Thinking,Kimbrough,Mark S,2,0,0,0,0,0,0,4.0
+Fall 2023,ENGI,2304,7,15247,Technical Communications,Estrada,Carl,10,13,1,0,0,0,0,3.334
+Fall 2023,ENGI,2304,12,15248,Technical Communications,Wilson,Chad A,5,1,0,1,0,0,0,3.334
+Fall 2023,CHEM,4115,3,15249,Inorganic Chem Laboratory II,Zaitsev,Vladimir G,5,10,4,0,0,0,0,2.983
+Fall 2023,MECE,3345,2,15251,Materials Science,Ryou,Jae-Hyun,18,29,4,0,2,0,1,3.114
+Fall 2023,PETR,6372,1,15252,Petroleum Production Operation,Wong,George K,6,11,2,5,0,0,0,2.723
+Fall 2023,POLS,3313,3,15254,Intro Internatl Relatns,Zwald,Zachary J,23,12,0,0,1,0,0,3.455
+Fall 2023,WGSS,3360,1,15255,Sexuality and Queer Theory,Chatterjee,Shraddha,4,7,7,0,2,0,3,2.633
+Fall 2023,PSYC,6344,1,15256,Functional Neuroanatomy,Leasure,Jennifer Leigh,3,5,2,0,0,0,0,2.968
+Fall 2023,COMM,1302,1,15257,Intro To Comm Theory,Lee,Jaesub,9,18,16,3,1,0,2,2.639
+Fall 2023,BZAN,6310,1,15258,Quant Analysis for Busn Dec,Hou,Jinghui,67,7,0,0,1,0,3,3.836
+Fall 2023,COMM,3317,1,15259,Multimedia Journalism,Baruch Blanco,Maria Felicitas,20,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2305,8,15261,Intro to Methods in Psychology,Weinstein,Andrew Philip,20,14,4,0,1,0,0,3.232
+Fall 2023,PSYC,2305,11,15263,Intro to Methods in Psychology,Shen,Shutian,19,12,0,2,1,0,5,3.314
+Fall 2023,INDS,3397,1,15265,Selected Topics,Jackson,Megan H,8,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,4384,1,15266,Developmental Biology,Lekven,Arne,20,13,2,1,1,0,0,3.325
+Fall 2023,BIOL,4355,1,15267,Human Virology,Zhang,Shaun Xiaoliu,36,30,11,4,1,0,0,3.135
+Fall 2023,BIOL,6384,1,15268,Developmental Biology,Lekven,Arne,2,0,0,0,0,0,0,4.0
+Fall 2023,GOVT,2306,2,15269,US and Texas Const/Politics,Cole,Jeffrey Bryan,17,11,6,4,4,0,1,2.746
+Fall 2023,INDS,3500,3,15270,Industrial Design Studio V,Kang,Chul Min,5,6,0,0,0,0,0,3.485
+Fall 2023,SOCI,1301,6,15272,Introduction To Sociology,Cooper,Chelsey Wells,50,8,2,0,1,0,1,3.705
+Fall 2023,SOCI,1301,7,15273,Introduction To Sociology,Cooper,Chelsey Wells,44,11,4,0,1,0,1,3.589
+Fall 2023,SOC,3355,1,15274,Sociology of India,Majumder,Sarasij,5,2,3,0,0,0,1,3.2
+Fall 2023,COMM,3369,3,15275,Strategic Comm. Writing,Emery II,Philip M,27,3,0,0,0,0,0,3.911
+Fall 2023,COMM,3380,1,15276,Electronic Field Production,Crowe,Craig Warren,10,9,1,0,0,0,0,3.417
+Fall 2023,PSYC,2317,5,15280,Intro to Psychology Statistics,Wu,Dongjie,16,20,23,9,7,0,4,2.351
+Fall 2023,COMM,4371,1,15281,American Cinema: The Directors,Carter,Nestor Gregory,15,6,3,0,0,0,0,3.5
+Fall 2023,PSYC,3339,2,15282,Intro To Clinical Psychology,Szafranski,Derek D,68,10,1,0,1,0,0,3.771
+Fall 2023,MANA,4353,1,15285,Mgmt Training and Career Devel,Bozeman,Dennis,29,23,7,1,0,0,0,3.421
+Fall 2023,MANA,6310,1,15286,Fundamentals of Business,Celly,Nikhil,24,0,0,0,0,0,0,3.973
+Fall 2023,SOCW,7335,2,15288,SW Practice in Communities,Pang,Melanie Espinosa,24,0,0,0,0,0,0,4.0
+Fall 2023,KIN,3306,2,15289,Physiology-Human Performance,Hamilton,Marc,13,20,18,8,7,0,12,2.334
+Fall 2023,PSYC,4344,8,15290,Cultural Psychology,Haddad,Sana,79,14,11,0,0,0,0,3.651
+Fall 2023,KIN,4370,1,15291,Exercise Testing,Breslin,Whitney L,12,4,3,0,0,0,0,3.352
+Fall 2023,MATH,4310,1,15299,Biostatistics,Labate,Demetrio,8,0,1,2,0,0,1,3.243
+Fall 2023,PSYC,2317,7,15300,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,23,29,11,5,4,0,8,2.829
+Fall 2023,PSYC,2317,11,15301,Intro to Psychology Statistics,Le,Giang Xuan,50,21,6,2,1,0,0,3.417
+Fall 2023,PSYC,2317,9,15305,Intro to Psychology Statistics,Babalola,Olusegun,27,27,15,3,5,0,0,2.84
+Fall 2023,MATH,6350,1,15306,Stat. Learning and Data Mining,Ryan,John M,27,0,0,0,0,0,1,3.988
+Fall 2023,BCHS,4396,1,15307,Senior Research Project,Rappenglueck,Bernhard,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3330,2,15308,Beg Creative Writing-Fiction,Parsons,Alexander M,17,2,0,0,0,0,0,3.86
+Fall 2023,ENGL,3331,3,15309,Beg Creative Writing-Poetry,Sutton,Anthony Villavelez,18,0,1,0,0,0,1,3.895
+Fall 2023,ENGL,4303,1,15313,Teaching Engl as a Second Lang,Duran,Chatwara,13,2,6,0,0,0,0,3.318
+Fall 2023,ECE,6331,1,15314,Advanced Telecommunications,Han,Zhu,8,2,0,0,0,0,0,3.734
+Fall 2023,NUTR,6303,1,15315,Nutrition Mgmt & Leadership,Haubrick,Kevin,14,6,0,0,0,0,0,3.634
+Fall 2023,NUTR,6302,1,15316,Adv Medical Nutrition Therapy,Ferrell,Carla Denise,9,2,0,0,0,0,0,3.668
+Fall 2023,ECE,5388,1,15317,Renewable Energy Technology,Huang,Hao,12,9,2,0,0,0,0,3.377
+Fall 2023,ECE,6372,1,15318,Advanced Hardware Design,Chen,Yuhua,25,4,0,0,0,0,0,3.839
+Fall 2023,ECE,5451,1,15319,Principles of Internetworking,Wolfe,John C,49,0,0,0,0,0,0,4.0
+Fall 2023,ECE,6321,1,15320,Principles of Internetworking,Wolfe,John C,44,19,29,0,0,0,0,3.163
+Fall 2023,TEPM,6391,2,15321,Project Management Seminar,Carden,Lila L,9,0,0,0,0,0,0,3.927
+Fall 2023,ACCT,3377,3,15322,Cost Accounting,Lin,Haijin,9,14,10,2,0,0,6,2.801
+Fall 2023,SCLT,4389,31,15323,Practicum in Supply Chain,Henson,Alfred Bernard,27,6,2,0,0,0,0,3.743
+Fall 2023,BIOL,4323,1,15324,Immunology,Sen,Mehmet,27,36,15,0,0,0,9,3.141
+Fall 2023,BIOL,6323,1,15325,Immunology,Peng,Weiyi,10,2,0,0,0,0,0,3.751
+Fall 2023,SOCW,7356,2,15326,Groups: Adv Clinical Practice,Robinson,Demetria,21,4,1,2,0,0,1,3.571
+Fall 2023,SOCW,7356,3,15327,Groups: Adv Clinical Practice,Gracely,Jill Marie,26,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7323,1,15328,Applied Equity Fund Management,George,Thomas J,15,1,0,0,0,0,0,3.917
+Fall 2023,COSC,3320,1,15330,Algorithms and Data Structures,Leiss,Ernst L,74,94,40,9,4,0,19,3.014
+Fall 2023,NUTR,4201,1,15331,Dietetics as a Profession II,Ferrell,Carla Denise,16,6,1,0,0,0,1,3.58
+Fall 2023,KIN,4300,1,15332,Phys Activity Older Adults,Alastuey,Lisa L,49,29,27,8,6,0,5,2.81
+Fall 2023,GHL,1320,1,15333,Foodservice Management,Haskell,Rebecca Erin,39,14,6,2,2,0,2,3.328
+Fall 2023,GHL,2356,1,15334,Comm Strategies for Hospitalty,Haskell,Rebecca Erin,47,6,1,4,1,0,1,3.56
+Fall 2023,ARCH,1358,1,15336,Introduction to Design Culture,Chernyakova,Irina,161,28,8,3,1,0,2,3.695
+Fall 2023,CIVE,4332,2,15337,Hydrology,Li,Hongyi,26,22,14,2,0,0,0,3.079
+Fall 2023,CIVE,4333,2,15338,Water and Wastewater Treatment,Rixey,William G,22,30,14,0,1,0,0,3.065
+Fall 2023,CIVE,5362,1,15340,Water Quality Engineering,Fiorenza,Stephanie,6,16,2,0,0,0,1,3.235
+Fall 2023,CIVE,3332,1,15341,Engineering Materials,Krakowiak,Konrad,4,16,4,0,0,0,1,3.096
+Fall 2023,CIVE,3380,1,15343,Plane Surveying Fundamentals,Glennie,Craig Len,5,12,9,1,0,0,2,2.79
+Fall 2023,HON,3331,1,15345,Intro to Civic Engagement,Lawler,Janet Marie,7,0,0,0,0,0,2,3.906
+Fall 2023,CNST,6307,1,15346,Stati and Optimiz Method in CM,Senouci,Ahmed,14,7,0,0,0,0,0,3.651
+Fall 2023,CNST,6308,1,15347,Data Analysis in Construc Mgmt,Gao,Lu,81,0,0,0,0,0,0,3.996
+Fall 2023,CNST,6350,20,15348,Decision Making and Risk Mgmt,Gao,Lu,8,0,0,0,0,0,1,4.0
+Fall 2023,GHL,3346,1,15349,Beer Appreciation,Corsi,Aaron James,21,2,0,0,0,0,0,3.899
+Fall 2023,GHL,3349,1,15350,Hosp Procurement & Purchasing,Ginapp,Kathrine,22,7,3,1,0,0,0,3.485
+Fall 2023,HON,3306,1,15352,Health and Human Rights,Lunstroth,John,15,2,0,0,0,0,0,3.863
+Fall 2023,BCHS,3307,1,15353,Biochem for Nutrition Majors,Fox,Robert O,7,5,1,0,1,0,0,3.191
+Fall 2023,BUSI,1301,4,15354,Business Principles,Carvalho,Diogo,177,64,20,3,4,0,6,3.498
+Fall 2023,GEOL,4330,1,15355,Intro To Geophysics,Sager,William W,5,5,3,4,0,0,0,2.647
+Fall 2023,GEOL,4381,1,15356,Geophysical Signals,Zheng,Yingcai,3,0,0,0,0,0,0,3.78
+Fall 2023,GEOL,3350,1,15358,Stratigraphy,Carlson,Brandee Nicole,15,7,0,0,0,0,0,3.592
+Fall 2023,ENGL,6323,1,15360,Fiction Workshop,Parsons,Alexander M,9,0,0,0,0,0,0,4.0
+Fall 2023,ECE,5115,1,15361,Control Systems Lab II,Provence,Robert S,1,1,0,0,0,0,0,3.335
+Fall 2023,ECE,6111,5,15362,Graduate Research Seminar,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2023,ENRG,4320,1,15363,Case Studies-Enrgy & Sustainbl,Hallmark,Terrell L,7,1,2,0,0,0,1,3.467
+Fall 2023,COMM,1303,1,15364,Writing for Communicators,Lyn,Robyn,72,11,3,1,7,0,1,3.433
+Fall 2023,COMM,2326,1,15365,Intro to Sports Broadcasting,Trupiano,Jerome,21,0,0,0,0,0,0,4.0
+Fall 2023,COMM,2356,1,15366,Business & Professional Comm,Uhrick,Jan,168,72,15,21,19,0,4,3.155
+Fall 2023,TEPM,6303,20,15370,Risk Assessment in Project Mgm,Rypien,David V,4,3,0,0,1,0,0,3.125
+Fall 2023,TEPM,6305,2,15375,Project Manager Tools,Sherman,Dennis Louis,9,0,0,0,0,0,0,4.0
+Fall 2023,TEPM,6306,2,15376,Project Management Office,Rypien,David V,7,1,0,0,0,0,0,3.875
+Fall 2023,TEPM,6308,1,15377,Project Procurement Practices,Conover,Sharon Cecilia,9,0,0,0,0,0,1,4.0
+Fall 2023,TEPM,6391,20,15378,Project Management Seminar,Carden,Lila L,3,0,0,0,0,0,0,4.0
+Fall 2023,TEPM,6395,2,15379,Integration Project,Carden,Lila L,9,0,0,0,0,0,0,3.963
+Fall 2023,LAW,5409,10,15394,Contracts,Trujillo,Elizabeth I,12,24,3,0,0,0,0,3.214
+Fall 2023,ARTS,1383,1,15395,Introduction to New Media,Reed,John G,4,2,3,1,1,0,7,2.696
+Fall 2023,LAW,5323,1,15397,Conflict of Laws,Ungureanu,Razvan C,7,23,1,0,0,0,0,3.247
+Fall 2023,LAW,5368,1,15398,Estate Planning,Buckles,Johnny R,4,4,0,0,0,1,0,3.418
+Fall 2023,LAW,6347,1,15399,Secured Financing,Dole,Richard F,4,10,0,0,0,0,0,3.38
+Fall 2023,HIST,3319,1,15408,Plagues and Pestilence,Schafer Jr,James A,21,8,1,0,1,0,0,3.516
+Fall 2023,ELET,4352,1,15410,Computational Tools for Tech,Zouridakis,George,20,28,1,0,1,0,1,3.307
+Fall 2023,ELET,2105,2,15411,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,20,2,2,0,0,0,0,3.736
+Fall 2023,DANC,4330,1,15412,Career Skills for Dancers,Valle,Toni Leago,7,2,2,2,1,0,1,2.857
+Fall 2023,MUSI,6100,1,15413,Chamber Music,Hester,Timothy E,12,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,1101,22,15414,College Physics I (lab),Wood,Lowell T,2,12,8,0,0,0,1,2.742
+Fall 2023,TEPM,6308,20,15415,Project Procurement Practices,Conover,Sharon Cecilia,1,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,1102,15,15416,College Physics II (lab),Wood,Lowell T,1,13,9,0,0,0,1,2.652
+Fall 2023,PHYS,1102,16,15417,College Physics II (lab),Wood,Lowell T,1,8,4,0,1,0,0,2.548
+Fall 2023,PHYS,1102,17,15418,College Physics II (lab),Wood,Lowell T,2,14,5,1,0,0,1,2.728
+Fall 2023,PHYS,1102,19,15420,College Physics II (lab),Wood,Lowell T,1,14,8,0,0,0,0,2.739
+Fall 2023,ENGL,7324,1,15421,Writers On Literature,Shaheen,Glenn,6,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6185,1,15424,Scenic Methods & Materials,Vlahos,Kalliope,2,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6294,1,15425,Design and Production Studio,Vlahos,Kalliope,2,0,1,0,0,0,0,3.333
+Fall 2023,COSC,2436,3,15426,Programming and Data Structure,Biediger,Daniel Edward,20,37,22,6,9,0,22,2.557
+Fall 2023,COSC,2436,5,15428,Programming and Data Structure,Rizk,Nouhad J,44,34,16,5,6,0,9,3.006
+Fall 2023,COSC,2436,7,15430,Programming and Data Structure,Rizk,Nouhad J,39,31,13,8,8,0,15,2.822
+Fall 2023,ARTH,3301,1,15431,Critical Theory,Meza,Abinadi,7,3,3,1,0,0,1,3.166
+Fall 2023,ARTH,6301,1,15432,Critical Theory,Meza,Abinadi,1,1,0,0,0,0,0,3.5
+Fall 2023,CIVE,3331,1,15433,Environmental Engineering,Louie,Stacey M,22,17,8,1,0,0,1,3.209
+Fall 2023,BIOE,4347,1,15434,Cell Biology for BME,Al-Ubaidi,Muayyad,6,3,5,0,0,0,0,3.095
+Fall 2023,PSYC,6308,1,15437,Foundations of Neuropsychology,Medina,Luis Daniel,1,2,0,0,0,0,1,3.443
+Fall 2023,BIOL,6350,1,15438,Biomedical Sciences Practicum,Gifford,Jenifer,22,2,0,0,0,0,0,3.917
+Fall 2023,BIOL,6351,1,15439,Integrative Anatomy & Physiol,Ogletree-Hughes,Monique L,10,11,1,0,0,0,0,3.409
+Fall 2023,MUSA,4430,1,15440,Applied Flute,Russell,Peggy,3,0,0,0,0,0,0,4.0
+Fall 2023,TLIM,3300,30,15441,Leadership & Innovation Fund,Evans,Gerald S,31,2,1,0,1,0,1,3.611
+Fall 2023,TLIM,3330,1,15442,Innovation Principles,Crawley,David L,8,2,7,1,0,0,1,2.798
+Fall 2023,MATH,6357,1,15443,Lin. Models & Des. Experiments,Wang,Wenshuang,28,0,0,0,0,0,2,3.953
+Fall 2023,MATH,4339,2,15445,Multivariate Statistics,Poliak,Cathy Dawn,20,9,0,1,0,0,1,3.556
+Fall 2023,NUTR,6311,1,15452,Capstone I,Haubrick,Kevin,3,0,0,0,0,0,0,3.89
+Fall 2023,ECON,3332,5,15454,Intermediate Microeconomics,Kim,Jeonghyeok,10,17,12,4,2,0,5,2.578
+Fall 2023,PHAR,5325,1,15457,Literature Evaluation,Hatfield,Catherine L,42,45,22,0,1,0,0,3.155
+Fall 2023,PHAR,5224,1,15458,Integrated Renal Module,Marwaha,Aditi,36,48,26,1,0,0,0,3.072
+Fall 2023,PHAR,5225,1,15459,Integrated GI Module,Udugamasooriya,Damith Gomika,20,62,28,1,0,0,0,2.91
+Fall 2023,PHAR,5226,1,15460,Integrated Respiratory Module,Eriksen,Jason,43,43,22,1,0,0,0,3.174
+Fall 2023,PHAR,5111,1,15461,Leadership and IPE,Varkey,Divya A,106,4,0,0,0,0,0,3.964
+Fall 2023,PHAR,5195,1,15462,Pharmacy Skills Program III,Davis,Shantera Rayford,52,11,0,0,1,0,0,3.766
+Fall 2023,PHAR,5158,1,15463,Module Related Skills Lab I,Davis,Shantera Rayford,54,8,1,1,0,0,0,3.797
+Fall 2023,ECE,6382,1,15465,Engineering Analysis I,Jackson,David R,4,0,0,0,0,0,0,4.0
+Fall 2023,ECE,6377,1,15466,Power Systems Analysis,Yellajosula,Jaya Raghavendra Arun Kumar,19,5,0,0,0,0,1,3.778
+Fall 2023,ECE,5377,1,15467,Power System Analysis,Yellajosula,Jaya Raghavendra Arun Kumar,17,6,0,0,0,0,0,3.696
+Fall 2023,GHL,1367,1,15468,Lodging Management,Cheatham,Cathy A,29,10,7,0,3,0,0,3.272
+Fall 2023,GHL,1367,2,15469,Lodging Management,Theis,Iuliana,18,10,8,2,0,0,0,3.08
+Fall 2023,ECE,6342,1,15470,Digital Signal Process,Hebert,Thomas James,6,10,1,0,0,0,6,3.294
+Fall 2023,DRAM,1310,10,15472,Introduction to Theatre,Hinkel,Heidi Anne,454,71,13,4,3,0,1,3.748
+Fall 2023,THEA,6310,1,15473,CAD II for Theatre Design,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6353,1,15474,"Scenic, Cost,& Light Design I",Willson,Paige A,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4298,2,15475,Special Problems in Pedagogy,Van Kekerix,Todd Evan,3,0,1,0,0,0,0,3.583
+Fall 2023,PHAR,5158,2,15476,Module Related Skills Lab I,Davis,Shantera Rayford,31,15,0,0,0,0,0,3.674
+Fall 2023,PHAR,5195,2,15477,Pharmacy Skills Program III,Davis,Shantera Rayford,38,8,0,0,0,0,0,3.826
+Fall 2023,MUSA,2340,3,15479,Applied Trumpet,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3446,1,15480,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8699,1,15481,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,2,0,
+Fall 2023,ENGL,8399,1,15482,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,3,0,
+Fall 2023,MECE,6345,1,15483,Fluid Dynamics 1,Yang,Di,11,12,4,0,0,0,3,3.186
+Fall 2023,MUSI,8399,1,15484,Doctoral Document,Maroney,Marcus K,0,0,0,0,0,1,0,
+Fall 2023,ENGL,7399,1,15485,Essay,Voskuil,Lynn M,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6291,1,15486,Project Implementation,Ramirez,Arlene D,0,0,0,0,0,11,0,
+Fall 2023,GHL,6348,1,15488,Beer Appreciation,Corsi,Aaron James,3,0,0,0,0,0,0,3.78
+Fall 2023,ENGL,7398,1,15490,Special Problems,Davies,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,3331,2,15491,Program Appl in Elec Comp Engr,Hebert,Thomas James,16,14,22,7,1,0,11,2.694
+Fall 2023,ARTS,4398,4,15494,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6204,1,15496,Conducting,Krager,Franz A,5,0,0,0,0,0,0,4.0
+Fall 2023,ILAS,2350,1,15497,Knowledge and Methods,Oliva,Luca,49,6,4,2,10,0,7,3.127
+Fall 2023,MUSA,2332,1,15499,Applied Oboe,Dinitz,Adam L,2,0,0,0,0,0,0,4.0
+Fall 2023,SCLT,4396,30,15502,Internship in Supply Chain,Kidd,Margaret A,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,7393,1,15503,Art History Internship,Harren,Natilee O,4,1,0,0,0,0,0,3.866
+Fall 2023,COMM,3374,1,15504,Strategic Social Media,Uhrick,Jan,23,5,0,0,1,0,1,3.69
+Fall 2023,ENGL,8698,1,15507,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2023,SCLT,2362,32,15509,Intro To Logistics Technology,Kidd,Margaret A,19,17,4,0,2,0,5,3.136
+Fall 2023,POLS,3312,4,15510,"Arguments, Data, Politics",Marcinek,Elizabeth Nicole Simas,19,10,5,0,1,0,5,3.305
+Fall 2023,MUSI,6106,2,15511,Grad Large Ensemble,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2023,HRD,4352,1,15514,Facilitation Strategies,Clancy,James Patrick,26,4,2,1,0,0,1,3.677
+Fall 2023,ENGL,3399,1,15516,Senior Honors Thesis,Lecourt,Sebastian Joseph,0,0,0,0,0,0,0,
+Fall 2023,MIS,7375,1,15517,Transaction Processing Systems,Messinger,Jacob Nelson,7,2,0,0,0,0,0,3.778
+Fall 2023,ARTS,3374,2,15518,Computer Imaging,Chen,Shang-Yee Mark,12,5,0,0,0,0,0,3.609
+Fall 2023,MUSA,4400,7,15519,Applied Voice,Vasquez,Hector A,2,0,0,0,0,0,0,4.0
+Fall 2023,MANA,3335,10,15521,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,192,49,4,3,0,0,2,3.726
+Fall 2023,POLS,6398,1,15523,Special Problems,Church,Jeffrey,3,0,0,0,0,0,0,4.0
+Fall 2023,CHIN,2311,2,15524,Intermediate Chinese I,Wang,Wei,3,4,3,2,0,0,0,2.612
+Fall 2023,PSYC,8399,24,15525,Doctoral Dissertation,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2023,ENTR,4380,1,15526,Venture Fund,Rassin,Keith David,3,0,0,0,0,0,0,3.78
+Fall 2023,MATH,6398,5,15528,Special Problems,Timofeyev,Ilya,0,0,0,0,0,5,0,
+Fall 2023,PHOP,7275,1,15529,Intro Comp Thinking w/Python,Della Santina,Luca,5,0,0,0,0,0,0,3.802
+Fall 2023,PHOP,6377,1,15530,Intro Opt Sense &Biophotonics,Larin,Kirill,1,0,0,0,0,0,0,3.67
+Fall 2023,PHAR,5683,1,15531,Cardiology,Wang,Elisabeth,2,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6257,12,15534,Research Practicum B,Cheng,Han,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8199,3,15535,Doctoral Dissertation,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8498,3,15543,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6304,2,15552,Conducting,Weber,Mary E,0,0,0,0,0,0,0,
+Fall 2023,SPAN,8399,14,15553,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,2,0,
+Fall 2023,NURS,3310,1,15554,Prof Role Dev & Practice Issue,Quintana,Danielle,32,5,0,0,0,0,0,3.865
+Fall 2023,PSYC,6359,3,15555,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6667,8,15558,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,2326,1,15563,Fundamentals of Sculpture,Patzke,Katie,8,2,0,0,2,0,0,3.084
+Fall 2023,CIS,3347,1,15564,IS Infrastructure & Networking,Martinez,Jose C,28,21,5,0,6,0,4,3.078
+Fall 2023,MATH,6380,1,15567,Programming for Data Analytics,Shastri,Dvijesh J,8,11,2,0,0,0,2,3.223
+Fall 2023,MUSA,8241,2,15569,Doctoral Recital II,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2023,MIS,4374,4,15573,Info Technology Project Mgmt,Jagtap,Pankaj,6,19,0,0,0,0,0,3.174
+Fall 2023,PCOL,8998,3,15576,Doctoral Research,Hussain,Tahir,0,0,0,0,0,1,0,
+Fall 2023,PHCA,8698,5,15577,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,8298,4,15578,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,2101,21,15588,Anatomy & Physiology Lab I,Gill,Tejendra,5,10,5,1,3,0,0,2.473
+Fall 2023,BIOE,8598,3,15594,Doctoral Research,Mohan,Chandra,0,0,0,0,0,3,0,
+Fall 2023,MUSA,1322,1,15599,Applied Viola,Brooks,Wayne A,1,1,0,0,0,0,0,3.665
+Fall 2023,COMM,1303,2,15603,Writing for Communicators,Lyn,Robyn,65,11,6,0,12,0,1,3.231
+Fall 2023,MIS,7378,1,15604,Info.Tech Management & Control,Kniffen,Richard Chad,6,9,0,0,0,0,0,3.4
+Fall 2023,MUSA,6142,2,15605,Graduate Recital III,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6400,3,15606,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2305,13,15607,Intro to Methods in Psychology,Shen,Shutian,17,19,2,0,1,0,0,3.316
+Fall 2023,CHEE,6398,1,15609,Research,Karim,Alamgir,0,0,0,0,0,1,0,
+Fall 2023,PHCA,8298,5,15612,Doctoral Dissertation Research,Thornton,James D,2,0,0,0,0,0,0,4.0
+Fall 2023,MIS,4374,3,15613,Info Technology Project Mgmt,Campbell,Phillip James,30,8,2,0,0,0,0,3.642
+Fall 2023,PCEU,6698,4,15614,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,2,0,
+Fall 2023,MECT,4331,2,15615,Heat Transfer Applications,Alba,Kamran,3,10,15,3,0,0,1,2.536
+Fall 2023,PETR,2311,1,15617,Reservoir Petrophysics,Hathon,Lori A,3,7,2,0,0,0,0,3.111
+Fall 2023,PHCA,6298,6,15619,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2023,OPTO,5133,1,15622,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,17,6,0,0,0,0,0,3.739
+Fall 2023,OPTO,5133,2,15623,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,17,7,1,0,0,0,0,3.64
+Fall 2023,MUSA,6342,1,15624,Applied French Horn,Johnson,Robert,2,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,4300,1,15630,Intro-Study of Language,Zentz,Lauren R,26,1,1,0,0,0,0,3.834
+Fall 2023,PCEU,8399,3,15631,Doctoral Dissertation,Tam,Vincent H,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4434,1,15633,Applied Clarinet,Griffin,Randall S,3,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,5330,1,15648,Advanced Accounting,Ramaswamy,Vinita,0,0,0,0,0,0,1,
+Fall 2023,PHCA,6298,7,15650,Special Problems,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,8699,11,15651,Doctoral Dissertation,Ledoux,Tracey A,0,0,0,0,0,1,0,
+Fall 2023,SOCI,1301,4,15652,Introduction To Sociology,Dorsey,Patricia Lynne,16,21,15,3,4,0,3,2.734
+Fall 2023,PEP,8699,3,15653,Doctoral Dissertation,LaVoy,Emily Claire-Pyle,0,0,0,0,0,1,0,
+Fall 2023,BIOL,4396,3,15656,Senior Research Project,Nunez,Martin A,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6322,1,15657,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,2326,4,15658,Fundamentals of Sculpture,Vega,Zulma C.,12,0,0,0,0,0,0,3.973
+Fall 2023,PHCA,6298,8,15659,Special Problems,Abughosh,Susan M,2,0,1,0,0,0,0,3.333
+Fall 2023,PCOL,8998,7,15660,Doctoral Research,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2023,CNST,3185,2,15662,Construction Experience,Lyon,Eva Yaneth,26,7,1,0,0,0,0,3.677
+Fall 2023,ENGL,1301,43,15672,First Year Writing I,O'Connor,Bevin,14,3,1,0,0,0,0,3.649
+Fall 2023,ENGL,1301,44,15673,First Year Writing I,O'Connor,Bevin,13,4,1,0,1,0,0,3.404
+Fall 2023,MUSI,6114,1,15677,Chamber Music - Brass,Bertman,David Garry,8,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,1501,19,15678,Elementary Spanish I,Lumbierres,M Pilar,4,10,6,1,2,0,0,2.537
+Fall 2023,SPAN,2311,1,15679,Intermediate Spanish I,Ruffino,Gustavo,5,8,6,0,1,0,3,2.784
+Fall 2023,PHCA,6298,2,15682,Special Problems,Aparasu,Rajender R,2,0,0,0,0,0,0,4.0
+Fall 2023,DIGM,4396,30,15683,Internship in Digital Media,Liao,Tony Chung-Li,2,0,0,0,0,0,0,4.0
+Fall 2023,PHLA,7299,2,15684,Masters Thesis,Tolleson,Shane Russell,0,0,0,0,0,1,0,
+Fall 2023,DRAM,1310,11,15689,Introduction to Theatre,Hinkel,Heidi Anne,39,8,2,1,0,0,0,3.674
+Fall 2023,ACCT,5337,1,15694,Management Accounting,Lin,Haijin,2,3,4,0,0,0,0,2.778
+Fall 2023,PHYS,1101,23,15695,College Physics I (lab),Wood,Lowell T,2,11,8,0,0,0,1,2.683
+Fall 2023,COMM,6390,1,15698,Applied Project,Olson,Beth M,0,0,0,0,0,1,0,
+Fall 2023,PSYC,8399,26,15703,Doctoral Dissertation,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,7392,5,15704,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,2,0,0,0,0,0,0,3.835
+Fall 2023,PCOL,8198,1,15709,Doctoral Research,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,7391,9,15711,Clinic in Speech Lang Disorder,Townsend,Alayna,2,1,0,0,0,0,0,3.557
+Fall 2023,COMD,7391,1,15712,Clinic in Speech Lang Disorder,Jacobson,Shannon,3,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,8242,3,15717,Doctoral Recital III,Jones,Timothy J,1,0,0,0,0,0,0,3.67
+Fall 2023,RELS,2340,1,15721,Introduction to Hinduism,Borkataky-Varma,Sravana,25,8,4,2,0,0,0,3.326
+Fall 2023,PHCA,6198,1,15726,SP- Outcomes Research,Varkey,Divya A,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,3396,3,15732,Senior Research Project,Chung,Sanghyuk,0,0,0,0,0,0,0,
+Fall 2023,MUSA,8241,3,15734,Doctoral Recital II,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6365,7,15738,Dir Rsch in Dev Cog Beh Neuro,Kosten,Therese A,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8398,1,15739,Doctoral Research,Akay,Metin,0,0,0,0,0,4,0,
+Fall 2023,BIOE,8598,5,15740,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Fall 2023,ENGL,4398,1,15741,Independent Study,Turchi,Peter D,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,8999,3,15745,Doctoral Dissertation,Ramos,Raul,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,6498,38,15746,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Fall 2023,MUSA,2334,2,15747,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Fall 2023,POLS,8399,10,15750,Doctoral Dissertation,Kennedy,Ryan P,0,0,0,0,0,1,0,
+Fall 2023,ECON,3357,1,15753,Data Mgmt with Econ Appl,Peru Durayalage,Dhanushka Arunasiri,16,17,6,1,0,0,3,3.225
+Fall 2023,CLAS,3308,2,15755,Myths & Cult of the Greek Gods,Kidder,Kathleen,17,15,3,1,1,0,1,3.208
+Fall 2023,WCL,2351,2,15756,World Cultures Thru Lit & Arts,Ambikaipaker,Mohan,8,9,3,1,5,0,2,2.577
+Fall 2023,WCL,2352,1,15757,World Cinema,Centeno,Daniel,14,11,3,1,0,0,0,3.219
+Fall 2023,WCL,3366,2,15758,Latin American and Latino Film,Centeno,Daniel,7,16,4,1,0,0,1,2.906
+Fall 2023,MATH,1351,5,15760,Intro to Geometric Reasoning,Hollyer,Virginia Leigh,20,56,30,16,12,0,12,2.349
+Fall 2023,MATH,1342,3,15762,Elementary Statistical Methods,Caputo,Matthew G,154,230,80,36,20,0,64,2.825
+Fall 2023,MATH,2305,5,15764,Discrete Mathematics,Douglas,Casey,81,44,22,11,9,0,10,3.052
+Fall 2023,MATH,3338,1,15765,Probability,Haynes,Alan K,49,15,4,1,5,0,1,3.334
+Fall 2023,MATH,3339,1,15766,Statistics for the Sciences,Fu,Wenjiang,45,25,22,7,20,0,13,2.555
+Fall 2023,MATH,4364,2,15767,Intro to Numerical Analysis,He,Yunhui,3,11,16,3,2,0,4,2.229
+Fall 2023,MATH,1100,1,15768,Developmental Math,Caputo,Matthew G,0,0,0,0,0,211,30,
+Fall 2023,CHIN,3342,1,15769,Tales of East Asian Cities,Li,Melody Yunzi,6,2,0,0,0,0,0,3.75
+Fall 2023,BIOL,4315,1,15770,Neuroscience,Ziburkus,Jokubas,62,27,18,0,0,0,1,3.414
+Fall 2023,BIOL,4315,2,15771,Neuroscience,Ziburkus,Jokubas,57,25,10,0,0,0,4,3.511
+Fall 2023,COMD,2376,3,15772,Anatomy for Communication,Daniels,Stephanie K,12,7,10,4,4,0,8,2.46
+Fall 2023,COMD,4333,1,15774,Neuroscience for COMD,Bradbury,Kathleen E,10,13,2,0,1,0,1,3.192
+Fall 2023,ILAS,4350,1,15775,Interdisciplinary Problem Solv,Oliva,Luca,17,3,1,0,3,0,0,3.209
+Fall 2023,ENGI,1100,25,15776,Introduction To Engineering,Kota,Venkata Krishna Tulasi,17,8,4,0,0,0,1,3.369
+Fall 2023,NUTR,4351,1,15777,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,109,57,17,2,3,0,1,3.394
+Fall 2023,CHEM,6312,1,15778,Bonding,Wu,Judy,9,6,1,0,0,0,0,3.438
+Fall 2023,BIOL,6315,1,15779,Neuroscience,Ziburkus,Jokubas,5,1,1,0,0,0,0,3.619
+Fall 2023,PHYS,4360,1,15780,Space and Atmospheric Physics,Bering,Edgar A,6,2,1,0,0,0,0,3.519
+Fall 2023,GEOL,3150,1,15781,Prin-Stratigraphy Lab,Carlson,Brandee Nicole,5,2,2,0,0,0,0,3.333
+Fall 2023,GOVT,2306,5,15783,US and Texas Const/Politics,Jefferies,Kevin E,156,53,13,2,24,0,1,3.252
+Fall 2023,GOVT,2306,6,15785,US and Texas Const/Politics,McDonald,John Terrence George,66,86,51,21,16,0,6,2.65
+Fall 2023,GOVT,2306,10,15786,US and Texas Const/Politics,Marcinek,Elizabeth Nicole Simas,680,149,62,21,51,0,21,3.419
+Fall 2023,BIOE,4319,1,15787,Mass Transport Biosystems,Majd,Sheereen,0,1,0,0,0,0,0,3.33
+Fall 2023,IDNS,2112,1,15788,Precalculus SEP Workshop,Pattison,Donna,15,7,6,1,0,0,2,3.276
+Fall 2023,IDNS,2112,2,15789,Precalculus SEP Workshop,Pattison,Donna,24,3,2,1,0,0,1,3.678
+Fall 2023,BIOL,6354,1,15790,Endocrinology,Warner,Margaret,5,1,0,0,0,0,0,3.833
+Fall 2023,GEOL,7301,1,15791,Capstone Project,Khan,Shuhab D,1,1,0,0,0,0,0,3.665
+Fall 2023,BZAN,6354,1,15792,DB Mgt Tools Bus Analytics,Grimes,George M,21,12,0,0,0,0,0,3.636
+Fall 2023,BZAN,6356,1,15793,Adv DB Mgt Tools Bus Analytics,Grimes,George M,16,0,0,0,0,0,0,4.0
+Fall 2023,MIS,3360,4,15794,Systems Analysis and Design,Knighton,William B,31,24,7,1,0,0,0,3.349
+Fall 2023,MIS,3376,4,15795,Busn Appls Database Mgmt I,Jiang,Lianlian,48,10,2,1,0,0,1,3.754
+Fall 2023,IDNS,2113,1,15796,Calculus I SEP Workshop,Pattison,Donna,16,2,2,3,0,0,2,3.362
+Fall 2023,IDNS,2113,2,15797,Calculus I SEP Workshop,Pattison,Donna,22,4,1,1,1,0,3,3.495
+Fall 2023,IDNS,2113,3,15798,Calculus I SEP Workshop,Pattison,Donna,20,3,3,0,2,0,1,3.369
+Fall 2023,IDNS,2113,4,15799,Calculus I SEP Workshop,Pattison,Donna,22,2,2,0,0,0,1,3.769
+Fall 2023,IDNS,2114,1,15800,Calculus II SEP Workshop,Pattison,Donna,10,1,6,0,0,0,2,3.177
+Fall 2023,IDNS,2114,2,15801,Calculus II SEP Workshop,Pattison,Donna,16,7,6,1,0,0,0,3.289
+Fall 2023,IDNS,2133,1,15802,Calculus III SEP Workshop,Pattison,Donna,3,2,0,1,1,0,0,2.714
+Fall 2023,IDNS,3121,1,15803,Engineering Math SEP Workshop,Pattison,Donna,9,2,3,4,0,0,1,2.834
+Fall 2023,IDNS,1141,1,15804,Chemistry I SEP Workshop,Pattison,Donna,14,5,2,3,0,0,0,3.278
+Fall 2023,IDNS,1141,2,15805,Chemistry I SEP Workshop,Pattison,Donna,11,6,0,0,0,0,1,3.666
+Fall 2023,IDNS,1141,3,15806,Chemistry I SEP Workshop,Pattison,Donna,7,4,0,1,0,0,3,3.417
+Fall 2023,IDNS,1141,4,15807,Chemistry I SEP Workshop,Pattison,Donna,12,8,1,4,0,0,3,3.08
+Fall 2023,GOVT,2305,12,15808,"US Govt: Congress,Pres & Crts",Davis,Sharon M,15,42,65,15,14,0,15,2.166
+Fall 2023,IDNS,1141,5,15809,Chemistry I SEP Workshop,Pattison,Donna,11,6,2,0,0,0,1,3.474
+Fall 2023,IDNS,1141,6,15810,Chemistry I SEP Workshop,Pattison,Donna,19,3,4,1,0,0,3,3.506
+Fall 2023,IDNS,1142,1,15811,Chemistry II SEP Workshop,Pattison,Donna,7,4,0,3,0,0,3,3.001
+Fall 2023,IDNS,1142,2,15812,Chemistry II SEP Workshop,Pattison,Donna,15,6,1,3,0,0,3,3.307
+Fall 2023,IDNS,1142,3,15813,Chemistry II SEP Workshop,Pattison,Donna,6,1,3,2,0,0,0,2.889
+Fall 2023,IDNS,1142,4,15814,Chemistry II SEP Workshop,Pattison,Donna,17,9,3,3,0,0,4,3.229
+Fall 2023,IDNS,2123,1,15815,Organic Chem I SEP Workshop,Pattison,Donna,21,10,3,1,1,0,0,3.315
+Fall 2023,IDNS,2123,2,15816,Organic Chem I SEP Workshop,Pattison,Donna,19,10,5,2,0,0,0,3.296
+Fall 2023,IDNS,2123,3,15817,Organic Chem I SEP Workshop,Pattison,Donna,17,14,4,0,0,0,2,3.381
+Fall 2023,IDNS,2123,5,15820,Organic Chem I SEP Workshop,Pattison,Donna,22,7,7,1,0,0,0,3.334
+Fall 2023,IDNS,2123,6,15822,Organic Chem I SEP Workshop,Pattison,Donna,21,8,5,1,0,0,0,3.409
+Fall 2023,IDNS,2123,7,15823,Organic Chem I SEP Workshop,Pattison,Donna,22,4,3,1,0,0,2,3.534
+Fall 2023,IDNS,2123,8,15824,Organic Chem I SEP Workshop,Pattison,Donna,15,11,5,1,0,0,1,3.26
+Fall 2023,IDNS,2123,9,15825,Organic Chem I SEP Workshop,Pattison,Donna,8,6,9,4,1,0,2,2.571
+Fall 2023,IDNS,2125,1,15826,Organic Chem II SEP Workshop,Pattison,Donna,8,8,5,1,0,0,13,3.045
+Fall 2023,IDNS,2125,2,15827,Organic Chem II SEP Workshop,Pattison,Donna,9,6,5,3,0,0,4,2.985
+Fall 2023,MATH,5382,1,15828,Probability,Torok,Andrei S,2,4,0,0,0,0,0,3.278
+Fall 2023,GOVT,2305,5,15830,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,55,62,22,6,3,0,4,3.03
+Fall 2023,POLS,3366,1,15832,Political Parties,Cole,Jeffrey Bryan,5,23,6,1,1,0,4,2.888
+Fall 2023,SOC,3301,1,15834,Intro to Sociological Research,Tuthill,Zelma,30,0,0,0,0,0,0,3.967
+Fall 2023,BIOE,6319,1,15835,Mass Transport Bio Systems,Majd,Sheereen,2,0,0,0,0,0,0,3.835
+Fall 2023,CIS,6396,1,15836,Internship in Infor. Security,Conklin,William A,5,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7334,1,15837,Learning Sys &Mgmt Development,Bozeman,Dennis,10,7,2,0,1,0,0,3.283
+Fall 2023,MANA,7339,1,15838,Leadership Development,Witt,Lawrence A,35,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7355,1,15839,Staffing & Talent Management,Bozeman,Dennis,10,12,3,0,0,0,0,3.359
+Fall 2023,GHL,1320,2,15840,Foodservice Management,Sirsat,Sujata Ashok,25,8,2,1,1,0,2,3.371
+Fall 2023,MANA,4355,1,15841,Selection and Staffing,Phillips,James S,29,26,4,0,0,0,1,3.373
+Fall 2023,MANA,4341,1,15842,Leading Organizational Change,Evans,Klavdia Markelova,49,9,0,0,0,0,1,3.725
+Fall 2023,PSYC,2305,15,15843,Intro to Methods in Psychology,Myers,Annika Mariah,55,16,3,0,5,0,0,3.422
+Fall 2023,PSYC,2305,17,15845,Intro to Methods in Psychology,Yoruk,Harun,39,19,6,3,6,0,3,3.101
+Fall 2023,COMM,2311,1,15848,Writing for Print and Digital,Crixell,Charles A,9,10,1,1,3,0,0,2.944
+Fall 2023,INDE,6377,1,15849,Ind Eng Application,Irani,Shahrukh A,16,5,0,0,0,0,0,3.699
+Fall 2023,GHL,3364,1,15850,Hotel Sales,Kenyan,Erin Oeser,40,10,2,0,0,0,0,3.712
+Fall 2023,BUSI,4350,1,15851,Business Law and Ethics,Krylova,Ksenia O,23,2,0,0,0,0,0,3.788
+Fall 2023,GHL,3420,1,15852,Foodservice Operations,Ginapp,Kathrine,17,8,3,1,0,0,0,3.425
+Fall 2023,SCM,4390,3,15854,Supply Chain Strategy,Smith,Gordon D,24,28,4,1,0,0,2,3.327
+Fall 2023,SCM,7325,1,15855,Process Analysis and Design,Robinson Jr,Powell Ersell,12,12,0,0,0,0,0,3.431
+Fall 2023,BUSI,4350,2,15856,Business Law and Ethics,Currie,Daniel David,228,37,7,2,1,0,0,3.727
+Fall 2023,BUSI,4350,4,15858,Business Law and Ethics,Currie,Daniel David,203,64,5,1,0,0,2,3.69
+Fall 2023,BUSI,4350,6,15860,Business Law and Ethics,Williams,John M,141,61,13,3,3,0,1,3.455
+Fall 2023,BUSI,4350,8,15862,Business Law and Ethics,Williams,John M,59,16,0,0,1,0,0,3.702
+Fall 2023,BUSI,4350,10,15864,Business Law and Ethics,Williams,John M,66,20,9,4,1,0,1,3.401
+Fall 2023,PSYC,2305,19,15866,Intro to Methods in Psychology,Kennedy,Caitlin Grace,38,23,10,0,3,0,4,3.221
+Fall 2023,PSYC,2305,21,15868,Intro to Methods in Psychology,Snead,Alexandra L,41,40,16,3,12,0,7,2.81
+Fall 2023,CNST,4220,1,15870,Comp CM & Emerging Practices,Coble,Lana Kay,56,5,2,0,0,0,0,3.857
+Fall 2023,ECE,3317,1,15871,Applied Electromagnetic Waves,Jackson,David R,14,26,18,2,1,0,5,2.858
+Fall 2023,ECE,4117,1,15874,Telecommunications Laboratory,Han,Zhu,10,0,0,0,0,0,1,4.0
+Fall 2023,MECE,4364,1,15875,Heat Transfer,Liu,Dong,25,31,37,6,0,0,33,2.721
+Fall 2023,GHL,4350,1,15876,Strategy&Innovation Hosp Ind,Johnson,Tucker A,29,6,2,0,0,0,0,3.712
+Fall 2023,GHL,4352,1,15877,Hosp Organizational Behavior,Maneethai,Dustin,13,6,1,0,0,0,0,3.567
+Fall 2023,GHL,4360,1,15878,Professional Development,Kenyan,Erin Oeser,35,19,0,0,0,0,0,3.66
+Fall 2023,ECE,5127,1,15879,Power System Analysis Lab,Yellajosula,Jaya Raghavendra Arun Kumar,17,3,1,0,0,0,0,3.778
+Fall 2023,GHL,4352,2,15880,Hosp Organizational Behavior,Doudna,Simone P,32,6,2,2,6,0,2,3.077
+Fall 2023,PSYC,2320,2,15882,Abnormal Psychology,Kim,Jinu,30,30,10,0,5,0,2,3.053
+Fall 2023,COMM,2311,2,15884,Writing for Print and Digital,Crixell,Charles A,13,12,1,0,0,0,0,3.436
+Fall 2023,PSYC,2320,3,15886,Abnormal Psychology,Salentine,Cassidy,34,26,13,1,3,0,0,3.147
+Fall 2023,PSYC,2320,4,15887,Abnormal Psychology,Farrell,Abigail,41,19,10,2,2,0,4,3.199
+Fall 2023,PSYC,2320,5,15888,Abnormal Psychology,Mattuck,Shira Regina,10,26,17,3,10,0,10,2.303
+Fall 2023,ENGL,3348,1,15889,Thoreau,Guajardo,Paul,10,14,0,0,0,0,1,3.458
+Fall 2023,ENGL,4340,1,15890,Feminist Criticism and Theory,Gregory,Elizabeth,8,2,2,0,0,0,1,3.555
+Fall 2023,PSYC,2301,7,15892,Introduction to Psychology,Saiyed,Amna Shabbir,93,13,3,3,4,0,2,3.589
+Fall 2023,FINA,7382,1,15893,Developing Real Estate Project,Azuike,Acho Kelechi,3,1,0,0,0,0,0,3.668
+Fall 2023,INDE,6360,1,15894,Engineering Analytics,Lin,Ying,33,17,0,0,0,0,0,3.66
+Fall 2023,IEEM,6360,1,15895,Data Analytics for Engr. Mgt,Hu,Minxiang,69,4,0,0,0,0,0,3.936
+Fall 2023,ACCT,2301,13,15898,Prin of Financial Accounting,Newman,Michael Ray,21,4,0,0,0,0,0,3.814
+Fall 2023,ACCT,3366,3,15899,Financial Reporting Frameworks,Harris,Kathleen L,10,7,4,2,1,0,4,3.0
+Fall 2023,PSYC,2307,3,15900,Psychology of Adolescence,Anderson,Jill Annette,13,25,3,0,2,0,0,3.047
+Fall 2023,INDE,6380,1,15903,Accounting for Engr Managers,Hu,Minxiang,17,10,0,0,0,0,0,3.581
+Fall 2023,IEEM,6331,1,15904,Quant Methods for Engr Mgmt,Kamrani,Ali K,9,8,2,0,0,0,2,3.316
+Fall 2023,PETR,6352,1,15905,Shale Reservoirs,Hathon,Lori A,9,2,0,0,0,0,0,3.848
+Fall 2023,ECE,3337,2,15906,Signals and Systems Analysis,Reddy,Rohith Krishna,5,11,12,2,3,0,2,2.364
+Fall 2023,BUSI,2305,1,15907,Business Statistics,Patterson,Staci A,86,78,66,82,12,0,106,2.394
+Fall 2023,BUSI,2305,2,15908,Business Statistics,Patterson,Staci A,54,58,54,44,12,0,58,2.406
+Fall 2023,COSC,1437,1,15909,Introduction to Programming,Biediger,Daniel Edward,58,22,9,4,10,0,19,3.11
+Fall 2023,COSC,1437,3,15911,Introduction to Programming,Biediger,Daniel Edward,46,29,17,1,11,0,16,2.914
+Fall 2023,ARCH,1198,1,15913,Special Problems,Phan,Trang Anh Thuc,7,0,0,0,0,0,0,4.0
+Fall 2023,FINA,3332,6,15915,Prin of Financial Management,Suleymanov,Masim,97,67,51,5,3,0,1,3.133
+Fall 2023,ACCT,7378,1,15916,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,32,11,0,0,0,0,0,3.76
+Fall 2023,POLS,3315,1,15917,International Organization,Sisman,Ozlem,8,24,1,1,0,0,5,3.05
+Fall 2023,ELET,6352,1,15918,Matlab Engineering Technology,Zouridakis,George,2,1,0,0,0,0,0,3.777
+Fall 2023,ELET,6353,1,15919,Applied Stats for Technology,Pollonini,Luca,2,1,0,0,0,0,0,3.447
+Fall 2023,ELET,6350,1,15920,Overview Com Health Informatic,Pollonini,Luca,1,1,0,0,0,0,0,3.665
+Fall 2023,BUSI,1301,5,15921,Business Principles,Carvalho,Diogo,178,52,21,8,10,0,4,3.351
+Fall 2023,CIS,4375,2,15924,Project Management & Practice,Schlager,Alexander,11,19,2,0,0,0,1,3.25
+Fall 2023,HRD,4344,2,15925,Designing E-Learning,Bennett,LaTasha,46,3,0,1,0,0,0,3.84
+Fall 2023,HRD,4352,30,15926,Facilitation Strategies,Polesello,Daiane,11,5,2,0,0,0,0,3.482
+Fall 2023,SOCW,6307,1,15927,Policy in the Soc Environment,Dettlaff,Alan J,29,0,0,0,0,0,1,4.0
+Fall 2023,SOCW,6307,2,15928,Policy in the Soc Environment,Ortiz,Lillian Aguirre,26,0,0,0,0,0,1,4.0
+Fall 2023,SOCW,6307,3,15929,Policy in the Soc Environment,Pritzker,Suzanne,24,2,0,0,0,0,0,3.923
+Fall 2023,SOCW,6308,1,15930,Human Diversity & Development,Bagneris,Jessica Rene',23,4,0,0,0,0,1,3.852
+Fall 2023,SOCW,6308,2,15931,Human Diversity & Development,Scott Jr,Edward Douglas,27,0,0,0,0,0,1,4.0
+Fall 2023,SOCW,6308,3,15932,Human Diversity & Development,Bagneris,Jessica Rene',23,2,1,0,0,0,0,3.846
+Fall 2023,FORE,6396,1,15933,Internship,Hines,Andrew Lewis,3,0,0,0,0,0,0,4.0
+Fall 2023,HON,3341,1,15935,Pre-Modern Science & Medicine,Bland,Laura Elizabeth,24,0,0,0,0,0,0,4.0
+Fall 2023,HDCS,4374,1,15936,Entrepreneurial E-Tailing,Gatterson,Beverly,46,4,1,0,2,0,1,3.723
+Fall 2023,ENGI,8111,1,15937,FFP,Sharma,Pradeep,0,0,0,0,0,14,0,
+Fall 2023,HRD,3310,20,15938,Talent Management,Shakir,Khalimah,10,5,4,2,0,0,1,3.158
+Fall 2023,SCLT,3385,30,15939,Transport Economics and Policy,Henson,Alfred Bernard,45,17,4,0,0,0,0,3.501
+Fall 2023,ELET,4360,1,15941,Sustainable & Resilient Tech,Yuan,Xiaojing,8,10,0,0,0,0,0,3.426
+Fall 2023,HRD,3350,30,15942,Workforce Diversity and Global,Polesello,Daiane,26,4,2,1,1,0,3,3.501
+Fall 2023,SOCW,7310,1,15943,Program Planning & Evaluation,Guzman,Paola E,19,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,6306,5,15945,Social Work Practice Skills,White,Tamika Alonzo,19,6,1,0,1,0,0,3.556
+Fall 2023,ELET,4350,1,15946,Computation Health Informatics,Pollonini,Luca,20,2,1,0,3,0,0,3.334
+Fall 2023,INTB,3355,4,15947,Global Environment of Business,Farah,Elena,93,24,6,0,0,0,1,3.654
+Fall 2023,TLIM,3360,31,15948,Law & Ethics-Tech & Innovation,Feriante,Chris,95,34,15,0,0,0,3,3.54
+Fall 2023,COMM,2327,1,15949,Introduction to Screen Writing,Vaughan,Thomas Michael,18,0,0,2,0,0,0,3.667
+Fall 2023,COMM,3300,1,15950,Health Communication,Yamasaki,Jill S,96,17,4,0,2,0,0,3.684
+Fall 2023,COMM,3315,1,15951,News and Social Media,Bhat,Nandikoor R Prashanth,19,1,0,0,0,0,0,3.901
+Fall 2023,COMM,3328,1,15954,Intro to Sports Production,Freedman,Michael,20,7,2,1,0,0,0,3.5
+Fall 2023,HRD,4350,30,15955,Org Dev & Consulting,Polesello,Daiane,15,3,1,0,1,0,0,3.534
+Fall 2023,ENGL,3328,1,15956,Masterpieces of British Lit II,Wood,Barry Albert,15,11,1,0,3,0,0,3.09
+Fall 2023,DIGM,1300,30,15960,Introduction to Digital Media,Liao,Pamara F,67,46,13,2,5,0,2,3.211
+Fall 2023,MECT,2354,1,15961,Introduction to Mechanics,Basaran,Burak,9,18,9,9,4,0,3,2.334
+Fall 2023,ITAL,6302,1,15963,Adv Ital Conv & Comp.,Nicosia,Alda,1,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5258,1,15964,Eminent Domain Property Rights,Hodge,Justin Allen,11,6,2,0,0,0,0,3.404
+Fall 2023,MUED,3106,1,15965,Percussion,Warren,Paul Alexander,9,4,2,0,0,0,0,3.379
+Fall 2023,PHAR,5371,1,15966,Ambulatory Practice Management,Thornton,James D,38,67,3,0,0,0,0,3.324
+Fall 2023,PHAR,5335,1,15967,Integrated Neurology Module,Tejada-Simon,Maria Victoria,43,55,9,1,0,0,0,3.296
+Fall 2023,PHAR,5236,1,15968,Integrated Immunology Module,Knoll,Brian J,17,56,34,2,0,0,0,2.807
+Fall 2023,PHAR,5337,1,15969,Integrated ID I Module,Williams,Louis,24,50,35,0,1,0,0,2.873
+Fall 2023,PHAR,5338,1,15970,Integrated ID II Module,Cuny,Gregory D,20,58,31,0,1,0,0,2.873
+Fall 2023,PHAR,5268,1,15971,Module Related Skills Lab III,El-Desoky,Rania Hany,53,46,6,3,0,0,0,3.38
+Fall 2023,HON,3350,1,15972,Principles of Data and Society,Kapral,Andrew J,15,4,0,0,0,0,0,3.72
+Fall 2023,MUSI,1121,2,15973,Concert Chorus,Koppel,Alexander,32,1,0,0,0,0,0,3.94
+Fall 2023,MUSI,1122,1,15974,Concert Chorale,Weber,Mary E,46,1,0,0,0,0,0,3.979
+Fall 2023,COMM,3376,1,15975,Media Effects,Vaughn,Ginger Koto,26,3,0,0,0,0,1,3.908
+Fall 2023,BZAN,6357,1,15976,BZAN-Frameworks & Methods,Ma,Xiao,27,9,0,0,0,0,0,3.778
+Fall 2023,COMM,3380,3,15977,Electronic Field Production,Newlin,Julye G,13,5,1,1,1,0,0,3.223
+Fall 2023,COMM,4365,2,15979,Digital PR and Advertising,Huang,Yan,16,3,0,0,0,0,0,3.807
+Fall 2023,MATH,4323,1,15980,Data Science and Stats Learn,Wang,Wenshuang,67,20,8,2,1,0,2,3.497
+Fall 2023,COSC,6320,1,15981,Data Structures & Algorithms,Pandurangan,Gopal,6,11,4,0,0,0,1,3.174
+Fall 2023,COSC,3320,2,15982,Algorithms and Data Structures,Wu,Panruo,30,71,34,0,7,0,7,2.782
+Fall 2023,GEOL,1102,5,15983,Intro to Climate Change Lab,Zhang,Honghai,10,6,5,0,1,0,0,3.001
+Fall 2023,GEOL,1102,6,15984,Intro to Climate Change Lab,Zhang,Honghai,6,7,2,0,0,0,0,3.245
+Fall 2023,COMM,4381,1,15985,Digital Cinematography,Houk,Keith R,21,0,1,0,0,0,0,3.909
+Fall 2023,TLIM,3330,30,15988,Innovation Principles,Mehring,Brian George,10,3,11,1,0,0,1,2.827
+Fall 2023,TLIM,3350,30,15989,Emergency Management Principle,Freedkin,Aaron Samuel,42,12,0,1,1,0,1,3.525
+Fall 2023,HIST,3353,1,15990,England To 1689,Patterson,Catherine F,11,14,3,4,2,0,1,2.843
+Fall 2023,LAW,6233,1,15992,Internet Law,Raimer,Anna,6,14,0,0,0,0,1,3.251
+Fall 2023,LAW,5267,1,15993,Tax Accounting,Gupta,Ajay,4,0,0,0,0,1,0,4.0
+Fall 2023,LAW,6377,1,15994,Entertainment Law,Alonso,Yocel,14,15,0,0,0,1,0,3.437
+Fall 2023,LAW,7341,1,15995,WRS: Modern Corporation,Nelson,James D,5,7,0,0,0,0,0,3.389
+Fall 2023,LAW,6376,1,15996,Intellectual Property Survey,Michaels,Andrew Charles,17,54,0,0,0,4,0,3.411
+Fall 2023,LAW,6369,1,15997,Legal Analysis and Writing,Davis,Megan Leigh-Wilson,0,0,0,0,0,6,0,
+Fall 2023,LAW,7324,1,15998,WRC: Advanced Legal Writing,Maselli,Jani,5,7,0,0,0,0,0,3.389
+Fall 2023,ARTH,3380,1,16001,17Th Century Dutch Art,Nevitt Jr,Hugh R,16,1,1,0,0,0,2,3.815
+Fall 2023,ARTH,6322,1,16002,17th Century Dutch Art,Nevitt Jr,Hugh R,4,0,0,0,0,0,0,4.0
+Fall 2023,NURS,4215,1,16003,Maternal Newborn Women Hlth,Ecby,Chanique,5,37,0,0,0,0,0,3.119
+Fall 2023,NURS,4217,1,16004,Maternal Newborn Women Clin,Ecby,Chanique,37,5,0,0,0,0,0,3.881
+Fall 2023,NURS,4316,1,16005,Medical Surgical Concepts,Edwards-Maddox,Shermel Vinese,3,39,0,1,0,0,0,3.023
+Fall 2023,NURS,4417,1,16006,Medical Surgical Clinical,Edwards-Maddox,Shermel Vinese,29,12,0,2,0,0,0,3.581
+Fall 2023,DIGM,2357,30,16008,Content Strategy & Development,Alters,Monika Joanna,41,68,12,0,0,0,1,3.253
+Fall 2023,POLS,6382,1,16009,Quantitative Methods III,Zhu,Ling,8,0,1,0,0,0,1,3.741
+Fall 2023,ARLD,6370,1,16015,Intro to Museum Management,DeHoyos-Sauder,Ashley Delara,6,0,0,0,0,0,0,3.945
+Fall 2023,FINA,4323,1,16021,Investment & Mutual Fund Mgt,Blanchfield,Craig,36,10,2,1,1,0,0,3.593
+Fall 2023,MATH,4322,2,16022,Data Science and Machine Learn,Poliak,Cathy Dawn,86,13,1,0,0,0,0,3.853
+Fall 2023,PHYS,4340,3,16024,Research Methods,Ekeoba,Jacqueline Njideka,4,2,0,0,0,0,0,3.667
+Fall 2023,MECT,1364,30,16026,Materials & Processes,Afrin,Samia,5,12,14,1,3,0,2,2.391
+Fall 2023,MUSA,3402,1,16028,Applied Composition,Maroney,Marcus K,1,0,1,0,0,0,0,2.835
+Fall 2023,POLS,6302,1,16029,Research Design,Jenke,Elizabeth,5,3,0,0,0,0,0,3.708
+Fall 2023,MARK,4380,1,16030,Digital Selling,Herman,Carl,14,12,0,0,0,0,0,3.5
+Fall 2023,MARK,4380,2,16031,Digital Selling,Herman,Carl,14,12,0,0,0,0,0,3.437
+Fall 2023,MUSA,2340,1,16032,Applied Trumpet,Hughes,Mark Alan,3,0,0,0,0,0,0,4.0
+Fall 2023,COSC,6342,1,16033,Machine Learning,Vilalta,Ricardo,35,22,7,0,0,0,0,3.329
+Fall 2023,COSC,6398,101,16035,Special Problems,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2023,COSC,6398,102,16036,Special Problems,Chen,Guoning,0,0,0,0,0,1,0,
+Fall 2023,COSC,6398,106,16039,Special Problems,Deng,Zhigang,0,0,0,0,0,1,0,
+Fall 2023,COSC,6398,109,16042,Special Problems,Gnawali,Omprakash D,0,0,0,0,0,4,0,
+Fall 2023,COSC,6398,114,16047,Special Problems,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2023,COSC,6398,117,16050,Special Problems,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2023,COSC,6398,120,16053,Special Problems,Pandurangan,Gopal,0,0,0,0,0,2,0,
+Fall 2023,COSC,6398,124,16057,Special Problems,Shah,Shishir,0,0,0,0,0,3,0,
+Fall 2023,COSC,6398,125,16058,Special Problems,Shi,Weidong,0,0,0,0,0,1,0,
+Fall 2023,COSC,6398,130,16063,Special Problems,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,101,16065,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,102,16066,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Fall 2023,COSC,8398,103,16067,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,106,16070,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,
+Fall 2023,COSC,8398,109,16073,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,2,0,
+Fall 2023,COSC,8398,112,16076,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,2,0,
+Fall 2023,COSC,8398,116,16080,Doctoral Research,Leiss,Ernst L,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,118,16082,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,119,16083,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,120,16084,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,126,16090,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,127,16091,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,3,0,
+Fall 2023,COSC,8398,128,16092,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Fall 2023,COSC,8398,129,16093,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2023,COSC,8398,130,16094,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Fall 2023,COSC,8399,102,16097,Doctoral Dissertation,Chen,Guoning,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8399,107,16102,Doctoral Dissertation,Eick,Christoph F,1,0,0,0,0,0,0,3.67
+Fall 2023,COSC,8399,112,16107,Doctoral Dissertation,Huang,Shou-Hsuan Stephen,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8399,113,16108,Doctoral Dissertation,Johnsson,Lennart,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8399,117,16112,Doctoral Dissertation,Merchant,Fatima Aziz,0,0,0,0,0,2,0,
+Fall 2023,COSC,8399,122,16117,Doctoral Dissertation,Pavlidis,Ioannis T,2,0,0,0,0,1,0,4.0
+Fall 2023,COSC,8399,126,16121,Doctoral Dissertation,Solorio Martinez,Thamar Ivette,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8698,102,16128,Doctoral Research,Chen,Guoning,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,103,16129,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Fall 2023,COSC,8698,112,16138,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,2,0,
+Fall 2023,COSC,8698,113,16139,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,114,16140,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,117,16143,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,118,16144,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,119,16145,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,120,16146,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,122,16148,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,2,0,
+Fall 2023,COSC,8698,125,16151,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,126,16152,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,2,0,
+Fall 2023,COSC,8698,129,16155,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2023,COSC,8698,130,16156,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,3,0,
+Fall 2023,COSC,8699,109,16166,Doctoral Dissertation,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2023,COSC,8699,112,16169,Doctoral Dissertation,Huang,Shou-Hsuan Stephen,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8699,119,16176,Doctoral Dissertation,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,101,16189,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,102,16190,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Fall 2023,COSC,8998,103,16191,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,106,16194,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,107,16195,Doctoral Research,Eick,Christoph F,0,0,0,0,0,2,0,
+Fall 2023,COSC,8998,109,16197,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,112,16200,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,117,16205,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,122,16210,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,2,0,
+Fall 2023,COSC,8998,125,16213,Doctoral Research,Shi,Weidong,0,0,0,0,0,2,0,
+Fall 2023,COSC,8998,128,16216,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,3,0,
+Fall 2023,COSC,8998,129,16217,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,130,16218,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Fall 2023,COSC,8998,131,16219,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Fall 2023,FINA,4325,1,16220,Retirement and Estate Planning,Lopez,John C,2,12,3,2,6,0,0,2.172
+Fall 2023,COSC,6399,130,16250,Masters Thesis,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Fall 2023,IART,1300,1,16252,The Arts in Society,Noble,Melissa Lynn,20,4,2,0,1,0,0,3.568
+Fall 2023,IART,1300,2,16253,The Arts in Society,Gaona,Veronica,23,1,1,0,0,0,0,3.867
+Fall 2023,IART,1300,3,16254,The Arts in Society,Newkirk,Elizabeth Diane,21,2,0,0,0,0,2,3.856
+Fall 2023,IART,1300,4,16255,The Arts in Society,Harris,Jeanette Joy,16,4,2,0,2,0,1,3.333
+Fall 2023,COSC,7399,128,16283,Masters Thesis,Tsekos,Nikolaos V,0,1,0,0,0,0,0,3.0
+Fall 2023,BIOE,4302,1,16287,Numerical Analysis for BME,Zhang,Yingchun,11,0,0,0,1,0,0,3.639
+Fall 2023,ENGL,3352,1,16288,19th Century American Fiction,Wood,Barry Albert,12,11,1,3,3,0,1,2.801
+Fall 2023,DIGM,1350,30,16289,Graphics for Digital Media,Beyl,Charles Eugene,10,13,4,0,6,0,2,2.656
+Fall 2023,DIGM,1350,32,16290,Graphics for Digital Media,Beyl,Charles Eugene,18,7,3,1,4,0,1,3.02
+Fall 2023,DIGM,1350,33,16291,Graphics for Digital Media,Dawson,Michael John,17,4,3,1,2,0,5,3.173
+Fall 2023,MUSA,8320,2,16292,Doctoral Applied Music,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,3.67
+Fall 2023,ENGL,4382,1,16293,Poetry Writing,Belieu,Erin Colleen,7,3,0,0,0,0,2,3.766
+Fall 2023,MUSA,1300,5,16294,Applied Voice,Vasquez,Hector A,2,2,0,0,0,0,0,3.665
+Fall 2023,MUSA,2324,2,16295,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3424,2,16297,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3440,1,16299,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3440,2,16300,Applied Trumpet,Vassallo,Jim Cates,4,0,1,0,0,0,0,3.534
+Fall 2023,CHEM,8999,22,16305,Doctoral Dissertation,Do,Loi H,0,0,0,0,0,1,0,
+Fall 2023,ENGI,2304,14,16307,Technical Communications,Contos,Ashlie Meghan,12,9,1,1,2,0,0,3.041
+Fall 2023,ENGI,2304,15,16308,Technical Communications,Estrada,Carl,1,12,1,1,1,0,0,2.914
+Fall 2023,INDS,2355,2,16314,Design History I,Williams,Celeste,21,4,0,0,0,0,0,3.8
+Fall 2023,CHEM,8999,23,16317,Doctoral Dissertation,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Fall 2023,ARTS,1303,1,16318,Art Hist I(Prehistoric 14th C),Koontz,Rex A,143,43,18,5,5,0,13,3.444
+Fall 2023,ENGL,7699,2,16322,Thesis,Gregory,Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8399,2,16323,Doctoral Dissertation,Kastely,James L,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,6399,2,16324,Master's Thesis,Tejada,Roberto Jose,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8243,2,16327,Doctoral Lecture Recital,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,4,16328,Doctoral Applied Music,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6304,3,16329,Conducting,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8399,4,16331,Dissertation,Cheung,Monit,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,8999,25,16332,Doctoral Dissertation,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2023,HON,4398,4,16333,Independent Study,Rhoden,Brenda,3,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8399,12,16334,Doctoral Dissertation,Mang,Andreas,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8399,3,16336,Doctoral Dissertation,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5291,1,16338,Partnership Tax,Bergez,Craig,2,8,0,0,0,0,0,3.2
+Fall 2023,CHEM,8999,26,16339,Doctoral Dissertation,May,Jeremy A,1,0,0,0,0,2,0,4.0
+Fall 2023,HIST,2301,1,16341,Texas History to 1865,Ramos,Raul,24,7,3,0,4,0,1,3.176
+Fall 2023,MUSA,8242,1,16343,Doctoral Recital III,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4333,1,16344,Current Issues in Mgmt,Walker,William A,50,6,2,0,0,0,0,3.833
+Fall 2023,ENGL,7399,3,16346,Essay,Flynn,Nicholas,0,0,0,0,0,0,0,
+Fall 2023,ENGL,8698,2,16348,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8399,4,16349,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Fall 2023,GHL,4350,2,16352,Strategy&Innovation Hosp Ind,Morosan,Cristian,14,10,9,1,2,0,3,2.908
+Fall 2023,GHL,3336,2,16353,Beverage Management,Corsi,Aaron James,22,0,0,0,3,0,0,3.467
+Fall 2023,ENGL,8399,5,16354,Doctoral Dissertation,Mazella,David S,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8699,3,16355,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8399,6,16356,Doctoral Dissertation,Snediker,Michael,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8699,4,16357,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Fall 2023,PETR,5352,1,16367,Shale Reservoirs,Hathon,Lori A,6,0,0,0,0,0,0,4.0
+Fall 2023,MARK,3365,3,16368,Intro to Digital Marketing,Tirunillai,Seshadri N,91,60,15,2,2,0,0,3.342
+Fall 2023,BZAN,6353,1,16370,Res Design-Probs Busi Anlytcs,Aron,Ravi,6,19,0,0,1,0,0,3.128
+Fall 2023,TLIM,3330,2,16371,Innovation Principles,Feriante,Chris,9,7,7,0,0,0,2,3.073
+Fall 2023,MATH,4396,1,16373,Senior Research Project,Jaramillo,Gabriela T,1,0,0,0,0,0,0,4.0
+Fall 2023,DRAM,1310,13,16374,Introduction to Theatre,Egging,Jon Leo,32,7,3,2,1,0,3,3.467
+Fall 2023,MECE,4398,1,16375,Independent Study,Bering,Edgar A,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8296,3,16376,Doctoral Essay,Koozin,Timothy,1,0,0,0,0,1,0,4.0
+Fall 2023,CNST,6308,2,16377,Data Analysis in Construc Mgmt,Gao,Lu,19,1,0,0,0,0,0,3.934
+Fall 2023,MUSA,1312,1,16379,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,3332,5,16382,Prin of Financial Management,Lopez,John C,32,53,73,47,10,1,13,2.332
+Fall 2023,ENGL,8698,3,16383,Graduate Research,Berger,Jason,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8698,4,16384,Graduate Research,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8698,5,16385,Graduate Research,Wingard,Jennifer L,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8698,7,16387,Graduate Research,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8698,8,16388,Graduate Research,Belieu,Erin Colleen,0,0,0,0,0,1,0,
+Fall 2023,MANA,4358,1,16389,Compensation and Benefits,Zamanipour,Tina,48,8,2,0,1,0,0,3.729
+Fall 2023,ENGL,8698,9,16390,Graduate Research,Chatterjee,Sreya,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8698,10,16391,Graduate Research,Shepley,Nathan,0,0,0,0,0,1,0,
+Fall 2023,SPAN,1507,3,16392,Intns Elem Span Heritage Learn,Hernandez,Estela,14,7,1,2,0,0,0,3.279
+Fall 2023,SPAN,2308,1,16394,Span for Heritage Learners II,Martinez,Raquel,3,7,1,0,2,0,1,2.642
+Fall 2023,FINA,6335,1,16404,Managerial Finance,Berta,Dominique,10,2,0,0,0,0,0,3.778
+Fall 2023,GEOL,1102,7,16405,Intro to Climate Change Lab,Zhang,Honghai,17,5,0,0,1,0,0,3.537
+Fall 2023,MATH,2413,51,16407,Calculus I,Constante,Beatrice,228,102,82,54,32,0,20,2.873
+Fall 2023,ENGL,8399,8,16413,Doctoral Dissertation,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8699,5,16414,Doctoral Dissertation,Davies,Daniel,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8399,9,16415,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Fall 2023,ENGL,7399,4,16416,Essay,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2023,MUSA,8240,1,16417,Doctoral Recital I,Brooks,Wayne A,0,0,0,0,0,0,0,
+Fall 2023,HIST,3371,50,16418,Russian Imperial History,Rainbow,David,10,8,3,0,2,0,2,3.015
+Fall 2023,ENGL,8699,6,16419,Doctoral Dissertation,Lee,Eunjeong,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,6,16423,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Fall 2023,ECON,3385,1,16425,Economics of Energy,Hirs,Edward A,28,18,5,0,0,0,5,3.347
+Fall 2023,MUSI,8106,1,16428,Doctoral Large Ensemble,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,7340,1,16431,Data Analytics for PHOP,Varisco,Tyler J,4,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,7305,1,16432,Theory in PHOP,Sansgiry,Sujit Sharad,2,1,0,0,1,0,0,2.75
+Fall 2023,GENB,5303,4,16435,Prof Acct Communication,Newman,Michael Ray,3,6,0,0,1,0,0,3.132
+Fall 2023,GENB,7303,2,16436,Prof Accounting Communication,Newman,Michael Ray,17,8,0,0,2,0,0,3.42
+Fall 2023,MUSA,8320,7,16439,Doctoral Applied Music,Hester,Timothy E,6,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8395,1,16441,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,0,0,
+Fall 2023,MUSA,6140,5,16442,Graduate Recital I,Cho,Eunghee,1,0,0,0,0,0,0,3.67
+Fall 2023,CNST,3265,2,16444,Construction Layout & Site Dvp,Lupher,Jacob John,15,19,6,0,0,0,1,3.159
+Fall 2023,MUSA,1300,11,16445,Applied Voice,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,3.67
+Fall 2023,GERM,6361,1,16446,German Cinema,Frieden,Sandra M Gross,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1338,1,16447,Saxophone,Witt,Woodrow W,5,2,0,0,0,0,0,3.809
+Fall 2023,MUSA,1350,1,16448,Applied Percussion,Warren,Paul Alexander,6,3,0,0,0,0,1,3.593
+Fall 2023,HIST,2328,1,16449,Chicano History since 1910,San Miguel Jr,Guadalupe,19,7,3,2,3,0,0,3.059
+Fall 2023,CHEM,3336,1,16451,Org Chem Biol Molecules,Gilbertson,Scott R,17,11,6,3,0,0,3,3.153
+Fall 2023,MUSA,2310,3,16452,Applied Piano,Staupe,Andrew Paul,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2320,2,16453,Applied Violin,Lo,Mann-Wen,3,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,2338,1,16454,Applied Saxophone,Witt,Woodrow W,2,0,0,0,0,0,0,3.835
+Fall 2023,MUSA,3444,1,16455,Applied Trombone,Kauk,Brian Keith,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3450,2,16456,Applied Percussion,Wilkins,Blake M,5,2,0,0,0,0,0,3.573
+Fall 2023,MUSA,4420,2,16458,Applied Violin,Lo,Mann-Wen,3,0,0,0,0,0,0,3.89
+Fall 2023,MUSA,4450,2,16459,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,3313,5,16460,Intro Internatl Relatns,Zwald,Zachary J,33,6,0,1,1,0,1,3.506
+Fall 2023,MUSA,6330,2,16462,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6422,2,16463,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Fall 2023,CIS,4365,4,16466,Database Management,Hu,Renjie,33,19,3,0,2,0,1,3.305
+Fall 2023,CIS,3367,1,16467,Cloud Computing Architecture,Martinez,Jose C,22,19,10,0,2,0,0,3.101
+Fall 2023,TLIM,3330,3,16468,Innovation Principles,Crawley,David L,5,7,7,2,1,0,0,2.591
+Fall 2023,ARCH,3380,2,16469,Architecture Plus Film,Froehlich,Dietmar,19,0,0,0,0,0,0,3.844
+Fall 2023,EGRP,1141,2,16471,Engineering Applications IV,Luna Singh,Jennifer Austin,0,0,0,0,0,12,1,
+Fall 2023,EGRP,1150,2,16472,Engineering Applications VI,Luna Singh,Jennifer Austin,0,0,0,0,0,13,1,
+Fall 2023,EGRP,1142,2,16473,Engineering Applications V,Luna Singh,Jennifer Austin,0,0,0,0,0,18,0,
+Fall 2023,EGRP,1170,2,16474,Engineering Applications IX,Luna Singh,Jennifer Austin,0,0,0,0,0,6,0,
+Fall 2023,HIST,1301,50,16475,The U.S. to 1877,Vale,Timothy Eli,28,1,0,0,0,0,1,3.943
+Fall 2023,MUSI,1220,3,16476,Class Piano I,Van Kekerix,Todd Evan,9,4,1,0,0,0,0,3.501
+Fall 2023,ECE,5330,1,16479,Introduction to Robotics,Becker,Aaron T,4,3,1,0,0,0,0,3.251
+Fall 2023,PHYS,3214,1,16480,Advanced Laboratory II,Varghese,Oomman K,2,4,2,0,0,0,0,2.959
+Fall 2023,ARCH,6380,2,16482,Architecture Plus Film,Froehlich,Dietmar,4,1,0,0,0,0,0,3.734
+Fall 2023,ACCT,2301,5,16483,Prin of Financial Accounting,Newman,Michael Ray,18,5,0,0,0,0,0,3.74
+Fall 2023,ACCT,2301,8,16484,Prin of Financial Accounting,Newman,Michael Ray,15,8,0,0,0,0,0,3.652
+Fall 2023,MUSI,6112,1,16485,Chamber Music - Woodwind,Bertman,David Garry,7,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6350,2,16486,Applied Music Pedagogy,Cho,Eunghee,5,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3340,1,16487,Advanced Composition,Koulen,Marisa Theresa,18,2,0,0,0,0,1,3.851
+Fall 2023,MUED,3320,1,16488,Intro To Education in Music,McGinnis,Emily Jane,10,6,2,0,0,0,0,3.463
+Fall 2023,MARK,4377,1,16490,Sales for Social Impact,Moceri,Grace,11,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7332,1,16491,Effective Negotiating,Miller,Carl Chet,12,8,0,0,0,0,0,3.567
+Fall 2023,ENTR,4350,1,16492,Entrepreneurial Strategy,Boles,James Read,27,1,0,0,0,0,0,3.905
+Fall 2023,CHEE,5323,1,16493,Fundamental of Tissue Engineer,Horton,Renita Elillian,0,0,1,0,0,0,0,2.0
+Fall 2023,PCEU,7180,1,16499,Pharmaceutics Seminar,McConnell,Bradley K,0,0,0,0,0,2,0,
+Fall 2023,PHCA,7180,1,16500,Seminar,Aparasu,Rajender R,14,0,0,0,0,0,0,4.0
+Fall 2023,DRAM,1351,1,16501,Acting I,Ferrarone,Jessica,13,1,0,0,0,0,0,3.929
+Fall 2023,DRAM,1351,2,16502,Acting I,Ferrarone,Jessica,8,0,0,0,0,0,0,3.959
+Fall 2023,PHCA,7308,1,16503,Biostatistics,Abughosh,Susan M,9,6,1,0,1,0,0,3.294
+Fall 2023,GENB,5304,1,16504,Business Ethics for Accountant,Brant Jr,Robert Edward,5,5,0,0,0,0,0,3.566
+Fall 2023,GENB,7304,1,16505,Bus Ethics for Accountants,Brant Jr,Robert Edward,8,7,1,0,0,0,0,3.52
+Fall 2023,INDS,3360,2,16506,Human Factors,Vos,Gordon A,19,0,1,0,0,0,0,3.818
+Fall 2023,INAR,3360,2,16507,Human Factors in Interior Arch,Vos,Gordon A,18,1,0,0,0,0,0,3.895
+Fall 2023,INDS,6333,2,16508,Human Factors,Vos,Gordon A,2,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6361,3,16509,Integrated Practice,Rivers,Paul Joseph,4,4,0,0,0,0,0,3.5
+Fall 2023,ARCH,1500,23,16512,Design Studio I,Soto,Carlos E,4,6,2,0,2,0,0,2.738
+Fall 2023,ARCH,4510,21,16514,Integrated Arch Solutions,Roldan Caballero,Jose Manuel,8,8,2,0,0,0,0,3.37
+Fall 2023,AAS,2320,5,16518,Intro To African American Stdy,Thompson,Kevin Bernard,28,2,4,1,0,0,0,3.581
+Fall 2023,MUSA,8240,2,16519,Doctoral Recital I,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,3500,31,16521,Architecture Design Studio V,Beneytez-Duran,Rafael,6,5,4,1,0,0,1,3.062
+Fall 2023,ARCH,7600,11,16523,Architecture Design Studio V,Wienert,Ross George,4,2,0,0,0,0,0,3.667
+Fall 2023,ARCH,6600,5,16526,Architecture Design Studio I,Logan,Jason,7,3,1,0,0,0,0,3.515
+Fall 2023,PHYS,4398,4,16528,Independent Study,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Fall 2023,PHLA,7320,1,16534,Capstone,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4330,1,16535,Adv Instrumental Conducting,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Fall 2023,RELS,1301,4,16538,Intro To Religious Studies,Borkataky-Varma,Sravana,16,25,7,0,1,0,1,3.089
+Fall 2023,THEA,6325,1,16541,Alley Thea Dramaturgy Prac I,Coen,Elizabeth Manya,3,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4356,2,16542,Managing Diversity,Ruggs,Enrica N,19,17,4,2,2,0,2,3.159
+Fall 2023,ENGL,7399,5,16544,Essay,Nelson,Antonya,2,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8698,5,16545,Doctoral Research,Labate,Demetrio,0,0,0,0,0,8,0,
+Fall 2023,ENGL,1302,21,16553,First Year Writing II,Presswood,Phillip Hilliard,24,0,0,0,0,0,1,3.973
+Fall 2023,ENGL,1302,23,16554,First Year Writing II,Cowan,Joshua Jared,10,1,2,0,6,0,4,2.369
+Fall 2023,ENGL,1302,24,16555,First Year Writing II,Pogue,Donovan A,8,6,2,0,1,0,2,3.118
+Fall 2023,ENGL,2305,4,16556,Intro To Fiction,Griffin,Emelie Marie,15,7,0,0,0,0,1,3.652
+Fall 2023,ENGL,2307,2,16558,Intro To Drama,Bose,Godhuly,15,3,3,0,1,0,1,3.334
+Fall 2023,ENGL,2330,2,16559,Writing Discipline English,Coleman,Quintin,13,3,2,0,0,0,1,3.611
+Fall 2023,ENGL,1301,148,16560,First Year Writing I,Pachuca,Adrian,9,6,4,0,0,0,0,3.194
+Fall 2023,PHOP,6198,5,16564,Spec Prob-Physio Optics,Queener,Hope M,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6198,7,16577,Spec Prob-Physio Optics,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6356,1,16579,Medical Ethics,Determeyer,Peggy Lee,19,1,0,0,0,0,0,3.95
+Fall 2023,ENGL,3330,3,16580,Beg Creative Writing-Fiction,Fretwell,Leah M,20,0,0,0,0,0,0,3.901
+Fall 2023,BIOL,6398,2,16582,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7398,1,16583,Statistics in PSYC Practicum,Francis,David J,0,0,0,0,0,5,0,
+Fall 2023,ENGL,1302,12,16586,First Year Writing II,Sicinski,Michael J,15,6,0,0,2,0,2,3.262
+Fall 2023,ENGL,2305,1,16587,Intro To Fiction,Spencer,Jaxson Matthew,23,3,1,0,1,0,0,3.69
+Fall 2023,ENGL,2306,2,16588,Intro To Poetry,Woodward,Marshall B,26,2,0,0,0,0,1,3.905
+Fall 2023,ENGL,1301,64,16589,First Year Writing I,Colchado,Lea,10,4,2,1,1,0,1,3.038
+Fall 2023,ENGL,1301,65,16590,First Year Writing I,Dykes,Justin,5,10,5,0,0,0,3,3.0
+Fall 2023,ENGL,1301,66,16591,First Year Writing I,Sahi,Aishwarya,11,6,1,0,1,0,0,3.334
+Fall 2023,ENGL,1301,68,16592,First Year Writing I,Murray,Christopher Brean,12,3,3,0,1,0,0,3.264
+Fall 2023,ENGL,1301,69,16593,First Year Writing I,Murray,Christopher Brean,12,4,0,0,3,0,1,3.141
+Fall 2023,PHOP,6198,10,16600,Spec Prob-Physio Optics,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,3201,12,16602,Biochemistry I Laboratory,Pattison,Donna,8,9,1,1,0,0,0,3.246
+Fall 2023,BIOL,2101,22,16604,Anatomy & Physiology Lab I,Gill,Tejendra,4,12,7,0,0,0,1,2.956
+Fall 2023,BIOL,2101,23,16605,Anatomy & Physiology Lab I,Gill,Tejendra,3,17,3,0,0,0,0,3.1
+Fall 2023,BIOL,2101,24,16606,Anatomy & Physiology Lab I,Gill,Tejendra,7,11,3,0,1,0,0,2.985
+Fall 2023,WGSS,2350,12,16609,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,29,2,0,1,0,0,1,3.833
+Fall 2023,COSC,3399,2,16610,Senior Honors Thesis,Shah,Shishir,0,0,0,0,0,0,0,
+Fall 2023,PHCA,6297,1,16611,Selected Topics,Varkey,Divya A,3,0,0,0,0,0,0,4.0
+Fall 2023,DRAM,1310,12,16613,Introduction to Theatre,Hinkel,Heidi Anne,42,6,1,0,0,0,1,3.81
+Fall 2023,ECON,8399,7,16619,Doctoral Dissertation,Szabo,Andrea,0,0,0,0,0,1,0,
+Fall 2023,ECON,8399,8,16620,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,4,0,
+Fall 2023,PCOL,6398,1,16621,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Fall 2023,ENTR,3342,1,16622,Women in Entrepreneurship,McCormick,Kelly,29,6,1,0,0,0,0,3.723
+Fall 2023,ENTR,7342,1,16623,Women in Entrepreneurship,McCormick,Kelly,3,0,0,0,0,0,0,3.89
+Fall 2023,MANA,3335,13,16624,Intro Org Behavior and Mgmt,Rude,Dale,18,3,1,0,0,0,0,3.698
+Fall 2023,PCOL,8298,3,16626,Doctoral Research,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,8698,5,16629,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2023,HDCS,4303,3,16631,Merchandising Systems,Johnson,Olivia,8,15,5,0,0,0,0,3.107
+Fall 2023,PHLA,7299,5,16637,Masters Thesis,Wallace,David A,0,0,0,0,0,1,0,
+Fall 2023,PHLA,7299,6,16638,Masters Thesis,Wanat,Matthew A,0,0,0,0,0,1,0,
+Fall 2023,ENGL,1301,71,16639,First Year Writing I,Sahi,Aishwarya,9,4,1,0,2,0,1,3.063
+Fall 2023,ENGL,1301,72,16640,First Year Writing I,Downey,Carlton M,20,2,0,0,2,0,0,3.556
+Fall 2023,ENGL,1301,74,16641,First Year Writing I,Raza,Iqra,17,2,0,0,0,0,0,3.791
+Fall 2023,PCEU,8398,1,16644,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8399,27,16647,Doctoral Dissertation,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Fall 2023,MIS,3360,3,16648,Systems Analysis and Design,Kniffen,Richard Chad,23,28,10,1,0,0,1,3.177
+Fall 2023,PHOP,8199,6,16652,Doctoral Dissertation,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1301,75,16656,First Year Writing I,Raza,Iqra,12,4,1,0,1,0,0,3.353
+Fall 2023,MATH,8398,23,16657,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Fall 2023,SPAN,1502,1,16659,Elementary Spanish II,Hernandez,Stephanie,6,7,5,0,1,0,4,2.86
+Fall 2023,SPAN,1501,3,16661,Elementary Spanish I,Carrion Rivera,Lydiette,10,9,3,0,1,0,3,3.088
+Fall 2023,BIOE,6398,3,16664,Research,Mohan,Chandra,0,0,0,0,0,0,0,
+Fall 2023,ENGL,1301,53,16665,First Year Writing I,Hammon,Cameron Dezen,17,1,0,1,0,0,0,3.789
+Fall 2023,ENGL,1301,55,16666,First Year Writing I,Repass,Scott,11,4,0,2,2,0,0,3.001
+Fall 2023,ENGL,1301,56,16667,First Year Writing I,Stewart-Steele,Heather Marie,4,9,7,0,4,0,1,2.389
+Fall 2023,ENGL,1302,17,16668,First Year Writing II,Kozma,Andrew,9,6,5,0,5,0,5,2.507
+Fall 2023,ENGL,1302,18,16669,First Year Writing II,Kozma,Andrew,12,8,4,0,1,0,4,3.187
+Fall 2023,PHCA,7310,1,16670,Teaching Practicum,Varisco,Tyler J,2,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6198,13,16674,Spec Prob-Physio Optics,Ferreira,Tarsis Gesteira,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6214,1,16677,Applied Harpsichord,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,3340,2,16678,Intro. to Automata and Comp.,Singh,Raj Kumar,166,14,2,0,0,0,0,3.899
+Fall 2023,BCHS,3399,1,16683,Senior Honors Thesis,Sen,Mehmet,0,0,0,0,0,0,0,
+Fall 2023,IRW,1300,1,16684,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,40,1,
+Fall 2023,SOCI,1301,10,16690,Introduction To Sociology,Adams,Jennifer Lauren,34,12,4,0,6,0,6,3.149
+Fall 2023,CHEM,6498,39,16696,Special Problems,Gilbertson,Scott R,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6365,8,16697,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Fall 2023,SOCI,1301,12,16699,Introduction To Sociology,Davis,Mary A,40,7,5,4,3,0,0,3.277
+Fall 2023,COSC,4198,2,16700,Independent Study,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2023,HDCS,4369,4,16701,Entrepreneurship,Hitchman Sr,Cal M,42,6,0,0,0,0,1,3.854
+Fall 2023,ENGL,3399,2,16704,Senior Honors Thesis,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3399,3,16705,Senior Honors Thesis,Singh,Kavita Ashana,0,0,0,0,0,0,0,
+Fall 2023,ENGL,3399,4,16706,Senior Honors Thesis,Gonzalez,Maria C,0,0,0,0,0,0,0,
+Fall 2023,ENGL,4399,2,16707,Senior Honors Thesis,Zentz,Lauren R,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7398,2,16713,Special Problems,Womble,David Avari Patrick,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6420,1,16714,Applied Violin,Yon,Kirsten A,6,0,0,0,0,0,0,4.0
+Fall 2023,INDE,8399,3,16717,Doctoral Dissertation,Peng,Jiming Ouyang,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3399,5,16722,Senior Honors Thesis,Duran,Chatwara,0,0,0,0,0,0,0,
+Fall 2023,HRD,6399,1,16729,Master's Thesis,Waight,Consuelo L,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6198,3,16731,Research in Chamber Music,Lo,Mann-Wen,4,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,4398,4,16734,Independent Study,Nelms,Jodi Lynn,1,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,6398,2,16735,Special Problems,Ventura,Gabriela Baeza,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7335,1,16736,SW Practice in Communities,Mayer,Margaret,17,0,1,0,0,0,0,3.889
+Fall 2023,MATH,2312,8,16737,Precalculus,Almus,Melahat,48,22,32,2,32,0,32,2.334
+Fall 2023,MARK,6A61,3,16738,Marketing Administration,Krishnamurthy,Parthasarathy,16,3,0,0,0,0,0,3.825
+Fall 2023,FINA,6A35,1,16739,Managerial Finance,Povel,Paul,5,2,4,0,0,0,0,3.001
+Fall 2023,FINA,6A35,3,16740,Managerial Finance,Berger,Elizabeth,19,14,7,0,0,0,0,3.3
+Fall 2023,SCM,6A01,1,16742,SCM Concepts,Sahin,Funda,5,3,3,0,0,0,0,3.212
+Fall 2023,MARK,6A61,4,16743,Marketing Administration,Lish,Alan D,13,22,2,0,0,0,2,3.297
+Fall 2023,SCM,6A01,3,16744,SCM Concepts,Sahin,Funda,9,7,2,0,0,0,1,3.352
+Fall 2023,MANA,6A32,1,16745,Organizational Behavior & Mgt,Krylova,Ksenia O,19,2,0,0,0,0,0,3.81
+Fall 2023,FINA,7A20,1,16746,Capital Markets,Jacobs,Kris,5,6,0,0,0,0,1,3.545
+Fall 2023,MATH,1342,6,16748,Elementary Statistical Methods,Caputo,Matthew G,70,62,46,30,50,0,24,2.192
+Fall 2023,GENB,6A50,1,16749,Business Communications,Pineda,Dalia Rivera,8,1,0,0,0,0,0,3.779
+Fall 2023,GENB,6A50,2,16755,Business Communications,Pettiette,Michael R,25,1,1,0,0,0,1,3.754
+Fall 2023,MATH,1314,8,16756,College Algebra,Caglar,Atife,12,2,7,7,20,0,11,1.542
+Fall 2023,MATH,1324,7,16757,Finite Math with Applications,Sosa,Moses,76,52,22,14,50,0,30,2.384
+Fall 2023,MATH,1325,3,16758,Calc for Bus & Social Sciences,Constante,Beatrice,26,18,14,6,18,0,10,2.325
+Fall 2023,GHL,6317,1,16759,Innovative Hosp. Technologies,Lee,Minwoo,30,6,0,0,0,0,0,3.815
+Fall 2023,GHL,6324,1,16760,Hosp. Busn Strategies in Amer,Kim,Jaewook,36,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6340,1,16761,Behavior and Hosp. Lead. Strat,Madera,Juan Manuel,33,2,1,0,0,0,0,3.898
+Fall 2023,NURS,4314,2,16763,Nursing Research,Quintana,Danielle,60,0,0,0,0,0,1,4.0
+Fall 2023,BCHS,6230,1,16764,Grad Biochem Lab Rotation I,Widger,William R,4,0,0,0,0,0,0,4.0
+Fall 2023,MANA,6A83,1,16771,Strategic Analysis,Celly,Nikhil,6,0,0,0,0,0,0,3.945
+Fall 2023,FINA,7A10,2,16772,Valuation,Yerramilli,Vijay,7,3,1,0,1,0,0,3.168
+Fall 2023,GHL,6317,2,16774,Innovative Hosp. Technologies,Morosan,Cristian,8,0,0,0,0,0,0,4.0
+Fall 2023,GENB,6A50,3,16776,Business Communications,Pettiette,Michael R,19,1,0,0,0,0,4,3.686
+Fall 2023,SOCW,7334,1,16777,Social Work Leadership,Pang,Melanie Espinosa,15,0,0,0,0,0,0,4.0
+Fall 2023,FINA,6A98,1,16778,Research,Bean,Gregory S,6,0,0,0,0,0,0,4.0
+Fall 2023,MANA,6A25,5,16780,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,10,6,1,0,0,0,0,3.491
+Fall 2023,MANA,6A32,2,16781,Organizational Behavior & Mgt,Witt,Lawrence A,3,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7A49,1,16782,Managerial Decision Making,Carlin,Barbara A,22,4,0,0,0,0,0,3.795
+Fall 2023,BIOL,6230,1,16783,Advanced Cell Biology I,Dryer,Stuart E,11,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6231,1,16784,Advanced Cell Biology II,Khurana,Seema,10,2,0,0,0,0,0,3.778
+Fall 2023,FINA,7A20,2,16785,Capital Markets,Wu,Guojun,40,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7A30,1,16786,Advanced Corporate Finance,Povel,Paul,8,6,0,0,0,0,0,3.548
+Fall 2023,SOCW,7356,4,16787,Groups: Adv Clinical Practice,Eisenbaum,Stephanie,26,0,0,0,0,0,0,4.0
+Fall 2023,INDS,2260,1,16796,Materials and Fab Methods,Wells,Adam C,2,9,0,0,0,0,0,3.242
+Fall 2023,SOCW,7319,2,16797,SW Practice in Organizations,Powell,Torey Ian,24,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,8698,7,16802,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,0,0,0,0,0,1,0,
+Fall 2023,MARK,7A75,1,16806,Marketing Strategy,Lish,Alan D,16,7,1,1,0,0,0,3.428
+Fall 2023,SOCW,6306,6,16808,Social Work Practice Skills,Jacobs,Alexandra L,35,0,0,0,1,0,0,3.889
+Fall 2023,SOCW,6308,4,16809,Human Diversity & Development,Scott Jr,Edward Douglas,15,2,0,0,0,0,0,3.882
+Fall 2023,SOCW,6308,5,16810,Human Diversity & Development,Jennings,Sheara Williams,24,3,0,0,0,0,0,3.889
+Fall 2023,SOCW,6308,6,16811,Human Diversity & Development,Fernandez,Jason,26,0,0,0,0,0,1,4.0
+Fall 2023,SOCW,7356,5,16813,Groups: Adv Clinical Practice,Cheung,Poi Ten Ada,22,0,0,0,0,0,0,4.0
+Fall 2023,NURS,6351,1,16815,Evidence-Based Practice Projt,Kleinhans,Alicia Diane,4,2,0,0,0,0,0,3.667
+Fall 2023,FINA,7A50,1,16816,Derivatives I,Rabinovitch,Ramon,4,2,3,0,0,0,0,3.074
+Fall 2023,FINA,7A51,1,16817,Derivatives II,Rabinovitch,Ramon,5,1,0,0,0,0,0,3.723
+Fall 2023,FINA,7A40,1,16818,Fixed Income I,Doshi,Hitesh B,9,9,0,0,0,0,0,3.482
+Fall 2023,FINA,7A41,1,16819,Fixed Income II,Doshi,Hitesh B,9,4,0,1,0,0,0,3.5
+Fall 2023,FINA,7A37,1,16820,Corp Strategy-Equity Fund Mgt,Kumar,Praveen,16,0,0,0,0,0,0,4.0
+Fall 2023,INDS,3160,2,16821,Design Issues I,Jackson,Megan H,10,13,0,0,0,0,0,3.363
+Fall 2023,CHEM,1305,1,16822,Foundations of Chemistry,St Hill,Lydia Ruth,10,11,15,8,13,0,19,1.936
+Fall 2023,NURS,6306,1,16823,"Policy, Role & Economics",Dwyer,Carol Ann,3,1,0,0,0,0,0,3.75
+Fall 2023,FINA,6A31,2,16824,Analyzing Financial Statements,Woods,James D,3,4,3,3,0,0,0,2.538
+Fall 2023,FINA,7A10,3,16825,Valuation,Yerramilli,Vijay,25,2,0,0,0,0,0,3.865
+Fall 2023,PSYC,2301,8,16826,Introduction to Psychology,Saiyed,Amna Shabbir,107,9,1,1,2,0,0,3.77
+Fall 2023,ECON,4390,2,16828,Economics Internship,Troncoso,Pablo A,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,1301,102,16830,First Year Writing I,Stewart-Steele,Heather Marie,11,6,1,0,9,0,3,2.224
+Fall 2023,BIOE,8399,3,16831,Doctoral Dissertation,Merchant,Fatima Aziz,0,1,0,0,0,0,0,3.33
+Fall 2023,MATH,3325,2,16833,Transition to Advanced Math,Vershynina,Anna,7,5,9,0,0,0,3,2.92
+Fall 2023,MATH,3330,1,16834,Abstract Algebra,Haynes,Alan K,17,8,2,1,0,0,2,3.488
+Fall 2023,GEOL,1102,8,16835,Intro to Climate Change Lab,Zhang,Honghai,23,1,0,0,0,0,0,3.945
+Fall 2023,COMM,1303,3,16838,Writing for Communicators,Lyn,Robyn,66,10,9,2,10,0,2,3.224
+Fall 2023,COMM,2327,2,16839,Introduction to Screen Writing,Vaughan,Thomas Michael,13,6,1,0,0,0,0,3.584
+Fall 2023,COMM,2328,3,16840,Broadcast Writing Basics,Trigg,Katishia Leonna,6,14,2,0,1,0,3,3.13
+Fall 2023,PHYS,1301,5,16841,College Physics I (lecture),Forrest,Rebecca L,27,17,76,10,12,0,39,2.154
+Fall 2023,GEOL,1303,3,16845,Physical Geology,Murphy,Michael,152,108,30,9,9,0,10,3.228
+Fall 2023,GEOL,1303,5,16847,Physical Geology,Sisson,Virginia B,65,77,14,0,1,0,3,3.287
+Fall 2023,GEOL,1303,9,16848,Physical Geology,Robinson,Alexander C,32,40,29,5,0,0,5,2.897
+Fall 2023,GEOL,1303,7,16849,Physical Geology,Lytwyn,Jennifer N,42,58,51,17,13,0,25,2.529
+Fall 2023,GEOL,1303,8,16850,Physical Geology,Lytwyn,Jennifer N,39,74,36,15,6,0,21,2.729
+Fall 2023,COMM,4322,1,16851,TV Producing & Directing I,Crowe,Craig Warren,13,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4382,1,16854,Narrative Non-Linear Editing,Houk,Keith R,17,5,0,0,1,0,1,3.637
+Fall 2023,COMM,2311,3,16858,Writing for Print and Digital,Butler,Bryan C,14,8,2,0,0,0,1,3.418
+Fall 2023,COMM,2311,4,16860,Writing for Print and Digital,Roth,Geoffrey,21,2,2,0,0,0,0,3.734
+Fall 2023,COMM,2311,5,16862,Writing for Print and Digital,Radcliffe Andre,Jennifer,17,5,3,0,0,0,0,3.507
+Fall 2023,BIOL,7124,2,16864,Cell Biology Seminar,Peng,Weiyi,0,0,0,0,0,11,0,
+Fall 2023,GEOL,7331,1,16866,Seismic Structural Geology,Suppe,John,8,2,0,0,0,0,0,3.734
+Fall 2023,POLS,3397,1,16869,Selected Topics in Public Law,Abbott Jr,Kenneth Wayne,12,0,0,0,0,0,0,4.0
+Fall 2023,HON,3360,1,16870,Global Engagement,Myrick,Keri D,13,1,0,0,0,0,1,3.905
+Fall 2023,MATH,1314,3,16871,College Algebra,Hafeez,Shahinda,31,35,44,20,73,0,46,1.621
+Fall 2023,MATH,1324,4,16872,Finite Math with Applications,Watkins,Katie Nicole,96,124,72,38,130,0,126,1.987
+Fall 2023,HON,4350,1,16873,Data and Society in Practice,Kapral,Andrew J,7,1,0,0,0,0,0,3.834
+Fall 2023,COMM,3317,2,16874,Multimedia Journalism,Baruch Blanco,Maria Felicitas,15,4,0,0,0,0,0,3.807
+Fall 2023,COMM,2331,1,16875,Relational Communication,Hudson-Gillan,Gail,13,9,7,0,1,0,0,3.067
+Fall 2023,ECON,7330,1,16878,Quantitative Economic Analysis,Sorensen,Bent E,6,2,0,0,0,0,0,3.626
+Fall 2023,ECON,7341,1,16879,Microeconomic Theory I,Wang,Fan,2,13,0,0,0,0,0,3.265
+Fall 2023,ECON,7343,1,16880,Macroeconomic Theory I,Yi,Kei-Mu,4,5,0,0,0,0,0,3.554
+Fall 2023,ECON,8331,1,16881,Econometrics II,Sorensen,Bent E,6,4,1,0,0,0,0,3.455
+Fall 2023,ECON,2302,5,16882,Principles of Microeconomics,Pei,Yang,25,24,11,3,0,0,3,3.127
+Fall 2023,ECON,3320,1,16884,Intro to Econ Data Analysis,Troncoso,Pablo A,12,24,26,6,5,0,7,2.434
+Fall 2023,CLAS,3307,1,16885,Greek & Roman Myths of Heroes,Kidder,Kathleen,15,9,0,1,0,0,4,3.401
+Fall 2023,CLAS,4381,1,16886,Latin Classics in Translation,Behr,Francesca D,10,4,3,1,1,0,2,3.018
+Fall 2023,CHIN,6382,1,16887,Tales of East Asian Cities,Li,Melody Yunzi,1,0,0,0,0,0,0,4.0
+Fall 2023,KIN,3301,2,16888,Design/Eval Phys Activity Prog,Graham,Marilynn Hadassah,44,13,1,0,0,0,1,3.707
+Fall 2023,KIN,3305,2,16889,Sport Sociology,Hawkins,Billy J,12,27,8,0,0,0,1,3.057
+Fall 2023,KIN,3305,3,16890,Sport Sociology,Ogunrinde,Joyce,11,15,7,4,2,0,5,2.752
+Fall 2023,KIN,4315,2,16891,Motor Learning and Control,Park,Seoung Hoon,24,2,0,0,1,0,1,3.741
+Fall 2023,ENGL,3323,1,16892,Development of Lit Crit & Thry,Berger,Jason,17,8,2,0,0,0,3,3.556
+Fall 2023,BIOE,4348,1,16893,Tissue Engineering,Horton,Renita Elillian,1,0,1,0,0,0,0,3.0
+Fall 2023,ECON,3344,1,16894,History of Economic Doctrine,Saboury,Piruz,23,4,1,2,0,0,3,3.556
+Fall 2023,ITAL,1501,3,16895,Elementary Italian I,Nicosia,Alda,4,1,0,0,0,0,2,3.734
+Fall 2023,HIST,1302,7,16897,The U.S. Since 1877,Zarnow,Leandra Ruth,143,89,21,3,13,0,23,3.246
+Fall 2023,HIST,1302,52,16898,The U.S. Since 1877,Modaff,Abigail,19,2,1,1,0,0,1,3.71
+Fall 2023,WCL,4351,1,16899,Frames of Modernity I,Nguyen,Duy,5,6,0,0,1,0,1,3.112
+Fall 2023,WCL,3342,1,16901,Tales of East Asian Cities,Li,Melody Yunzi,4,1,0,0,0,0,0,3.8
+Fall 2023,COMD,6372,3,16902,Remediation of Child Lang Dis,Ivey,Michelle L,22,20,2,0,0,0,0,3.425
+Fall 2023,PSYC,7339,1,16905,CDLNeuropsych: Assess/App III,Medina,Luis Daniel,3,0,0,0,0,0,0,4.0
+Fall 2023,COMD,2339,5,16906,Language Development,Mills,Monique T,23,13,0,1,0,0,0,3.523
+Fall 2023,COMD,2339,6,16907,Language Development,Mills,Monique T,22,6,4,1,1,0,2,3.363
+Fall 2023,ENGI,2304,16,16909,Technical Communications,Salvo,Deborah C,23,2,0,1,0,0,0,3.706
+Fall 2023,KIN,4330,1,16910,Child and Adolescent Obesity,Breslin,Whitney L,16,13,9,1,2,0,2,2.919
+Fall 2023,KIN,4365,1,16911,Legal/Ethical Aspects of Sport,Cottingham,Michael,12,18,11,3,3,0,6,2.646
+Fall 2023,BIOL,1306,51,16912,Biology for Science Majors I,Hanke,Marc H,3,6,7,2,0,0,3,2.519
+Fall 2023,BIOL,1306,52,16913,Biology for Science Majors I,Hanke,Marc H,6,13,5,5,0,0,0,2.769
+Fall 2023,BIOL,1306,53,16914,Biology for Science Majors I,Sharp,Rita Evelyn,19,5,2,2,0,0,0,3.429
+Fall 2023,GHL,4343,2,16915,Financial Admin for Hosp.Ind.,Johnson,Tucker A,24,17,10,0,0,0,0,3.229
+Fall 2023,HIST,3324,1,16916,Oral History Methods,Harwell,Debbie Z,10,0,0,0,1,0,0,3.606
+Fall 2023,HON,3304,1,16917,Material Cultures of Medicine,Lunstroth,John,12,3,0,0,0,0,0,3.646
+Fall 2023,ARCH,6393,4,16918,Master's Project Preparation,Longoria,Rafael R,5,4,0,0,0,0,0,3.666
+Fall 2023,PSYC,4305,1,16920,Persuasion & Behavior,Knee,Clifford R,20,0,0,0,0,0,0,3.934
+Fall 2023,GHL,3440,1,16922,Hotel Operations,Cheatham,Cathy A,27,8,2,2,1,0,0,3.458
+Fall 2023,GHL,4361,1,16923,Marketing Strategies,Mohamed,Mohamed Elsayed AbdElaziz,14,15,3,4,0,0,2,3.083
+Fall 2023,GHL,4370,1,16924,Project Dev & Mgmt in Hosp Ind,Li,Ningqiao,14,0,0,0,0,0,1,3.953
+Fall 2023,PEP,6355,3,16926,Promotional Strategies,Cottingham,Michael,9,6,1,0,0,0,0,3.521
+Fall 2023,BIOE,4150,1,16928,Genomic & Proteomic Lab,Akay,Metin,3,1,0,0,0,0,0,3.75
+Fall 2023,SOCW,7301,1,16931,Confronting Oppression & Injus,Barthelemy,Juan,28,2,1,0,1,0,1,3.75
+Fall 2023,SOCW,7301,2,16932,Confronting Oppression & Injus,Barthelemy,Juan,20,2,1,0,0,0,0,3.826
+Fall 2023,SOCW,7301,3,16934,Confronting Oppression & Injus,Mendoza,Yvonne Anette,26,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7301,4,16935,Confronting Oppression & Injus,Shepherd,Donisha Shanice,23,0,0,0,0,0,0,4.0
+Fall 2023,PHIL,1301,5,16936,Intro To Philosophy,Aiman,Edwin E,45,17,5,2,4,0,2,3.275
+Fall 2023,GHL,7337,1,16937,Human Resources in Hospitality,Madera,Juan Manuel,14,0,0,0,1,0,0,3.733
+Fall 2023,GHL,7341,1,16938,Food and Beverage Management,Legendre,Jungyoung Shin,18,1,0,0,2,0,0,3.556
+Fall 2023,HIST,2312,1,16941,Western Civilization from 1450,Ittmann,Karl,10,8,11,2,3,0,0,2.579
+Fall 2023,CHEM,1312,3,16942,Fundamentals of Chemistry 2,Czernuszewicz,Roman S,14,24,29,13,24,0,44,1.907
+Fall 2023,PHIL,1321,3,16945,Logic I,Haaga,Curtis W,17,15,3,2,2,0,9,3.06
+Fall 2023,COSC,1437,5,16946,Introduction to Programming,Rincon Castro,Carlos Alberto,44,20,19,7,12,0,15,2.739
+Fall 2023,COSC,2306,1,16948,Data Programming,Yan,Feng,19,8,12,4,1,0,6,2.887
+Fall 2023,COSC,4337,1,16949,Data Science II,Rizk,Nouhad J,7,19,4,2,1,0,0,2.879
+Fall 2023,COSC,6376,1,16951,Cloud Computing,Shi,Weidong,53,16,0,0,0,0,0,3.687
+Fall 2023,GHL,6352,1,16952,Hospitality Market Analysis,McCaslin,Glynn Randle,36,0,0,0,0,0,0,4.0
+Fall 2023,MATH,6360,1,16955,Applicable Analysis,Onofrei,Daniel T,6,0,0,0,0,0,0,4.0
+Fall 2023,NUTR,4345,2,16965,The Obesity Epidemic,Alastuey,Lisa L,58,38,8,0,2,0,0,3.353
+Fall 2023,TEPM,6304,1,16966,Quality Improvemnt in Proj Mgt,Kovach,Jamison,20,0,0,0,0,0,0,4.0
+Fall 2023,ATP,6113,3,16969,Lower Extremity Evaluation Lab,Harrison,Layci,11,3,0,0,0,0,0,3.786
+Fall 2023,ATP,6112,3,16970,Therapeutic Intervention 1 Lab,Gililland,Darrell Jon,14,0,0,0,0,0,0,4.0
+Fall 2023,ATP,6313,3,16971,Lower Extremity Evaluation,Harrison,Layci,7,7,2,0,0,0,0,3.313
+Fall 2023,ATP,7112,1,16972,Therapeutic Intervention 2 Lab,Gililland,Darrell Jon,15,0,0,0,0,0,0,4.0
+Fall 2023,BUSI,3300,4,16973,Intro to Personal Finance,Munchbach,Jim,44,2,0,2,2,0,3,3.64
+Fall 2023,FINA,4320,6,16974,Investment Management,Suleymanov,Masim,10,25,4,2,1,0,0,3.015
+Fall 2023,FINA,4353,3,16975,Practicum Pers Finan Planning,Lopez,John C,8,1,3,0,0,0,0,3.362
+Fall 2023,BUSI,3300,5,16976,Intro to Personal Finance,Munchbach,Jim,47,2,2,0,0,0,4,3.824
+Fall 2023,BUSI,3300,6,16977,Intro to Personal Finance,Harvey,Danny,55,0,0,0,0,0,0,4.0
+Fall 2023,BUSI,3300,7,16978,Intro to Personal Finance,Harvey,Danny,55,0,0,0,0,0,0,4.0
+Fall 2023,INDS,2500,5,16981,Industrial Design Studio III,Chow,George K,4,10,0,0,0,0,0,3.356
+Fall 2023,DIGM,3350,30,16985,Graph Comm Prod Processes,Pegram,Norman,10,4,0,0,0,0,1,3.596
+Fall 2023,DIGM,4351,30,16986,Portfolio Development for DIGM,Hargrove,Mark Stephen,63,19,0,0,0,0,1,3.728
+Fall 2023,INDS,3340,1,16990,Computer Aided Indus Design II,Chow,George K,6,18,0,0,0,0,0,3.209
+Fall 2023,INDS,6340,1,16993,Advanced Design Materials,Jackson,Megan H,1,1,0,0,0,0,0,3.5
+Fall 2023,INDS,4260,1,16995,Design Issues II,Jackson,Megan H,5,5,0,0,0,0,0,3.467
+Fall 2023,SPAN,1501,5,16996,Elementary Spanish I,Carrera Quiroga,Emilio Vicente,10,9,5,1,2,0,1,2.803
+Fall 2023,SPAN,1502,7,16998,Elementary Spanish II,Besovic,Helena,13,6,4,0,2,0,1,3.107
+Fall 2023,SPAN,2311,3,17000,Intermediate Spanish I,Scalzo,Dillon S,15,10,3,0,0,0,0,3.358
+Fall 2023,SPAN,1501,15,17001,Elementary Spanish I,Gonzalez,Viviannette,7,9,2,1,1,0,3,2.967
+Fall 2023,PSYC,2316,2,17003,Psychology of Personality,Damian,Rodica Ioana,36,34,6,1,0,0,0,3.295
+Fall 2023,PSYC,2316,3,17004,Psychology of Personality,Damian,Rodica Ioana,27,25,2,1,2,0,1,3.2
+Fall 2023,INDS,6360,3,17005,Industrial Design Studio,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Fall 2023,SCLT,2362,33,17007,Intro To Logistics Technology,Cassler,Daniel,33,24,2,0,0,0,2,3.436
+Fall 2023,SCLT,2380,30,17008,Distribution Channels,Elliott,Stephen Dwight,16,53,30,14,4,0,8,2.598
+Fall 2023,SCLT,3381,32,17009,Industrial and Consumer Sales,Cassler,Daniel,30,16,0,0,0,0,0,3.566
+Fall 2023,SCLT,6316,1,17010,Global Supply Chain Logistics,Wang,Kailai,7,2,0,0,0,0,0,3.814
+Fall 2023,PSYC,2319,4,17011,Intro to Social Psychology,Ravey,Eriksen,24,14,1,0,1,0,0,3.434
+Fall 2023,SCLT,6318,2,17012,Supply Chain Strategies,Bian,Zheyong,3,0,0,1,0,0,0,3.25
+Fall 2023,PSYC,3339,3,17014,Intro To Clinical Psychology,Healy,Nathaniel Andrew,23,30,14,1,1,0,8,3.029
+Fall 2023,CNST,1330,2,17015,Graphics I,Lyon,Eva Yaneth,19,34,0,0,1,0,1,3.254
+Fall 2023,ARCH,1500,41,17017,Design Studio I,Plauche',Roya,7,5,1,0,0,0,1,3.411
+Fall 2023,CNST,2351,2,17023,Construction Estimating I,Liggin,Gregory G,9,21,10,1,1,0,1,2.857
+Fall 2023,CNST,3331,2,17024,Constructn Plan and Scheduling,Weintraub,Marvin Stanley,9,12,5,2,1,0,0,2.897
+Fall 2023,CNST,3351,2,17025,Construction Estimating II,Siddiqui,Muhammad Ali,17,13,2,0,0,0,0,3.355
+Fall 2023,CORE,1101,2,17026,College Success,McKissic,Veronica,4,4,4,1,1,0,1,2.643
+Fall 2023,CORE,1101,3,17027,College Success,Jones,Tashemia V,4,4,1,0,0,0,3,3.223
+Fall 2023,CORE,1101,4,17028,College Success,Brower,Samuel Richard,8,6,2,1,0,0,0,3.216
+Fall 2023,CORE,1101,5,17029,College Success,Thomas,Dustine J,3,3,0,1,0,0,0,3.049
+Fall 2023,CORE,1101,7,17030,College Success,Mahoney,Margaret Elizabeth,7,1,1,0,0,0,0,3.667
+Fall 2023,CORE,1101,8,17031,College Success,Guidry,Vanessa Lynn,12,0,0,0,0,0,0,4.0
+Fall 2023,INTB,3361,1,17032,Global Engagement and Research,Miljanic,Andra Olivia,2,0,0,0,0,0,0,3.835
+Fall 2023,CORE,1101,12,17034,College Success,King,Kelly N,7,5,1,1,1,0,1,3.133
+Fall 2023,CORE,1101,13,17035,College Success,Warren,Celene,11,3,3,0,1,0,2,3.259
+Fall 2023,CORE,1101,14,17036,College Success,Floyd,Monica,8,2,4,1,0,0,0,3.111
+Fall 2023,CORE,1101,15,17037,College Success,Perry,Deidra,11,2,3,0,1,0,1,3.197
+Fall 2023,CORE,1101,16,17038,College Success,Simpson,James Keir,8,2,1,0,0,0,0,3.666
+Fall 2023,CORE,1101,23,17040,College Success,Johnson,Whitney Nicole,6,1,1,0,2,0,0,2.867
+Fall 2023,ARTS,2346,1,17041,Fundamentals of Ceramics,Oloshove,Angel,12,2,0,0,0,0,1,3.904
+Fall 2023,ARTS,2346,2,17042,Fundamentals of Ceramics,Oloshove,Angel,14,1,0,0,0,0,1,3.889
+Fall 2023,CORE,1101,24,17043,College Success,Vernon-Harrison,Miranda Angelena,11,2,2,0,0,0,0,3.578
+Fall 2023,CORE,1101,25,17044,College Success,Phan,Trang Anh Thuc,13,2,1,0,0,0,0,3.688
+Fall 2023,CORE,1101,27,17045,College Success,Price,Chelsea T,4,2,0,1,0,0,2,3.286
+Fall 2023,MECE,6384,2,17047,Methods of Applied Math I,Chen,Yi-Chao,1,3,5,1,1,0,4,2.182
+Fall 2023,MECE,6345,2,17048,Fluid Dynamics 1,Yang,Di,0,4,0,0,2,0,4,2.0
+Fall 2023,ELET,4105,1,17050,Senior Design Lab in EPET,Shi,Jian,1,0,0,0,0,0,0,4.0
+Fall 2023,ELET,4305,1,17051,Senior Design in EPET,Shi,Jian,26,0,0,0,0,0,0,4.0
+Fall 2023,CORE,1101,35,17052,College Success,Jones,Amber R,7,4,1,1,0,0,0,3.257
+Fall 2023,CORE,1101,36,17053,College Success,Spraggins,Brent R,4,0,2,0,1,0,0,2.904
+Fall 2023,CORE,1101,38,17055,College Success,Reed,Erin A,5,1,0,1,0,0,0,3.334
+Fall 2023,CORE,1101,42,17056,College Success,Thomas,Trever LeAnn,2,0,2,0,2,0,0,2.0
+Fall 2023,CORE,1101,44,17057,College Success,McCorr,Larreishia,4,3,1,2,1,0,0,2.516
+Fall 2023,CHEE,8598,13,17059,Doctoral Research,Orman,Mehmet,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8598,14,17060,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8598,15,17061,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,9,0,
+Fall 2023,CHEE,8598,16,17062,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8598,17,17063,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,4,0,
+Fall 2023,CHEE,8598,18,17064,Doctoral Research,Vekilov,Peter,0,0,0,0,0,2,0,
+Fall 2023,HDCS,1300,6,17068,Human Ecosystems & Tech Change,Vercher,Michelle Taylor,32,24,3,1,0,0,0,3.379
+Fall 2023,HDCS,1300,7,17069,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,40,11,2,2,3,0,2,3.403
+Fall 2023,ECE,5321,1,17071,Intro Nano Design & Fab,Brankovic,Stanko R,0,1,0,0,0,0,0,3.0
+Fall 2023,ACCT,3368,3,17072,Intermediate Accounting II,Sun,Xue,12,18,7,0,0,0,2,3.224
+Fall 2023,CIVE,6377,1,17073,Environmental Chemistry,Rahimi,Mohammad,10,2,0,0,0,0,0,3.751
+Fall 2023,SPAN,4343,1,17074,Health & Society in Hisp World,Zubiate,Maria Laura,10,0,0,0,0,0,0,3.967
+Fall 2023,LAW,5344,1,17077,Appellate Advocacy I,Flores,Chad,8,22,0,0,0,2,0,3.366
+Fall 2023,ARTS,3370,1,17078,Traditional Photography,Casagranda,Madison Anne,14,1,0,0,2,0,1,3.432
+Fall 2023,MECT,3360,30,17080,Automated Manufacturing System,Risal,Sandesh,12,19,6,1,3,0,3,2.854
+Fall 2023,ENGL,3317,1,17084,The British Novel Before 1832,Mazella,David S,18,1,1,1,2,0,7,3.391
+Fall 2023,ENGL,3343,1,17086,Advanced Composition: Style,Butler,Paul G,8,9,0,0,0,0,3,3.432
+Fall 2023,ENGL,4385,1,17088,Fiction Forms,Kanwal,Tayyba,20,1,0,0,0,0,0,3.858
+Fall 2023,MANA,4341,2,17089,Leading Organizational Change,Lozano Garcia,Miguel Angel,10,1,0,0,1,0,0,3.583
+Fall 2023,ENGL,6313,1,17090,Modern Literary Theory,Aboul-Ela,Hosam,11,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4347,1,17092,Ethics and Corp Soc Respon.,Salaiz,Ashley,51,6,2,0,1,0,0,3.745
+Fall 2023,ENGL,7323,1,17093,Advncd Fiction Workshop,Divakaruni,Chitra B,4,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4336,1,17094,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,10,34,10,2,1,0,3,2.848
+Fall 2023,MANA,4337,1,17095,Stress and Work,Sebastijanovic,Marina,48,9,2,0,0,0,0,3.774
+Fall 2023,MANA,4355,2,17097,Selection and Staffing,Zamanipour,Tina,34,8,1,0,0,0,2,3.767
+Fall 2023,ENGL,8392,1,17098,Topics in Poetics,Snediker,Michael,10,2,0,0,0,0,0,3.778
+Fall 2023,MANA,4385,2,17099,Intro to Strategic Management,Tabesh,Pooya,42,8,6,0,0,0,1,3.578
+Fall 2023,ENGL,2330,3,17100,Writing Discipline English,Presswood,Phillip Hilliard,16,0,0,0,3,0,0,3.316
+Fall 2023,HRD,3346,1,17101,Performance Assessment & Eval,Del Grande,Lisa,46,4,1,0,0,0,1,3.818
+Fall 2023,HRD,4350,1,17102,Org Dev & Consulting,Clancy,James Patrick,16,5,0,0,0,0,1,3.715
+Fall 2023,ECE,3355,2,17103,Electronics,Ruchhoeft,Paul,10,4,2,0,2,0,1,3.056
+Fall 2023,SOCI,1301,14,17105,Introduction To Sociology,Dorsey,Patricia Lynne,18,24,11,2,4,0,1,2.831
+Fall 2023,GENB,5335,1,17106,Brainstorming to Bankrolling,Khumawala,Saleha B,1,0,0,0,0,0,0,4.0
+Fall 2023,MANA,6A25,6,17107,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,12,8,1,0,1,0,0,3.364
+Fall 2023,GOVT,2306,11,17108,US and Texas Const/Politics,Littlepage,Kelley G,86,102,29,8,12,0,9,3.014
+Fall 2023,ARCH,6603,7,17109,Architecture Design Studio III,Johnson,Matthew W,9,2,0,0,0,0,0,3.698
+Fall 2023,ARCH,6603,9,17111,Architecture Design Studio III,Plauche',Roya,5,5,0,0,0,0,0,3.533
+Fall 2023,ARCH,6603,11,17113,Architecture Design Studio III,Woodfill,Celeste Ponce,3,7,0,1,0,0,0,3.031
+Fall 2023,LAW,6347,2,17115,Secured Financing,Hart,Matthew Olivier,4,12,0,0,0,0,0,3.209
+Fall 2023,LAW,6364,1,17116,Contract Drafting,Toedt III,Dell Charles,4,13,0,0,0,2,0,3.274
+Fall 2023,LAW,6364,2,17117,Contract Drafting,Toedt III,Dell Charles,5,9,0,0,0,2,0,3.31
+Fall 2023,LAW,5326,1,17118,Criminal Procedure,Braley,Timothy Shawn,19,39,2,0,0,10,0,3.195
+Fall 2023,LAW,5326,2,17119,Criminal Procedure,Bregant,Jessica Lynn,23,21,1,0,0,0,0,3.394
+Fall 2023,ARTS,4381,1,17120,Pursuing Utopia,Reed,John G,14,4,2,0,0,0,0,3.501
+Fall 2023,LAW,5383,2,17121,Family Law,Oldham,J Thomas,20,34,1,0,0,15,0,3.339
+Fall 2023,LAW,5307,1,17122,How to Reason,Crump,David L,10,12,0,0,0,0,0,3.395
+Fall 2023,HIST,4369,1,17123,Modern Mexico 1810 To Present,Cedillo,Adela Cedillo,2,9,0,0,1,0,0,2.917
+Fall 2023,FINA,4330,5,17127,Corporate Finance,Berger,Elizabeth,26,19,9,2,0,0,0,3.185
+Fall 2023,FINA,4330,6,17128,Corporate Finance,De Angelis,David,13,16,6,2,0,0,1,3.054
+Fall 2023,FINA,4330,7,17129,Corporate Finance,De Angelis,David,11,8,6,1,1,0,2,2.963
+Fall 2023,MUSI,6120,1,17132,Percussion Ensemble,Wilkins,Blake M,3,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7336,1,17133,Strategic Human Resource Mgt,Fernandez,Alejandro,15,0,1,0,0,0,0,3.875
+Fall 2023,MANA,7356,1,17134,Inclusive Leadership,Fernandez,Alejandro,25,0,0,0,0,0,0,3.987
+Fall 2023,MUSI,4378,1,17136,History of Jazz I,Marmolejo,Noe J,11,3,2,0,0,0,0,3.542
+Fall 2023,MUED,3105,1,17137,Strings,Hansen,Erin Melissa,1,3,0,1,0,0,0,2.866
+Fall 2023,MUED,3103,1,17138,Brasses,Bell,Priscilla Garrett,13,2,1,0,0,0,0,3.75
+Fall 2023,ECE,6112,1,17139,Department Colloquium,Nguyen,Hien V,0,0,0,0,0,4,0,
+Fall 2023,ECE,6317,1,17140,Motor Drives,Rajashekara,Kaushik,10,5,3,0,0,0,0,3.242
+Fall 2023,ARCH,3500,33,17141,Architecture Design Studio V,Clovis,Sam,6,9,2,0,0,0,0,3.177
+Fall 2023,ARCH,3500,35,17143,Architecture Design Studio V,Truitt,William C,10,5,0,0,0,0,0,3.557
+Fall 2023,ARCH,3500,37,17145,Architecture Design Studio V,Self,Ronnie L,5,7,1,2,2,0,0,2.608
+Fall 2023,ARCH,3500,39,17147,Architecture Design Studio V,Davis,Curtis M,2,4,7,0,1,0,0,2.311
+Fall 2023,ARCH,3500,41,17149,Architecture Design Studio V,Roldan Caballero,Jose Manuel,3,6,4,2,0,0,0,2.601
+Fall 2023,ARCH,3500,43,17151,Architecture Design Studio V,Jacobs,Daniel,7,7,2,0,0,0,0,3.292
+Fall 2023,OPTO,7230,1,17154,Glaucoma,Dempsey,Robert L,12,52,34,0,2,0,0,2.694
+Fall 2023,OPTO,7375,1,17155,Contact Lens II,Dempsey,Robert L,46,49,5,0,0,0,0,3.41
+Fall 2023,OPTO,7336,1,17156,Ocular Pathology III,Harrison,Wendy W,18,61,20,0,1,0,0,2.907
+Fall 2023,OPTO,7131,1,17157,Clinical Medicine,Dempsey,Robert L,81,10,8,0,0,0,0,3.737
+Fall 2023,NURS,6301,1,17159,Adv Rsrch Intgrtd Evdnce Prctc,Varghese,Shainy B,1,3,0,0,0,0,1,3.25
+Fall 2023,NURS,6333,1,17161,Population Health,Dwyer,Carol Ann,4,1,0,0,0,0,0,3.8
+Fall 2023,OPTO,8696,1,17162,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,27,0,
+Fall 2023,OPTO,8338,1,17163,Recent Developments/Round,Wheat,Joe L,13,16,1,0,0,0,0,3.411
+Fall 2023,OPTO,8384,1,17164,Practice Management II,Davis,Mark K,25,4,0,0,0,0,0,3.76
+Fall 2023,LAW,6213,1,17166,Innocence Investigations,Dow,David R,2,9,0,0,0,0,0,3.392
+Fall 2023,LAW,6240,1,17168,Death Penalty & Crim Appeals,Dow,David R,2,6,0,0,0,2,0,3.374
+Fall 2023,NURS,3311,2,17169,Health Assess Across Life Span,Kleinhans,Alicia Diane,9,25,0,2,0,0,2,3.139
+Fall 2023,NURS,4314,1,17171,Nursing Research,Connelly,Linda K,40,2,0,0,0,0,0,3.952
+Fall 2023,PUBL,6342,3,17173,Budgeting For Public Agencies,Koelling,Peter,9,1,0,0,0,0,0,3.9
+Fall 2023,CIVE,4364,1,17174,Structural Steel Design,Mercan,Bulent,11,21,6,2,1,0,0,2.895
+Fall 2023,THEA,2342,1,17175,Dramatic Structures & Genres,Coen,Elizabeth Manya,16,8,6,0,1,0,1,3.151
+Fall 2023,EDRS,8380,2,17176,Rsch Mthds in Educ,Johnson,Detra DeVerne,4,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8301,2,17177,Leadership Theory School Admin,Shockley,Gerald,5,0,0,0,0,0,0,4.0
+Fall 2023,GENB,6350,1,17178,Business Communications,Vandaveer,Amy L,11,0,0,0,0,0,0,3.97
+Fall 2023,MIS,3376,3,17179,Busn Appls Database Mgmt I,Jiang,Lianlian,57,2,0,0,0,0,1,3.977
+Fall 2023,MARK,4332,2,17180,Social Media Marketing,Zahn,William J,26,13,0,0,0,0,0,3.667
+Fall 2023,DANC,1103,1,17184,Freshman Seminar in Somatics,Valle,Toni Leago,14,4,0,0,0,0,0,3.741
+Fall 2023,MATH,1100,2,17185,Developmental Math,Caputo,Matthew G,0,0,0,0,0,79,5,
+Fall 2023,MATH,1100,3,17186,Developmental Math,Caputo,Matthew G,0,0,0,0,0,54,12,
+Fall 2023,MATH,1100,4,17187,Developmental Math,Caputo,Matthew G,0,0,0,0,0,9,2,
+Fall 2023,ARCH,7600,13,17188,Architecture Design Studio V,Munenzon Titelboim,Dalia,11,4,0,0,0,0,0,3.623
+Fall 2023,INDE,7340,1,17191,Integer Programming,Lim,Gino Jinho,2,1,0,0,0,0,0,3.777
+Fall 2023,HLT,2320,3,17192,Introduction to Public Health,Solari Williams,Kayce D,45,44,14,0,1,0,2,3.231
+Fall 2023,CIS,3347,2,17194,IS Infrastructure & Networking,Peddoju,Suresh Kumar,43,6,6,2,3,0,1,3.4
+Fall 2023,HON,4355,1,17196,Engaged Data,Konstantinidis,Ioannis,3,0,0,0,0,0,1,3.89
+Fall 2023,BUSI,2305,4,17197,Business Statistics,Wiley,Briceon C,20,12,10,2,2,0,4,2.957
+Fall 2023,CIS,4375,3,17198,Project Management & Practice,Martinez,Jose C,18,19,1,0,1,0,0,3.334
+Fall 2023,HLT,3304,1,17200,Child and Adolescent Health,Proctor,Robin Ann,61,26,3,0,0,0,0,3.567
+Fall 2023,LAW,5402,2,17203,Entrpr Community Dev Clinic I,Heard,Christopher D,1,7,0,0,0,0,0,3.373
+Fall 2023,HRD,6303,2,17206,Assessment & Evaluation in Hrd,Shin,Daeun,6,4,0,0,0,0,0,3.633
+Fall 2023,WGSS,2350,13,17207,Intro To Women's Studies,Slatton,Brittany Chevon,24,2,3,0,0,0,2,3.713
+Fall 2023,WGSS,2350,14,17208,Intro To Women's Studies,Slatton,Brittany Chevon,18,6,1,3,0,0,1,3.393
+Fall 2023,TLIM,3330,31,17211,Innovation Principles,Mehring,Brian George,5,7,6,2,2,0,2,2.485
+Fall 2023,WGSS,2360,7,17212,Introduction to LGBT Studies,Pegoda,Andrew Joseph,4,9,5,0,3,0,6,2.524
+Fall 2023,WGSS,2360,9,17214,Introduction to LGBT Studies,Stone,Lauren Michelle,23,4,2,1,0,0,0,3.611
+Fall 2023,BUSI,2305,5,17215,Business Statistics,Wiley,Briceon C,68,108,118,104,28,0,80,2.186
+Fall 2023,TLIM,3331,30,17216,Innovation Development,Crawley,David L,4,0,3,0,3,0,0,2.068
+Fall 2023,TLIM,4335,1,17217,Communicating Innovation,Crawley,David L,2,2,2,0,0,0,0,2.835
+Fall 2023,LAW,5342,1,17218,Prof Writing Strategies,Swift,Kenneth Richard,5,6,0,0,0,0,1,3.395
+Fall 2023,MUSI,4100,2,17221,Chamber Music,Bertman,David Garry,23,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4100,3,17222,Chamber Music,Bertman,David Garry,9,0,0,0,0,0,0,4.0
+Fall 2023,TLIM,3371,30,17223,Budgeting and Financial Princ,Burns,Maria,34,0,0,0,0,0,1,3.99
+Fall 2023,AAMS,4300,1,17224,Asian Amer Culture/Community,Nguyen,An,4,7,0,0,0,0,1,3.304
+Fall 2023,MARK,4379,2,17225,Personal Branding,Muschalik,Monica Harper,23,0,0,0,0,0,1,3.971
+Fall 2023,RELS,2360,1,17226,Introduction to Buddhism,Huynh,Trung,20,10,1,2,1,0,1,3.401
+Fall 2023,RELS,3339,1,17227,Secularisms and Atheisms,Pegoda,Andrew Joseph,5,10,1,1,4,0,2,2.54
+Fall 2023,LAW,5321,1,17230,Law Office Management,Grabowski,Paul Stanley,4,30,0,0,0,15,0,3.195
+Fall 2023,ARCH,2327,3,17231,Technology I,Diehl,Tom,15,45,27,10,7,0,3,2.506
+Fall 2023,CUIN,4325,1,17233,Teach Science in Grades 4-8 I,Varnado,Jakarda Wiltz,7,3,0,0,0,0,0,3.634
+Fall 2023,HLT,4303,2,17234,The Obesity Epidemic,Olvera,Norma E,19,25,9,5,0,0,2,2.898
+Fall 2023,ANTH,2301,1,17235,Intro to Physical Anthropology,McElvaney,Katherine Anne,13,18,6,2,2,0,2,2.959
+Fall 2023,ANTH,2302,1,17236,Introduction to Archeology,Chase,Arlen F,42,24,3,0,1,0,2,3.472
+Fall 2023,ANTH,2346,1,17237,Introduction to Anthropology,Rasmussen,Susan J,5,24,24,6,5,0,10,2.328
+Fall 2023,ANTH,6310,1,17238,Anthropological Resrch Design,Hannaford,Dinah Rebecca,5,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6393,5,17242,Master's Project Preparation,Froehlich,Dietmar,8,1,0,0,0,0,0,3.742
+Fall 2023,PHLS,8348,1,17243,Evidence-Based Practice,Smith,Bradley,6,0,0,0,0,0,0,4.0
+Fall 2023,INDE,8699,5,17244,Doctoral Dissertation,Lin,Ying,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6393,7,17248,Master's Project Preparation,Zweig,Peter J,8,1,0,0,0,0,0,3.779
+Fall 2023,MIS,8398,1,17249,Special Problems in MIS,Cooper,Randolph B,1,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,5368,2,17251,Intermediate Accounting II,Muslu,Volkan,1,5,2,1,0,0,0,2.703
+Fall 2023,CIS,4355,3,17252,Information Systems Operations,Peddoju,Suresh Kumar,46,6,4,3,2,0,1,3.492
+Fall 2023,MANA,4350,1,17255,International Management,Celly,Nikhil,51,8,1,0,0,0,0,3.745
+Fall 2023,FINA,4328,2,17256,Principles of Personal Finance,Coleman,Alfred G,44,7,1,1,0,0,1,3.755
+Fall 2023,FINA,6A35,5,17257,Managerial Finance,De Angelis,David,4,3,0,0,1,0,0,3.084
+Fall 2023,ACCT,4332,1,17258,Corporate Taxation,Fernandez,Ramon,5,6,1,0,0,0,0,3.388
+Fall 2023,ACCT,5332,3,17259,Taxation of Business Entities,Fernandez,Ramon,1,2,2,0,0,0,0,2.866
+Fall 2023,GENB,6350,2,17260,Business Communications,Vandaveer,Amy L,4,1,0,0,0,0,0,3.866
+Fall 2023,ARCH,4367,1,17261,Case Studies in Sustain Design,Taylor,Rives,6,2,2,0,0,0,0,3.4
+Fall 2023,SCM,6A01,4,17264,SCM Concepts,Sahin,Funda,6,6,0,0,0,0,1,3.473
+Fall 2023,SCM,7A01,1,17265,Project Management,Tibodeau,Dale,9,7,0,0,0,0,0,3.48
+Fall 2023,BIOE,6320,1,17269,Tissue Engineering,Horton,Renita Elillian,3,1,0,1,0,0,0,3.2
+Fall 2023,ARTS,3300,1,17270,Advanced Drawing,Peterson,John Ben,18,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,3300,2,17271,Advanced Drawing,Peterson,John Ben,17,3,0,0,0,0,0,3.85
+Fall 2023,NSS,4345,1,17275,Capstone - Nat. Sec. Studies,Curiel,Ernesto,3,1,0,0,2,0,0,2.445
+Fall 2023,FINA,7A10,4,17276,Valuation,Povel,Paul,2,0,0,0,0,0,0,3.835
+Fall 2023,FINA,4335,1,17277,Brainstorming to Bankrolling,Khumawala,Saleha B,16,1,2,0,0,0,0,3.685
+Fall 2023,MUSA,8320,5,17281,Doctoral Applied Music,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8199,3,17283,Dissertation,Margulis,Milena A,0,0,0,0,0,3,0,
+Fall 2023,BUSI,4396,2,17284,Business Internship,Wortzel,Zachary,0,0,0,0,0,7,0,
+Fall 2023,GEOL,8998,1,17286,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,4,0,
+Fall 2023,GEOL,8699,1,17290,Doctoral Dissertation,Stewart,Robert R,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8698,1,17292,Doctoral Research,Fu,Qi,0,0,0,0,0,2,0,
+Fall 2023,PHLS,8199,4,17293,Dissertation,de Dios,Marcel A,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8199,5,17298,Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Fall 2023,GEOL,8998,3,17300,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8998,4,17301,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2023,ACCT,5335,1,17303,Financial Statement Auditing,Kuruvilla,Mohan,2,2,0,0,0,0,1,3.253
+Fall 2023,ACCT,4335,2,17304,Financial Statement Auditing,Kuruvilla,Mohan,1,1,0,0,0,0,0,3.5
+Fall 2023,ACCT,5377,1,17305,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,7,6,2,0,0,0,0,3.355
+Fall 2023,SPAN,2311,6,17306,Intermediate Spanish I,Ruffino,Gustavo,7,9,8,0,0,0,0,2.945
+Fall 2023,SPAN,2311,8,17307,Intermediate Spanish I,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,4,16,6,0,2,0,0,2.691
+Fall 2023,SPAN,2312,6,17308,Intermediate Spanish II,Serrano,Paloma A,6,5,5,2,2,0,4,2.567
+Fall 2023,SPAN,2312,7,17309,Intermediate Spanish II,Morales Utria,Yordanis,9,12,5,0,0,0,0,3.078
+Fall 2023,COSC,6360,1,17310,Operating Systems,Cheng,Albert M K,2,5,0,0,1,0,2,2.916
+Fall 2023,PHLS,8699,4,17311,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8998,7,17314,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,
+Fall 2023,BIOE,4115,3,17315,Intro Bioinstrumentation Lab,An,Ran,18,1,0,0,1,0,0,3.767
+Fall 2023,INDS,6330,1,17319,Comp Aided Industr Design II,Chow,George K,0,1,0,0,0,0,0,3.33
+Fall 2023,PHAR,5675,4,17322,Disease State Management,Rosario,Natalie,5,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5696,4,17324,Ambulatory Care - Primary Care,Rosario,Natalie,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8999,2,17329,Doctoral Dissertation,Choi,Yunsoo,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8698,5,17330,Doctoral Research,Castagna,John P,0,0,0,0,0,1,0,
+Fall 2023,ENGL,4386,1,17335,Short Story Writing,Fretwell,Leah M,12,2,1,0,1,0,0,3.438
+Fall 2023,SPAN,2311,9,17338,Intermediate Spanish I,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,4,12,5,1,1,0,1,2.753
+Fall 2023,SPAN,2312,3,17339,Intermediate Spanish II,Serrano,Paloma A,6,7,8,0,1,0,1,2.683
+Fall 2023,BUSI,4396,3,17340,Business Internship,Newman,Michael Ray,0,0,0,0,0,3,0,
+Fall 2023,GEOL,8398,3,17344,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,1,0,
+Fall 2023,CHEM,3333,1,17347,Inorganic Chemistry I,Zastrow,Melissa L,13,32,9,0,1,0,4,3.006
+Fall 2023,BZAN,7320,1,17348,Bus Modeling For Comp Adv,Murray,Michael J,8,5,0,0,0,0,0,3.666
+Fall 2023,DRAM,1310,14,17349,Introduction to Theatre,Egging,Jon Leo,32,10,2,2,1,0,1,3.447
+Fall 2023,PETR,6350,2,17353,Natural Gas Engineering,Farouq-Ali,Syed,1,1,0,0,0,0,1,3.335
+Fall 2023,PETR,6352,2,17354,Shale Reservoirs,Hathon,Lori A,2,2,0,0,0,0,0,3.418
+Fall 2023,PETR,6362,2,17355,Reservoir Engineering I,Lee,Kyung Jae,4,0,0,0,0,0,0,3.753
+Fall 2023,PETR,6368,2,17356,Well Drilling and Completion I,Samuel,Robello,3,0,1,0,0,0,1,3.418
+Fall 2023,PETR,6372,2,17357,Petroleum Production Operation,Wong,George K,0,2,1,0,0,0,1,2.667
+Fall 2023,PETR,6332,2,17358,Deterministic Reserves Estimat,Zargar,Zeinab,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7398,3,17359,Special Problems,Boswell,Robert L,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,3399,1,17361,Senior Honors Thesis,Hernandez,Jose A,0,0,0,0,0,0,0,
+Fall 2023,GEOL,8998,13,17362,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,2,0,
+Fall 2023,GEOL,8698,6,17363,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7399,4,17367,Masters Thesis,Robinson,Alexander C,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,6399,4,17369,Masters Thesis,Khan,Shuhab D,0,0,0,0,0,1,0,
+Fall 2023,WGSS,2350,17,17371,Intro To Women's Studies,Shelton,Laura,18,6,0,0,0,0,1,3.75
+Fall 2023,GEOL,8398,4,17373,Doctoral Research,Murphy,Michael,0,0,0,0,0,2,0,
+Fall 2023,MUSA,8240,4,17374,Doctoral Recital I,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8399,3,17376,Doctoral Dissertation,Crawford,Kerri M,1,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,7316,1,17379,Pharmacoepidemiology,Chen,Hua,2,3,0,1,0,0,0,3.0
+Fall 2023,PHCA,7306,1,17380,Health Outcomes and Quality,Aparasu,Rajender R,2,3,1,0,0,0,0,3.167
+Fall 2023,BIOE,8298,26,17381,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2023,MATH,6380,2,17382,Programming for Data Analytics,Shastri,Dvijesh J,1,4,0,0,0,0,1,3.134
+Fall 2023,MATH,6358,3,17383,Probability & Stat. Computing,Poliak,Cathy Dawn,4,0,0,0,0,0,1,4.0
+Fall 2023,GEOL,8698,7,17384,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,1,0,
+Fall 2023,MECE,8399,19,17385,Doctoral Dissertation,Ardebili,Haleh,0,0,0,0,0,1,0,
+Fall 2023,FINA,6387,5,17387,Managerial Analysis,Basu,Swati,23,9,0,0,0,0,0,3.688
+Fall 2023,INDE,2333,2,17390,Engineering Statistics I,Wiggins,Nathanial David,17,6,0,1,0,0,1,3.515
+Fall 2023,ENGR,2301,3,17391,Mechanics I (Statics),Wu,Yuntian,5,9,0,0,0,0,1,3.357
+Fall 2023,MUSA,8240,5,17392,Doctoral Recital I,Krager,Franz A,1,0,0,0,0,0,0,4.0
+Fall 2023,MIS,7373,1,17394,Bus Appls Database Mgt Sys I,Scamell,Richard W,7,1,1,0,0,0,0,3.52
+Fall 2023,GHL,6382,1,17395,Meth of Res in Hospitality Ind,Legendre,Jungyoung Shin,5,1,0,0,0,0,1,3.888
+Fall 2023,GEOL,8998,14,17401,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,4,0,
+Fall 2023,GEOL,8998,15,17403,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,7,0,
+Fall 2023,HIST,1302,53,17405,The U.S. Since 1877,Modaff,Abigail,19,3,2,1,0,0,0,3.574
+Fall 2023,TMTH,3360,1,17408,Applied Technical Statistics,Schroeder,Susan L,12,24,9,1,1,0,2,2.922
+Fall 2023,PHLS,8699,5,17410,Doctoral Dissertation,Margulis,Milena A,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8399,3,17411,Doctoral Dissertation,Dauwalder,Brigitte,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6326,1,17413,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,6399,4,17415,Master's Thesis,Harren,Natilee O,1,0,0,0,0,0,0,3.67
+Fall 2023,GEOL,8998,17,17417,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2023,ENGL,6311,1,17420,Research Methods,Christensen,Ann C,5,3,4,0,0,0,2,3.138
+Fall 2023,GEOL,8398,5,17422,Doctoral Research,Mann,Paul,0,0,0,0,0,2,0,
+Fall 2023,PUBL,6346,1,17424,Seminar Emergency Mgt,Sanchez,Francisco,7,1,0,0,0,0,0,3.916
+Fall 2023,ECE,6305,2,17425,Power Electronics,Krishnamoorthy,Harish Sarma,3,13,4,0,0,0,2,2.901
+Fall 2023,CIS,6324,1,17427,Cybersecurity Risk Management,Conklin,William A,13,11,0,0,0,0,0,3.487
+Fall 2023,COSC,4370,1,17428,Interactive Computer Graphics,Deng,Zhigang,42,19,1,0,2,0,2,3.48
+Fall 2023,MECE,8298,25,17429,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,4,0,
+Fall 2023,BZAN,6350,2,17430,Quant Found for Busi Analytics,Tan,Yinliang,10,5,0,0,2,0,2,3.196
+Fall 2023,ENGL,1301,29,17432,First Year Writing I,Moore,Kelly L,5,10,3,0,0,0,0,2.964
+Fall 2023,ENGL,1301,104,17433,First Year Writing I,Horton,Lara,6,8,6,0,0,0,0,2.984
+Fall 2023,ENGL,1301,107,17434,First Year Writing I,Horton,Lara,9,9,1,0,1,0,0,3.118
+Fall 2023,ENGL,1301,108,17435,First Year Writing I,Moore,Kelly L,10,10,0,0,0,0,0,3.434
+Fall 2023,ENGL,1301,114,17436,First Year Writing I,Moore,Kelly L,13,7,0,0,0,0,0,3.551
+Fall 2023,ENGL,1301,116,17437,First Year Writing I,McAlister,Susan Barbara,4,8,4,1,3,0,0,2.434
+Fall 2023,ENGL,1301,117,17438,First Year Writing I,Edens,Jenifer,6,1,6,1,4,0,0,2.222
+Fall 2023,ENGL,1301,118,17439,First Year Writing I,Edens,Jenifer,17,3,0,0,0,0,0,3.834
+Fall 2023,ENGL,1301,126,17440,First Year Writing I,Bass,Kasey Dawn,14,2,1,1,0,0,0,3.556
+Fall 2023,GEOL,8999,4,17446,Doctoral Dissertation,Zhou,Hua-Wei,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLA,6206,1,17448,Lean Six Sigma,Garey,Kevin W,6,1,0,0,0,0,0,3.857
+Fall 2023,TLIM,3330,32,17450,Innovation Principles,Feriante,Chris,10,9,8,0,0,0,1,3.111
+Fall 2023,ECE,6337,2,17452,Stochastic Processes,Prasad,Saurabh,6,1,0,0,0,0,0,3.621
+Fall 2023,MUSA,6350,1,17454,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2023,HRD,6353,30,17455,Methods of Adult Learning,Shirmohammadi,Melika,5,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,7399,7,17456,Masters Thesis,Mann,Paul,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8998,19,17457,Doctoral Research,Bissada,Kadry K,0,0,0,0,0,1,0,
+Fall 2023,FINA,6A35,6,17462,Managerial Finance,De Angelis,David,15,9,1,0,1,0,0,3.423
+Fall 2023,FINA,6A35,7,17463,Managerial Finance,Berger,Elizabeth,18,17,1,2,0,0,2,3.333
+Fall 2023,PUBL,6314,1,17464,Administrative Law,Abbott Jr,Kenneth Wayne,8,0,0,0,0,0,0,3.959
+Fall 2023,MECE,7399,16,17465,Masters Thesis,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2023,PCOL,8399,3,17466,Doctoral Dissertation,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2023,MECE,8298,26,17468,Doctoral Research,Chen,Zheng,0,0,0,0,0,4,0,
+Fall 2023,COSC,4377,901,17472,Intro To Computer Networks,Long,Kevin B,50,53,15,0,1,0,3,3.269
+Fall 2023,BIOL,6398,4,17474,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6398,8,17477,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2023,COSC,6306,1,17479,Data Structures,Mukherjee,Arjun,4,0,0,1,0,0,0,3.268
+Fall 2023,MECE,8398,1,17482,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,3,0,
+Fall 2023,BIOL,6498,3,17485,Special Problems,Chung,Sanghyuk,0,0,0,0,0,6,0,
+Fall 2023,BIOL,6498,5,17487,Special Problems,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6498,8,17490,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6498,9,17491,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2023,BZAN,6351,2,17492,Basic Prog for Busi Analytics,Wang,Cheng,62,0,1,1,0,0,1,3.922
+Fall 2023,ANTH,4310,1,17493,Theories of Culture,Small,Ivan Victor,20,2,3,0,2,0,2,3.407
+Fall 2023,IRW,1300,2,17512,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,37,0,
+Fall 2023,ENGL,1301,14,17513,First Year Writing I,Campese,Kathleen Ann,13,6,1,1,2,0,0,3.203
+Fall 2023,ENGL,1301,38,17514,First Year Writing I,Downey,Carlton M,21,1,0,0,3,0,0,3.467
+Fall 2023,MECE,8298,29,17521,Doctoral Research,Song,Gangbing,0,0,0,0,0,2,0,
+Fall 2023,MECE,8298,30,17523,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2023,MECE,8398,3,17527,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,26,17529,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8699,10,17531,Doctoral Dissertation,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,2330,4,17533,Writing Discipline English,Coleman,Quintin,11,6,2,0,1,0,0,3.267
+Fall 2023,ENGL,2330,5,17534,Writing Discipline English,Ornell,Colby,13,4,0,1,1,0,1,3.386
+Fall 2023,DANC,2202,1,17535,Sophomore Technique,Lockett,KeyAira,17,2,1,0,0,0,0,3.8
+Fall 2023,OPTO,5250,1,17536,Seminar Scientific Investigatn,Frishman,Laura J,1,0,0,0,0,0,0,4.0
+Fall 2023,OPTO,5198,3,17540,Spec Prob - Clerkship,Berntsen,David A,0,0,0,0,0,8,0,
+Fall 2023,MUSA,8420,1,17544,Doctoral Applied Music,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,6598,2,17554,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6598,3,17555,Special Problems,Briggs,James M,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6598,4,17556,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2023,PHOP,6767,3,17566,Research Practicum A,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,6598,6,17568,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6298,2,17572,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2023,CIVE,7342,3,17580,Engineer Geographic Info. Syst,Xie,Surui,3,1,0,0,0,0,0,3.75
+Fall 2023,GEOL,8398,7,17583,Doctoral Research,Stewart,Robert R,0,0,0,0,0,2,0,
+Fall 2023,BIOE,6350,2,17586,Genomic and Proteomic Engr,Wu,Tianfu,15,1,0,0,0,0,0,3.958
+Fall 2023,BIOL,6598,3,17589,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6598,4,17590,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6598,7,17593,Special Problems,Dryer,Stuart E,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6598,9,17595,Special Problems,Pennings,Steven C,0,0,0,0,0,2,0,
+Fall 2023,BIOL,8598,6,17602,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8598,7,17603,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8598,9,17605,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2023,CHEE,6331,2,17606,Math Mtds in Chem Engr,Mountziaris,Triantafillos John,0,1,0,0,0,0,0,3.33
+Fall 2023,ECE,2201,3,17609,Circuit Analysis I,Shattuck,David P,20,19,12,4,2,0,6,2.895
+Fall 2023,BIOL,6298,4,17613,Special Problems,Pennings,Steven C,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6298,5,17614,Special Problems,Stuckert,Adam,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6298,6,17615,Special Problems,Dryer,Stuart E,0,0,0,0,0,0,0,
+Fall 2023,GEOL,8398,8,17620,Doctoral Research,Castagna,John P,0,0,0,0,0,2,0,
+Fall 2023,OPTO,5198,1,17622,Spec Prob - Clerkship,Dempsey,Robert L,0,0,0,0,0,9,0,
+Fall 2023,BZAN,4397,2,17627,Sel Topics in Bus Analytics,Wang,Cheng,4,1,0,0,0,0,2,3.8
+Fall 2023,PSYC,2305,31,17629,Intro to Methods in Psychology,Anderson,Jill Annette,69,39,7,2,0,0,1,3.468
+Fall 2023,HDCS,1300,8,17633,Human Ecosystems & Tech Change,Ginwright,Alexis Jordan,32,15,5,0,1,0,7,3.484
+Fall 2023,PETR,8298,5,17636,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,5,0,
+Fall 2023,FINA,8338,2,17639,Sem in Financial Management I,Kumar,Praveen,3,2,0,0,0,0,0,3.534
+Fall 2023,DIGM,1376,30,17640,User Experience (UX)Principles,Rodwell,Elizabeth Ann,91,77,34,18,17,0,5,2.846
+Fall 2023,MECE,8298,31,17641,Doctoral Research,Yang,Di,0,0,0,0,0,2,0,
+Fall 2023,ECE,2201,5,17643,Circuit Analysis I,Ramachandran,Deepa,2,2,1,6,0,0,0,1.88
+Fall 2023,MECE,8699,22,17644,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Fall 2023,ACCT,4379,1,17645,Enterprise Risk Management,Neely,Gregory Wayne,2,4,1,0,0,0,0,3.284
+Fall 2023,PHYS,2126,1,17650,University Physics Lab II,Wood,Lowell T,17,68,23,2,0,0,1,2.873
+Fall 2023,BIOL,8698,4,17653,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Fall 2023,ENGI,1331,8,17659,Computing for Engineers,Burleson,Daniel W,23,24,7,3,0,0,3,3.199
+Fall 2023,BIOL,8999,2,17660,Doctoral Dissertation,Fujita,Masaya,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8698,3,17670,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2023,PSYC,2305,33,17684,Intro to Methods in Psychology,Anderson,Jill Annette,54,49,9,0,5,0,1,3.265
+Fall 2023,MECE,8399,27,17687,Doctoral Dissertation,Liu,Dong,0,0,0,0,0,1,0,
+Fall 2023,MECE,8398,5,17688,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,
+Fall 2023,MECE,8298,32,17689,Doctoral Research,Franchek,Matthew,0,0,0,0,0,7,0,
+Fall 2023,MECE,8399,28,17690,Doctoral Dissertation,Franchek,Matthew,0,0,0,0,0,2,0,
+Fall 2023,ACCT,2302,2,17698,Prin of Managerial Accounting,Seltz,Joe D,14,17,24,6,3,0,2,2.593
+Fall 2023,ACCT,2302,4,17699,Prin of Managerial Accounting,Seltz,Joe D,5,13,17,6,3,0,7,2.303
+Fall 2023,ACCT,2302,5,17700,Prin of Managerial Accounting,Weber,Catherine K,45,29,13,6,0,0,2,3.279
+Fall 2023,ACCT,3371,2,17701,Accounting Information Systems,Seijas,Nuria S,12,7,1,2,2,0,3,3.069
+Fall 2023,ACCT,5371,1,17702,Accounting Information Systems,Seijas,Nuria S,5,4,1,0,0,0,0,3.4
+Fall 2023,GEOL,8998,20,17711,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,27,17715,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2023,MANA,6A32,3,17729,Organizational Behavior & Mgt,Krylova,Ksenia O,13,4,1,0,1,0,2,3.456
+Fall 2023,MECE,8398,6,17732,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,2,0,
+Fall 2023,MECE,8598,28,17734,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,4,0,
+Fall 2023,MECE,8399,32,17735,Doctoral Dissertation,Selvamanickam,Venkat,1,0,0,0,0,1,0,4.0
+Fall 2023,MECE,8398,9,17740,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2023,HLT,1353,3,17742,Personal Health,Shamblin,Angel Ann,76,27,7,3,4,0,2,3.371
+Fall 2023,BIOL,8399,4,17756,Doctoral Dissertation,Peng,Weiyi,1,0,0,0,0,0,0,4.0
+Fall 2023,HLT,3304,2,17760,Child and Adolescent Health,Drenner,Kelli Linn,36,17,7,4,2,0,1,3.202
+Fall 2023,BIOE,8699,3,17761,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8398,10,17762,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Fall 2023,MECE,8399,34,17763,Doctoral Dissertation,Chen,Zheng,1,0,0,0,0,1,0,4.0
+Fall 2023,HIST,8377,2,17766,Reading for Comps Exams,Hopkins,Kelly Y,0,0,0,0,0,1,0,
+Fall 2023,RELS,2350,1,17768,Introduction to Islam,Haq,Muhammad Nisarul,27,18,0,0,0,0,3,3.512
+Fall 2023,MECE,8598,29,17772,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,
+Fall 2023,MECE,8399,35,17774,Doctoral Dissertation,Joshi,Shailendra Pramod,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGI,1100,27,17778,Introduction To Engineering,Luna Singh,Jennifer Austin,12,2,0,0,0,0,1,3.904
+Fall 2023,FINA,3332,1,17780,Prin of Financial Management,Suleymanov,Masim,22,3,1,0,0,0,0,3.795
+Fall 2023,BIOE,8598,27,17781,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2023,SCM,7A01,3,17783,Project Management,Tibodeau,Dale,20,3,1,0,0,0,0,3.695
+Fall 2023,ENTR,7335,1,17784,Entreprnl Profit & Cash Mgt,Becker,Charles D,18,7,1,0,0,0,2,3.565
+Fall 2023,MECE,8399,36,17786,Doctoral Dissertation,Sun,Li,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,30,17788,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Fall 2023,MECE,7399,20,17793,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,33,17803,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,
+Fall 2023,MUSA,6440,1,17807,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8398,15,17820,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Fall 2023,WGSS,2350,18,17824,Intro To Women's Studies,Martinez,Itzel Areli,25,1,1,3,1,0,0,3.495
+Fall 2023,GEOL,8698,12,17825,Doctoral Research,Mann,Paul,0,0,0,0,0,4,0,
+Fall 2023,GEOL,8398,12,17836,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,1,0,
+Fall 2023,PHCA,6397,1,17837,Selected Topics,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8399,5,17839,Doctoral Dissertation,Khurana,Seema,1,0,0,0,0,0,0,3.67
+Fall 2023,MIS,8999,1,17842,Doctoral Dissertation in MIS,Silva,Leiser O,0,0,0,0,0,1,0,
+Fall 2023,MARK,8999,2,17843,Doctoral Dissertation,Ahearne,Michael,0,0,0,0,0,1,0,
+Fall 2023,MIS,7373,2,17846,Bus Appls Database Mgt Sys I,Grimes,George M,10,14,3,0,0,0,2,3.259
+Fall 2023,COMM,1303,4,17847,Writing for Communicators,Lyn,Robyn,55,21,6,1,5,0,6,3.326
+Fall 2023,BCHS,8399,4,17848,Doctoral Dissertation,Gunaratne,Preethi H,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8398,14,17850,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2023,PHYS,2326,7,17854,University Physics II(lecture),Chen,Shuo,60,108,76,1,0,0,1,2.9
+Fall 2023,GEOL,7199,1,17867,Master Thesis,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2023,MANA,8699,1,17868,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,1,0,
+Fall 2023,PSYC,2319,5,17873,Intro to Social Psychology,Browne,Lindsay J,18,15,5,0,2,0,0,3.15
+Fall 2023,FINA,8398,2,17874,Special Problems,Doshi,Hitesh B,1,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,2350,19,17877,Intro To Women's Studies,Slatton,Brittany Chevon,1,2,1,0,0,0,0,3.083
+Fall 2023,ACCT,8999,3,17880,Doctoral Dissertation,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,6398,2,17881,Research,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,8398,3,17883,Special Problems,Kumar,Praveen,1,1,0,0,0,0,0,3.665
+Fall 2023,FINA,8368,2,17884,Seminar in Investments,Jacobs,Kris,3,0,0,0,0,0,0,3.67
+Fall 2023,ECE,6314,1,17885,Nanoscale Design & Fabrication,Brankovic,Stanko R,3,9,2,0,0,0,0,3.048
+Fall 2023,HIST,6380,2,17887,Public History Internship,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6434,2,17892,Applied Clarinet,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8998,26,17894,Doctoral Research,Suppe,John,0,0,0,0,0,1,0,
+Fall 2023,MECE,8398,17,17900,Doctoral Research,Liu,Dong,0,0,0,0,0,3,0,
+Fall 2023,ARCH,3198,2,17901,Independent Study,Phan,Trang Anh Thuc,6,1,0,0,0,0,0,3.857
+Fall 2023,CHEM,6398,37,17905,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2023,PCEU,8998,4,17906,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2023,MECE,8298,37,17909,Doctoral Research,Liu,Dong,0,0,0,0,0,3,0,
+Fall 2023,PHLS,8199,7,17912,Dissertation,Arbona,Consuelo,0,0,0,0,0,2,0,
+Fall 2023,MECE,8598,37,17917,Doctoral Research,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2023,MECE,8398,18,17919,Doctoral Research,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2023,MECE,7399,23,17925,Masters Thesis,Liu,Dong,0,0,0,0,0,0,0,
+Fall 2023,MUSI,4198,4,17934,Research in Chamber Music,Suits,Brian J,0,0,0,0,0,0,1,
+Fall 2023,MECE,8298,38,17936,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6298,8,17938,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6398,8,17939,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8998,29,17950,Doctoral Research,Sager,William W,0,0,0,0,0,2,0,
+Fall 2023,PHYS,4398,5,17952,Independent Study,Bering,Edgar A,0,0,0,0,0,0,1,
+Fall 2023,ECON,3363,1,17964,Environmental Economics,Kohlhase,Janet E,11,18,9,1,1,0,6,2.826
+Fall 2023,ECON,4345,1,17966,Social Economics,Maheshri,Vikram,9,22,10,0,0,0,0,3.008
+Fall 2023,ECON,4377,1,17967,Urban Economics,Kohlhase,Janet E,5,13,6,0,1,0,3,2.827
+Fall 2023,BIOL,3311,1,17972,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,93,40,11,0,8,0,5,3.349
+Fall 2023,SPAN,2311,2,17973,Intermediate Spanish I,Torres,Cristina,13,9,3,0,1,0,2,3.231
+Fall 2023,LAW,5116,1,17975,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,2,0,
+Fall 2023,CLAS,3345,1,17978,Myth&Performance in Greek Trag,Kidder,Kathleen,17,6,3,0,0,0,2,3.437
+Fall 2023,LAW,5125,1,17981,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,2,0,
+Fall 2023,LAW,5128,1,17982,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,51,0,
+Fall 2023,LAW,5129,1,17983,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,10,0,
+Fall 2023,GERM,3350,1,17990,20Th C Thru German Culture,Kleinheider,Julia D,8,8,6,0,3,0,3,2.694
+Fall 2023,GERM,4398,1,17991,Independent Study,Glass,Hildegard,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,4361,5,17999,Second Language Methodology,Latiolais,Cheryl S,2,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,1147,3,18001,Introductory Meteorology Lab,Zheng,Youtong,10,7,2,0,0,0,1,3.404
+Fall 2023,CUIN,7383,1,18003,Early Chld Curr,Li,Xin,9,1,0,0,0,0,0,3.867
+Fall 2023,ARED,2310,2,18007,Intro Critical Visual Culture,Ripley,Lindsay N,24,2,2,1,1,0,0,3.534
+Fall 2023,WCL,3385,1,18008,Cultures and Capitalisms,Majumder,Sarasij,4,2,0,0,0,0,0,3.557
+Fall 2023,MATH,2305,2,18011,Discrete Mathematics,Xhabli,Blerina,28,23,16,15,10,0,12,2.478
+Fall 2023,JWST,2380,1,18013,Introduction to Jewish Studies,Tamber-Rosenau,Caryn M,2,3,3,0,2,0,0,2.234
+Fall 2023,JWST,3380,1,18014,American Jewish Culture,Weiss,Kenneth Scott,2,1,1,1,2,0,1,2.047
+Fall 2023,WCL,2380,1,18015,Introduction to Jewish Studies,Tamber-Rosenau,Caryn M,5,1,1,0,0,0,1,3.619
+Fall 2023,WCL,3380,1,18016,American Jewish Culture,Weiss,Kenneth Scott,2,6,1,0,5,0,0,2.0
+Fall 2023,CUIN,7393,1,18017,Practicum for Rdg Specialist,Reis,Nancy,0,0,0,0,0,1,0,
+Fall 2023,FINA,3332,2,18021,Prin of Financial Management,Suleymanov,Masim,93,68,46,10,3,0,3,3.088
+Fall 2023,JAPN,1501,1,18023,Elementary Japanese I,Ji,Fang,25,4,1,0,1,0,2,3.603
+Fall 2023,JAPN,1501,3,18025,Elementary Japanese I,Ji,Fang,19,6,3,0,1,0,4,3.414
+Fall 2023,HISP,2374,3,18027,Spanish American Culture & Civ,Ruisanchez Serra,Jose Ramon,8,8,5,0,2,0,2,2.87
+Fall 2023,HISP,2375,1,18028,US Hispanic Culture & Civ,Sisk,Christina L,8,12,5,2,0,0,1,2.951
+Fall 2023,SPAN,1501,23,18029,Elementary Spanish I,Torres-Calle,Maria Jose,12,4,5,0,1,0,1,3.107
+Fall 2023,PHYS,4350,1,18031,Computational Physics,Koerner,Lisa Whitehead,6,4,1,0,1,0,0,3.194
+Fall 2023,PHYS,1301,6,18032,College Physics I (lecture),Forrest,Rebecca L,31,33,89,14,16,0,28,2.167
+Fall 2023,SPAN,3301,1,18035,Span Oral Comm for Crit Think,Sisk,Christina L,10,2,1,0,0,0,1,3.692
+Fall 2023,SPAN,3331,1,18036,Mexican American Literature,Ventura,Gabriela Baeza,10,7,1,1,1,0,0,3.151
+Fall 2023,POLC,1311,1,18041,Public Policy Laboratory,Sands,Sara,14,6,0,0,1,0,3,3.414
+Fall 2023,PUBL,6398,1,18042,Special Probs Publ Adm/Policy,Koelling,Peter,2,0,0,0,0,0,0,4.0
+Fall 2023,POLC,2312,1,18044,Intro to Econ Policy Analysis,Heath,Katelyn,8,16,2,0,2,0,1,2.988
+Fall 2023,POLC,3313,1,18045,Contemporary Poli Phil Policy,Munawar,Sarah,6,20,0,0,1,0,2,3.074
+Fall 2023,POLC,3314,1,18046,Leadership and Public Policy,Witt,Lawrence A,26,0,0,0,0,0,2,4.0
+Fall 2023,POLC,3315,1,18047,Policy Res Methods Stat & Reg,Yuasa,Toshiyuki,3,2,5,4,2,0,1,1.959
+Fall 2023,POLC,3322,1,18048,Public Policy Analysis,Heller,Blake Harrison,11,7,1,0,0,0,2,3.457
+Fall 2023,POLC,3341,1,18049,State Authority and Freedom,Bronk,Robert C,10,1,0,0,0,0,0,3.849
+Fall 2023,MARK,3338,1,18051,Intro to Marketing Analytics,Hu,Ye,59,73,11,1,2,0,2,3.251
+Fall 2023,MARK,3338,2,18052,Intro to Marketing Analytics,Hu,Ye,46,80,15,2,3,0,3,3.135
+Fall 2023,MANA,4338,2,18059,Performance Management Systems,Sullivan,David Walter,15,6,3,0,0,0,0,3.541
+Fall 2023,MANA,4346,3,18060,Leadership Development,Lozano Garcia,Miguel Angel,16,4,3,0,2,0,0,3.28
+Fall 2023,MANA,7342,1,18062,Challenges in Healthcare Law,Kroger,Edward John,4,0,0,0,0,0,0,3.835
+Fall 2023,MANA,6A83,2,18065,Strategic Analysis,Carlin,Barbara A,20,12,2,0,0,0,1,3.481
+Fall 2023,MANA,6A83,3,18066,Strategic Analysis,Wesley Jr,Curtis LEONUS,9,5,0,0,0,0,1,3.596
+Fall 2023,PHIL,1321,4,18067,Logic I,Buckner,Cameron J,32,28,10,7,7,0,16,2.845
+Fall 2023,PHIL,1361,5,18068,Philosophy and the Arts,Drapela,Nick Gerard,21,12,10,2,1,0,4,3.101
+Fall 2023,ARCH,4376,1,18069,Community Design Workshop,Rogers,Susan,15,0,0,0,0,0,0,3.802
+Fall 2023,MANA,7357,1,18070,Fund of Diversity Equity & Inc,Baldwin,Cheryl,10,1,0,0,0,0,0,3.909
+Fall 2023,CUIN,3317,11,18071,Kindergarten/Elem Curr & Instr,Christensen,Caroline,9,0,0,0,0,0,1,3.927
+Fall 2023,CUIN,4315,11,18072,Assessment of Children,Christensen,Caroline,9,0,0,0,0,0,1,3.963
+Fall 2023,CUIN,3316,11,18073,Prekindergarten Curr & Instr,Christensen,Caroline,9,0,0,0,0,0,1,3.963
+Fall 2023,PHIL,3358,1,18075,Classics in Hist of Ethics,Morrison,Iain P D,6,13,1,0,0,0,0,3.382
+Fall 2023,BUSI,2305,6,18079,Business Statistics,Patterson,Staci A,10,8,22,12,0,0,24,2.27
+Fall 2023,CUIN,7341,1,18080,Math Education Capstone,Gallagher,Melissa Ann,13,1,0,0,0,0,0,3.905
+Fall 2023,ENGI,1100,28,18081,Introduction To Engineering,Claydon,Frank J,17,3,2,0,0,0,0,3.652
+Fall 2023,ENGI,1100,29,18082,Introduction To Engineering,Claydon,Frank J,12,12,3,0,0,0,0,3.26
+Fall 2023,BIOL,4342,50,18085,Introduction to Marine Biology,Hanke,Marc H,11,17,4,3,0,0,1,2.991
+Fall 2023,ANTH,3396,1,18088,Selected Tops in Cultural Anth,Ramirez,Marie Theresa,8,5,6,0,0,0,0,3.14
+Fall 2023,CHEM,1321,1,18091,Honors Fund. of Chem 1,Halasyamani,P Shiv,10,11,8,7,1,0,15,2.63
+Fall 2023,PSYC,6343,1,18094,Psychopharmacology,Kosten,Therese A,7,0,0,0,0,0,0,4.0
+Fall 2023,STAT,3331,2,18095,Statistical Anal Bus Appl I,Wiley,Briceon C,4,7,11,10,0,0,6,2.187
+Fall 2023,HIST,4340,1,18104,Philosophies of History,Hernandez,Jose A,4,1,2,0,1,0,4,2.834
+Fall 2023,HIST,4318,1,18106,Africa and The Oil Industry,Klieman,Kairn,12,5,1,0,0,0,3,3.538
+Fall 2023,BIOL,3301,1,18109,Mendelian and Pop Genetics,Lin,Chin-Yo,76,44,23,8,4,0,5,3.149
+Fall 2023,BIOL,3301,2,18112,Mendelian and Pop Genetics,Lin,Chin-Yo,75,42,23,5,6,0,8,3.17
+Fall 2023,BIOL,3301,3,18113,Mendelian and Pop Genetics,Farmer,Lisa M,54,98,64,19,3,0,7,2.724
+Fall 2023,HIST,3376,1,18114,Caribbean History,Howard,Philip,3,7,11,0,4,0,1,2.042
+Fall 2023,HIST,3336,1,18117,History of U.S. Latinx Music,Goldberg,Mark A,17,12,2,0,2,0,0,3.243
+Fall 2023,PSYC,4363,1,18118,Abnormal Child Psych,Hernandez Ortiz,Jessica G,11,24,8,4,0,0,2,2.866
+Fall 2023,HIST,3310,1,18119,"Jacksonian America, 1820-1850",Deyle,Steven H,17,8,7,0,0,0,2,3.261
+Fall 2023,BIOL,4354,2,18122,Endocrinology,Gill,Tejendra,15,65,3,2,1,0,4,2.974
+Fall 2023,CHEM,4373,2,18124,Survey of Physical Chemistry,Baldelli,Steve,4,16,3,3,0,0,3,2.782
+Fall 2023,CHEM,6115,2,18125,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,6,0,
+Fall 2023,POLS,3340,1,18128,Ancient/Medieval Pol Thought,Fumurescu,Alin,13,4,5,6,1,0,10,2.724
+Fall 2023,GEOL,1103,14,18130,Physical Geology Lab,Hauptvogel,Daniel William,12,4,4,2,1,0,1,3.072
+Fall 2023,SCM,7390,1,18132,Global Supply Chain Strategy,Smith,Gordon D,1,6,0,0,0,0,0,3.096
+Fall 2023,GEOL,1302,1,18133,Intro To Global Climate Change,Zhang,Honghai,301,98,23,5,3,0,11,3.54
+Fall 2023,HON,3376,1,18134,Constitutional Cases & Controv,Erwing,Douglas A,11,0,0,0,0,0,3,3.97
+Fall 2023,GEOL,1303,1,18135,Physical Geology,Capuano,Regina M,51,36,18,6,1,0,10,3.146
+Fall 2023,POLS,3352,50,18136,Immigration: Politics/Policy,Belco,Michelle Helene,24,1,1,0,0,0,0,3.859
+Fall 2023,GEOL,1303,10,18137,Physical Geology,Wellner,Julia S,7,12,9,6,4,0,5,2.324
+Fall 2023,MIS,3370,4,18139,Info Systems Development Tools,Zamarripa,Ivan,23,16,12,4,2,0,5,2.947
+Fall 2023,MIS,3371,2,18140,Transaction Processing Sys I,Messinger,Jacob Nelson,13,2,0,0,0,0,4,3.845
+Fall 2023,SOCI,1301,16,18145,Introduction To Sociology,Davis,Mary A,48,5,3,1,3,0,2,3.528
+Fall 2023,SGNL,1301,9,18146,Elementary Sign Language I,Brittain,Terrell,7,8,3,0,1,0,3,2.879
+Fall 2023,GEOL,4398,1,18155,Independent Study,Bering,Edgar A,0,0,0,0,0,0,1,
+Fall 2023,ACCT,2301,14,18157,Prin of Financial Accounting,Sykes,Mary Reeves,21,10,1,2,1,0,5,3.447
+Fall 2023,ACCT,2301,16,18159,Prin of Financial Accounting,Parthasarathy,Kiran M,67,61,21,7,6,0,10,3.176
+Fall 2023,BUSI,4305,1,18160,Business Ethics for Accountant,Brant Jr,Robert Edward,6,8,0,0,0,0,0,3.523
+Fall 2023,ACCT,2302,7,18161,Prin of Managerial Accounting,Seltz,Joe D,19,25,12,10,2,0,5,2.793
+Fall 2023,ACCT,2302,8,18162,Prin of Managerial Accounting,Seltz,Joe D,19,26,12,12,2,0,2,2.723
+Fall 2023,ACCT,2302,9,18163,Prin of Managerial Accounting,Seltz,Joe D,25,12,9,3,1,0,5,3.206
+Fall 2023,SOC,3360,1,18164,Sociology of Food,Grigorian,Stella,24,7,0,1,2,0,4,3.471
+Fall 2023,HISP,2374,4,18165,Spanish American Culture & Civ,De Los Reyes Heredia,Jose Guillermo,17,12,2,0,3,0,2,3.167
+Fall 2023,ACCT,3366,5,18167,Financial Reporting Frameworks,Parthasarathy,Kiran M,21,12,3,3,1,0,4,3.2
+Fall 2023,ACCT,3367,4,18177,Intermediate Accounting I,Kilic,Emre,18,20,16,1,2,0,8,2.97
+Fall 2023,ACCT,3368,4,18179,Intermediate Accounting II,Muslu,Volkan,8,28,23,0,0,0,0,2.667
+Fall 2023,ACCT,7379,1,18180,Current Issues in Taxation,Evetts,Nancy Zalmanek,32,1,0,0,0,0,0,3.97
+Fall 2023,ACCT,7384,1,18182,Enterprise Risk Management,Neely,Gregory Wayne,13,1,0,0,0,0,0,3.929
+Fall 2023,ACCT,7320,1,18184,Intro to Data Analytics-Acct,Miles,Carolyn A,12,4,0,0,1,0,0,3.491
+Fall 2023,ACCT,5301,1,18186,Financial and Managerial Acct,Kuruvilla,Mohan,4,4,4,0,2,0,6,2.524
+Fall 2023,ELED,4311,1,18189,Science in Elementary School I,Domjan,Heather N,22,2,0,0,0,0,0,3.848
+Fall 2023,ELED,4311,5,18190,Science in Elementary School I,Wong,Sissy S,32,2,0,0,0,0,0,3.941
+Fall 2023,ELED,4311,4,18193,Science in Elementary School I,Rodriguez,Alberto J,24,7,2,0,0,0,0,3.617
+Fall 2023,MATH,5333,1,18195,Analysis,Ji,Shanyu,7,3,2,0,0,0,0,3.444
+Fall 2023,MATH,6322,1,18196,Func Complex Variable,Nicol,Matthew J,17,0,0,0,0,0,1,4.0
+Fall 2023,MATH,5310,1,18200,History of Mathematics,Ji,Shanyu,10,4,0,0,0,0,1,3.714
+Fall 2023,ARTS,3304,3,18201,Intermediate Painting,Willis,William H,20,0,0,0,0,0,0,4.0
+Fall 2023,COMD,3321,1,18203,Multicultural Consid -- COMD,Castilla-Earls,Anny,21,4,1,0,0,0,1,3.668
+Fall 2023,COMD,3371,1,18204,Speech Devel & Dis in Children,Schaff,Carrie Allyson,27,5,0,0,0,0,0,3.885
+Fall 2023,COMD,3385,1,18205,Speech Science,Hein Machado,Sofia,14,18,5,0,0,0,0,3.216
+Fall 2023,BCHS,3304,50,18206,General Biochemistry I,Widger,William R,5,8,0,0,1,0,10,3.119
+Fall 2023,ENTR,3310,6,18207,Entrepreneurship,Boles,James Read,13,6,0,0,0,0,0,3.597
+Fall 2023,BIOL,3311,2,18208,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,54,12,5,0,5,0,1,3.421
+Fall 2023,ENTR,4330,1,18213,Entrepreneurial Costs/Budgets,Becker,Charles D,18,6,3,1,0,0,2,3.453
+Fall 2023,MARK,6A61,5,18222,Marketing Administration,Lish,Alan D,6,21,5,0,1,0,2,2.849
+Fall 2023,ARTS,3330,3,18224,Intermediate Graphic Design,Cardoza,Daniel Gil,12,8,2,0,0,0,1,3.395
+Fall 2023,GEOL,1103,15,18225,Physical Geology Lab,Hauptvogel,Daniel William,13,5,0,0,1,0,1,3.492
+Fall 2023,GEOL,1103,16,18226,Physical Geology Lab,Hauptvogel,Daniel William,11,5,2,0,0,0,1,3.537
+Fall 2023,ARCH,3311,1,18227,Topics in Design History,Kacmar,Donna,3,12,0,0,1,0,0,2.979
+Fall 2023,AAS,2320,6,18228,Intro To African American Stdy,Poindexter-Sylvers,Carole Jean,26,4,0,0,2,0,2,3.512
+Fall 2023,AAS,2330,1,18230,Black Liberation Theology,Johnson,Alexander Emmitt Maurice,11,11,3,0,2,0,2,3.086
+Fall 2023,ARCH,4510,9,18231,Integrated Arch Solutions,Hager,Jesse,9,8,1,0,0,0,0,3.389
+Fall 2023,LAW,5390,2,18238,Environmental Law,Hester,Tracy,24,36,3,0,0,9,0,3.339
+Fall 2023,LAW,6326,1,18241,Diplomacy for Oil and Gas,Cardenas Garcia,Julian Jose,11,14,0,0,0,5,0,3.427
+Fall 2023,LAW,7305,1,18242,WRS: Hot Topic Crim Law & Proc,Thompson,Sandra Guerra,5,7,0,0,0,0,0,3.389
+Fall 2023,LAW,6396,1,18244,Genetics and the Law,Roberts,Jessica,23,22,0,0,0,2,0,3.46
+Fall 2023,KIN,4370,3,18246,Exercise Testing,Breslin,Whitney L,27,74,33,6,1,0,1,2.846
+Fall 2023,COMM,3374,2,18250,Strategic Social Media,Choi,Ho Joon,29,2,0,0,0,0,1,3.935
+Fall 2023,COMM,4355,1,18251,Organizational Comm,Liu,Wenlin,23,6,0,0,0,0,1,3.725
+Fall 2023,IDNS,2114,3,18252,Calculus II SEP Workshop,Pattison,Donna,15,3,6,2,0,0,3,3.116
+Fall 2023,COMM,4357,1,18253,Intercultural Communication,Liu,Wenlin,19,9,0,0,1,0,1,3.461
+Fall 2023,ARTS,3350,1,18255,Intermediate Ceramics,Mayer,Anna W,10,4,1,0,1,0,1,3.334
+Fall 2023,SCLT,4386,30,18256,Project Logistics,Poisler,Marco A,15,0,0,0,0,0,0,4.0
+Fall 2023,COMM,3315,2,18257,News and Social Media,Roth,Geoffrey,20,0,0,1,0,0,0,3.81
+Fall 2023,ACCT,4105,2,18261,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,26,4,
+Fall 2023,POLS,3354,1,18263,Law and Society,Davis,Sharon M,24,14,0,0,0,0,2,3.571
+Fall 2023,ACCT,4106,2,18264,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,45,0,
+Fall 2023,SCLT,6316,2,18265,Global Supply Chain Logistics,Wang,Kailai,23,0,0,0,0,0,0,3.986
+Fall 2023,BIOL,3301,50,18266,Mendelian and Pop Genetics,Dominic Louis Raj,Abishai,22,3,0,0,0,0,8,3.84
+Fall 2023,BIOL,3301,51,18267,Mendelian and Pop Genetics,Dominic Louis Raj,Abishai,13,4,2,0,0,0,3,3.648
+Fall 2023,MANA,7339,2,18268,Leadership Development,Atwater,Leanne E,25,5,0,0,0,0,0,3.833
+Fall 2023,MUSI,1116,2,18269,Aural Skills I,Snyder,John L,5,13,4,0,0,0,1,3.03
+Fall 2023,NUTR,3330,2,18270,Mgmt in Food & Nutr Systems,Haubrick,Kevin,4,7,1,0,1,0,1,2.848
+Fall 2023,NUTR,4352,1,18271,Child and Adolescent Nutrition,Vollrath,Kirstin,31,29,5,2,3,0,0,3.186
+Fall 2023,HIST,1301,3,18273,The U.S. to 1877,Johnson,Michele R,113,97,61,12,12,0,9,3.003
+Fall 2023,HIST,1301,4,18274,The U.S. to 1877,Johnson,Michele R,198,122,62,31,27,0,13,2.975
+Fall 2023,HIST,1301,5,18275,The U.S. to 1877,Romero,Todd,265,102,34,23,23,0,12,3.192
+Fall 2023,HIST,1301,6,18276,The U.S. to 1877,Romero,Todd,156,73,35,9,25,0,7,3.065
+Fall 2023,HIST,1301,7,18277,The U.S. to 1877,McDonald,Eric John,38,65,24,3,11,0,6,2.781
+Fall 2023,MUSI,1181,4,18319,Group Piano I,Van Kekerix,Todd Evan,12,2,0,0,0,0,0,3.786
+Fall 2023,MUSI,1181,5,18321,Group Piano I,Van Kekerix,Todd Evan,10,3,0,0,1,0,0,3.382
+Fall 2023,HIST,1302,1,18322,The U.S. Since 1877,Buzzanco,Robert,149,100,21,8,7,0,8,3.308
+Fall 2023,HIST,1302,2,18323,The U.S. Since 1877,Buzzanco,Robert,177,69,21,6,12,0,10,3.403
+Fall 2023,HIST,1302,3,18324,The U.S. Since 1877,Deyle,Steven H,139,99,19,5,18,0,9,3.162
+Fall 2023,HIST,1302,4,18325,The U.S. Since 1877,Rector,Josiah John,192,57,24,7,10,0,8,3.385
+Fall 2023,HIST,1302,5,18326,The U.S. Since 1877,Zarnow,Leandra Ruth,103,93,34,8,29,0,13,2.844
+Fall 2023,HIST,1302,6,18327,The U.S. Since 1877,Schafer Jr,James A,133,102,42,9,9,0,4,3.155
+Fall 2023,MUSI,1311,2,18331,Music Theory I,Snyder,John L,5,11,2,0,1,0,3,2.965
+Fall 2023,POLS,3344,1,18335,Inter'l Law & Law of War,Littlepage,Kelley G,7,9,3,2,0,0,10,2.921
+Fall 2023,POLS,3387,1,18337,Politics of the Qur'an,Contractor,Cyrus Ali,21,3,0,0,0,0,0,3.806
+Fall 2023,POLS,3356,1,18339,Intro-Constitutionl Law,Abbott Jr,Kenneth Wayne,36,2,0,0,0,0,0,3.852
+Fall 2023,POLS,3392,1,18340,Nuclear Weapons and Security,Zwald,Zachary J,10,9,1,0,1,0,1,3.254
+Fall 2023,GHL,3153,1,18354,Htl Mrktng New York Style,Boger Jr,Carl A,9,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6153,1,18359,Hotel Marketing-New York Style,Boger Jr,Carl A,7,0,0,0,0,0,0,4.0
+Fall 2023,PHIL,3354,1,18360,Medical Ethics,Determeyer,Peggy Lee,7,2,0,0,0,0,0,3.778
+Fall 2023,ACCT,3366,7,18362,Financial Reporting Frameworks,Parthasarathy,Kiran M,61,37,22,3,3,0,15,3.167
+Fall 2023,CHEE,8298,20,18363,Doctoral Research,Zerze,Gul,0,0,0,0,0,4,0,
+Fall 2023,GHL,7369,1,18366,Hospitality Financial Assets,Koh,Yoon,16,4,0,0,1,0,0,3.525
+Fall 2023,CHEE,8398,21,18368,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8598,20,18371,Doctoral Research,Zerze,Gul,0,0,0,0,0,1,0,
+Fall 2023,CHEE,8399,20,18374,Doctoral Dissertation,Zerze,Gul,0,0,0,0,0,3,0,
+Fall 2023,HDFS,4397,1,18378,Selected Topics in Hdfs,Master,Allison,4,2,0,0,0,0,0,3.722
+Fall 2023,ENGL,7368,1,18381,CSA Theories and Methods,Harrell,Haylee C,10,0,0,0,0,0,1,4.0
+Fall 2023,TECH,1301,2,18386,Intro to Data Analytics Tools,Roberts,Phyllis Rayburn,17,21,4,0,5,0,0,2.936
+Fall 2023,ELCS,8310,2,18388,The Superintendency,Butcher,Keith,6,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,7392,2,18390,Internship in Superintendent,Klussmann,Duncan Foster,2,0,0,0,0,0,0,4.0
+Fall 2023,RELS,1301,3,18395,Intro To Religious Studies,Eberhart,Christian,18,20,4,1,0,0,1,3.164
+Fall 2023,RELS,3330,1,18398,Christianity,Pegoda,Andrew Joseph,4,14,5,1,2,0,4,2.679
+Fall 2023,RELS,2380,1,18399,Religion and Film,Clark,Laura B,25,5,3,1,3,0,2,3.253
+Fall 2023,ANTH,2304,1,18404,Intro To Language and Culture,Rasmussen,Susan J,6,18,15,3,2,0,4,2.508
+Fall 2023,PSYC,2330,5,18409,Biological Psychology,Rech,Megan Elizabeth,48,19,8,2,2,0,0,3.309
+Fall 2023,PSYC,3310,3,18410,Indstrl-Orgnztnl Psy,Thomas,Kalifa Nailah,53,17,6,1,2,0,0,3.544
+Fall 2023,PSYC,2301,4,18414,Introduction to Psychology,Schoolfield,Lucy,58,13,7,0,1,0,0,3.62
+Fall 2023,PSYC,2301,5,18415,Introduction to Psychology,Silva,Karina,35,32,7,2,3,0,1,3.14
+Fall 2023,PSYC,3339,4,18417,Intro To Clinical Psychology,Cifre,Anthony Ballachie,39,28,4,2,2,0,2,3.333
+Fall 2023,ENGL,3318,1,18420,The British Novel Since 1832,Chatterjee,Sreya,22,7,0,0,2,0,0,3.484
+Fall 2023,ENGL,3380,1,18421,Modern Indian Literature,Majumder,Auritro,17,10,1,0,0,0,2,3.583
+Fall 2023,ENGL,4383,1,18422,Poetic Forms,Murray,Christopher Brean,21,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4303,6,18427,Communication Law and Ethics,Kirkland,Steven Earl,74,12,4,0,1,0,1,3.711
+Fall 2023,ARCH,3112,1,18428,Topics in Design Media,Kudless,Andrew Justin,8,5,0,0,0,0,1,3.59
+Fall 2023,ENGL,1370,3,18429,Composition II-Honors,Cooper,Carol B,2,5,0,0,1,0,0,2.958
+Fall 2023,ENGL,1370,4,18430,Composition II-Honors,Cooper,Carol B,2,3,0,0,0,0,0,3.466
+Fall 2023,ENGL,1370,5,18431,Composition II-Honors,Cremins,Robert Paul,2,2,0,0,0,0,0,3.5
+Fall 2023,ENGL,1370,6,18432,Composition II-Honors,Cremins,Robert Paul,3,0,1,0,0,0,0,3.17
+Fall 2023,ENGL,1370,7,18433,Composition II-Honors,Garner,Richard A,4,1,0,0,0,0,0,3.734
+Fall 2023,ENGL,1370,8,18434,Composition II-Honors,Lyke,Larry,3,3,2,0,0,0,0,3.084
+Fall 2023,ENGL,1370,9,18435,Composition II-Honors,Morrison,Iain P D,0,5,0,0,0,0,0,3.198
+Fall 2023,ENGL,1370,10,18436,Composition II-Honors,Rayneard,Max James Anthony,4,0,1,0,0,0,1,3.402
+Fall 2023,ENGL,1370,11,18437,Composition II-Honors,Rayneard,Max James Anthony,4,4,0,0,0,0,0,3.294
+Fall 2023,ENGL,1370,12,18438,Composition II-Honors,Sommers,Tamler S,5,1,0,0,0,0,0,3.833
+Fall 2023,ENGL,1370,13,18439,Composition II-Honors,Vollrath,Lesli A,2,3,0,0,0,0,0,3.4
+Fall 2023,ENGL,1370,17,18440,Composition II-Honors,Garner,Richard A,6,1,1,0,0,0,1,3.46
+Fall 2023,ARCH,3112,3,18444,Topics in Design Media,Noldt,Peter,16,0,0,0,0,0,0,3.835
+Fall 2023,MECT,3345,1,18446,Fund Power Generation Tech,Bose,Anima B,6,12,2,0,0,0,0,3.233
+Fall 2023,BUSI,1301,6,18447,Business Principles,Carvalho,Diogo,197,51,12,8,5,0,2,3.522
+Fall 2023,ENGL,1370,21,18448,Composition II-Honors,Bland,Laura Elizabeth,3,1,1,0,0,0,0,3.4
+Fall 2023,ENGL,1370,22,18449,Composition II-Honors,Bland,Laura Elizabeth,3,7,0,0,0,0,0,3.366
+Fall 2023,ENGL,1370,23,18450,Composition II-Honors,Charara,Hayan S,5,3,0,0,1,0,0,3.149
+Fall 2023,ENGL,1370,24,18451,Composition II-Honors,Charara,Hayan S,0,1,0,0,0,0,0,3.33
+Fall 2023,ENGL,1370,25,18452,Composition II-Honors,Ferguson,Jamie H,3,2,0,0,0,0,0,3.336
+Fall 2023,ENGL,1370,26,18453,Composition II-Honors,Gish,Dustin,6,3,1,0,0,0,0,3.335
+Fall 2023,ENGL,1370,27,18454,Composition II-Honors,Gish,Dustin,3,5,0,0,0,0,0,3.416
+Fall 2023,ENGL,1370,28,18455,Composition II-Honors,Hallmark,Terrell L,5,2,0,0,0,0,0,3.526
+Fall 2023,ENGL,1370,29,18456,Composition II-Honors,Hallmark,Terrell L,3,2,0,0,0,0,0,3.534
+Fall 2023,ENGL,1370,30,18457,Composition II-Honors,Rainbow,David,2,2,0,0,0,0,0,3.418
+Fall 2023,ENGL,1370,31,18458,Composition II-Honors,Rainbow,David,4,3,0,0,0,0,1,3.571
+Fall 2023,ENGL,1370,32,18459,Composition II-Honors,Rainbow,Jesse J,2,2,0,1,0,0,0,2.934
+Fall 2023,ENGL,1370,33,18460,Composition II-Honors,Sisman,Cengiz,3,4,0,0,0,0,0,3.523
+Fall 2023,ENGL,1370,34,18461,Composition II-Honors,Sisman,Cengiz,3,1,0,0,0,0,0,3.668
+Fall 2023,ENGL,1370,35,18462,Composition II-Honors,Trninic,Marina,4,2,0,0,1,0,0,3.143
+Fall 2023,ENGL,1370,36,18463,Composition II-Honors,Trninic,Marina,1,3,0,0,0,0,0,3.333
+Fall 2023,ENGL,2360,3,18468,Western World Lit I--Honors,Cooper,Carol B,9,2,0,0,0,0,0,3.638
+Fall 2023,ENGL,2360,4,18469,Western World Lit I--Honors,Cooper,Carol B,10,4,0,0,0,0,0,3.691
+Fall 2023,ENGL,2360,5,18470,Western World Lit I--Honors,Cremins,Robert Paul,8,4,0,0,0,0,1,3.639
+Fall 2023,ENGL,2360,6,18471,Western World Lit I--Honors,Cremins,Robert Paul,10,3,0,0,0,0,0,3.541
+Fall 2023,ENGL,2360,7,18472,Western World Lit I--Honors,Garner,Richard A,10,2,0,0,0,0,1,3.723
+Fall 2023,ENGL,2360,8,18473,Western World Lit I--Honors,Lyke,Larry,10,1,0,0,0,0,0,3.729
+Fall 2023,ENGL,2360,9,18474,Western World Lit I--Honors,Morrison,Iain P D,5,7,0,0,0,0,1,3.307
+Fall 2023,ENGL,2360,10,18475,Western World Lit I--Honors,Rayneard,Max James Anthony,4,2,1,0,0,0,1,3.334
+Fall 2023,ENGL,2360,11,18476,Western World Lit I--Honors,Rayneard,Max James Anthony,6,5,0,0,0,0,0,3.335
+Fall 2023,ENGL,2360,12,18477,Western World Lit I--Honors,Sommers,Tamler S,10,3,0,0,0,0,0,3.769
+Fall 2023,ENGL,2360,13,18478,Western World Lit I--Honors,Vollrath,Lesli A,8,5,0,0,0,0,0,3.463
+Fall 2023,ENGL,2360,14,18479,Western World Lit I--Honors,Vollrath,Lesli A,7,4,1,0,0,0,1,3.363
+Fall 2023,ENGL,2360,15,18480,Western World Lit I--Honors,Werner,Andrew Timothy,9,2,1,0,0,0,0,3.502
+Fall 2023,ENGL,2360,16,18481,Western World Lit I--Honors,Werner,Andrew Timothy,8,3,0,0,0,0,1,3.697
+Fall 2023,ENGL,2360,17,18482,Western World Lit I--Honors,Garner,Richard A,6,2,0,0,0,0,0,3.668
+Fall 2023,ENGL,2360,21,18486,Western World Lit I--Honors,Bland,Laura Elizabeth,6,7,1,0,0,0,0,3.357
+Fall 2023,ENGL,2360,22,18487,Western World Lit I--Honors,Bland,Laura Elizabeth,4,5,0,0,0,0,0,3.591
+Fall 2023,ENGL,2360,23,18488,Western World Lit I--Honors,Charara,Hayan S,6,2,0,0,0,0,2,3.668
+Fall 2023,ENGL,2360,24,18489,Western World Lit I--Honors,Charara,Hayan S,8,7,1,0,0,0,0,3.499
+Fall 2023,ENGL,2360,25,18490,Western World Lit I--Honors,Ferguson,Jamie H,7,5,0,0,0,0,0,3.556
+Fall 2023,ENGL,2360,26,18491,Western World Lit I--Honors,Gish,Dustin,6,2,0,0,0,0,0,3.668
+Fall 2023,ENGL,2360,27,18492,Western World Lit I--Honors,Gish,Dustin,4,3,1,0,0,0,0,3.334
+Fall 2023,ENGL,2360,28,18493,Western World Lit I--Honors,Hallmark,Terrell L,7,4,0,0,0,0,0,3.606
+Fall 2023,ENGL,2360,29,18494,Western World Lit I--Honors,Hallmark,Terrell L,8,5,0,0,0,0,0,3.565
+Fall 2023,ENGL,2360,30,18495,Western World Lit I--Honors,Rainbow,David,7,7,0,0,0,0,1,3.406
+Fall 2023,ENGL,2360,31,18496,Western World Lit I--Honors,Rainbow,David,6,2,0,0,0,0,1,3.668
+Fall 2023,ENGL,2360,32,18497,Western World Lit I--Honors,Rainbow,Jesse J,6,5,0,0,0,0,0,3.515
+Fall 2023,ENGL,2360,33,18498,Western World Lit I--Honors,Sisman,Cengiz,10,2,0,0,0,0,0,3.723
+Fall 2023,ENGL,2360,34,18499,Western World Lit I--Honors,Sisman,Cengiz,13,0,0,0,0,0,0,3.848
+Fall 2023,ENGL,2360,35,18500,Western World Lit I--Honors,Trninic,Marina,6,4,0,0,0,0,2,3.501
+Fall 2023,ENGL,2360,36,18501,Western World Lit I--Honors,Trninic,Marina,10,5,0,0,0,0,0,3.579
+Fall 2023,LAW,5310,1,18505,White Collar Crime,Kwok,David Y,12,16,1,0,0,4,0,3.391
+Fall 2023,ARCH,3112,4,18507,Topics in Design Media,Noldt,Peter,8,1,2,0,0,0,0,3.515
+Fall 2023,ARCH,3112,6,18511,Topics in Design Media,Noldt,Peter,9,3,1,1,0,0,0,3.311
+Fall 2023,ENGL,3361,1,18512,Mexican American Lit,Ellis,Amanda,18,7,2,0,2,0,1,3.299
+Fall 2023,ARCH,3112,9,18513,Topics in Design Media,Martinez,Marcus E,14,0,0,0,0,0,1,4.0
+Fall 2023,ARCH,3312,3,18514,Topics in Design Media,Noldt,Peter,7,5,1,0,1,0,0,3.073
+Fall 2023,ARCH,3312,4,18515,Topics in Design Media,Smith,Joshua S,11,4,0,0,0,0,0,3.777
+Fall 2023,HLT,3380,2,18516,Culture and Health,Fedor Amador,Theresa Marie,45,14,3,1,0,0,1,3.483
+Fall 2023,ARCH,3312,5,18517,Topics in Design Media,Jacobs,Daniel,8,5,1,0,0,0,1,3.382
+Fall 2023,HON,3375,1,18519,Law & Ethics in Ancient Near E,Rainbow,Jesse J,11,2,0,0,0,0,0,3.745
+Fall 2023,ENGI,1100,30,18520,Introduction To Engineering,Metrovich,Brian,13,31,10,0,2,0,3,2.97
+Fall 2023,RELS,3375,1,18521,Christianity and Ethics,Rainbow,Jesse J,3,3,1,0,1,0,0,2.958
+Fall 2023,COSC,6335,1,18523,Data Mining,Eick,Christoph F,13,23,1,0,0,0,0,3.289
+Fall 2023,INDE,6333,1,18525,Probability Stat For Engineers,Chung,Christopher,3,5,3,2,0,0,2,2.642
+Fall 2023,KIN,4310,2,18527,Measurement Tech Human Perf,Parikh,Pranav J,78,20,3,0,0,0,0,3.68
+Fall 2023,COSC,1336,6,18530,Computer Science & Program,Yun,Changhoon,23,34,20,8,8,0,31,2.567
+Fall 2023,COSC,1336,4,18531,Computer Science & Program,Alipour,Mohammad Amin,45,28,14,9,6,0,17,2.919
+Fall 2023,COMD,3383,1,18533,Language Disorders in Children,Ivey,Michelle L,14,10,5,0,0,0,0,3.31
+Fall 2023,CUIN,4315,6,18534,Assessment of Children,Hernandez,Berky,19,0,2,0,0,0,0,3.668
+Fall 2023,LAW,5409,2,18536,Contracts,Buckles,Johnny R,7,31,0,0,0,0,0,3.271
+Fall 2023,LAW,5409,3,18537,Contracts,Dow,David R,11,26,0,0,0,0,0,3.342
+Fall 2023,LAW,5409,4,18538,Contracts,Gebru,Aman K,13,23,2,0,0,0,0,3.342
+Fall 2023,LAW,5387,1,18539,International Tax,Wells,Douglas,4,7,0,0,0,3,0,3.364
+Fall 2023,LAW,5374,1,18540,Legal History,Siegel,Martin Jonathan,11,33,0,0,0,0,0,3.213
+Fall 2023,HLT,1353,4,18543,Personal Health,Proctor,Robin Ann,116,2,1,0,0,0,0,3.958
+Fall 2023,HLT,4398,2,18544,Independent Study,Solari Williams,Kayce D,1,0,0,0,0,0,0,4.0
+Fall 2023,BZAN,6354,2,18545,DB Mgt Tools Bus Analytics,Grimes,George M,8,4,0,2,0,0,1,3.286
+Fall 2023,CIVE,6378,1,18546,Principles Enviromntl Modeling,Louie,Stacey M,3,2,1,0,1,0,0,2.857
+Fall 2023,CIVE,6378,2,18547,Principles Enviromntl Modeling,Louie,Stacey M,3,0,0,1,0,0,0,3.25
+Fall 2023,CIVE,2332,1,18556,Mechanics of Solids,Mansour,Mohamad Y,4,8,17,7,0,0,0,2.25
+Fall 2023,ACCT,3371,3,18560,Accounting Information Systems,Miles,Carolyn A,13,20,9,1,1,0,1,2.902
+Fall 2023,ACCT,3377,4,18561,Cost Accounting,Serrato,Darlene Marie  Bohac,11,12,7,4,0,0,6,2.902
+Fall 2023,CIVE,6393,1,18562,Geostatistics,Lee,Hyongki,4,2,0,0,0,0,1,3.557
+Fall 2023,MECT,4326,30,18564,Fundamentals Offshore Systems,Al-Jamal,Helmi,3,3,2,1,0,0,2,2.962
+Fall 2023,SOCI,1301,18,18566,Introduction To Sociology,Adams,Jennifer Lauren,48,9,1,2,1,0,1,3.645
+Fall 2023,SOCI,1301,20,18567,Introduction To Sociology,Colbert,Sharla Stettnisch,45,8,4,0,2,0,1,3.593
+Fall 2023,SOCI,1301,26,18568,Introduction To Sociology,Adams,Jennifer Lauren,45,10,2,1,1,0,3,3.605
+Fall 2023,SOC,3311,1,18569,Sociology of Law,Nelson,Steven M,21,15,12,1,1,0,2,3.06
+Fall 2023,MANA,6A83,4,18573,Strategic Analysis,Celly,Nikhil,11,0,0,0,0,0,0,3.88
+Fall 2023,SCM,6A01,5,18577,SCM Concepts,Sahin,Funda,1,1,0,0,0,0,0,3.5
+Fall 2023,FINA,7381,1,18578,Principles of Real Estate,Disch,Kathryn Annette,6,0,0,0,0,0,0,3.945
+Fall 2023,CNST,2360,1,18580,Communication in Construction,Zerwas,Philip,10,16,2,0,0,0,2,3.286
+Fall 2023,BTEC,2322,30,18585,Introduction to Biopython,Chitrala,Kumaraswamy Naidu,15,4,2,0,0,0,0,3.666
+Fall 2023,BTEC,4100,30,18586,Principles Bioinformatics Lab,Balan,Venkatesh,2,3,1,0,0,0,1,3.112
+Fall 2023,POLS,1335,1,18587,World Politics,Sisman,Ozlem,11,18,6,4,1,0,0,2.801
+Fall 2023,BIOE,6301,2,18593,Statistical Methods in BME,Wang,Lu,20,15,0,0,0,0,0,3.562
+Fall 2023,SOC,3315,2,18594,Sexuality and Society,Baumle,Amanda K,28,11,9,4,2,0,1,3.068
+Fall 2023,CHEE,3321,3,18596,Analytical Methods Chem Engr,Grabow,Lars C,0,1,0,0,0,0,1,2.67
+Fall 2023,CHEE,3333,2,18597,Chem Engr Thermodyn II,Orman,Mehmet,2,0,0,0,0,0,1,4.0
+Fall 2023,CHEE,3363,2,18598,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,0,0,0,0,0,0,1,
+Fall 2023,DRAM,1310,15,18601,Introduction to Theatre,Egging,Jon Leo,70,14,5,1,7,0,3,3.375
+Fall 2023,MAS,3346,1,18603,Latinas in the United States,Pino,Diana,9,7,0,0,0,0,0,3.542
+Fall 2023,CHEE,3462,1,18604,Unit Operations,Zerze,Hasan,20,1,0,0,0,0,0,3.858
+Fall 2023,NAVY,3302,1,18608,Naval Operations,Davis,Danyelle,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7A42,1,18612,Banking and Credit Analysis,Lara,Alexander J,13,1,0,0,1,0,1,3.557
+Fall 2023,MARK,7366,1,18613,Digital Marketing Analytics,Tirunillai,Seshadri N,18,0,0,0,0,0,0,3.945
+Fall 2023,POLS,3349,1,18614,American Political Thought,Koganzon,Rita,7,7,6,2,2,0,0,2.584
+Fall 2023,COMM,3318,3,18615,Multimedia Storytelling,Uhrick,Jan,24,0,0,0,0,0,1,3.986
+Fall 2023,ACCT,4332,2,18616,Corporate Taxation,Fernandez,Ramon,5,1,1,0,0,0,0,3.619
+Fall 2023,ACCT,5332,4,18617,Taxation of Business Entities,Fernandez,Ramon,0,2,0,0,0,0,1,3.165
+Fall 2023,ACCT,7375,3,18618,Taxation of Business Entities,Fernandez,Ramon,1,2,1,0,0,0,1,3.083
+Fall 2023,ACCT,4335,4,18619,Financial Statement Auditing,Kuruvilla,Mohan,8,10,4,3,7,0,4,2.343
+Fall 2023,ACCT,7360,1,18620,Partnership Taxation,King,Sheldon,7,5,0,0,0,0,0,3.583
+Fall 2023,ACCT,7367,1,18621,Advanced Internal Auditing,Brant Jr,Robert Edward,4,7,1,0,0,0,0,3.388
+Fall 2023,GOVT,2305,6,18622,"US Govt: Congress,Pres & Crts",Clark,Jennifer H,159,74,10,2,1,0,2,3.549
+Fall 2023,WGSS,2350,20,18625,Intro To Women's Studies,Tuthill,Zelma,25,3,0,0,1,0,1,3.736
+Fall 2023,ACCT,7385,1,18626,Forensic Accounting,Ramey,Dan T,7,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,1311,5,18629,Fundamentals of Chemistry,Bittner,Eric R,7,15,25,3,7,0,20,2.164
+Fall 2023,NURS,4312,1,18635,Ldership and Mgmt in Prof Nur,Quintana,Danielle,43,16,0,2,0,0,0,3.639
+Fall 2023,ECE,6302,1,18637,Introductn To Neuroengineering,Sheth,Bhavin R,3,4,0,0,0,0,1,3.381
+Fall 2023,NURS,6345,1,18639,Mgmt of Hlth Dsordrs in Wom/Ch,Varghese,Shainy B,1,0,2,0,0,0,0,2.667
+Fall 2023,NURS,6346,1,18640,Mgmt of Hlth Dsordrs in Wo/Ch,Varghese,Shainy B,0,0,0,0,0,3,0,
+Fall 2023,MATH,1300,1,18641,Fundamentals of Mathematics,Constante,Beatrice,0,0,0,0,0,28,2,
+Fall 2023,HDCS,3384,1,18643,Consumer Sales,Mudd,Blake Stevens,39,7,2,1,2,0,0,3.575
+Fall 2023,CIS,2334,31,18644,Information Systems Applicatns,Detillier,Bret James,69,62,29,2,6,0,19,3.06
+Fall 2023,CIS,2348,31,18645,Info Systems Appl Development,Ratner,Edward,9,14,26,0,9,0,10,2.173
+Fall 2023,CIS,3320,1,18646,Information Visualization,Ratner,Edward,59,55,12,4,11,0,3,2.996
+Fall 2023,CNST,3210,1,18647,Safety for Industrial Projects,Zayas,Frederick A,1,2,12,4,0,0,1,2.0
+Fall 2023,GOVT,2305,7,18650,"US Govt: Congress,Pres & Crts",Sisman,Ozlem,156,43,15,10,17,0,8,3.237
+Fall 2023,ACCT,7340,3,18652,Financial Statement Analysis,Lu,Tong,13,0,0,0,0,0,0,3.924
+Fall 2023,GENB,5303,5,18653,Prof Acct Communication,Newman,Michael Ray,1,0,0,0,0,0,0,4.0
+Fall 2023,GENB,7303,3,18654,Prof Accounting Communication,Newman,Michael Ray,11,5,1,0,0,0,0,3.627
+Fall 2023,MUSA,2300,9,18656,Applied Voice,Averyt,Zachary Benjamin,2,0,0,0,0,0,0,3.835
+Fall 2023,BIOE,4303,2,18657,Biomaterials,Abidian,Mohammad Reza,10,4,0,0,0,0,0,3.738
+Fall 2023,BIOE,6303,2,18658,Biomaterials,Abidian,Mohammad Reza,9,1,0,0,0,0,0,3.867
+Fall 2023,ENGL,1301,150,18660,First Year Writing I,Bass,Kasey Dawn,20,0,0,0,0,0,0,3.984
+Fall 2023,ENGL,1301,151,18661,First Year Writing I,Braniger,Leslie,7,7,6,0,0,0,0,3.083
+Fall 2023,ENGL,1301,152,18662,First Year Writing I,Edens,Jenifer,9,9,2,0,0,0,0,3.218
+Fall 2023,ENGL,1301,153,18663,First Year Writing I,Horton,Lara,5,6,7,0,0,0,0,2.816
+Fall 2023,ECON,2302,2,18667,Principles of Microeconomics,Hossain,Md Shahadath,56,175,48,21,8,0,12,2.826
+Fall 2023,GHL,6343,1,18669,Beverage Management,Corsi,Aaron James,7,0,0,0,0,0,0,3.906
+Fall 2023,GEOL,7333,3,18670,Seismic Wave & Ray Theory,Chesnokov,Evgeni M,7,0,0,0,0,0,0,3.811
+Fall 2023,BTEC,4301,30,18673,Principles of Bioprocessing,Lin,Yuheng,16,7,0,0,0,0,0,3.724
+Fall 2023,ACCT,4331,3,18675,Federal Income Tax,Fernandez,Ramon,8,45,16,1,0,0,3,2.933
+Fall 2023,ACCT,5331,2,18676,Federal Income Tax,Fernandez,Ramon,0,1,0,0,0,0,0,3.0
+Fall 2023,MUSA,4440,1,18678,Applied Trumpet,Vassallo,Jim Cates,1,0,0,0,0,0,0,3.67
+Fall 2023,ECON,2301,3,18680,Principles of Macroeconomics,Maden,Bitaran Jang,57,135,79,29,28,0,16,2.512
+Fall 2023,SPAN,3384,3,18682,Intro To Hispanic Literature,Hasbun,Rodrigo,7,4,0,0,1,0,0,3.278
+Fall 2023,MUSA,4442,1,18683,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,8999,30,18684,Doctoral Dissertation,Brgoch,Jakoah,0,0,0,0,0,2,0,
+Fall 2023,FINA,3332,7,18686,Prin of Financial Management,Chisholm,Darla,6,22,18,11,4,0,3,2.192
+Fall 2023,MUSA,6212,1,18687,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,SGNL,1302,3,18691,Elementary Sign Language II,Warmack,Chris Kiskinis,6,13,4,2,0,0,0,2.946
+Fall 2023,PHIL,3386,1,18693,19th Century Philosophy,Werner,Andrew Timothy,15,7,3,1,2,0,1,3.119
+Fall 2023,PHIL,3383,1,18694,His of Ancient Phi,Werner,Andrew Timothy,16,7,3,0,2,0,1,3.132
+Fall 2023,MUSA,2322,1,18695,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5130,1,18696,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,14,0,
+Fall 2023,LAW,5130,2,18697,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,0,0,
+Fall 2023,ENGL,7398,6,18698,Special Problems,Snediker,Michael,1,0,0,0,0,0,0,3.67
+Fall 2023,FINA,7326,1,18705,Private Equity & Invest Bankin,Stewart,Marcus,12,8,0,0,0,0,0,3.584
+Fall 2023,HDFS,4318,3,18706,Parent-Child Relationships,Fraser,Camille,24,8,2,4,1,0,1,3.214
+Fall 2023,HDFS,4318,4,18707,Parent-Child Relationships,Frankel,Leslie Ann,19,3,0,0,0,0,2,3.789
+Fall 2023,BIOE,6305,2,18709,Brain Machine Interfacing,Francis,Joseph Thachil,4,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8399,10,18711,Doctoral Dissertation,Gonzalez,Maria C,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6257,18,18713,Research Practicum B,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,7399,2,18717,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,3,0,
+Fall 2023,GEOL,8398,17,18718,Doctoral Research,Jiang,Xun,0,0,0,0,0,2,0,
+Fall 2023,GEOL,8698,14,18719,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Fall 2023,MUSA,1334,3,18724,Applied Clarinet,Potiomkin,Alexander,4,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5232,1,18725,Trade Secrets,Beebe,James L,12,16,0,0,0,5,0,3.429
+Fall 2023,PSYC,6498,8,18727,Special Problems,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2023,MARK,7366,2,18729,Digital Marketing Analytics,Tirunillai,Seshadri N,15,0,0,0,0,0,0,3.956
+Fall 2023,PHLS,8199,8,18730,Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,
+Fall 2023,MUSA,1300,3,18734,Applied Voice,Ceres,Emily Margaret,1,0,0,0,0,0,0,4.0
+Fall 2023,LAW,7314,1,18735,WRS: Antidiscrimination,Areheart,Bradley Allan,7,3,2,0,0,0,0,3.389
+Fall 2023,SGNL,2301,6,18737,Intermediate Sign Language I,Sheneman,Naomi,5,7,1,0,1,0,0,2.954
+Fall 2023,BIOE,4319,2,18738,Mass Transport Biosystems,Majd,Sheereen,4,3,0,0,0,0,0,3.571
+Fall 2023,BIOE,6319,2,18739,Mass Transport Bio Systems,Majd,Sheereen,4,1,0,0,0,0,0,3.8
+Fall 2023,ENGR,2301,4,18740,Mechanics I (Statics),Wu,Yuntian,4,6,0,0,0,0,1,3.4
+Fall 2023,FINA,7A40,2,18742,Fixed Income I,Doshi,Hitesh B,2,2,0,0,0,0,0,3.5
+Fall 2023,ENGL,8399,11,18743,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Fall 2023,FINA,7A41,2,18744,Fixed Income II,Doshi,Hitesh B,2,0,0,0,0,0,0,3.835
+Fall 2023,POLC,6312,1,18745,Public Finance,Obregon,Alexander Wade,14,1,0,0,0,0,0,3.867
+Fall 2023,ENGL,8399,12,18747,Doctoral Dissertation,Stock,Lorraine K,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6398,17,18751,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,2,0,
+Fall 2023,ECON,3347,1,18760,Capital Market Economics,Maden,Bitaran Jang,15,15,16,1,2,0,2,2.796
+Fall 2023,HLT,4307,5,18763,Research and Eval in Health,Ripperger-Suhler,Ken,18,11,6,2,0,0,1,3.136
+Fall 2023,BZAN,7320,2,18764,Bus Modeling For Comp Adv,Murray,Michael J,6,4,3,0,0,0,1,3.155
+Fall 2023,HDFS,4325,3,18765,Theory to Practice in HDFS,Jordan,Erica F,15,2,0,1,0,0,1,3.741
+Fall 2023,ENGL,8399,13,18770,Doctoral Dissertation,Harris,Francine Julia,0,0,0,0,0,1,0,
+Fall 2023,SCM,7380,2,18775,Analytics & Enterprise Opertns,Murray,Michael J,14,4,1,0,0,0,0,3.684
+Fall 2023,SCM,7390,2,18776,Global Supply Chain Strategy,Smith,Gordon D,6,3,0,0,0,0,0,3.593
+Fall 2023,COSC,4396,2,18782,Senior Research Project,Cheng,Albert M K,0,1,0,0,0,0,0,2.67
+Fall 2023,HIST,7399,1,18786,Masters Thesis,Reed,Linda,0,0,0,0,0,1,0,
+Fall 2023,HIST,6399,1,18787,Masters Thesis,Reed,Linda,0,0,0,0,0,1,0,
+Fall 2023,CIVE,6111,3,18788,Graduate Seminar,Xie,Surui,0,0,0,0,0,13,0,
+Fall 2023,FINA,4360,1,18791,International Financial Mgmt,Hitzemann,Steffen,6,14,6,0,0,0,1,2.962
+Fall 2023,PHLS,8199,9,18792,Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2023,FINA,7360,1,18794,International Finance,Hitzemann,Steffen,5,5,0,0,0,0,0,3.467
+Fall 2023,MUSA,8242,4,18796,Doctoral Recital III,Yon,Kirsten A,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,4402,2,18799,Applied Composition,Smith,Robert Thomas,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8330,1,18802,Doctoral Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2023,CIS,3368,3,18803,Adv Info Systems Development,Peddoju,Suresh Kumar,26,7,10,0,3,0,4,3.202
+Fall 2023,GEOL,7399,11,18804,Masters Thesis,Lapen,Thomas J,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8312,7,18810,Lab of Practice-Res Meth Devel,Johnson,Detra DeVerne,0,0,0,0,0,1,0,
+Fall 2023,SGNL,2301,3,18817,Intermediate Sign Language I,Warmack,Chris Kiskinis,5,12,4,0,0,0,0,3.0
+Fall 2023,MUSA,1310,4,18819,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2023,CLAS,3308,3,18820,Myths & Cult of the Greek Gods,Kidder,Kathleen,19,19,2,0,0,0,2,3.4
+Fall 2023,MUSA,3410,2,18821,Applied Piano,Norian,Gary,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,6198,1,18823,Special Problems in Human Perf,Pearson,Demetrius W,0,0,0,0,0,1,0,
+Fall 2023,BUSI,3302,4,18825,Connecting Bauer to Business,Belinne,Jamie King,316,69,17,4,0,0,5,3.717
+Fall 2023,ENGL,8399,14,18826,Doctoral Dissertation,Davies,Daniel,0,0,0,0,0,1,0,
+Fall 2023,MECE,8399,41,18827,Doctoral Dissertation,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,8193,1,18830,COMD Proseminar,Blake,Margaret T,0,0,0,0,0,8,0,
+Fall 2023,INDS,4180,1,18831,Design Internship,Kimbrough,Mark S,3,0,0,0,0,0,0,4.0
+Fall 2023,INDS,4380,1,18832,Design Internship,Kimbrough,Mark S,5,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,12,18834,Doctoral Applied Music,Kitai,Anthony T,0,0,0,0,0,0,0,
+Fall 2023,MUSA,8320,13,18835,Doctoral Applied Music,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,7141,1,18836,Pharmacological Liter. Review,Bond,Richard A,0,0,0,0,0,13,0,
+Fall 2023,MATH,1324,8,18840,Finite Math with Applications,Hong,Yuqi,24,16,20,2,6,0,14,2.677
+Fall 2023,MUSA,6324,2,18842,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,6306,4,18843,Social Work Practice Skills,White,Tamika Alonzo,21,6,0,0,0,0,1,3.778
+Fall 2023,ACCT,3367,5,18844,Intermediate Accounting I,Kraten,Michael,20,31,5,2,2,0,2,3.006
+Fall 2023,ACCT,5371,2,18845,Accounting Information Systems,Seijas,Nuria S,0,1,0,0,0,0,0,3.33
+Fall 2023,ACCT,7320,2,18847,Intro to Data Analytics-Acct,Miles,Carolyn A,12,6,1,0,0,0,0,3.509
+Fall 2023,ARTS,3300,3,18848,Advanced Drawing,Safai Takhteh Fooladi,Farima,18,0,1,0,0,0,1,3.86
+Fall 2023,ARTS,2316,4,18849,Fundamentals of Painting,Meza,Edgar,18,2,0,0,0,0,0,3.884
+Fall 2023,MUSI,6351,1,18850,Applied Music Pedagogy,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7324,2,18857,Writers On Literature,Divakaruni,Chitra B,8,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8296,1,18858,Doctoral Essay,Snyder,John L,0,0,0,0,0,2,0,
+Fall 2023,HIST,4398,3,18859,Independent Study,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8399,9,18863,Doctoral Dissertation,Zheng,Yingcai,2,0,0,0,0,1,0,4.0
+Fall 2023,MUSA,6141,1,18864,Graduate Recital II,Cho,Eunghee,0,0,0,0,0,0,0,
+Fall 2023,ARCH,3198,3,18866,Independent Study,Froehlich,Dietmar,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1332,1,18873,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8398,132,18881,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Fall 2023,COSC,8998,132,18885,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Fall 2023,ARTH,3399,1,18887,Senior Honors Thesis,Koontz,Rex A,0,0,0,0,0,0,0,
+Fall 2023,ARTS,3301,2,18888,Life Drawing,Souvorova,Daria,14,4,2,0,0,0,0,3.551
+Fall 2023,MUSA,8320,14,18893,Doctoral Applied Music,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Fall 2023,HLT,3300,2,18903,Social Health and Wellness,Farmer,Jennifer,78,13,4,1,2,0,0,3.65
+Fall 2023,ARCH,3314,1,18904,Topics in Design Technology,Kyropoulou,Amygdalia,2,0,0,0,0,0,0,4.0
+Fall 2023,INDE,2333,3,18917,Engineering Statistics I,Wiggins,Nathanial David,31,3,3,0,0,0,1,3.694
+Fall 2023,GHL,6172,1,18918,Mgmt Training Work Exp Prog I,Shepherd,Ashley,3,0,0,0,0,0,0,4.0
+Fall 2023,ANTH,4331,1,18923,Medical Anthropology,Ghazali,Marwa,14,4,0,1,0,0,1,3.649
+Fall 2023,ANTH,6322,1,18924,Seminar in Medical Anth,Ghazali,Marwa,4,0,0,0,0,0,0,3.918
+Fall 2023,ENTR,7336,2,18926,Entrepreneurship Overview,Wilbur,Stephen,4,5,0,0,0,0,0,3.408
+Fall 2023,PETR,3363,1,18928,Fluid Mechanics for PETR Engr,Myers,Michael Tolbert,0,2,0,0,0,0,0,2.835
+Fall 2023,MUSA,8320,26,18929,Doctoral Applied Music,Weber,Mary E,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,3313,3,18938,Silkscreen,Bender,Hannah,12,1,0,0,0,0,0,3.872
+Fall 2023,MUSA,8320,28,18939,Doctoral Applied Music,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2023,DIGM,4398,1,18940,Independent Study,Liao,Tony Chung-Li,1,0,0,0,0,0,0,4.0
+Fall 2023,MIS,6A41,3,18941,Information Systems,Silva,Leiser O,15,0,0,0,0,0,0,3.868
+Fall 2023,CIS,2337,31,18944,Fund of Information Security,Lee,Kyu In,75,62,15,4,1,0,1,3.291
+Fall 2023,CNST,3205,2,18946,Construction Safety Management,Hart,Lee J,13,2,0,0,0,0,0,3.867
+Fall 2023,SCM,3301,3,18958,SCM Fundamentals,Anderson Fletcher,Elizabeth,14,6,1,0,0,0,1,3.572
+Fall 2023,SCM,3301,4,18959,SCM Fundamentals,Anderson Fletcher,Elizabeth,18,4,0,0,0,0,0,3.773
+Fall 2023,PCEU,7142,1,18960,Pharmaceutic Literature Review,Bond,Richard A,0,0,0,0,0,3,0,
+Fall 2023,CIVE,3331,2,18962,Environmental Engineering,Kiaghadi,Amin,46,32,12,2,1,0,0,3.241
+Fall 2023,INDE,6372,2,18963,Advanced Linear Optimization,Diaz Martinez,Neil Orlando,1,1,0,0,0,0,1,3.5
+Fall 2023,CIVE,3337,2,18964,Structural Analysis,Phatak,Tejasree Mohan,9,17,11,3,0,0,1,2.759
+Fall 2023,CIVE,3339,3,18965,Geotechnical Engineering,Phatak,Tejasree Mohan,5,17,11,1,4,0,1,2.448
+Fall 2023,ECE,3355,3,18967,Electronics,Ruchhoeft,Paul,20,18,16,4,0,0,0,2.954
+Fall 2023,ECE,3317,3,18972,Applied Electromagnetic Waves,Chen,Jiefu,16,37,6,0,0,0,0,3.164
+Fall 2023,MECE,3369,2,18977,Solid Mechanics,Baxevanis,Theocharis,11,23,8,1,0,0,0,2.954
+Fall 2023,ECE,2201,7,18978,Circuit Analysis I,Ramachandran,Deepa,34,15,1,0,0,0,0,3.627
+Fall 2023,ANTH,4398,1,18986,Independent Study,Sen,Debarati,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8298,1,18990,Doctoral Research,Song,Gangbing,0,0,0,0,0,7,0,
+Fall 2023,PHLS,8396,1,18992,Doctoral Research,Margulis,Milena A,0,0,0,0,0,2,0,
+Fall 2023,EDS,6333,1,18993,Probability and Statistics,Kulkarni,Yashashree,97,3,0,0,0,0,0,3.97
+Fall 2023,EDS,6342,1,18995,Intro to Machine Learning,Kulkarni,Yashashree,38,19,2,0,0,0,0,3.61
+Fall 2023,MUSA,6430,1,18996,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,3321,6,18998,Engineering Mathematics,West,James David,116,52,39,24,17,0,1,2.911
+Fall 2023,MATH,3363,6,18999,Introduction To PDE,Morgan,Jeffrey,35,33,16,4,4,0,0,3.0
+Fall 2023,COMD,7392,6,19009,Adv Pract Sp & Lang Dis,Guerra,Teresa Evangelina,3,0,0,0,0,0,0,3.89
+Fall 2023,COMD,7392,7,19011,Adv Pract Sp & Lang Dis,Oicata de Torres,Nancy,2,0,0,0,0,0,0,3.835
+Fall 2023,BIOE,8398,27,19013,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2023,MUSA,2350,2,19015,Applied Percussion,Wilkins,Blake M,3,0,0,0,0,0,0,4.0
+Fall 2023,MIS,3376,5,19017,Busn Appls Database Mgmt I,Jiang,Lianlian,50,9,2,0,0,0,1,3.819
+Fall 2023,CIS,6321,40,19019,Principles of Cybersecurity,Lee,Kyu In,16,0,0,0,0,0,0,3.959
+Fall 2023,CHEM,1112,25,19020,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,9,3,1,0,0,3,2.822
+Fall 2023,CHEM,1112,26,19021,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,2,0,0,0,1,3.136
+Fall 2023,MUSA,1320,1,19025,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2023,CIS,6325,40,19027,Network Security,Conklin,William A,12,1,0,0,0,0,1,3.822
+Fall 2023,PHLS,8699,13,19028,Doctoral Dissertation,de Dios,Marcel A,0,0,0,0,0,0,0,
+Fall 2023,COSC,2425,3,19032,Computer Org & Architecture,Johnsson,Lennart,42,52,9,6,7,0,7,3.023
+Fall 2023,COSC,2425,5,19034,Computer Org & Architecture,Mantini,Pranav,93,37,12,3,3,0,2,3.372
+Fall 2023,COSC,2425,801,19036,Computer Org & Architecture,Long,Kevin B,26,31,0,2,0,0,1,3.373
+Fall 2023,PCOL,6198,7,19038,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Fall 2023,TEPM,6301,40,19039,Project Management Principles,Sherman,Dennis Louis,17,5,0,0,0,0,1,3.728
+Fall 2023,TEPM,6302,40,19040,Leadership and Team Building,Hopkins,Ronald K,1,1,0,0,0,0,0,3.665
+Fall 2023,TEPM,6304,40,19041,Quality Improvemnt in Proj Mgt,Kovach,Jamison,2,0,1,0,0,0,1,3.333
+Fall 2023,MATH,1324,9,19053,Finite Math with Applications,Winkle,James J,118,102,72,22,56,0,30,2.519
+Fall 2023,BIOE,8198,2,19054,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2023,PHOP,6267,5,19062,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2023,OPTO,5198,8,19071,Spec Prob - Clerkship,Sapoznik,Kaitlyn Anne,0,0,0,0,0,53,0,
+Fall 2023,CIVE,8298,2,19073,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Fall 2023,CIVE,8498,2,19074,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Fall 2023,FORE,6311,40,19075,Introduction to Foresight,Schultz,Wendy L,7,0,0,0,0,0,1,4.0
+Fall 2023,FORE,6331,40,19076,Social Change,Mudge,James Thomas,4,2,0,0,0,0,1,3.667
+Fall 2023,HLT,1353,5,19077,Personal Health,Shamblin,Angel Ann,89,21,4,1,2,0,2,3.59
+Fall 2023,FORE,6351,40,19078,Futures Research,Hines,Andrew Lewis,7,0,0,0,0,0,0,3.953
+Fall 2023,MARK,6A61,6,19080,Marketing Administration,Krishnamurthy,Parthasarathy,10,1,0,0,0,0,0,3.759
+Fall 2023,ENGL,1301,154,19081,First Year Writing I,Worley,Sharon J,16,2,0,1,5,0,1,2.848
+Fall 2023,ENGL,1301,155,19082,First Year Writing I,Braniger,Leslie,8,12,5,3,1,0,1,2.736
+Fall 2023,ENGL,1301,156,19083,First Year Writing I,Rajkumar,Nidhi,13,4,3,1,3,0,1,2.945
+Fall 2023,ENGL,1301,157,19084,First Year Writing I,Braniger,Leslie,9,14,1,1,0,0,0,3.134
+Fall 2023,ENGL,1301,158,19085,First Year Writing I,Stewart-Steele,Heather Marie,7,12,2,0,0,0,2,3.144
+Fall 2023,ENGL,1301,159,19086,First Year Writing I,Stewart-Steele,Heather Marie,7,11,4,0,3,0,0,2.654
+Fall 2023,ENGL,1301,160,19087,First Year Writing I,Anderson,Claire F,23,2,1,0,3,0,1,3.437
+Fall 2023,ENGL,1301,161,19089,First Year Writing I,Rolater,Sara C,19,3,3,5,0,0,0,3.046
+Fall 2023,ENGL,1301,162,19090,First Year Writing I,Islam,Muhammad Nurul,17,1,0,0,0,0,1,3.816
+Fall 2023,ENGL,1301,163,19091,First Year Writing I,Rolater,Sara C,4,12,6,4,2,0,2,2.429
+Fall 2023,ENGL,1302,62,19093,First Year Writing II,Denton,Amy,13,2,1,1,0,0,1,3.491
+Fall 2023,ENGL,1302,63,19094,First Year Writing II,Denton,Amy,8,6,2,1,0,0,1,3.196
+Fall 2023,CIVE,8398,2,19097,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8398,4,19099,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Fall 2023,CIVE,8298,3,19100,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,4,0,
+Fall 2023,PHOP,6357,12,19104,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4424,1,19106,Applied Violoncello,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6398,5,19107,Special Problems,Boini,Krishna M,2,1,0,0,0,1,0,3.557
+Fall 2023,PCOL,6298,3,19108,Special Problems,Boini,Krishna M,1,0,0,0,0,1,0,4.0
+Fall 2023,PCOL,6198,4,19109,Special Problems,Wu,Mingfu,1,2,0,0,0,0,0,3.223
+Fall 2023,ECE,6398,29,19112,Research,Malki,Heidar A,0,0,0,0,0,0,3,
+Fall 2023,PSYC,7399,8,19113,Masters Thesis,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,7399,12,19114,Masters Thesis,Reyes,Denise Lucia,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,1112,27,19115,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,10,4,0,0,0,2,2.875
+Fall 2023,SCM,4362,1,19116,Demand and Supply Integration,Khumawala,Basheer M,42,21,12,2,1,0,0,3.223
+Fall 2023,SCM,4362,2,19117,Demand and Supply Integration,Khumawala,Basheer M,9,6,5,0,0,0,0,3.151
+Fall 2023,CIVE,8198,2,19118,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Fall 2023,CIS,3351,2,19120,Intrusion Detect & Incid Resp,Nsoh,Jovita T,1,0,0,0,0,0,0,4.0
+Fall 2023,BTEC,6101,40,19124,Biotechnology Techniques Metho,Khan,Abdul Latif,5,0,0,0,0,0,0,4.0
+Fall 2023,HIST,1302,51,19125,The U.S. Since 1877,Modaff,Abigail,23,1,0,0,0,0,0,3.876
+Fall 2023,BIOE,8598,29,19126,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2023,TLIM,3363,3,19135,Technical Communications,Bracken II,William Terry,20,4,1,1,2,0,1,3.31
+Fall 2023,TLIM,3363,34,19136,Technical Communications,Piercy,Penelope Junker,23,9,6,0,1,0,0,3.317
+Fall 2023,EDS,6340,1,19137,Introduction to Data Science,Kulkarni,Yashashree,94,11,0,0,0,0,0,3.895
+Fall 2023,MUSA,4400,9,19138,Applied Voice,Laine,Eric G,2,0,0,0,0,0,0,3.835
+Fall 2023,CIVE,8298,4,19139,Doctoral Research,Lee,Hyongki,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8398,5,19141,Doctoral Research,Lee,Hyongki,0,0,0,0,0,1,0,
+Fall 2023,HIST,4391,1,19143,Public History Internship,Young,Nancy Beck,3,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,4350,2,19144,Genomic & Proteomic Engr,Wu,Tianfu,2,1,0,0,0,0,0,3.667
+Fall 2023,CIVE,8298,5,19147,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8298,6,19148,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Fall 2023,ECE,7399,6,19152,Masters Thesis,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8398,6,19156,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8598,2,19157,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8598,3,19158,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8498,5,19159,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8698,18,19161,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Fall 2023,THEA,6307,1,19162,Theatrical Project Planning,Vlahos,Kalliope,0,0,1,0,0,0,0,2.0
+Fall 2023,POLS,8999,10,19166,Doctoral Dissertation,Basinger,Scott J,0,0,0,0,0,1,0,
+Fall 2023,POLS,8999,12,19168,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,2,0,
+Fall 2023,PCOL,6198,8,19169,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7399,13,19170,Masters Thesis,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Fall 2023,ENGL,1301,166,19171,First Year Writing I,Cervantes,Kimberly Ann,14,3,1,1,0,0,0,3.509
+Fall 2023,ENGL,1301,167,19172,First Year Writing I,Islam,Muhammad Nurul,17,1,0,0,0,0,0,3.871
+Fall 2023,ENGL,1301,169,19174,First Year Writing I,Worley,Sharon J,15,6,0,0,1,0,3,3.455
+Fall 2023,ENGL,1301,170,19175,First Year Writing I,Murray,Christopher Brean,14,2,1,0,0,0,2,3.687
+Fall 2023,ENGL,1301,171,19176,First Year Writing I,Lowder,Will,17,2,0,0,0,0,0,3.877
+Fall 2023,ENGL,1301,172,19177,First Year Writing I,Barr,Anna Kate,15,2,1,0,0,0,1,3.759
+Fall 2023,ENGL,1301,173,19178,First Year Writing I,Al-Bedawi,Layla,12,2,2,1,2,0,0,3.123
+Fall 2023,ENGL,1301,174,19179,First Year Writing I,Al-Bedawi,Layla,13,2,1,2,0,0,1,3.371
+Fall 2023,ENGL,1301,175,19180,First Year Writing I,Seelen,William,14,2,2,0,0,0,0,3.612
+Fall 2023,ENGL,1301,176,19181,First Year Writing I,Lee,Nathanael D,12,3,0,1,1,0,1,3.295
+Fall 2023,ENGL,1301,177,19182,First Year Writing I,Berg,Caleb J.,14,5,0,0,0,0,0,3.719
+Fall 2023,ENGL,1302,66,19183,First Year Writing II,Gonzalez,Maria C,12,3,0,0,2,0,2,3.295
+Fall 2023,ENGL,1302,67,19184,First Year Writing II,Braniger,Leslie,4,8,3,1,3,0,6,2.439
+Fall 2023,TECH,4310,1,19188,Future of Energy & Environment,Breaux,James William,38,0,0,0,0,0,0,3.974
+Fall 2023,PCOL,6198,9,19189,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6198,10,19190,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Fall 2023,ENGL,7699,7,19191,Thesis,Divakaruni,Chitra B,0,0,0,0,0,1,0,
+Fall 2023,ENGL,7699,8,19192,Thesis,Peynado,Brenda,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8698,19,19193,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2023,PSYC,8399,29,19194,Doctoral Dissertation,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Fall 2023,MECE,6399,5,19195,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Fall 2023,CIS,6325,3,19198,Network Security,Conklin,William A,23,14,0,0,1,0,0,3.518
+Fall 2023,MECE,8598,1,19200,Doctoral Research,Chen,Tian,0,0,0,0,0,2,0,
+Fall 2023,ENGL,8399,15,19202,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Fall 2023,AAS,2320,7,19203,Intro To African American Stdy,Walker,Alan,25,6,0,0,0,0,2,3.732
+Fall 2023,ENGL,8399,16,19204,Doctoral Dissertation,Lee,Eunjeong,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,2,19206,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,2,0,
+Fall 2023,OPTO,5198,11,19210,Spec Prob - Clerkship,Dempsey,Robert L,0,0,0,0,0,1,0,
+Fall 2023,PHLS,8999,5,19211,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6410,1,19212,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8298,2,19214,Doctoral Research,Floryan,Daniel,0,0,0,0,0,3,0,
+Fall 2023,MUSA,8241,7,19217,Doctoral Recital II,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2023,HLT,4320,3,19221,Admin of Health Services,Haq,Arooba A,24,9,2,0,0,0,0,3.534
+Fall 2023,PHCA,8698,1,19223,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2023,INTB,3355,5,19224,Global Environment of Business,Carvalho,Emilia Barreto,191,36,13,6,1,0,2,3.672
+Fall 2023,CIVE,8298,7,19226,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2023,PCOL,8998,10,19230,Doctoral Research,Ruan,Ke-He,0,0,0,0,0,0,0,
+Fall 2023,SCM,4302,1,19231,Energy Supply Chain,Venugopal,Kalyanaraman,33,24,10,0,0,0,0,3.264
+Fall 2023,DIGM,1300,31,19232,Introduction to Digital Media,Liao,Pamara F,0,0,0,0,1,0,0,0.0
+Fall 2023,MIS,8999,2,19234,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Fall 2023,MIS,8999,3,19235,Doctoral Dissertation in MIS,Chin,Wynne W,0,0,0,0,0,1,0,
+Fall 2023,MUSA,8242,5,19243,Doctoral Recital III,Morgulis,Tali,0,0,0,0,0,0,0,
+Fall 2023,MECE,7399,10,19245,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8398,8,19248,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8298,8,19249,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8498,7,19250,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Fall 2023,CIS,2336,33,19251,Web Application Development,Faiyaz,Sajida,14,28,25,1,3,0,10,2.765
+Fall 2023,ELET,1400,4,19252,Circuit Theory and Lab I,Soneja,Chandrayee,13,9,5,2,1,0,4,3.044
+Fall 2023,GEOL,8998,30,19256,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Fall 2023,GEOL,6399,12,19260,Masters Thesis,Wellner,Julia S,1,0,0,0,0,0,0,4.0
+Fall 2023,CNST,4302,1,19261,Construction Law and Ethics,Escobar,C Mauricio,8,8,3,1,0,0,0,3.084
+Fall 2023,MECE,8298,10,19262,Doctoral Research,Zhao,Bo,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8398,10,19263,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Fall 2023,MUSA,8243,5,19265,Doctoral Lecture Recital,Jones,Timothy J,0,0,0,0,0,0,0,
+Fall 2023,PHCA,8199,4,19266,Doctoral Dissertation Defense,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,7399,14,19269,Masters Thesis,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2023,PCEU,6398,6,19272,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8598,10,19273,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7399,15,19274,Masters Thesis,Alfano,Candice A,2,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8398,11,19276,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,2,0,
+Fall 2023,ELET,6396,1,19285,Master's Project,Zouridakis,George,2,0,0,0,0,0,0,4.0
+Fall 2023,SUBS,6320,3,19286,Riser Design,Sun,Li,0,1,0,0,0,0,1,3.0
+Fall 2023,ECE,2100,3,19289,Circuit Analysis Laboratory,Leigh,Kevin Benny,7,4,1,0,0,0,0,3.39
+Fall 2023,GEOL,6399,13,19290,Masters Thesis,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8399,2,19291,Doctoral Dissertation,Glennie,Craig Len,0,0,0,0,0,2,0,
+Fall 2023,PEP,8699,5,19293,Doctoral Dissertation,Markofski,Melissa,0,0,0,0,0,1,0,
+Fall 2023,MIS,8999,4,19299,Doctoral Dissertation in MIS,Aron,Ravi,0,0,0,0,0,1,0,
+Fall 2023,MUSA,8220,6,19300,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2023,DANC,2303,3,19311,Introduction to Dance,Bobet,Jacqueline A,26,6,6,4,8,0,6,2.8
+Fall 2023,DRAM,1310,6,19313,Introduction to Theatre,Young,Courtney Leigh,38,6,2,1,0,0,3,3.73
+Fall 2023,PHLS,8396,2,19315,Doctoral Research,Arbona,Consuelo,0,0,0,0,0,2,0,
+Fall 2023,ENGL,6698,3,19316,Research,Parsons,Alexander M,0,0,0,0,0,1,0,
+Fall 2023,MARK,7A43,2,19317,Digital and Inside Sales,Herman,Carl,5,0,0,0,0,0,0,4.0
+Fall 2023,MARK,7A44,2,19318,Customer Relationship Mgt,Herman,Carl,5,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8398,12,19320,Doctoral Research,Momen,Mostafa,0,0,0,0,0,3,0,
+Fall 2023,HIST,8399,5,19327,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,1,0,
+Fall 2023,MUSI,6106,6,19328,Grad Large Ensemble,Koppel,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,8999,7,19331,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Fall 2023,CIVE,7399,5,19336,Master's Thesis,Kalliontzis,Dimitrios,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,31,19340,Doctoral Applied Music,Witt,Woodrow W,1,0,0,0,0,0,0,3.67
+Fall 2023,PSYC,8199,5,19345,Doctoral Dissertation,Gallagher,Matthew Ward,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8399,3,19346,Doctoral Dissertation,Wang,Keh-Han,0,0,0,0,0,0,0,
+Fall 2023,PHCA,6297,2,19349,Selected Topics,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,7399,16,19350,Masters Thesis,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8298,9,19351,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Fall 2023,MECE,7399,11,19361,Masters Thesis,Wang,Su Su,0,0,0,0,0,0,0,
+Fall 2023,GEOL,8398,22,19362,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8398,13,19364,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,5,0,
+Fall 2023,COMD,7391,12,19366,Clinic in Speech Lang Disorder,Chapman,Amanda,2,1,0,0,0,0,0,3.557
+Fall 2023,COMD,7392,8,19367,Adv Pract Sp & Lang Dis,Townsend,Alayna,2,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7392,9,19368,Adv Pract Sp & Lang Dis,Guerra,Teresa Evangelina,2,0,0,0,0,0,0,3.835
+Fall 2023,COMD,7392,10,19369,Adv Pract Sp & Lang Dis,Walker,Dionne A,2,0,0,0,0,0,0,3.835
+Fall 2023,CIVE,8298,10,19370,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Fall 2023,GEOL,8999,8,19379,Doctoral Dissertation,Wang,Guoquan,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8398,23,19381,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Fall 2023,FINA,8398,4,19383,Special Problems,Yerramilli,Vijay,1,0,0,0,0,0,0,3.67
+Fall 2023,FINA,8398,5,19385,Special Problems,Susmel,Raul,1,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,8398,3,19386,Special Problems,Crawford,Steven,2,0,0,0,0,0,0,4.0
+Fall 2023,ELET,6325,1,19387,Practicum in Engineering Tech,Pollonini,Luca,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8398,33,19391,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8398,14,19392,Doctoral Research,Zhang,Ruda,0,0,0,0,0,2,0,
+Fall 2023,ELCS,8399,7,19395,Doctoral Dissertation,Carales,Vincent D,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8298,11,19396,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6342,2,19399,Applied French Horn,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7354,1,19400,Financial Econometrics,Susmel,Raul,3,0,0,0,0,0,0,3.89
+Fall 2023,DIGM,4398,2,19404,Independent Study,Liao,Pamara F,2,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,8699,2,19409,Doctoral Dissertation,Crawford,Steven,1,0,0,0,0,0,0,4.0
+Fall 2023,INDE,8598,8,19412,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,5,0,
+Fall 2023,MUSA,8320,32,19414,Doctoral Applied Music,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2023,INDE,8398,9,19415,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,
+Fall 2023,MUSA,6304,4,19417,Conducting,Koppel,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,3399,1,19424,Senior Honors Thesis,Camaj,Lindita,0,0,0,0,0,0,0,
+Fall 2023,ECON,3399,1,19426,Senior Honor Thesis,Wang,Fan,0,0,0,0,0,0,0,
+Fall 2023,MUSA,4210,1,19432,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,SPEC,6396,2,19433,Clinical Teaching II,Thompson,Amber M,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6424,2,19435,Applied Violoncello,Cho,Eunghee,1,1,0,0,0,0,0,3.5
+Fall 2023,PCEU,8998,5,19437,Doctoral Research,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2023,ARCH,3198,4,19444,Independent Study,Phan,Trang Anh Thuc,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6100,4,19451,Chamber Music,Hester,Timothy E,5,0,0,0,0,0,0,4.0
+Fall 2023,ENTR,6398,1,19455,Research,Wilbur,Stephen,3,2,0,0,0,0,0,3.6
+Fall 2023,MUSA,8243,6,19456,Doctoral Lecture Recital,Pollack,Howard J,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8999,10,19466,Doctoral Dissertation,Sun,Jiajia,0,0,0,0,0,0,0,
+Fall 2023,DRAM,1310,22,19467,Introduction to Theatre,Egging,Jon Leo,27,5,4,0,9,0,4,2.889
+Fall 2023,SPEC,6395,2,19468,Clinical Teaching I,Culpepper,Shea Mosley,0,0,0,0,0,1,0,
+Fall 2023,MECE,8298,8,19470,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,1,0,
+Fall 2023,ENGI,4198,6,19474,Independent Study,Kowal,Marsha Christine,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8398,27,19481,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Fall 2023,CUIN,7373,1,19497,Instr Strat Tchng Adult,Alarcon,Jeannette Driscoll,15,1,0,0,0,0,0,3.917
+Fall 2023,ECON,8396,1,19515,International Trade,Yi,Kei-Mu,9,0,0,0,0,0,0,3.78
+Fall 2023,ECON,7365,1,19516,Labor Economics,Juhn,Chinhui,8,0,0,0,0,0,0,4.0
+Fall 2023,ECON,7354,1,19517,Social Economics,Maheshri,Vikram,7,0,0,0,0,0,0,4.0
+Fall 2023,ECON,7385,1,19518,Monetary Policy,Papell,David H,6,0,0,0,0,0,0,4.0
+Fall 2023,ECON,4349,1,19521,Introduction To Game Theory,Ujhelyi,Gergely,3,7,10,8,5,0,3,1.818
+Fall 2023,ECON,4389,1,19522,Tops-Contemporary Economics II,Szabo,Andrea,4,0,0,0,0,0,1,4.0
+Fall 2023,ECON,4389,2,19523,Tops-Contemporary Economics II,Saboury,Piruz,7,3,4,0,0,0,1,3.285
+Fall 2023,ECON,3365,1,19524,Labor Economics,Hossain,Md Shahadath,10,13,5,0,0,0,2,3.143
+Fall 2023,ECON,3362,1,19525,Mathematics for Economics,Wang,Fan,10,12,5,0,3,0,3,2.834
+Fall 2023,GEOL,1104,2,19529,Historical Geology Lab,Hauptvogel,Daniel William,14,4,4,0,0,0,0,3.47
+Fall 2023,GEOL,1302,2,19531,Intro To Global Climate Change,Choi,Yunsoo,339,131,19,6,0,0,1,3.565
+Fall 2023,GEOL,1303,6,19532,Physical Geology,Hauptvogel,Daniel William,207,219,72,4,6,0,9,3.19
+Fall 2023,GENB,7397,1,19534,Selected Topics,Webb,James R,6,1,0,0,0,0,0,3.904
+Fall 2023,GENB,7397,2,19535,Selected Topics,Wilbur,Stephen,10,2,0,0,0,0,0,3.806
+Fall 2023,GEOL,3338,1,19536,Environmental Hydrogeology,Capuano,Regina M,10,17,13,2,0,0,2,2.818
+Fall 2023,GEOL,6366,1,19537,Hydrogeology,Capuano,Regina M,6,2,0,0,0,0,0,3.668
+Fall 2023,GEOL,3382,1,19538,Atmospheric Chemistry,Rappenglueck,Bernhard,11,1,1,0,0,0,0,3.668
+Fall 2023,GEOL,6334,1,19540,Atmospheric Chemistry,Rappenglueck,Bernhard,5,2,0,0,0,0,0,3.573
+Fall 2023,GEOL,4346,1,19541,Air Pollution Meteorology,Rappenglueck,Bernhard,7,9,3,0,0,0,0,3.245
+Fall 2023,GEOL,6332,1,19543,Air Pollution Meteorology,Rappenglueck,Bernhard,4,0,0,0,0,0,0,3.835
+Fall 2023,GEOL,4334,1,19544,Environmental Data Analysis,Wang,Yuxuan,14,11,1,0,0,0,1,3.525
+Fall 2023,GEOL,6328,1,19547,Atmos Data Analysis & Stats,Wang,Yuxuan,16,0,0,0,0,0,0,3.938
+Fall 2023,GEOL,4336,1,19548,Atmospheric Radiation,Jiang,Xun,12,2,1,0,0,0,0,3.623
+Fall 2023,GEOL,4386,1,19549,Petr Geos for Petr Engineers,Zhou,Hua-Wei,8,8,0,0,0,0,1,3.397
+Fall 2023,GEOL,6327,1,19553,Atmospheric Radiation,Jiang,Xun,21,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,6357,1,19554,Soils and Paleosols,Beverly,Emily Jane,7,2,0,0,0,0,0,3.704
+Fall 2023,GEOL,3357,1,19558,Soils,Beverly,Emily Jane,26,12,1,0,0,0,0,3.539
+Fall 2023,IDNS,2197,2,19564,Top-Natrl Sci & Mth,Stokes,Donna,3,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,6378,1,19567,Basin Analysis for Petrol Expl,Mann,Paul,5,5,1,0,0,0,0,3.364
+Fall 2023,GEOL,6397,1,19568,Selected Topics in Geology,Castagna,John P,14,1,0,0,1,0,0,3.564
+Fall 2023,FINA,7397,1,19574,Selected Topics in Finance,Khumawala,Saleha B,3,0,0,0,0,0,0,3.89
+Fall 2023,FINA,4397,1,19575,Selected Topics in Finance,Susmel,Raul,3,1,0,0,0,0,1,3.585
+Fall 2023,FINA,4397,2,19576,Selected Topics in Finance,Hughes,James F,18,19,3,0,0,0,0,3.375
+Fall 2023,FINA,4397,3,19577,Selected Topics in Finance,Bean,Gregory S,13,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7397,3,19580,Selected Topics in Finance,Smith III,Edwin A,2,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7397,4,19581,Selected Topics in Finance,George,Thomas J,4,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7397,5,19582,Selected Topics in Finance,Bean,Gregory S,12,0,0,0,0,0,0,4.0
+Fall 2023,FINA,8397,1,19583,Selected Topics in Finance,Susmel,Raul,4,4,0,0,0,0,0,3.583
+Fall 2023,FINA,8397,2,19584,Selected Topics in Finance,Jacobs,Kris,5,0,0,0,0,0,0,4.0
+Fall 2023,FINA,4376,1,19587,Energy Trading Systems,Pena,Juan F,85,17,4,0,0,0,1,3.749
+Fall 2023,PUBL,6325,1,19590,Capstone Problem Project,Koelling,Peter,3,0,0,0,0,0,0,3.89
+Fall 2023,SPEC,8395,1,19591,Dissertation in Practice,Hawkins,Jacqueline McLean,1,0,0,0,0,1,0,4.0
+Fall 2023,SPEC,8695,1,19592,Dissertation in Practice,Hawkins,Jacqueline McLean,2,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,7333,1,19913,Developing Algebraic Thinking,Chauvot,Jennifer B,10,0,0,0,0,0,0,3.901
+Fall 2023,BZAN,6360,1,19919,Capstone Practicum in BZAN I,Aron,Ravi,4,4,0,0,0,0,0,3.665
+Fall 2023,BZAN,6361,1,19920,Capstone Practicum in BZAN II,Aron,Ravi,7,1,0,0,0,0,0,3.834
+Fall 2023,ECON,3334,5,19924,Intermediate Macroeconomics,Thornton,Rebecca Achee,9,8,11,7,3,0,6,2.342
+Fall 2023,CHEE,5384,1,19925,Petrochemical Processes,Smith,Christopher Michael,2,2,0,0,0,0,0,3.418
+Fall 2023,CHEE,6384,1,19926,Petrochemical Processes,Smith,Christopher Michael,2,4,0,0,0,0,0,3.388
+Fall 2023,CHEE,6390,1,19930,Energy and the Environment,Harold,Michael P,8,8,2,0,0,0,1,3.315
+Fall 2023,CUIN,7308,1,19931,Educational Uses of CMC,McNeil,Sara G,8,3,0,0,0,0,1,3.637
+Fall 2023,CUIN,7374,1,19932,Educational Multimedia,Dogan,Bulent,9,1,0,0,0,0,0,3.867
+Fall 2023,CUIN,7374,2,19933,Educational Multimedia,Dogan,Bulent,26,0,0,0,0,0,0,3.975
+Fall 2023,MATH,2305,1,19935,Discrete Mathematics,Winkle,James J,21,17,29,20,3,0,6,2.407
+Fall 2023,MATH,1314,7,19938,College Algebra,Hafeez,Shahinda,58,41,61,37,47,0,18,2.075
+Fall 2023,MATH,2318,7,19939,Linear Algebra,Charon,Nicolas,11,9,3,0,2,0,4,3.054
+Fall 2023,IDNS,2197,1,19945,Top-Natrl Sci & Mth,Pattison,Donna,5,2,0,2,1,0,2,2.767
+Fall 2023,CUIN,8318,1,19946,Issues in Urban Education,Cole,Mikel Walker,19,1,0,0,0,0,0,3.917
+Fall 2023,CUIN,8380,1,19947,Research Methods in CUIN,Thomas,Dustine J,20,0,0,0,0,0,0,4.0
+Fall 2023,ELED,7320,2,19948,Foundations of Literacy Instru,Alba,Celeste,20,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6350,3,19951,School Leadership-Principalshp,Butcher,Keith,11,1,0,0,0,0,0,3.889
+Fall 2023,ELCS,6370,3,19955,Research for Educatnal Leaders,Shockley,Gerald,22,0,0,0,0,0,0,3.985
+Fall 2023,ELCS,6332,1,19956,Student Develop/Student Affair,Hernandez,Belkis Pamela,6,0,0,0,0,0,0,3.945
+Fall 2023,ELCS,7354,1,19958,Leadership for Change,McKinney,Lonnie Lyle,7,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,7354,2,19959,Leadership for Change,McKinney,Lonnie Lyle,15,3,1,0,0,0,1,3.737
+Fall 2023,ELCS,6322,1,19960,Org & Admin Stud. Support Serv,Hernandez,Belkis Pamela,14,1,1,0,0,0,0,3.771
+Fall 2023,ELCS,8360,1,19961,Studies Post Secondary Educatn,Louis,Dave A,14,1,0,0,0,0,0,3.955
+Fall 2023,EDRS,8380,3,19962,Rsch Mthds in Educ,Hernandez,Belkis Pamela,11,3,1,0,0,0,0,3.645
+Fall 2023,SPEC,8395,2,19972,Dissertation in Practice,Santi,Kristi L,0,0,0,0,0,1,0,
+Fall 2023,SPEC,8695,2,19973,Dissertation in Practice,Santi,Kristi L,4,0,0,0,0,0,0,4.0
+Fall 2023,MANA,7392,1,19976,Managerial Issues,Walker,William A,18,1,1,0,0,0,0,3.867
+Fall 2023,MANA,7359,1,19977,Diversity Equity & Inc Strat,Avery,Derek Reynold,4,3,0,0,0,0,0,3.477
+Fall 2023,MANA,7372,1,19979,Leading Change in Healthcare,Kroger,Edward John,6,1,0,0,0,0,0,3.857
+Fall 2023,MANA,4397,5,19980,Selected Topics in Mana,Salaiz,Ashley,25,5,0,0,0,0,1,3.811
+Fall 2023,PHIL,6395,1,19981,Seminar Philos Problems,Phillips,David K,16,0,0,0,0,0,0,3.918
+Fall 2023,PHIL,6395,2,19982,Seminar Philos Problems,Loewenstein,Yael R,14,2,0,0,0,0,0,3.834
+Fall 2023,PHIL,6395,3,19983,Seminar Philos Problems,Buckner,Cameron J,10,5,0,0,0,0,0,3.667
+Fall 2023,PHIL,3382,1,19984,Medieval Philosophy,Hattab,Helen,2,10,3,1,1,0,12,2.531
+Fall 2023,PHIL,3388,1,19985,Hist of 20Th Cent Phi,Weisberg,Joshua,15,10,4,1,1,0,0,3.13
+Fall 2023,PHIL,3335,1,19986,Theory of Knowledge,Oliveira,Luis RG,25,5,0,0,0,0,0,3.811
+Fall 2023,PHIL,2321,1,19987,Logic II,Garson,James W,12,5,3,1,1,0,4,3.107
+Fall 2023,PHIL,3395,1,19988,Selected Topics in Phil,Coates,Daniel J,23,3,0,0,0,0,1,3.872
+Fall 2023,PHIL,3395,2,19989,Selected Topics in Phil,Mag Uidhir,Christopher Domh,9,11,2,2,2,0,2,2.859
+Fall 2023,PHYS,6378,1,19991,Advanced Statistical Mechanics,Cardoso Barato,Andre,16,13,1,0,0,0,0,3.5
+Fall 2023,PHYS,6365,1,19993,Quantum Many-Body Theory,Ting,Chin Sen,6,4,0,0,0,0,0,3.633
+Fall 2023,PHYS,7397,1,19995,Selected Topics in Phy,Morrison,Gregory C,6,2,0,0,0,0,0,3.75
+Fall 2023,PHYS,7312,1,19996,Modern Optics,Wood,Lowell T,6,5,0,0,0,0,0,3.635
+Fall 2023,MIS,7375,2,20004,Transaction Processing Systems,Messinger,Jacob Nelson,12,2,0,0,1,0,2,3.534
+Fall 2023,POLC,6391,1,20036,Public Policy Internship,Bronk,Robert C,5,0,0,0,0,0,0,3.934
+Fall 2023,IDNS,2136,1,20049,Data Structures SEP Workshop,Pattison,Donna,30,4,2,0,0,0,0,3.796
+Fall 2023,IDNS,2136,2,20050,Data Structures SEP Workshop,Pattison,Donna,17,0,3,1,0,0,2,3.619
+Fall 2023,MIS,7397,1,20051,Selected Topics in MIS,Cooper,Randolph B,8,10,2,2,1,0,1,2.957
+Fall 2023,MIS,7397,2,20053,Selected Topics in MIS,Pena,Juan F,58,0,1,0,0,0,0,3.961
+Fall 2023,MIS,7397,3,20054,Selected Topics in MIS,Hosseini,Leila,14,4,1,0,0,0,1,3.58
+Fall 2023,MIS,7397,4,20055,Selected Topics in MIS,Campbell,Phillip James,5,3,1,0,1,0,0,3.1
+Fall 2023,MIS,7397,5,20056,Selected Topics in MIS,Lewis,Michael Joseph,6,9,0,0,0,0,0,3.4
+Fall 2023,MIS,7397,6,20057,Selected Topics in MIS,Gonzalez Jr,Frederick,30,0,0,0,0,0,0,4.0
+Fall 2023,MIS,7397,7,20058,Selected Topics in MIS,Lewis,Michael Joseph,6,3,0,0,0,0,1,3.667
+Fall 2023,MIS,7397,8,20059,Selected Topics in MIS,Tan,Yinliang,15,4,0,0,0,0,0,3.703
+Fall 2023,MIS,8397,1,20060,Selected Topics in MIS,Cooper,Randolph B,2,3,0,0,0,0,0,3.334
+Fall 2023,MIS,8397,2,20061,Selected Topics in MIS,Grimes,George M,2,0,0,0,0,0,0,4.0
+Fall 2023,POLC,4390,1,20102,Public Policy Internship,Cross,Renee Danielle,8,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,4361,1,20140,Clinical Biochemistry,Bawa-Khalfe,Tasneem,26,4,2,1,0,0,0,3.697
+Fall 2023,BCHS,4370,1,20141,Frontier in Nano-Biotechnology,Wang,Yuhong,30,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,4397,1,20142,Topics-Biochem & Biophys Sci,Fujita,Masaya,8,13,6,0,1,0,2,2.976
+Fall 2023,BCHS,6397,1,20144,Sel Top-Biochm&Bphs Sci,Fujita,Masaya,1,1,0,0,0,0,0,3.665
+Fall 2023,BIOL,6410,1,20431,Applied Biostatistics,Kelleher Meisel,Erin S,10,6,0,0,0,0,0,3.646
+Fall 2023,BIOL,6397,1,20435,Selected Topics in Biology,Pennings,Steven C,6,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6798,1,20438,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Fall 2023,POLC,4325,1,20459,Adv Policy Research Methods,Atsusaka,Yuki,3,0,0,0,0,0,1,3.89
+Fall 2023,MARK,3336,5,20467,Introduction to Marketing,Kraemer,Martin,26,33,9,1,0,0,1,3.193
+Fall 2023,MARK,4338,2,20468,Marketing Research,Hui,Kachuen Sam,9,4,0,0,0,0,1,3.667
+Fall 2023,MARK,4397,1,20469,Selected Topics in Mkt,Pogge,Joe M,18,13,1,0,0,0,0,3.531
+Fall 2023,MARK,7397,1,20470,Selected Topics in Marketing,Hu,Ye,11,5,1,0,0,0,0,3.627
+Fall 2023,BIOL,4397,1,20472,Selected Topics in Biology,McKeon,Frank D,19,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,1197,1,20473,Selected Topics in Biology,Ogletree-Hughes,Monique L,40,5,5,1,5,0,0,3.321
+Fall 2023,BIOL,1197,2,20474,Selected Topics in Biology,Ogletree-Hughes,Monique L,25,6,2,0,0,0,0,3.677
+Fall 2023,MIS,3376,2,20475,Busn Appls Database Mgmt I,Scamell,Richard W,18,12,10,0,0,0,7,3.233
+Fall 2023,MIS,4397,1,20476,Selected Topics in MIS,Hosseini,Leila,7,6,1,0,0,0,1,3.381
+Fall 2023,BIOL,4301,1,20478,Conservation Biology,Crawford,Kerri M,20,9,1,0,1,0,0,3.505
+Fall 2023,MIS,4397,2,20480,Selected Topics in MIS,Scott,Carl P,8,16,0,0,0,0,0,3.402
+Fall 2023,MIS,4397,3,20483,Selected Topics in MIS,Grimes,George M,32,0,0,0,1,0,1,3.879
+Fall 2023,MIS,4397,4,20486,Selected Topics in MIS,Wang,Cheng,47,4,1,0,0,0,0,3.866
+Fall 2023,CIS,4339,4,20503,Enterprise Appls Development,Wu,Xuqing,26,16,6,1,0,0,2,3.334
+Fall 2023,PEP,7397,1,20590,Adv Selected Topic Human Perf,Markofski,Melissa,7,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7397,2,20593,Adv Selected Topic Human Perf,Ogunrinde,Joyce,6,0,0,0,0,0,0,3.89
+Fall 2023,PEP,8350,1,20598,HHP Candidacy Project Research,Layne,Charles S,5,1,0,0,0,0,0,3.833
+Fall 2023,ACCT,5367,2,20618,Intermediate Accounting I,Kraten,Michael,0,1,0,0,0,0,0,3.0
+Fall 2023,ACCT,3367,6,20619,Intermediate Accounting I,Kraten,Michael,38,19,8,1,1,0,1,3.344
+Fall 2023,MATH,5331,1,20623,Linear Algebra W/ Applications,Etgen,Garret J,13,11,0,0,0,0,1,3.514
+Fall 2023,ENTR,7397,1,20624,Sel Topics in Entrepreneurship,McCormick,Kelly,5,0,1,0,0,0,0,3.722
+Fall 2023,ENTR,4397,1,20625,Sel Topics in Entrepreneurship,McCormick,Kelly,24,4,0,0,1,0,0,3.701
+Fall 2023,CUIN,4361,2,20626,Second Language Methodology,Burgess,Miguel,26,2,0,0,0,0,0,3.905
+Fall 2023,MATH,6374,1,20627,Num Part Diff Equations,Quaini,Annalisa,8,6,0,0,0,0,0,3.619
+Fall 2023,CUIN,3345,1,20628,Writing & Grammar Tch English,Ortiz,Elizabeth Carter,15,2,0,1,1,0,1,3.457
+Fall 2023,MATH,6397,1,20629,Selected Topics in Math,Josic,Kresimir,8,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,4349,1,20630,Teaching Geometry and Algebra,Chauvot,Jennifer B,17,2,0,0,0,0,0,3.808
+Fall 2023,MATH,6397,2,20631,Selected Topics in Math,Mamonov,Alexander V,5,2,0,0,0,0,0,3.667
+Fall 2023,MATH,6397,3,20632,Selected Topics in Math,Jun,Mikyoung,4,0,0,0,0,0,0,3.753
+Fall 2023,MATH,7350,1,20633,Geometry of Manifolds,Heier,Gordon,9,0,0,0,0,0,0,3.963
+Fall 2023,ECON,6394,2,20637,Tpcs-Eco of Socl Issue,Prokopovych,Pavlo,2,2,0,0,0,0,0,3.665
+Fall 2023,ECON,6394,3,20638,Tpcs-Eco of Socl Issue,Verchenko,Olesia,4,0,0,0,0,0,0,4.0
+Fall 2023,CIS,6397,6,20640,Selected Topics,Venkataramani,Suresh,5,8,0,0,0,0,0,3.486
+Fall 2023,BIOL,1319,1,20641,Human Genetics and Society,Graur,Dan,10,11,11,1,1,0,14,2.814
+Fall 2023,BIOL,2397,1,20642,Selected Topics in Biology,Nunez,Martin A,22,2,0,0,0,0,1,3.889
+Fall 2023,SOCW,6308,7,20643,Human Diversity & Development,Fernandez,Jason,18,0,0,0,1,0,0,3.789
+Fall 2023,SOCW,7318,2,20645,Cognitive Behavioral Interven,Cheung,Monit,22,2,0,0,0,0,0,3.917
+Fall 2023,SOCW,7318,3,20646,Cognitive Behavioral Interven,O'Neal,Vaughn,21,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7318,4,20647,Cognitive Behavioral Interven,Parks,Steven Lee,17,2,0,0,1,0,0,3.7
+Fall 2023,CHEE,8298,22,20648,Doctoral Research,Wen,Mingjian,0,0,0,0,0,2,0,
+Fall 2023,MATH,4397,1,20652,Selected Topics in Math,Josic,Kresimir,0,0,0,0,1,0,1,0.0
+Fall 2023,SCLT,3381,33,20655,Industrial and Consumer Sales,Cassler,Daniel,21,19,3,0,0,0,1,3.342
+Fall 2023,AAS,3375,1,20656,Black Women in U.S. Society,Shakir,Ameenah,4,3,3,0,1,0,1,2.788
+Fall 2023,AAS,3394,1,20657,Selected Topics Afr Am Stdy,Langa,Neema Michael,2,2,0,1,1,0,0,2.39
+Fall 2023,SCLT,2362,34,20658,Intro To Logistics Technology,Cassler,Daniel,46,14,0,0,0,0,1,3.635
+Fall 2023,SOCW,7356,6,20659,Groups: Adv Clinical Practice,Lucas,Virginia,25,1,0,0,0,0,0,3.962
+Fall 2023,SOCW,7356,7,20660,Groups: Adv Clinical Practice,Lucas,Virginia,18,1,1,0,1,0,0,3.667
+Fall 2023,SOCW,7356,8,20661,Groups: Adv Clinical Practice,O'Neal,Vaughn,17,0,1,0,0,0,0,3.889
+Fall 2023,MATH,6326,1,20663,Partial Diff Equations,Perepelitsa,Mikhail Antolyevic,12,5,0,0,0,0,0,3.609
+Fall 2023,ARCH,4510,23,20666,Integrated Arch Solutions,Moore,Emily E,15,4,0,0,0,0,0,3.598
+Fall 2023,PSYC,7397,1,20668,Selected Topics in Psychology,Sharp,Carla,3,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,3347,2,20669,Problems of Normal Life,Anderson,Jill Annette,34,34,9,1,1,0,0,3.207
+Fall 2023,PHIL,1361,6,20670,Philosophy and the Arts,Mag Uidhir,Christopher Domh,72,85,50,22,12,0,18,2.746
+Fall 2023,NUTR,6304,1,20671,Adv Nutr Counseling & Educ,Ledoux,Tracey A,16,5,0,0,0,0,0,3.683
+Fall 2023,NUTR,7313,1,20672,Urban Fitness,Alastuey,Lisa L,7,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,6384,2,20674,Petrochemical Processes,Smith,Christopher Michael,2,1,0,0,0,0,0,3.667
+Fall 2023,HIST,6372,1,20675,Rdgs in US Social Policy,Young,Nancy Beck,12,0,0,0,0,0,0,3.945
+Fall 2023,CHEE,6390,2,20677,Energy and the Environment,Harold,Michael P,6,2,0,0,0,0,3,3.668
+Fall 2023,PSYC,6397,1,20678,Sel Top in Psychology,Neighbors,Clayton T,7,0,1,0,0,0,0,3.75
+Fall 2023,CIS,3330,1,20679,Info Systems in Organizations,Detillier,Bret James,3,45,38,1,0,0,1,2.575
+Fall 2023,PUBL,6312,1,20680,Public Finance,Obregon,Alexander Wade,6,0,0,0,0,0,0,3.89
+Fall 2023,CNST,6399,3,20684,Thesis,Senouci,Ahmed,0,0,0,0,0,0,0,
+Fall 2023,JAPN,2311,1,20691,Intermediate Japanese I,Ji,Fang,12,12,5,1,0,0,2,3.079
+Fall 2023,KORE,1501,1,20692,Beginning Korean I,Back,Eunkyung Lee,9,8,5,0,2,0,4,2.903
+Fall 2023,KORE,1501,3,20694,Beginning Korean I,Back,Eunkyung Lee,11,0,0,1,1,0,4,3.36
+Fall 2023,CHEM,6314,1,20697,Spectroscopy,Chiang,Naihao,9,4,0,0,0,0,0,3.667
+Fall 2023,CHEM,6333,1,20699,Fund-Chemical Analysis,Baldelli,Steve,10,1,0,0,0,0,0,3.759
+Fall 2023,CHEM,6377,1,20700,Solid State Chemistry,Bocarsly,Joshua David,9,9,0,0,0,0,0,3.518
+Fall 2023,KORE,2311,1,20702,Intermediate Korean I,Back,Eunkyung Lee,10,7,3,1,0,0,0,3.191
+Fall 2023,ITAL,4308,1,20704,Dante and His World,Carrera,Alessandro,19,2,0,0,0,0,1,3.826
+Fall 2023,ITAL,6365,1,20705,Dante's Legacy,Carrera,Alessandro,1,0,0,0,0,0,0,4.0
+Fall 2023,ITAL,6392,1,20706,Read Italian for Non-Majors I,Nicosia,Alda,3,0,0,0,0,0,0,4.0
+Fall 2023,HON,4397,1,20707,Honors Selected Topics,Liddell,Robert B,24,0,0,0,0,0,0,4.0
+Fall 2023,HON,3397,1,20708,Honors Selected Topics,Williamson,Jonathan Lyle,2,1,0,0,0,0,0,3.667
+Fall 2023,ENGL,1370,14,20709,Composition II-Honors,Vollrath,Lesli A,3,2,0,0,0,0,0,3.732
+Fall 2023,ENGL,1370,15,20710,Composition II-Honors,Werner,Andrew Timothy,2,1,2,0,0,0,0,3.0
+Fall 2023,ENGL,1370,16,20711,Composition II-Honors,Werner,Andrew Timothy,3,1,1,0,0,0,0,3.466
+Fall 2023,ENRG,3310,2,20713,Intro to Energy & Sustainblty,Jacobsen,Nicolas Fisher,22,1,1,0,0,0,1,3.861
+Fall 2023,HON,3397,3,20714,Honors Selected Topics,Vollrath,Lesli A,15,0,0,0,0,0,0,3.934
+Fall 2023,PSYC,7397,2,20716,Selected Topics in Psychology,Foss,Donald J,9,0,0,0,0,0,0,4.0
+Fall 2023,CNST,2360,2,20717,Communication in Construction,Ducran,Denis George,9,14,4,1,1,0,0,3.0
+Fall 2023,BIOL,4397,2,20718,Selected Topics in Biology,Meisel,Richard P,5,9,1,2,1,0,2,2.797
+Fall 2023,BIOL,6397,2,20719,Selected Topics in Biology,Meisel,Richard P,4,1,0,0,0,0,0,3.8
+Fall 2023,CNST,4397,2,20721,Sel Tops in Construction Mgmt,Kim,Kinam,5,2,0,0,0,0,1,3.573
+Fall 2023,POLS,3343,50,20724,Democratic Theory,Gish,Dustin,6,11,0,0,0,0,1,3.314
+Fall 2023,HIST,4361,50,20725,20th Century Genocides,Guenther,Irene V,19,2,0,0,0,0,3,3.905
+Fall 2023,HON,3313,1,20726,Nations and Imaginations,Cremins,Robert Paul,12,2,0,0,0,0,1,3.763
+Fall 2023,HON,4397,2,20727,Honors Selected Topics,Garner,Richard A,10,1,0,0,0,0,0,3.909
+Fall 2023,POLS,3310,50,20728,Intro to Political Theory,Cooper,Carol B,16,4,2,1,0,0,3,3.407
+Fall 2023,HON,3397,6,20731,Honors Selected Topics,Leland,Alison W,10,12,1,0,0,0,2,3.42
+Fall 2023,HON,3397,7,20733,Honors Selected Topics,Modaff,Abigail,10,2,0,0,0,0,0,3.861
+Fall 2023,HON,4397,3,20734,Honors Selected Topics,Reynolds,Aaron E,22,2,0,0,0,0,0,3.889
+Fall 2023,HON,3308,1,20735,Lyric Medicine,Lambeth,Laurie Regine Clements,16,0,0,0,0,0,0,3.918
+Fall 2023,ENRG,4397,1,20736,Sel Topics-Enrgy & Sustainblty,Jacobsen,Nicolas Fisher,6,1,0,0,0,0,0,3.857
+Fall 2023,TECH,1301,4,20737,Intro to Data Analytics Tools,Shin,Daeun,23,7,2,0,4,0,4,3.241
+Fall 2023,SOC,3390,2,20773,Sociology of Gender,Haltom,Trenton Matthews,27,10,6,1,3,0,1,3.192
+Fall 2023,SOC,3357,1,20774,Urban Sociology,Brailey,Carla,45,4,1,0,0,0,5,3.88
+Fall 2023,SOC,3314,1,20775,Juvenille Delinquency,Gallo,Joseph Ralph,35,8,4,4,2,0,0,3.321
+Fall 2023,SOC,6391,1,20776,Seminar in Sexuality & Society,Baumle,Amanda K,8,1,1,0,0,0,0,3.7
+Fall 2023,SOC,6397,1,20777,Selected Topics in Sociology,Langa,Neema Michael,4,0,0,0,0,0,0,4.0
+Fall 2023,FREN,3364,1,20778,Writing Holocausts,Glass,Hildegard,2,0,0,0,0,0,1,4.0
+Fall 2023,HON,3397,8,20779,Honors Selected Topics,Rayder,Benjamin Taylor,9,0,0,0,0,0,0,3.927
+Fall 2023,FREN,3313,1,20780,Advanced Grammar & Comp,Green,Viola V,4,3,5,5,1,0,0,2.167
+Fall 2023,FREN,3335,1,20781,French Popular Music,Giacchetti,Claudine A,4,4,6,1,0,0,0,2.711
+Fall 2023,FREN,4333,1,20782,French for the Professions,Giacchetti,Claudine A,6,2,2,0,0,0,1,3.334
+Fall 2023,TMTH,3360,6,20785,Applied Technical Statistics,Telles,John E,13,15,10,2,4,0,2,2.6
+Fall 2023,ARCH,1500,15,20786,Design Studio I,Woodfill,Celeste Ponce,2,9,3,0,0,0,0,2.952
+Fall 2023,SOC,3300,4,20788,Intro to Sociological Theory,Grigorian,Stella,26,14,1,0,2,0,1,3.396
+Fall 2023,ARCH,1500,21,20789,Design Studio I,Smith,Joshua S,7,6,1,0,0,0,0,3.429
+Fall 2023,SOC,3300,5,20790,Intro to Sociological Theory,Katz,Sheila,20,18,6,0,0,0,0,3.273
+Fall 2023,SOC,3335,1,20792,Sociology of Punishment,Adams,Jennifer Lauren,42,9,1,0,2,0,0,3.599
+Fall 2023,SOC,3336,1,20793,Aggression and Violence,Colbert,Sharla Stettnisch,22,15,11,0,4,0,3,2.981
+Fall 2023,POPH,2300,1,20794,Intro to Population Health,Bruce,Marino A,15,8,0,0,0,0,1,3.695
+Fall 2023,SOC,3326,1,20795,Immigration in US Society,Lee,Shayne,33,9,2,0,0,0,1,3.75
+Fall 2023,ARCH,2500,37,20796,Arc/Int Arc Design Studio III,Perez Lopez,Elena Maria,7,10,0,0,0,0,0,3.354
+Fall 2023,SOC,3350,1,20798,Sociology of the Body,Kwan,Samantha S,20,20,4,3,1,0,1,3.084
+Fall 2023,SOC,3380,1,20799,Intro/Soc Health Care,Monserud,Maria Aleksandrovna,37,4,2,0,1,0,5,3.727
+Fall 2023,SOC,3397,1,20800,Sel-Topics in Sociology,Langa,Neema Michael,5,1,2,0,0,0,0,3.375
+Fall 2023,ARCH,1500,43,20803,Design Studio I,Lee,Seo Hee,1,8,1,2,1,0,0,2.487
+Fall 2023,GERM,3384,1,20804,Fascism and German Cinema,Frieden,Sandra M Gross,18,0,1,0,0,0,0,3.843
+Fall 2023,GERM,3381,1,20806,German Cinema,Kleinheider,Julia D,9,16,2,2,0,0,1,3.149
+Fall 2023,GERM,3364,1,20807,Writing Holocausts,Glass,Hildegard,5,5,1,0,1,0,0,2.973
+Fall 2023,HON,3397,9,20809,Honors Selected Topics,Price,Daniel M,7,0,0,0,0,0,2,4.0
+Fall 2023,INDS,7300,1,20814,Design Thesis I,Morshedzadeh,Elham,1,1,0,0,0,0,0,3.5
+Fall 2023,TEPM,6303,40,20819,Risk Assessment in Project Mgm,Rypien,David V,1,7,1,0,0,0,0,3.073
+Fall 2023,TEPM,6305,40,20820,Project Manager Tools,Sherman,Dennis Louis,5,0,0,0,0,0,0,4.0
+Fall 2023,TEPM,6306,40,20821,Project Management Office,Rypien,David V,6,0,1,0,0,0,0,3.667
+Fall 2023,TEPM,6307,40,20822,Advanced Project Management,Sherman,Dennis Louis,3,2,0,0,0,0,0,3.666
+Fall 2023,TEPM,6308,40,20823,Project Procurement Practices,Conover,Sharon Cecilia,3,0,0,0,0,0,0,4.0
+Fall 2023,TEPM,6391,40,20824,Project Management Seminar,Carden,Lila L,5,0,0,0,0,0,0,3.934
+Fall 2023,PHYS,6319,1,20856,Advanced Mechanics I,Gunaratne,Gemunu,11,9,0,0,0,0,1,3.501
+Fall 2023,PHYS,6313,1,20857,Methods of Math Physics I,Ratti,Claudia,10,12,0,0,0,0,0,3.44
+Fall 2023,CHIN,3352,1,20862,Chin Cul & Soc Thru Mod Lit,Wen,Xiaohong Sharon,8,7,3,1,1,0,2,3.017
+Fall 2023,CHIN,6352,1,20863,Chin Cult & Soc Thru Mod Lit,Wen,Xiaohong Sharon,1,0,0,0,0,0,0,3.67
+Fall 2023,ARCH,5500,17,20864,Architecture Design Studio IX,Rodriguez Fernandez,Marta,12,0,2,0,0,0,0,3.714
+Fall 2023,CHIN,3343,1,20866,Chinese Popular Culture,Li,Melody Yunzi,15,1,0,0,0,0,1,3.896
+Fall 2023,CHIN,3347,1,20867,Chinese Language & Pragmatics,Wang,Wei,3,8,2,0,0,0,3,3.153
+Fall 2023,WCL,1102,1,20868,Introduction to World Cultures,Ramirez,Marie Theresa,12,5,0,1,0,0,0,3.537
+Fall 2023,ARCH,5500,21,20871,Architecture Design Studio IX,Wienert,Ross George,10,3,0,0,0,0,0,3.541
+Fall 2023,WCL,1102,2,20872,Introduction to World Cultures,Ramirez,Marie Theresa,14,4,2,0,0,0,0,3.551
+Fall 2023,WCL,1102,3,20874,Introduction to World Cultures,Ramirez,Marie Theresa,12,3,2,0,1,0,2,3.352
+Fall 2023,ARCH,5500,23,20875,Architecture Design Studio IX,Race,Bruce Alan,7,14,1,0,0,0,0,3.333
+Fall 2023,ARCH,5500,25,20877,Architecture Design Studio IX,Brune,Geoffrey,9,6,0,0,0,0,0,3.512
+Fall 2023,ARCH,7600,15,20881,Architecture Design Studio V,Diehl,Tom,0,0,0,0,0,0,0,
+Fall 2023,ARCH,7601,1,20883,Architecture Design Studio VI,Longoria,Rafael R,1,0,0,0,0,0,0,3.67
+Fall 2023,HIST,2321,2,20888,Study of Early Civilizations,Neumann,Kristina Marie,5,18,5,6,1,0,0,2.524
+Fall 2023,SCLT,6397,30,20890,Selected Topics,Dong,Zhijie,3,2,0,0,0,0,1,3.666
+Fall 2023,SCLT,6397,31,20896,Selected Topics,Bian,Zheyong,2,5,1,0,0,0,0,3.331
+Fall 2023,HIST,2322,1,20903,Modern Civilizations,Yuksel,Emire Cihan,23,5,0,0,2,0,5,3.446
+Fall 2023,HIST,2327,1,20908,Chicano History to 1910,Ramos,Raul,19,9,2,0,1,0,1,3.42
+Fall 2023,HIST,2367,1,20919,History of Mexico,Hernandez,Jose A,20,3,1,0,0,0,1,3.792
+Fall 2023,HIST,2371,1,20922,Latin America 1492-1820,Gharala,Norah Linda Andrews,16,13,5,2,0,0,3,3.121
+Fall 2023,HIST,6310,1,20935,Col Latin Am Historiography,Gharala,Norah Linda Andrews,9,0,0,0,0,0,0,3.89
+Fall 2023,HIST,6383,1,20936,Topics in Public Hist,Goldberg,Mark A,12,1,0,0,0,0,0,3.847
+Fall 2023,HIST,6300,1,20937,Rdgs in Global History,McNally,David Joseph,9,0,0,0,0,0,0,3.963
+Fall 2023,HIST,2369,1,20938,"Jesus, Africa, and History",Chery,Tshepo Morongwa,10,9,5,0,2,0,3,2.898
+Fall 2023,HIST,4386,1,20939,Africa 1945 To Present,Chery,Tshepo Morongwa,8,15,1,0,1,0,3,3.081
+Fall 2023,HIST,4384,1,20940,East Asian Women in Hist & Cul,Cong,Xiaoping,3,2,0,0,1,0,0,2.835
+Fall 2023,HIST,4363,1,20941,Capstone in US History,Mizelle Jr,Richard M,11,0,0,0,0,0,2,3.85
+Fall 2023,HIST,4346,1,20942,Tudor England 1485-1603,Patterson,Catherine F,15,6,7,0,0,0,4,3.18
+Fall 2023,HIST,4327,1,20943,Europe 1930-1945,Boyd,Sarah Fishman,9,5,0,0,0,0,0,3.619
+Fall 2023,HIST,4306,1,20944,Antebellum Social Reform,Clavin,Matthew J,7,1,2,0,0,0,2,3.434
+Fall 2023,HIST,4304,1,20945,The American Revolution,Hopkins,Kelly Y,4,6,2,0,0,0,1,3.277
+Fall 2023,HIST,3397,1,20946,Sel Tops-African History,Yuksel,Emire Cihan,26,1,0,0,1,0,8,3.786
+Fall 2023,HIST,3333,1,20950,Global Health Care History,Chakrabarti,Pratik,11,7,0,0,2,0,0,3.151
+Fall 2023,HIST,3354,1,20952,England Since 1689,Ittmann,Karl,7,7,7,2,1,0,1,2.695
+Fall 2023,HIST,3368,1,20953,World Environ History to 1800,Klieman,Kairn,17,14,4,0,3,0,2,3.036
+Fall 2023,HIST,3384,1,20955,Palestine and Arab-Israeli,Takriti,Abdel Razzaq,31,0,0,0,0,0,0,4.0
+Fall 2023,WCL,3397,1,20956,Selected Topics in WCL,Ambikaipaker,Mohan,3,2,0,0,1,0,0,2.835
+Fall 2023,WCL,2370,1,20960,Cultures of India,Tiwari,Bhavya,7,15,2,4,2,0,0,2.799
+Fall 2023,WCL,3372,1,20970,Indian Film:Bollywood & Beyond,Tiwari,Bhavya,2,1,0,0,0,0,0,3.777
+Fall 2023,WCL,4355,1,20976,Global South WWII to Present,Ramirez,Marie Theresa,5,2,0,0,0,0,0,3.573
+Fall 2023,PSYC,3334,1,20986,Psychology & Law,Capuozzo,Kristen Irene,13,32,15,5,2,0,12,2.835
+Fall 2023,PSYC,7397,3,20987,Selected Topics in Psychology,Woods,Steven Paul,0,0,0,0,0,4,0,
+Fall 2023,PSYC,7397,4,20988,Selected Topics in Psychology,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2023,BIOL,3350,50,20997,Science Comm Strategies,Sharp,Rita Evelyn,23,1,0,1,0,0,0,3.8
+Fall 2023,PEP,6397,1,21004,Selected Topics in Human Perf,Walsh,David W,5,3,1,1,0,0,0,3.167
+Fall 2023,JWST,3373,1,21005,Jews in the Ancient World,Tamber-Rosenau,Caryn M,2,0,0,0,1,0,0,2.447
+Fall 2023,INDI,3372,1,21007,Bollywood and Beyond,Tiwari,Bhavya,5,1,1,0,1,0,0,3.043
+Fall 2023,CLAS,3350,1,21009,Law & Society in Ancient Rome,Armstrong,Richard H,21,2,0,0,1,0,0,3.75
+Fall 2023,CLAS,2366,1,21010,Who Owns Antiquity,Due Hackney,Casey L,13,1,0,0,0,0,0,3.881
+Fall 2023,CLAS,3366,1,21012,Greek Art and Archaeology,Due Hackney,Casey L,9,4,1,0,0,0,1,3.619
+Fall 2023,CLAS,6366,1,21014,Greek Art and Archaeology,Due Hackney,Casey L,1,0,0,0,0,0,0,4.0
+Fall 2023,INDS,3312,1,21018,Topics in Design Media,Kang,Chul Min,6,7,1,0,0,0,4,3.334
+Fall 2023,SPAN,6308,1,21033,Intro to Spanish Linguistics,Gutierrez,Manuel J,4,2,0,0,0,0,0,3.777
+Fall 2023,SPAN,6390,1,21034,Research Heritage Lang Educ,Fairclough,Marta A,7,3,0,0,0,0,0,3.634
+Fall 2023,SPAN,6397,1,21035,Topics in Span-Amer Lit,Rivera Garza,Cristina,13,0,0,0,0,0,0,4.0
+Fall 2023,HON,3378,1,21036,Writing the Nation: Antebellum,Trninic,Marina,4,0,0,0,0,0,0,3.918
+Fall 2023,SPAN,6397,2,21037,Topics in Span-Amer Lit,Cuesta,Mabel,7,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,6355,1,21038,Spanish Phonology,Goodin-Mayeda,Carrie Elizabeth,5,0,0,0,0,0,1,3.802
+Fall 2023,MATH,6397,4,21040,Selected Topics in Math,Jun,Mikyoung,4,2,1,0,0,0,0,3.334
+Fall 2023,ANTH,6395,1,21041,Selected Topics in Ant,Majumder,Sarasij,1,0,0,0,0,0,0,4.0
+Fall 2023,ANTH,3391,1,21042,Global Ethnographies of Labor,Sen,Debarati,10,9,0,0,2,0,1,3.19
+Fall 2023,ANTH,6395,2,21043,Selected Topics in Ant,Sen,Debarati,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,5500,29,21052,Architecture Design Studio IX,Kacmar,Donna,4,10,1,0,0,0,0,3.134
+Fall 2023,POLS,3309,1,21054,Democratization,Kennedy,Ryan P,23,16,1,0,0,0,0,3.426
+Fall 2023,ARCH,4324,1,21066,High-Rise Structures,Colaco,Joseph P,3,9,2,0,0,0,0,3.071
+Fall 2023,ARCH,6314,1,21068,Topics in Design Technology,Colaco,Joseph P,0,4,1,0,0,0,0,2.866
+Fall 2023,ARCH,6314,2,21072,Topics in Design Technology,Taylor,Rives,2,2,1,0,0,0,0,3.266
+Fall 2023,ARCH,4311,1,21104,Adv. Topics in Design History,Ramaswamy,Deepa,4,1,0,0,0,0,0,3.734
+Fall 2023,ARCH,6311,1,21105,Topics in Design History,Ramaswamy,Deepa,1,0,0,0,0,0,0,4.0
+Fall 2023,DIGM,3357,30,21106,Social Media Apps & Analytics,Liao,Pamara F,18,4,1,0,1,0,0,3.556
+Fall 2023,DIGM,4379,30,21107,Transmedia Marketing,Lee,Seo Yoon,8,5,1,0,0,0,0,3.382
+Fall 2023,ARCH,6312,1,21109,Topics in Design Media,Noldt,Peter,2,1,1,0,0,0,0,3.168
+Fall 2023,ARCH,6312,2,21111,Topics in Design Media,Jacobs,Daniel,4,0,0,0,0,0,0,3.835
+Fall 2023,ARCH,6312,3,21112,Topics in Design Media,Smith,Joshua S,2,0,0,0,0,0,0,4.0
+Fall 2023,POLS,3311,3,21113,Intro Compar Politics,Bagashka,Tanya G,9,11,6,4,9,0,1,2.112
+Fall 2023,POLS,3333,1,21114,Comparative Elections,Kennedy,Ryan P,18,12,10,0,0,0,0,3.151
+Fall 2023,SPAN,3373,1,21115,Spanish Culture & Civilization,Gutierrez,Pedro Revuelta,8,6,1,0,0,0,1,3.445
+Fall 2023,SPAN,3386,1,21117,Spanish Culture Through Film,Solino,Maria Elena,29,11,2,1,2,0,0,3.4
+Fall 2023,POLS,3391,1,21119,Political Scandals,Davis,Sharon M,27,7,2,1,2,0,1,3.385
+Fall 2023,ARCH,3112,5,21120,Topics in Design Media,Noldt,Peter,14,1,0,0,0,0,0,3.823
+Fall 2023,ARCH,3112,7,21121,Topics in Design Media,Noldt,Peter,4,2,0,0,0,0,0,3.612
+Fall 2023,RELS,3373,1,21123,Jews in the Ancient World,Tamber-Rosenau,Caryn M,7,6,0,0,0,0,0,3.513
+Fall 2023,ARCH,3112,10,21124,Topics in Design Media,Murray,Cara,15,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,2325,5,21125,University Physics I (lecture),Ordonez,Carlos,39,28,17,3,3,0,24,3.103
+Fall 2023,ARCH,3112,12,23423,Topics in Design Media,Jackson,Megan H,12,0,0,0,0,0,0,3.973
+Fall 2023,ARCH,3112,14,23425,Topics in Design Media,Logan,Jason,5,2,0,0,0,0,0,3.714
+Fall 2023,ARCH,3112,15,23426,Topics in Design Media,Plauche',Roya,4,0,0,0,1,0,0,3.134
+Fall 2023,ARCH,3112,16,23427,Topics in Design Media,Smith,Joshua S,5,0,0,0,0,0,1,4.0
+Fall 2023,POLS,4340,1,23429,Intelligence Analysis,Lubotzky,Asher,12,1,0,1,0,0,1,3.667
+Fall 2023,POLS,3396,1,23430,Sel Topics Comp Internatl Pol,Lubotzky,Asher,8,1,1,0,0,0,0,3.667
+Fall 2023,MECE,3336,2,23431,Mechanics II,Chen,Xuemei,6,13,16,6,4,0,6,2.237
+Fall 2023,POLS,3368,1,23432,"Race,Gender & Ethnic Politics",Raychaudhuri,Tanika,18,19,2,0,0,0,0,3.385
+Fall 2023,POLS,3364,1,23433,Legislative Processes,Clark,Jennifer H,20,5,2,1,1,0,1,3.403
+Fall 2023,SPAN,6344,1,23434,US Hispanic Literature,Kanellos,Nicolas,5,3,2,0,1,0,2,3.03
+Fall 2023,SPAN,6395,1,23435,Topics-Lang&Linguistics,Ruisanchez Serra,Jose Ramon,10,1,0,0,0,0,2,3.759
+Fall 2023,ARCH,6198,1,23436,Special Problems,Noldt,Peter,3,0,0,0,0,0,0,3.78
+Fall 2023,ARCH,6198,2,23437,Special Problems,Noldt,Peter,1,0,0,0,0,0,0,3.67
+Fall 2023,ARCH,6198,3,23438,Special Problems,Noldt,Peter,3,0,0,0,0,0,0,3.78
+Fall 2023,ARCH,6198,8,23443,Special Problems,Martinez,Marcus E,2,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6198,10,23445,Special Problems,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6198,13,23448,Special Problems,Logan,Jason,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6198,14,23449,Special Problems,Plauche',Roya,4,0,0,0,0,0,0,3.918
+Fall 2023,EDS,6348,1,23451,Intro to Cloud Computing,Kulkarni,Yashashree,60,19,2,0,0,0,0,3.716
+Fall 2023,EDS,6397,1,23452,Selected Topics,Kulkarni,Yashashree,56,29,1,0,0,0,0,3.64
+Fall 2023,EDS,6397,2,23453,Selected Topics,Kulkarni,Yashashree,39,0,0,0,0,0,0,4.0
+Fall 2023,POLS,3361,1,23454,Politics and Literature,Hawley,Michael C,9,11,2,1,1,0,2,3.083
+Fall 2023,POLS,3345,1,23456,National Security Law,Abbott Jr,Kenneth Wayne,23,5,1,0,1,0,0,3.6
+Fall 2023,GOVT,2305,1,23457,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,94,86,50,10,3,0,5,3.025
+Fall 2023,GOVT,2305,8,23458,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,52,99,47,11,20,0,12,2.674
+Fall 2023,GOVT,2305,9,23459,"US Govt: Congress,Pres & Crts",Church,Jeffrey,77,34,12,7,15,0,4,3.007
+Fall 2023,GOVT,2305,11,23461,"US Govt: Congress,Pres & Crts",Colby,Cory G,87,65,58,17,15,0,4,2.701
+Fall 2023,COSC,1336,7,23464,Computer Science & Program,Yun,Changhoon,20,28,31,8,6,0,31,2.456
+Fall 2023,COSC,3337,2,23465,Data Science I,Shah,Shishir,26,14,0,0,0,0,1,3.642
+Fall 2023,COSC,3360,3,23466,Operating Systems,Rincon Castro,Carlos Alberto,45,26,20,9,6,0,18,2.893
+Fall 2023,COSC,3380,3,23467,Database Systems,Ramamurthy,Uma,16,24,16,7,4,0,10,2.543
+Fall 2023,COSC,4370,2,23469,Interactive Computer Graphics,Hilford,Victoria,23,16,9,4,3,0,3,2.903
+Fall 2023,COSC,6377,1,23471,Computer Networks,Gnawali,Omprakash D,23,10,0,0,1,0,1,3.559
+Fall 2023,COSC,7373,1,23472,Advanced Computer Vision,Kakadiaris,Ioannis A,5,0,0,0,0,0,0,3.868
+Fall 2023,COMD,4382,1,23473,Aural Rehabilitation,Andrews,Chereece N,17,2,0,0,0,0,0,3.843
+Fall 2023,GOVT,2306,8,23474,US and Texas Const/Politics,Hanna,Tom Leard,130,67,15,11,5,0,20,3.338
+Fall 2023,GOVT,2306,12,23475,US and Texas Const/Politics,McDonald,John Terrence George,92,95,32,10,8,0,7,3.048
+Fall 2023,GOVT,2305,4,23476,"US Govt: Congress,Pres & Crts",Badas,Alex,41,73,81,29,11,0,12,2.41
+Fall 2023,POLS,3386,1,23477,Criminal Law,Jackson,Jerald W,26,12,5,0,0,0,0,3.435
+Fall 2023,POLS,3355,1,23478,Judicial Process,Badas,Alex,6,10,11,0,2,0,0,2.666
+Fall 2023,WCL,3397,4,23481,Selected Topics in WCL,Li,Melody Yunzi,7,2,1,1,2,0,2,2.795
+Fall 2023,ACCT,2301,19,23483,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,15,41,11,10,9,0,7,2.611
+Fall 2023,COMM,4366,2,23491,Advertising Account Planning,Tinnel,Jason Wayne,8,3,3,0,1,0,1,3.067
+Fall 2023,BIOL,4324,1,23492,Bioinformatics,Stuckert,Adam,2,5,5,1,1,0,1,2.334
+Fall 2023,LAW,5416,1,23497,Civil Justice Clinic I,Krasny,Frederick A,3,6,0,0,0,0,0,3.443
+Fall 2023,PSYC,3338,1,23498,Psychology of Older Adults,Mustafa,Andrea Iman,73,4,1,0,2,0,0,3.804
+Fall 2023,INDI,3380,1,23500,Sociology of India,Majumder,Sarasij,13,6,0,0,0,0,0,3.58
+Fall 2023,LAW,5224,1,23501,Civil Justice Clinic II,Marquez,Ryan Michael,1,0,0,0,0,0,0,3.67
+Fall 2023,LAW,6301,1,23502,Civil Justice Clinic II,Marquez,Ryan Michael,0,0,0,0,0,1,0,
+Fall 2023,PSYC,4397,2,23504,Selected Topics in Psychology,Alfano,Candice A,10,8,10,3,2,0,2,2.616
+Fall 2023,ACCT,4335,5,23505,Financial Statement Auditing,Zhao,Yuping,33,36,3,0,0,0,0,3.499
+Fall 2023,ACCT,5372,3,23507,Intro-Data Analytics in ACCT,Miles,Carolyn A,1,2,0,0,0,0,1,3.443
+Fall 2023,WCL,6397,1,23509,Selected Topics in WCL,Ramirez,Marie Theresa,1,0,0,0,0,0,0,4.0
+Fall 2023,SOC,3400,4,23516,Intro To Social Statistics,Hwang,Hyunseok,8,12,6,0,3,0,1,2.781
+Fall 2023,COMM,4314,1,23534,Social Issues in Journalism,Camaj,Lindita,11,9,6,0,3,0,0,2.862
+Fall 2023,PSYC,2319,6,23537,Intro to Social Psychology,Browne,Lindsay J,15,16,2,5,0,0,2,3.088
+Fall 2023,AAS,4373,1,23539,Black Leaders of 20Th Century,Green,Tara T,4,6,1,0,1,0,1,2.973
+Fall 2023,PSYC,2319,7,23540,Intro to Social Psychology,Osika,Matylda Maria,16,18,14,5,5,0,5,2.581
+Fall 2023,ENGL,2315,2,23548,Literature and Film,Sicinski,Michael J,11,8,0,3,0,0,2,3.047
+Fall 2023,PSYC,3339,5,23553,Intro To Clinical Psychology,Li,Xinge,59,15,5,0,0,0,0,3.621
+Fall 2023,ANTH,3306,1,23556,Sex & Culture,Hannaford,Dinah Rebecca,22,3,2,1,1,0,1,3.517
+Fall 2023,ANTH,6395,3,23557,Selected Topics in Ant,Hannaford,Dinah Rebecca,4,0,1,0,0,0,0,3.534
+Fall 2023,PSYC,4397,3,23562,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Fall 2023,PSYC,7397,5,23564,Selected Topics in Psychology,Grigorenko,Elena L,7,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3354,1,23567,Contemp Amer Fiction,Harrell,Haylee C,22,3,0,0,0,0,0,3.827
+Fall 2023,SOCW,7367,3,23568,Social Policy Analysis,Pang,Melanie Espinosa,26,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,3368,1,23569,Topics in Asian Am Lit Studies,Yang,Sunny Chen,18,5,3,0,1,0,1,3.371
+Fall 2023,ENGL,4311,1,23571,Language Socialization,Zentz,Lauren R,23,3,1,1,1,0,0,3.586
+Fall 2023,SOCW,7302,1,23572,SW in Health Care Settings,Charles,Janea Nicole Adams,27,1,0,0,0,0,0,3.964
+Fall 2023,ENGL,4387,1,23573,SR Writing Proj CW: Fiction,Turchi,Peter D,6,3,0,0,0,0,0,3.703
+Fall 2023,SOCW,7309,1,23574,Contemporary Issues in MH,Ross,Tiffany Monique,24,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,4396,1,23575,SR Experience Seminar Topics,Butler,Paul G,11,1,3,1,2,0,0,3.018
+Fall 2023,ECE,5397,1,23578,Selected Topics,Han,Zhu,7,3,1,0,0,0,1,3.455
+Fall 2023,ANTH,3396,4,23582,Selected Tops in Cultural Anth,Ambikaipaker,Mohan,14,4,0,0,2,0,0,3.285
+Fall 2023,ACCT,5372,5,23585,Intro-Data Analytics in ACCT,Miles,Carolyn A,3,0,1,0,0,0,1,3.335
+Fall 2023,ACCT,5372,6,23586,Intro-Data Analytics in ACCT,Miles,Carolyn A,1,0,0,0,0,0,0,3.67
+Fall 2023,ENGL,8323,1,23587,Master Workshop: Narrative,Turchi,Peter D,5,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7369,1,23588,Intro to Postcolonial Studies,Chatterjee,Sreya,11,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7370,1,23592,History of Rhetoric,Kastely,James L,11,2,0,0,0,0,0,3.846
+Fall 2023,ACCT,5374,2,23594,App Data Analy Comp Tech-Acct,Seijas,Nuria S,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,5397,4,23595,Selected Topics,Shan,Xiaonan,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7336,1,23597,Methods of Teaching EAL,Duran,Chatwara,9,0,0,0,1,0,0,3.6
+Fall 2023,ENGL,7396,1,23599,Topics in Language & Literatre,Womble,David Avari Patrick,7,6,1,0,0,0,1,3.499
+Fall 2023,ENGL,8362,1,23600,Topics in 19th-C Brit Studies,Lecourt,Sebastian Joseph,11,0,0,0,0,0,0,4.0
+Fall 2023,ECE,5397,5,23602,Selected Topics,Nguyen,Hien V,20,0,0,0,0,0,0,3.951
+Fall 2023,ECE,6397,1,23603,Selected Topics,Nguyen,Hien V,28,0,1,0,0,0,0,3.908
+Fall 2023,ENGL,3350,2,23604,Am Lit To 1865,Snediker,Michael,10,13,4,1,0,0,0,3.119
+Fall 2023,ECE,6397,2,23605,Selected Topics,Shan,Xiaonan,67,0,0,0,0,0,1,3.961
+Fall 2023,ANTH,6395,4,23607,Selected Topics in Ant,Ghazali,Marwa,6,0,0,0,0,0,0,3.945
+Fall 2023,ANTH,4313,1,23608,Feminist Ethnography,Ghazali,Marwa,23,1,0,2,1,0,2,3.605
+Fall 2023,POLS,3319,1,23610,Politics of Social Policy,Kharmats,Polina G,19,2,0,0,0,0,0,3.905
+Fall 2023,SOCI,1301,17,23611,Introduction To Sociology,Cooper,Chelsey Wells,53,8,0,0,0,0,1,3.826
+Fall 2023,BTEC,4350,30,23613,Biotechnology Capstone II,Khan,Abdul Latif,35,0,0,0,0,0,0,3.972
+Fall 2023,ENGL,2318,1,23618,Creation and Perform of Lit,Harris,Francine Julia,17,7,1,1,0,0,3,3.462
+Fall 2023,ARAB,1501,1,23636,Beginning Arabic I,Hefter,Thomas H,8,3,3,0,0,0,2,3.334
+Fall 2023,ARAB,1501,3,23639,Beginning Arabic I,Hefter,Thomas H,10,6,1,1,0,0,2,3.352
+Fall 2023,HIST,6300,2,23936,Rdgs in Global History,Bhattacharya,Nandini Saradindu,8,1,0,0,0,0,0,3.889
+Fall 2023,HRD,4396,1,24221,Internship in HRD,Polesello,Daiane,12,2,1,2,0,0,0,3.315
+Fall 2023,MECE,5397,1,24224,Selected Topics,Chen,Zheng,5,4,4,0,0,0,2,3.026
+Fall 2023,MECE,5397,2,24225,Selected Topics,Chen,Tian,16,6,6,0,0,0,1,3.298
+Fall 2023,MECE,6397,2,24227,Selected Topics,Zhao,Bo,2,1,0,0,0,0,1,3.777
+Fall 2023,MECE,6397,3,24228,Selected Topics,Franchek,Matthew,4,7,2,0,0,0,1,3.103
+Fall 2023,MECE,6397,4,24229,Selected Topics,Chen,Tian,4,1,0,2,0,0,0,2.953
+Fall 2023,MECE,6336,1,24237,Engineering Heat Transfer,Xu,Ben,10,1,0,0,0,0,0,3.909
+Fall 2023,MECE,6358,1,24238,Superconductor Materials,Selvamanickam,Venkat,9,7,0,0,0,0,0,3.542
+Fall 2023,HRD,3340,2,24241,Principles of HRD,Hattier,Beth,27,17,1,1,1,0,2,3.327
+Fall 2023,POLS,6308,1,24285,Political Economy,Bagashka,Tanya G,8,5,0,0,0,0,0,3.666
+Fall 2023,POLS,6349,1,24286,American Political Thought,Koganzon,Rita,7,1,0,0,0,0,0,3.834
+Fall 2023,POLS,6394,1,24287,Selected Topics in Methods,Kennedy,Ryan P,5,0,1,0,0,0,0,3.557
+Fall 2023,POLS,6395,1,24288,Selected Topics American Pol,Rottinghaus,Brandon J,10,1,0,0,0,0,0,3.909
+Fall 2023,POLS,6313,1,24289,International Relations,Soules,Michael,6,3,0,0,0,0,0,3.703
+Fall 2023,GHL,1337,3,24290,Intro To Hospitality Industry,Barth,Stephen C,15,5,3,2,3,0,1,2.894
+Fall 2023,HIST,3395,1,24305,Sel Top-European Hist,Glass,Hildegard,2,1,0,0,1,0,0,2.75
+Fall 2023,GHL,3155,1,24315,Event Planning,Haskell,Rebecca Erin,18,0,0,0,0,0,0,4.0
+Fall 2023,GHL,3197,1,24316,Selected Topics in Hospitality,Padilla,Magdalena Manzano,7,12,6,0,8,0,2,2.303
+Fall 2023,GHL,3315,1,24317,Spa Marketing,Doudna,Simone P,22,24,3,0,1,0,0,3.261
+Fall 2023,GHL,3366,1,24318,Social Media in the Hosp Ind,Lee,Minwoo,14,7,1,0,0,0,1,3.561
+Fall 2023,ACCT,7320,4,24329,Intro to Data Analytics-Acct,Miles,Carolyn A,25,10,1,0,0,0,0,3.667
+Fall 2023,ACCT,7360,2,24330,Partnership Taxation,King,Sheldon,4,2,0,0,0,0,0,3.667
+Fall 2023,ACCT,7367,2,24331,Advanced Internal Auditing,Brant Jr,Robert Edward,4,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,7373,2,24333,Data Analytics Tools Acct,Miles,Carolyn A,4,4,1,0,0,0,0,3.407
+Fall 2023,ACCT,7374,1,24337,Data Analytics Comp Tech Acct,Seijas,Nuria S,6,0,0,0,0,0,0,4.0
+Fall 2023,CIS,1332,31,24351,Intro Information Technology,Huang,Yueqin,58,6,3,0,0,0,0,3.781
+Fall 2023,CIS,6397,7,24353,Selected Topics,Lindner,Peggy,45,0,0,0,0,0,0,3.993
+Fall 2023,CIS,6397,8,24354,Selected Topics,Wu,Xuqing,17,0,0,0,0,0,0,3.922
+Fall 2023,CIS,4375,4,24363,Project Management & Practice,Martinez,Jose C,8,22,5,1,0,0,0,3.019
+Fall 2023,EDUC,4314,2,24364,Student Teaching Sec,Evans,Paige K,11,4,1,0,0,0,1,3.687
+Fall 2023,ANTH,2301,2,24365,Intro to Physical Anthropology,McElvaney,Katherine Anne,32,10,0,1,0,0,2,3.629
+Fall 2023,HDCS,3304,2,24368,Visual Merchandising,Mudd,Blake Stevens,18,6,1,0,1,0,0,3.488
+Fall 2023,COMM,4397,1,24373,Selected Topics Communication,Trupiano,Jerome,21,0,0,0,0,0,0,4.0
+Fall 2023,GENB,7393,1,24374,Business Consulting Lab I,Galvani,Paul,5,0,0,0,0,0,0,3.934
+Fall 2023,GENB,7394,1,24375,Business Consulting Lab II,Galvani,Paul,5,0,0,0,0,0,0,3.934
+Fall 2023,MARK,4367,1,24377,Advertising and Promotion Mgt,Noriega,Jaime L,31,15,3,1,0,0,0,3.408
+Fall 2023,MARK,7393,1,24378,Business Consulting Lab I,Galvani,Paul,2,1,0,0,0,0,0,3.667
+Fall 2023,ECON,3320,2,24379,Intro to Econ Data Analysis,Troncoso,Pablo A,7,10,8,6,4,0,2,2.257
+Fall 2023,MARK,7394,1,24380,Business Consulting Lab II,Galvani,Paul,2,1,0,0,0,0,0,3.667
+Fall 2023,ARLD,6372,1,24381,Museum Education,Cachia,Amanda,10,0,0,0,0,0,0,4.0
+Fall 2023,ARLD,6373,1,24382,Leadership in Public Art,Guidry,Michael Stack,4,2,0,0,0,0,0,3.612
+Fall 2023,MARK,7397,3,24389,Selected Topics in Marketing,Krishnamurthy,Parthasarathy,7,1,0,0,0,0,0,3.834
+Fall 2023,ARLD,6398,1,24390,Special Prob in Arts Leadrshp,Fernando,Fleurette S,0,0,0,0,0,0,0,
+Fall 2023,ARLD,6380,1,24391,Introduction to Arts in Health,Kulha,Shay Thornton,7,1,0,0,0,0,0,3.916
+Fall 2023,MARK,7397,4,24393,Selected Topics in Marketing,Krishnamurthy,Parthasarathy,10,1,0,0,0,0,0,3.849
+Fall 2023,MATH,3333,4,24394,Intermediate Analysis,Leger,Nicholas M,5,3,12,3,1,0,6,2.278
+Fall 2023,MIS,4374,5,24395,Info Technology Project Mgmt,Jagtap,Pankaj,5,14,5,0,0,0,0,2.931
+Fall 2023,MIS,4378,4,24396,Admin of Computer-Based MIS,Knighton,William B,41,10,0,0,0,0,0,3.804
+Fall 2023,MIS,4397,5,24397,Selected Topics in MIS,Lewis,Michael Joseph,6,7,1,0,0,0,0,3.357
+Fall 2023,MIS,4397,6,24398,Selected Topics in MIS,Eierdam,Richard R,16,1,3,3,1,0,6,3.153
+Fall 2023,MIS,4397,7,24399,Selected Topics in MIS,Messinger,Jacob Nelson,6,1,0,0,0,0,1,3.857
+Fall 2023,MIS,4397,8,24400,Selected Topics in MIS,Gonzalez Jr,Frederick,29,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6329,1,24403,Negotiations for Services Ind.,Abbott,Jeanna L,14,1,0,0,0,0,1,3.955
+Fall 2023,GHL,6364,1,24405,Hosp. Managerial Accounting,Johnson,Tucker A,6,0,1,0,0,0,0,3.573
+Fall 2023,GHL,6363,1,24406,Social Media and the Hosp. Ind,Lee,Minwoo,13,1,0,0,0,0,0,3.858
+Fall 2023,GHL,6397,1,24407,Selected Topics,Doudna,Simone P,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,8188,1,24408,Ph.D. Colloquium,Kim,Jaewook,0,0,0,0,0,3,0,
+Fall 2023,GHL,6197,1,24409,Selected Topics,Padilla,Magdalena Manzano,8,1,0,0,0,0,0,3.889
+Fall 2023,GHL,6197,2,24410,Selected Topics,Haskell,Rebecca Erin,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6197,3,24411,Selected Topics,Padilla,Magdalena Manzano,11,1,0,0,0,0,0,3.917
+Fall 2023,GHL,6364,2,24412,Hosp. Managerial Accounting,Johnson,Tucker A,4,1,1,0,0,0,0,3.555
+Fall 2023,ENGL,8390,1,24413,Literary Translation,Ferguson,Jamie H,6,0,0,0,0,0,1,3.945
+Fall 2023,HLT,4397,1,24414,Selected Topics in Health,Carmack,Chakema,14,5,1,0,0,0,0,3.634
+Fall 2023,IRW,1100,1,24415,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,49,1,
+Fall 2023,IRW,1100,2,24416,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,45,3,
+Fall 2023,IRW,1100,3,24417,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,47,2,
+Fall 2023,IRW,1100,4,24418,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,28,0,
+Fall 2023,LAW,5197,1,24419,Selected Topics,Brem,Katherine B,0,0,0,0,0,29,0,
+Fall 2023,INDS,2270,1,24422,Digital Sketch Techniques II,Kimbrough,Mark S,13,2,0,0,0,0,0,3.757
+Fall 2023,ANTH,4372,1,24451,Maya Archaeology,Chase,Arlen F,19,7,3,0,0,0,0,3.597
+Fall 2023,ACCT,4380,1,24480,Contro & Sec Intern Fin Inform,Brant Jr,Robert Edward,3,4,0,0,0,0,0,3.523
+Fall 2023,LAW,5197,3,24537,Selected Topics,Simmons,Laurel Ellis Parker,0,0,0,0,0,12,0,
+Fall 2023,HDFS,3310,1,24538,Introduction to Child Life,Fraser,Camille,19,9,1,0,0,0,1,3.587
+Fall 2023,PHLS,8342,1,24539,Seminar Learning Theories,Master,Allison,7,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5297,2,24609,Selected Topics,Willis,Tasha L,0,1,0,0,0,0,0,3.33
+Fall 2023,LAW,5397,1,24610,Selected Topics,Willis,Tasha L,0,1,0,0,0,0,0,3.33
+Fall 2023,LAW,5497,1,24611,Selected Topics,Willis,Tasha L,0,2,0,0,0,0,0,3.33
+Fall 2023,ACCT,2302,15,24614,Prin of Managerial Accounting,Weber,Catherine K,41,43,43,9,3,0,2,2.853
+Fall 2023,LAW,5397,2,24615,Selected Topics,Alonso,Yocel,0,3,0,0,0,0,0,3.33
+Fall 2023,LAW,5297,4,24616,Selected Topics,Lumpkin,Layla Dotson,7,8,0,0,0,0,0,3.401
+Fall 2023,LAW,7321,1,24617,WRC: Domestic Violence Law,Bell,Richard Thomas,7,6,1,0,0,0,0,3.358
+Fall 2023,LAW,5364,1,24618,Texas Coastal and Ocean Law,Irvine,Charles W,4,6,0,0,0,0,0,3.4
+Fall 2023,ARTH,2388,1,24645,"African, Oceania, Americas Art",Casique,Yvonne,22,2,0,1,1,0,3,3.628
+Fall 2023,PETR,3318,1,24646,Drilling Engineering I,Soliman,Mohamed Yousef,8,0,0,0,0,0,0,3.753
+Fall 2023,ARTH,3335,1,24647,Surrealism and Its Legacies,Zalman,Sandra,5,10,6,0,1,0,0,2.803
+Fall 2023,ARTH,6394,1,24648,Sel Top in Art History,Zalman,Sandra,2,0,0,0,0,0,0,3.835
+Fall 2023,PETR,7304,1,24654,Advanced Numerical Analysis,Qin,Guan,2,0,0,0,0,0,1,4.0
+Fall 2023,INDS,4365,1,24655,Design Practice and Business,McCormick,Kelly,12,11,0,1,0,0,0,3.375
+Fall 2023,PETR,7324,1,24656,Advanced Geomechanics,Myers,Michael Tolbert,7,2,0,0,0,0,0,3.631
+Fall 2023,POLS,3369,1,24657,The Presidency,Rottinghaus,Brandon J,5,15,7,1,1,0,0,2.793
+Fall 2023,POLS,3381,1,24658,Political Psychology,Jenke,Elizabeth,15,20,2,1,0,0,0,3.263
+Fall 2023,HRD,4344,3,24659,Designing E-Learning,Bennett,LaTasha,20,5,1,0,1,0,0,3.544
+Fall 2023,ELET,4353,1,24660,Statistics for ET,Pollonini,Luca,6,3,1,0,1,0,1,3.092
+Fall 2023,SPAC,6398,1,24859,Special Problems,Kennedy,Kriss Jon,5,3,0,0,0,0,0,3.666
+Fall 2023,PETR,6314,1,24862,Pressure Transient Testing,Hatzignatiou,Dimitrios Georgios,0,1,1,0,0,0,1,2.5
+Fall 2023,LAW,5237,1,24864,FDA Law,Armstrong,Mark S,11,10,1,0,0,0,0,3.47
+Fall 2023,LAW,5238,1,24867,Mental Health Law,Brents,Melinda Heath,8,11,0,0,0,2,0,3.404
+Fall 2023,LAW,5314,30,24873,Lawyering Skills & Strategy I,Esterholm,Melissa Hurter,7,9,0,0,0,0,0,3.396
+Fall 2023,GEOL,3373,4,24874,Igneous & Met. Petrogenesis,Lapen,Thomas J,8,9,0,0,1,0,0,3.296
+Fall 2023,GEOL,3130,3,24882,Paleobiology Laboratory,Maddocks,Rosalie F,0,1,3,1,0,0,0,1.934
+Fall 2023,GEOL,3130,4,24883,Paleobiology Laboratory,Maddocks,Rosalie F,5,2,4,0,2,0,0,2.59
+Fall 2023,LAW,6322,1,24887,Military Justice Clinic,Marquez,Jason R,0,2,0,0,0,0,0,3.33
+Fall 2023,LAW,5411,1,24888,Military Justice Clinic,Marquez,Jason R,1,0,0,0,0,0,0,3.67
+Fall 2023,LAW,5412,1,24889,Judicial Externship II,Powers,William,0,0,0,0,0,1,0,
+Fall 2023,LAW,5216,1,24891,Space Law,Bresnik,Rebecca M,13,8,5,0,0,3,0,3.32
+Fall 2023,GEOL,4397,2,24892,Selected Topics-Geology,Sun,Jiajia,14,2,0,0,1,0,0,3.55
+Fall 2023,GEOL,6322,1,24896,Geophysical Programming,Sun,Jiajia,11,1,0,0,0,0,0,3.917
+Fall 2023,LAW,6344,1,24898,U.S. Import Regulation,Hanson,Lawrence W,5,9,0,0,0,0,0,3.357
+Fall 2023,LAW,6341,1,24899,Water Law,Hester,Tracy,7,10,0,0,0,4,0,3.392
+Fall 2023,LAW,5120,1,24900,Texas Legal Research,Dykes,Christopher,8,11,0,0,0,0,0,3.386
+Fall 2023,COMM,6335,1,24902,Health Comm. Theory & Research,Xiao,Zhiwen,9,0,0,0,0,0,0,3.89
+Fall 2023,COMM,7397,1,24904,Selected Topics - Comm,Choi,Ho Joon,12,0,0,0,0,0,1,3.973
+Fall 2023,LAW,7344,1,24914,WRS: Energy & the Environment,Warren,Gina S,4,8,0,0,0,0,0,3.388
+Fall 2023,LAW,6332,1,24915,ADR Survey,Bregant,Jessica Lynn,6,11,0,0,0,0,0,3.372
+Fall 2023,LAW,6210,1,24916,Construction Law,LaPar,Kelly,11,8,2,0,0,0,0,3.397
+Fall 2023,LAW,5297,6,24918,Selected Topics,Watson,Amanda,6,6,0,0,0,2,0,3.39
+Fall 2023,LAW,5297,7,24921,Selected Topics,Watson,Amanda,4,7,0,0,0,2,0,3.394
+Fall 2023,ACCT,5378,1,24923,Control & Security of Fin Info,Brant Jr,Robert Edward,2,1,1,0,0,0,0,3.25
+Fall 2023,LAW,5297,8,24924,Selected Topics,Watson,Amanda,4,10,0,0,0,0,0,3.404
+Fall 2023,ACCT,7337,2,24938,Oil & Gas Taxation,Wright,Denney L,4,1,0,0,0,0,0,3.8
+Fall 2023,ACCT,7337,3,24939,Oil & Gas Taxation,Wright,Denney L,11,11,0,0,0,0,0,3.455
+Fall 2023,ACCT,7390,1,24950,Contrl & Secur of Finan Inform,Brant Jr,Robert Edward,12,10,0,0,0,0,0,3.59
+Fall 2023,ARTH,3333,1,24994,Issues in Contemporary Design,Orto,Luisa,14,5,1,0,0,0,1,3.568
+Fall 2023,ARTH,6333,1,24996,Issues in Contemporary Design,Orto,Luisa,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,3334,2,25000,History of Graphic Design,Orto,Luisa,21,18,1,1,0,0,0,3.423
+Fall 2023,ARTH,6334,2,25002,History of Graphic Design,Orto,Luisa,4,1,0,0,0,0,0,3.8
+Fall 2023,ARTH,3394,2,25006,Sel Tops in Art History,Koontz,Rex A,20,1,0,0,0,0,0,3.921
+Fall 2023,ARTH,6394,2,25007,Sel Top in Art History,Koontz,Rex A,3,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,3394,3,25009,Sel Tops in Art History,Decker,Arden,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTH,6394,3,25010,Sel Top in Art History,Decker,Arden,4,2,0,0,0,0,0,3.667
+Fall 2023,ARTH,4394,2,25014,Sel Tops in Art History,Nevitt Jr,Hugh R,12,0,0,0,0,0,1,4.0
+Fall 2023,MATH,2305,3,25015,Discrete Mathematics,Winkle,James J,13,30,27,14,3,0,7,2.44
+Fall 2023,ARTH,6394,5,25016,Sel Top in Art History,Nevitt Jr,Hugh R,3,0,0,0,0,0,0,4.0
+Fall 2023,MATH,1332,3,25025,Contemporary Mathematics,Hafeez,Shahinda,31,35,43,15,20,0,6,2.248
+Fall 2023,SOCW,7337,1,25112,Crit Cinical Case Form & Diag,Gearing,Robin Edward,25,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7337,2,25113,Crit Cinical Case Form & Diag,Maldonado-Morales,Maria Ximena,29,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7337,3,25115,Crit Cinical Case Form & Diag,Parks,Steven Lee,22,4,0,0,0,0,0,3.846
+Fall 2023,SOCW,7337,4,25116,Crit Cinical Case Form & Diag,Parks,Steven Lee,20,3,1,0,0,0,2,3.792
+Fall 2023,SOCW,7337,5,25118,Crit Cinical Case Form & Diag,Taylor,Patricia G,21,0,0,0,0,0,1,4.0
+Fall 2023,SOCW,7337,6,25119,Crit Cinical Case Form & Diag,Parks,Steven Lee,26,2,0,0,0,0,0,3.929
+Fall 2023,SOCW,7343,1,25122,Families: Adv Clinical Practic,Walton,Quenette,30,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7343,2,25123,Families: Adv Clinical Practic,Amtsberg,Donna K,30,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7343,3,25124,Families: Adv Clinical Practic,Jacobs,Alexandra L,27,0,1,0,0,0,0,3.929
+Fall 2023,SOCW,7343,4,25125,Families: Adv Clinical Practic,Amtsberg,Donna K,20,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7343,5,25126,Families: Adv Clinical Practic,Miyawaki,Christina E,19,5,0,0,0,0,0,3.792
+Fall 2023,SOCW,7343,6,25127,Families: Adv Clinical Practic,Miyawaki,Christina E,19,2,0,0,0,0,0,3.905
+Fall 2023,SOCW,7343,7,25128,Families: Adv Clinical Practic,Burkley,Casondra,12,9,1,0,0,0,0,3.5
+Fall 2023,SOCW,7343,8,25129,Families: Adv Clinical Practic,McMorris,Saralyn Dionne,23,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4397,1,25192,Sel Topics in Fine Arts,Litos,Joshua David,9,5,2,0,0,0,0,3.458
+Fall 2023,ARTS,4397,2,25194,Sel Topics in Fine Arts,Willis,William H,16,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8330,1,25196,Cognitive Neuroscience,Hernandez,Arturo E,8,0,0,0,0,0,0,4.0
+Fall 2023,BTEC,6302,40,25198,Intro to Regulatory Affairs,Flavier,Albert B,5,0,0,0,0,0,0,3.934
+Fall 2023,BTEC,6304,40,25200,Computational Methods in BTEC,Chitrala,Kumaraswamy Naidu,4,0,0,0,0,0,1,3.918
+Fall 2023,CIS,6323,40,25207,Applied Cryptography,Zhang,Yunpeng,9,3,0,0,0,0,1,3.778
+Fall 2023,CIS,6324,40,25208,Cybersecurity Risk Management,Conklin,William A,7,4,0,0,0,0,1,3.606
+Fall 2023,ARTS,4397,3,25212,Sel Topics in Fine Arts,Lowe,Rick,6,2,1,0,0,0,0,3.592
+Fall 2023,CIS,6397,46,25213,Selected Topics,Venkataramani,Suresh,2,0,0,0,0,0,0,3.835
+Fall 2023,CIS,6397,47,25215,Selected Topics,Lendasse,Amaury,8,0,0,0,0,0,0,3.959
+Fall 2023,CHEE,5350,1,25216,Adv Oxidn Proc Water Treatment,Rojas,Mario Roberto,10,1,2,1,0,0,0,3.358
+Fall 2023,ARTS,6396,1,25218,Sel Topics in Fine Arts Media,Giampietro,Francis A,5,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,3396,1,25375,Selected Tops Studio Practice,Giampietro,Francis A,9,0,0,0,0,0,0,3.927
+Fall 2023,ARTS,6396,2,25376,Sel Topics in Fine Arts Media,Giampietro,Francis A,1,0,0,0,0,0,1,4.0
+Fall 2023,PSYC,2317,10,25383,Intro to Psychology Statistics,Babalola,Olusegun,20,38,7,1,5,0,6,2.906
+Fall 2023,ELET,6350,40,25400,Overview Com Health Informatic,Pollonini,Luca,1,0,0,0,0,0,0,4.0
+Fall 2023,GRET,6332,40,25406,Consumer Issues and Apps.,Johnson,Olivia,0,0,2,0,0,0,0,2.0
+Fall 2023,GRET,6334,40,25407,Global E-Tailing Systems,Ezell,Shirley D,4,1,0,0,0,0,0,3.734
+Fall 2023,GRET,6336,40,25408,Global Retail Analysis,Robinson,Ebony M,1,2,1,0,0,0,1,3.0
+Fall 2023,SCLT,6316,40,25411,Global Supply Chain Logistics,Wang,Kailai,3,2,0,0,0,0,0,3.468
+Fall 2023,SCLT,6318,40,25412,Supply Chain Strategies,Bian,Zheyong,1,2,0,0,0,0,0,3.443
+Fall 2023,PSYC,3347,3,25413,Problems of Normal Life,Anderson,Jill Annette,33,37,8,0,3,0,1,3.173
+Fall 2023,SCLT,6397,40,25418,Selected Topics,Dong,Zhijie,0,0,0,0,0,0,2,
+Fall 2023,MUED,6312,1,25451,History & Philosophy of Mus Ed,McGinnis,Emily Jane,8,2,0,0,0,0,0,3.767
+Fall 2023,SCM,4330,4,25483,Bus Modeling and Dec Analysis,Cossick,Kathy L,2,1,1,0,1,0,0,2.468
+Fall 2023,SCM,4367,3,25487,Process and Quality Management,Miller,Bradley D,1,0,0,0,1,0,0,2.0
+Fall 2023,SCM,4390,4,25492,Supply Chain Strategy,Smith,Gordon D,0,2,0,0,0,0,0,3.0
+Fall 2023,MANA,4355,3,25493,Selection and Staffing,Belinne,Jamie King,13,2,1,1,0,0,0,3.627
+Fall 2023,SCM,8397,1,25495,Selected Topics in SCM,Tan,Yinliang,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,1102,3,25497,Wind Ensemble,Bertman,David Garry,20,0,0,0,0,0,2,4.0
+Fall 2023,MUSI,1116,3,25498,Aural Skills I,Snyder,John L,14,5,2,0,0,0,1,3.509
+Fall 2023,SCM,4350,2,25509,Strategic Supply Management,Wayhan,Victor Brian,2,2,2,1,0,0,0,2.714
+Fall 2023,MUSI,1311,3,25510,Music Theory I,Snyder,John L,8,7,3,0,1,0,3,3.071
+Fall 2023,MUSI,4122,1,25515,Electronic Composition,Welch,Carl Chapman,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4197,1,25517,Selected Topics in Music,Suits,Brian J,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4312,1,25518,Orchestration,Maroney,Marcus K,4,2,3,0,1,0,2,2.668
+Fall 2023,MUSI,4397,1,25519,Selected Topics in Music,Koozin,Timothy,6,2,0,0,0,0,0,3.585
+Fall 2023,MUSI,6397,1,25520,Selected Topics-Music,Koozin,Timothy,8,0,0,0,0,0,0,3.876
+Fall 2023,MUSI,6397,2,25526,Selected Topics-Music,Dirst,Matthew C,6,3,1,0,0,0,0,3.434
+Fall 2023,MUSI,6340,2,25561,Graduate Music History Review,Caton,Kathryn L.,14,3,0,0,0,0,0,3.765
+Fall 2023,PHLS,8393,2,25562,Doctoral Practicum in Psy,Arbona,Consuelo,0,0,0,0,0,8,0,
+Fall 2023,MUSI,4397,3,25563,Selected Topics in Music,Pollack,Howard J,4,1,0,0,1,0,1,3.112
+Fall 2023,MUSI,6397,3,25564,Selected Topics-Music,Pollack,Howard J,1,1,1,0,0,0,0,3.11
+Fall 2023,MUSI,6397,4,25565,Selected Topics-Music,Lee,Ji Yeon,14,1,0,0,0,0,0,3.955
+Fall 2023,MUSI,6397,5,25566,Selected Topics-Music,Bertagnolli,Paul A,3,3,2,0,0,0,0,3.166
+Fall 2023,MUSI,8301,1,25567,Seminar in Perform Pedagogy,Cho,Eunghee,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8350,1,25568,Ren Bar Performance Practice,Dirst,Matthew C,4,3,1,0,0,0,0,3.499
+Fall 2023,PHLS,7302,1,25569,Internship I,McCoy,Leah,0,0,0,0,0,5,0,
+Fall 2023,PHLS,7302,2,25570,Internship I,Ashley,Candice R,0,0,0,0,0,10,0,
+Fall 2023,PHLS,7302,3,25571,Internship I,Zatopek,Audrey,0,0,0,0,0,9,0,
+Fall 2023,PHLS,7302,4,25572,Internship I,Lee,Jungeun,0,0,0,0,0,10,0,
+Fall 2023,PHLS,7375,1,25574,Intro To Family Counsl,Whitaker,Rachael Gwin,16,2,0,0,0,0,0,3.907
+Fall 2023,PHLS,7375,2,25575,Intro To Family Counsl,Whitaker,Rachael Gwin,13,1,2,0,0,0,1,3.605
+Fall 2023,DANC,3203,1,25577,Contact Improvisation,Scates,Leslie Ann,7,0,0,0,0,0,0,4.0
+Fall 2023,DANC,3306,1,25578,Dance Composition III,Lockett,KeyAira,6,0,0,0,0,0,0,3.89
+Fall 2023,DANC,4197,1,25579,Selected Topics,Valle,Toni Leago,9,0,0,0,0,0,2,3.963
+Fall 2023,SOCW,8695,1,25581,Pre-Dissertation Research,Walton,Quenette,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8995,1,25582,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,3,0,
+Fall 2023,PHLS,8398,1,25586,Special Problems,Fan,Weihua,2,0,0,0,0,0,0,4.0
+Fall 2023,RELS,2336,1,25588,Introduction to Jewish Studies,Tamber-Rosenau,Caryn M,6,0,0,1,2,0,0,2.814
+Fall 2023,ARCH,3397,1,25589,Selected Topics,Bell,Larry S,9,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6397,1,25590,Sel Tpcs-Arc/Urbn Desgn,Bell,Larry S,4,0,0,0,0,0,0,4.0
+Fall 2023,HLT,4317,2,25591,Found of Epi in Public Health,Drenner,Kelli Linn,12,24,19,4,2,0,3,2.623
+Fall 2023,ARCH,6397,2,25592,Sel Tpcs-Arc/Urbn Desgn,Rogers,Susan,3,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6306,1,25593,Rigging,Vlahos,Kalliope,1,0,0,0,0,0,0,3.67
+Fall 2023,ARCH,4397,1,25596,Selected Topics,Race,Bruce Alan,0,1,1,0,0,0,0,2.665
+Fall 2023,CUST,6370,1,25599,Cultural Found Amer Edu,Carales,Vincent D,5,0,0,0,0,0,0,3.868
+Fall 2023,WGSS,3351,1,25601,Gender and Work,Sen,Debarati,5,4,0,0,0,0,0,3.519
+Fall 2023,LAW,7397,1,25602,Selected Topics,Portuondo,Laura,5,7,0,0,0,0,0,3.389
+Fall 2023,LAW,7397,2,25603,Selected Topics,Marquez,Ryan Michael,4,7,0,0,0,0,0,3.394
+Fall 2023,LAW,5197,4,25605,Selected Topics,Brownell,Robert Bruce Anthony,1,6,0,0,0,0,0,3.379
+Fall 2023,LAW,5397,3,25606,Selected Topics,Warren,Gina S,13,13,2,0,0,0,1,3.369
+Fall 2023,LAW,5397,4,25607,Selected Topics,Ginsburg,Richard Allen,7,4,1,0,0,0,3,3.39
+Fall 2023,MECT,4341,1,25608,Materials Select & Management,Robles Hernandez,Francisco C,10,0,0,0,0,0,0,3.802
+Fall 2023,MECT,4368,30,25609,Systems Simulation,Wari,Ezra Tsegaye,7,8,12,0,0,0,0,2.705
+Fall 2023,SOCW,8398,1,25611,Independent Study,Walton,Quenette,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,1220,2,25613,Class Piano I,Van Kekerix,Todd Evan,8,2,1,0,0,0,0,3.606
+Fall 2023,MUSI,2116,3,25614,Aural Skills III,Lee,Ji Yeon,3,8,3,0,1,0,0,2.844
+Fall 2023,MUSI,2210,3,25615,Theory III,Lee,Ji Yeon,4,10,1,0,1,0,0,2.918
+Fall 2023,INDE,2333,4,25616,Engineering Statistics I,Wang,Yaping,41,23,25,3,1,0,8,2.994
+Fall 2023,MUSI,4230,3,25617,Instrumental Conducting I,Bertman,David Garry,23,0,0,0,0,0,0,4.0
+Fall 2023,LAW,6334,1,25622,Acct and Finance for Lawyers,Thakkar,Shobhan,14,13,2,0,0,12,0,3.391
+Fall 2023,MUSA,4189,1,25629,Senior Recital,Yon,Kirsten A,0,0,0,0,0,0,0,
+Fall 2023,LAW,5365,1,25631,Bankrptcy&Creditrs Rgts,Anapolsky,Jeffrey,15,15,3,0,0,0,0,3.304
+Fall 2023,MECT,4323,30,25632,Application in Stress Analysis,Basaran,Burak,4,7,8,0,1,0,0,2.601
+Fall 2023,TLIM,4378,30,25635,Senior Project,Burns,Maria,24,0,0,0,0,0,0,3.986
+Fall 2023,ENGI,1100,4,25636,Introduction To Engineering,Metrovich,Brian,19,23,13,0,1,0,3,3.059
+Fall 2023,LAW,5352,1,25637,Corporate Taxation,Wells,Douglas,3,0,0,0,0,0,0,3.78
+Fall 2023,WGSS,3395,1,25638,Sel Tops in Women's Studies,Shakir,Ameenah,6,6,1,0,1,0,0,3.119
+Fall 2023,AAS,3366,1,25640,AAS Community Internship,Green,Tara T,6,3,1,0,0,0,1,3.467
+Fall 2023,PSYC,4355,1,25641,Psychology of PM&R,Williams,Michael W,19,7,2,2,0,0,4,3.4
+Fall 2023,MUSA,4189,2,25642,Senior Recital,Staupe,Andrew Paul,1,0,0,0,0,0,0,3.67
+Fall 2023,ELET,4356,1,25645,Info Visualization in ET,Merchant,Fatima Aziz,5,10,3,1,0,0,4,3.104
+Fall 2023,ELET,6356,1,25646,Health Analytics Visualization,Merchant,Fatima Aziz,4,2,0,0,0,0,0,3.612
+Fall 2023,BTEC,4101,30,25648,Principle of Bioprocessing Lab,Lin,Yuheng,18,4,1,0,0,0,0,3.667
+Fall 2023,FINA,7360,2,25649,International Finance,Hitzemann,Steffen,5,5,1,0,0,0,0,3.364
+Fall 2023,FINA,7397,6,25650,Selected Topics in Finance,Fellers,Vanessa,6,5,1,0,1,0,0,3.205
+Fall 2023,FINA,7397,7,25651,Selected Topics in Finance,Huang,Yonghui,1,3,2,0,1,0,0,2.429
+Fall 2023,FINA,7397,8,25652,Selected Topics in Finance,Fellers,Vanessa,3,4,0,0,1,0,0,2.918
+Fall 2023,MANA,7397,1,25653,Selected Topics in Management,Witt,Lawrence A,7,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,7390,1,25654,Instructional Design,Gronseth,Susie L B,14,0,0,0,0,0,3,3.953
+Fall 2023,MANA,6A25,2,25661,Ethical Leadrshp & Crit Reason,Krylova,Ksenia O,11,0,0,0,0,0,0,3.97
+Fall 2023,ACCT,2301,20,25662,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,17,35,11,5,3,0,7,2.905
+Fall 2023,ACCT,2301,21,25663,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,24,29,13,9,1,0,3,2.968
+Fall 2023,ACCT,2302,18,25668,Prin of Managerial Accounting,Weber,Catherine K,24,25,14,5,1,0,1,3.033
+Fall 2023,ACCT,3366,9,25669,Financial Reporting Frameworks,Serrato,Darlene Marie  Bohac,0,0,0,1,1,0,2,0.5
+Fall 2023,LAW,5297,9,25688,Selected Topics,Ewer,Michael S,5,10,0,0,0,0,0,3.443
+Fall 2023,ACCT,3368,5,25691,Intermediate Accounting II,Kraten,Michael,12,8,5,0,2,0,2,2.976
+Fall 2023,ACCT,2301,22,25693,Prin of Financial Accounting,Zhu,Limin,11,26,11,2,9,0,5,2.598
+Fall 2023,ACCT,2301,23,25694,Prin of Financial Accounting,Zhu,Limin,10,17,13,8,4,0,6,2.505
+Fall 2023,ACCT,2301,24,25695,Prin of Financial Accounting,Zhu,Limin,16,25,14,5,5,0,1,2.788
+Fall 2023,POLC,4323,1,25696,Data Analytics and Visual,Yuasa,Toshiyuki,3,1,1,1,0,0,2,3.0
+Fall 2023,FORE,6359,20,25697,Design Futures,Cowart,Adam David,10,1,0,0,0,0,0,3.909
+Fall 2023,POLC,4397,1,25698,Selected Topics Public Policy,Koelling,Peter,1,0,0,0,0,0,0,3.67
+Fall 2023,FORE,6359,40,25699,Design Futures,Cowart,Adam David,4,0,0,0,0,0,0,4.0
+Fall 2023,PETR,6354,1,25700,Reservoir Engineering Fund,Ehlig-Economides,Christine A,5,3,0,0,0,0,0,3.625
+Fall 2023,MARK,7399,1,25703,MS Marketing Prof Project,Koch,Steven F,7,0,0,0,0,0,1,3.906
+Fall 2023,MARK,7399,2,25704,MS Marketing Prof Project,Koch,Steven F,6,0,0,0,0,0,0,3.945
+Fall 2023,HDCS,6331,40,25709,Adv Strat For Futures Planning,Hines,Andrew Lewis,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,4189,3,25710,Senior Recital,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,4330,1,25711,European Renaissance,Carrera,Alessandro,2,1,0,0,0,0,0,3.667
+Fall 2023,ACCT,2302,19,25715,Prin of Managerial Accounting,Zhu,Limin,13,18,27,4,0,0,0,2.709
+Fall 2023,CUIN,7315,1,25727,Assess & Eval in Bilingual Ed,Burgess,Miguel,27,1,1,0,0,0,0,3.908
+Fall 2023,LAW,7397,3,25728,Selected Topics,Hoffman,Lonny,6,10,0,0,0,0,0,3.396
+Fall 2023,CUIN,8322,1,25729,Mixed Methods Research,Li,Miao,4,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8399,1,25730,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,1,0,
+Fall 2023,CUIN,7378,5,25733,Models of Teaching,McNeil,Sara G,13,0,1,0,0,0,0,3.857
+Fall 2023,CUIN,7345,1,25735,Learning Theories for Instr,Hausmann,Robert Carl,15,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5397,5,25738,Selected Topics,Willis,Tasha L,2,7,0,0,0,0,0,3.406
+Fall 2023,ELCS,6370,1,25739,Research for Educatnal Leaders,Horner,Glenda Sue,11,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6370,2,25740,Research for Educatnal Leaders,Horner,Glenda Sue,7,0,0,0,0,0,0,4.0
+Fall 2023,SCM,3301,5,25743,SCM Fundamentals,Miller,Bradley D,31,12,4,0,1,0,0,3.486
+Fall 2023,LAW,5697,1,25748,Selected Topics,Cabot,Jessica Anna,3,4,0,0,0,0,0,3.381
+Fall 2023,WGSS,3322,1,25750,Intersectionalities,Pegoda,Andrew Joseph,10,6,8,0,1,0,4,2.907
+Fall 2023,SOCW,8198,1,25751,Independent Study,Leung,Yuk-Hi Patrick,0,0,0,0,0,1,0,
+Fall 2023,CNE,3310,1,25753,Construction Engr Project Mgmt,Safa,Mahdi,0,2,0,0,0,0,0,3.0
+Fall 2023,CIVE,3339,5,25755,Geotechnical Engineering,Zamiran,Siavash,1,1,0,0,0,0,0,3.5
+Fall 2023,ANTH,3382,1,25756,Cultures & Capital India Asia,Majumder,Sarasij,12,3,0,0,0,0,3,3.756
+Fall 2023,PHLS,8396,4,25774,Doctoral Research,Master,Allison,0,0,0,0,0,1,0,
+Fall 2023,HLT,4392,1,25787,Field Work in Community Health,Farmer,Jennifer,34,0,0,0,1,0,0,3.857
+Fall 2023,HLT,4392,2,25788,Field Work in Community Health,Farmer,Jennifer,23,2,0,0,0,0,0,3.946
+Fall 2023,HLT,4392,3,25789,Field Work in Community Health,Proctor,Robin Ann,28,5,0,0,0,0,0,3.848
+Fall 2023,KIN,4350,1,25793,Sport Marketing,Lee,Dong Hun,38,9,2,1,0,0,0,3.634
+Fall 2023,KIN,1352,4,25794,"Foundations of KIN, HLT, FIT",Ojemaye,Lukachukwu Fitzgerald,38,7,1,2,1,0,0,3.565
+Fall 2023,KIN,1352,5,25795,"Foundations of KIN, HLT, FIT",Ojemaye,Lukachukwu Fitzgerald,33,11,1,0,3,0,1,3.424
+Fall 2023,ELCS,6393,1,25801,Internship in Higher Education,Carales,Vincent D,1,0,0,0,0,0,0,4.0
+Fall 2023,DANC,1247,1,25805,Jazz I,Bobet,Jacqueline A,14,2,1,0,0,0,2,3.726
+Fall 2023,GREK,3398,1,25807,Independent Study,Due Hackney,Casey L,2,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7376,2,25815,Energy Trading,Smith III,Edwin A,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,6397,1,25816,Selected Topics,Rojas,Mario Roberto,4,0,1,0,0,0,0,3.6
+Fall 2023,INAR,4393,1,25818,Senior Project Preparation,Davis,Curtis M,8,6,3,2,0,0,0,3.053
+Fall 2023,AAS,3394,2,25819,Selected Topics Afr Am Stdy,Harrell,Haylee C,1,1,0,0,0,0,1,3.335
+Fall 2023,ARCH,6314,3,25821,Topics in Design Technology,Kyropoulou,Amygdalia,6,0,0,0,0,0,0,4.0
+Fall 2023,COMM,3326,4,25823,Graphics Applications,Economou-Clarke,Ann M,23,7,0,0,0,0,0,3.712
+Fall 2023,IART,3395,1,25827,Sel Topics in Interdis Arts,Meza,Abinadi,3,0,0,0,0,0,0,4.0
+Fall 2023,IART,3395,2,25828,Sel Topics in Interdis Arts,Meza,Abinadi,3,0,0,0,0,0,0,4.0
+Fall 2023,IART,3395,3,25829,Sel Topics in Interdis Arts,Reed,John G,2,1,0,0,0,0,2,3.447
+Fall 2023,IART,3395,4,25830,Sel Topics in Interdis Arts,Lowe,Rick,0,0,1,0,0,0,0,2.33
+Fall 2023,MUED,6311,1,25831,Curriculum & Assessment,Hansen,Erin Melissa,3,1,0,0,0,0,0,3.833
+Fall 2023,MIS,7397,9,25832,Selected Topics in MIS,Jagtap,Pankaj,8,9,0,0,0,0,0,3.509
+Fall 2023,GEOL,6395,1,25833,Petroleum Seismology,Zhou,Hua-Wei,7,8,0,0,0,0,0,3.445
+Fall 2023,GEOL,7325,1,25834,Petrophysics & Formation Eval.,Myers,Michael Tolbert,4,10,0,0,0,0,1,3.215
+Fall 2023,GEOL,6390,2,25835,3-D Seismic Exploration I,Marfurt,Kurt J,6,8,0,0,0,0,1,3.358
+Fall 2023,CHEE,7350,1,25836,Appl Nonlinear Mtds for Engrs,Balakotaiah,Vemuri,5,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7322,1,25837,Advncd Poetry Workshop,Harris,Francine Julia,10,0,0,0,0,0,0,3.967
+Fall 2023,MARK,3337,5,25842,Professional Selling,Boehm-Miller,Elizabeth A,202,65,8,2,0,0,4,3.65
+Fall 2023,ECE,1197,1,25843,Selected Topics,De La Rosa-Pohl,Diana,18,2,0,0,1,0,1,3.714
+Fall 2023,CNST,6308,40,25844,Data Analysis in Construc Mgmt,Gao,Lu,2,0,0,0,0,0,0,4.0
+Fall 2023,CNST,6310,40,25845,Construction Contract Administ,Eldin,Neil N,3,0,0,0,0,0,0,4.0
+Fall 2023,CNST,6340,40,25846,Best Practices in Construction,Kim,Kinam,5,0,0,0,0,0,0,4.0
+Fall 2023,CNST,6350,40,25847,Decision Making and Risk Mgmt,Gao,Lu,3,0,0,0,0,0,0,4.0
+Fall 2023,ECE,5197,1,25850,Selected Topics,Nguyen,Hien V,7,0,0,0,0,0,0,4.0
+Fall 2023,ECE,5346,1,25851,Vlsi Design,Joardar,Biresh Kumar,4,0,0,0,0,0,0,3.918
+Fall 2023,ECE,6346,1,25852,Vlsi Design,Joardar,Biresh Kumar,22,22,4,0,0,0,0,3.368
+Fall 2023,ECE,6379,1,25853,Power Syst Oper and Modeling,Li,Xingpeng,8,1,1,0,0,0,0,3.667
+Fall 2023,DANC,4305,1,25854,Senior Project with Career Mgt,Chapman,Teresa Lynn,4,0,0,0,0,0,0,3.753
+Fall 2023,INDS,6398,4,25869,Independent Study,Chow,George K,0,1,0,0,0,0,0,2.67
+Fall 2023,LAW,5397,6,25870,Selected Topics,Alonso,Yocel,0,2,0,0,0,0,0,3.33
+Fall 2023,EGRP,1151,1,25876,Engineering Applications VII,Luna Singh,Jennifer Austin,0,0,0,0,0,6,1,
+Fall 2023,ARCH,3311,3,25887,Topics in Design History,Rodriguez Fernandez,Marta,10,0,0,0,0,0,1,3.934
+Fall 2023,ARCH,6311,3,25888,Topics in Design History,Rodriguez Fernandez,Marta,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6204,3,25891,Conducting,Marmolejo,Noe J,2,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6112,1,25892,Topics in Design Media,Smith,Joshua S,2,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8390,2,25893,Dissertation in Practice,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8390,3,25894,Dissertation in Practice,McNeil,Sara G,0,0,0,0,0,2,0,
+Fall 2023,CUIN,8390,5,25895,Dissertation in Practice,Hausmann,Robert Carl,1,0,0,0,0,2,0,4.0
+Fall 2023,MUSA,3434,3,25901,Applied Clarinet,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8395,1,25903,Dissertation in practice,Shockley,Gerald,0,0,0,0,0,1,1,
+Fall 2023,ELCS,8395,2,25904,Dissertation in practice,Davis,Bradley,0,0,0,0,0,12,1,
+Fall 2023,ELCS,8395,3,25905,Dissertation in practice,Butcher,Keith,0,0,0,0,0,6,0,
+Fall 2023,ELCS,8395,5,25907,Dissertation in practice,Johnson,Detra DeVerne,0,0,0,0,0,3,0,
+Fall 2023,ELCS,8395,6,25908,Dissertation in practice,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Fall 2023,ELCS,8395,8,25910,Dissertation in practice,Peters-Hawkins,April,3,0,1,0,0,3,0,3.5
+Fall 2023,ELCS,8395,9,25911,Dissertation in practice,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,3,0,4.0
+Fall 2023,BIOL,4397,3,25914,Selected Topics in Biology,Frankino,William A,3,0,0,0,0,0,0,3.89
+Fall 2023,LAW,5219,1,25915,E-Health,Rivera,Julian,6,9,0,0,0,1,0,3.4
+Fall 2023,MUSA,4189,4,25917,Senior Recital,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,2318,8,25919,Linear Algebra,Olshanskiy,Maxim Alexandrovich,11,11,10,3,4,0,8,2.429
+Fall 2023,NAVY,3303,1,25921,Evolution of Warfare,Collins,Daniel W,1,5,0,0,0,0,0,3.277
+Fall 2023,THEA,6396,1,25923,Selected Topics Theatre,Coen,Elizabeth Manya,3,0,0,0,0,0,0,3.89
+Fall 2023,THEA,3302,1,25924,Playwriting Workshop: Realism,Romero,Gregory John,10,2,0,0,0,0,0,3.806
+Fall 2023,DIGM,4398,3,25925,Independent Study,Rodwell,Elizabeth Ann,7,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,8998,3,25932,Doctoral Research,Bellwied,Rene,0,0,0,0,0,2,0,
+Fall 2023,CIS,4398,1,25934,Independent Study,Lindner,Peggy,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,3399,3,25935,Senior Honors Thesis,Song,Gangbing,0,0,0,0,0,0,0,
+Fall 2023,PHYS,8998,6,25938,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8998,8,25940,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,10,25942,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7397,6,25943,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Fall 2023,COSC,6310,3,25945,Fundamentals of Operating Syst,Rincon Castro,Carlos Alberto,2,2,1,0,0,0,1,3.266
+Fall 2023,PHYS,8998,11,25947,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,4,0,
+Fall 2023,PHYS,8998,13,25949,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8998,15,25951,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,3,0,
+Fall 2023,PHYS,8998,18,25954,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,19,25955,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,20,25956,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,21,25957,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,23,25959,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8998,24,25960,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,3,0,
+Fall 2023,PHYS,8998,25,25961,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,3,0,
+Fall 2023,PHYS,8998,28,25964,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8998,30,25966,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Fall 2023,MANA,7338,1,25976,Org Power Politics & Culture,Abbott,Jeanna L,26,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,6398,1,25978,Rd&Research in Lang&Lit,Harris,Francine Julia,0,0,0,0,0,1,0,
+Fall 2023,ECE,4437,3,25980,Embedded Microcomputer Systems,Le,Hung Quang,8,22,12,0,0,0,0,2.905
+Fall 2023,HIST,3344,1,25983,Drug History in Latin America,Cedillo,Adela Cedillo,9,16,4,0,2,0,3,2.946
+Fall 2023,ARCH,3311,4,25984,Topics in Design History,Diehl,Tom,3,6,5,0,0,0,1,2.834
+Fall 2023,ARCH,6311,4,25985,Topics in Design History,Diehl,Tom,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,4189,5,25987,Senior Recital,Kitai,Anthony T,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,6210,1,25988,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,8698,2,25990,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8698,3,25991,Doctoral Research,Bellwied,Rene,0,0,0,0,0,4,0,
+Fall 2023,PHYS,8698,7,25995,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,12,26000,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8698,13,26001,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8698,15,26003,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,16,26004,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,21,26009,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8698,23,26011,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Fall 2023,PHYS,8698,24,26012,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,3,0,
+Fall 2023,PHYS,8698,26,26014,Doctoral Research,Stokes,Donna,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,28,26016,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,29,26017,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,32,26020,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2023,ELCS,6320,1,26021,Instructional Leadership I,Butcher,Keith,22,4,0,0,0,0,0,3.833
+Fall 2023,PSYC,6397,2,26022,Sel Top in Psychology,Bick,Johanna R,4,1,0,0,0,0,0,3.734
+Fall 2023,PSYC,6335,1,26023,Prof. Development in Soc Psyc,Derrick,Jaye L,9,2,0,0,0,0,0,3.818
+Fall 2023,ELCS,6391,1,26024,Practicum in the Principalship,Klussmann,Duncan Foster,8,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6391,2,26025,Practicum in the Principalship,Klussmann,Duncan Foster,12,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,6391,3,26026,Practicum in the Principalship,Ude,Audra Diane,13,0,0,0,0,0,0,3.924
+Fall 2023,MUSA,4189,6,26027,Senior Recital,Jones,Timothy J,0,1,0,0,0,0,0,3.33
+Fall 2023,MATH,4383,1,26029,Number Theory and Cryptography,Ru,Min,7,9,7,6,2,0,3,2.483
+Fall 2023,ARTS,7381,1,26031,Pursuing Utopia,Reed,John G,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,7460,1,26032,Intro to Medicinal Chemistry,Das,Joydip,2,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,7370,1,26033,Scientific Writing,Trivedi,Meghana,22,4,0,0,0,0,0,3.846
+Fall 2023,ENGL,6398,2,26034,Rd&Research in Lang&Lit,Prufer,Kevin D,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6214,2,26035,Applied Harpsichord,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,ACCT,3371,4,26036,Accounting Information Systems,Seijas,Nuria S,20,19,3,1,2,0,1,3.237
+Fall 2023,GHL,4398,1,26058,Independent Study,Kenyan,Erin Oeser,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8898,1,26059,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,2,0,
+Fall 2023,GHL,6398,1,26061,Special Problems,Boger Jr,Carl A,1,0,0,0,0,0,0,4.0
+Fall 2023,KIN,1304,4,26063,Public Hlt Issues in Phys/Obes,Johnston,Craig Allen,266,31,18,9,11,0,6,3.558
+Fall 2023,PHLS,6325,3,26064,Theories of Counseling,Lee,Jungeun,10,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6399,3,26067,Masters Thesis,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Fall 2023,HLT,4306,2,26072,Women's Health Issues,Solari Williams,Kayce D,52,20,5,0,0,0,2,3.546
+Fall 2023,GHL,6190,1,26073,Hospitality Research Proposal,Madera,Juan Manuel,0,0,0,0,0,2,0,
+Fall 2023,HIST,3399,2,26075,Senior Honors Thesis,Harwell,Debbie Z,0,0,0,0,0,0,0,
+Fall 2023,CEA,3201,1,26076,Comp Program for Engineers,Hebert,Thomas James,3,4,2,1,0,0,2,2.867
+Fall 2023,CEA,3337,1,26079,Digital Signals and Systems,Csutak,Sebastian,3,5,0,0,0,0,1,3.375
+Fall 2023,CEA,3338,1,26080,Microprocessor Systems,Ramachandran,Deepa,7,2,1,0,0,0,0,3.633
+Fall 2023,CUIN,8690,5,26081,Dissertation in Practice,Hutchison,Laveria F,3,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8690,7,26083,Dissertation in Practice,Hausmann,Robert Carl,3,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5397,7,26084,Selected Topics,Davis,Megan Leigh-Wilson,5,10,2,0,0,0,0,3.138
+Fall 2023,LAW,5397,8,26085,Selected Topics,Simmons,Laurel Ellis Parker,9,8,1,0,0,0,0,3.353
+Fall 2023,ARAB,3314,1,26086,Women and Gender in Arabic Lit,El-Badawi,Emran,2,6,1,1,0,0,2,2.999
+Fall 2023,ELCS,8695,2,26088,Dissertation in Practice,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Fall 2023,ELCS,8695,3,26089,Dissertation in Practice,Butcher,Keith,0,0,0,0,0,3,0,
+Fall 2023,ELCS,8695,6,26092,Dissertation in Practice,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Fall 2023,ELCS,8695,9,26095,Dissertation in Practice,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,1,0,4.0
+Fall 2023,PSYC,3310,4,26099,Indstrl-Orgnztnl Psy,Ng,Vincent,17,11,5,4,2,0,2,2.991
+Fall 2023,GHL,4198,1,26102,Independent Study,Kenyan,Erin Oeser,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8302,1,26106,Seminar Comp & Theory Ped,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,8398,42,26108,Doctoral Research,Bittner,Eric R,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,33,26113,Doctoral Research,Bittner,Eric R,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8998,34,26115,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Fall 2023,MARK,4379,4,26116,Personal Branding,Richards,Sean Wesley,26,5,0,0,0,0,0,3.807
+Fall 2023,DRAM,2336,1,26117,Voice and Articulation,Taylor,Allison Grace,12,1,0,0,1,0,0,3.596
+Fall 2023,ENGL,8398,1,26121,Graduate English Resrch,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2023,ENGL,6398,3,26122,Rd&Research in Lang&Lit,Nelson,Antonya,0,0,0,0,0,2,0,
+Fall 2023,SPAC,6298,1,26126,Special Problems,Bell,Larry S,7,0,0,0,0,0,0,3.953
+Fall 2023,BIOL,8399,6,26127,Doctoral Dissertation,Feng,Qin,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8399,7,26128,Doctoral Dissertation,Liu,Yu,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6399,4,26129,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2023,MATH,3363,5,26131,Introduction To PDE,Fitzgibbon,William E,5,9,6,1,1,0,4,2.682
+Fall 2023,PSYC,8699,3,26132,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,1,0,
+Fall 2023,WCL,3397,5,26133,Selected Topics in WCL,Vijayalakshmi,Thangavel,5,0,0,0,0,0,0,4.0
+Fall 2023,MECE,6336,2,26141,Engineering Heat Transfer,Xu,Ben,4,3,0,0,0,0,0,3.666
+Fall 2023,MECE,6336,3,26142,Engineering Heat Transfer,Xu,Ben,2,4,0,0,0,0,0,3.388
+Fall 2023,MECE,6345,3,26143,Fluid Dynamics 1,Yang,Di,2,2,0,0,0,0,0,3.5
+Fall 2023,MECE,6358,2,26144,Superconductor Materials,Selvamanickam,Venkat,2,2,0,0,0,0,0,3.253
+Fall 2023,MECE,6358,3,26145,Superconductor Materials,Selvamanickam,Venkat,0,1,0,0,0,0,1,3.33
+Fall 2023,MECE,6377,2,26146,Continuum Mechs I,Kulkarni,Yashashree,0,5,1,0,1,0,0,2.429
+Fall 2023,MECE,6377,3,26147,Continuum Mechs I,Kulkarni,Yashashree,1,2,0,0,0,0,0,3.003
+Fall 2023,MECE,6384,3,26148,Methods of Applied Math I,Chen,Yi-Chao,1,1,3,1,0,0,0,2.333
+Fall 2023,BIOE,2397,30,26150,Selected Topics,Li,Zhengwei,2,11,0,0,0,0,0,3.103
+Fall 2023,DIGM,4378,30,26152,Senior Project,Alters,Monika Joanna,10,2,0,0,1,0,0,3.488
+Fall 2023,ENGL,6398,4,26153,Rd&Research in Lang&Lit,Kastely,James L,0,0,0,0,0,3,0,
+Fall 2023,FINA,7397,9,26156,Selected Topics in Finance,Smith III,Edwin A,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8398,2,26157,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,2,0,
+Fall 2023,HLT,4302,2,26161,Hlt Aspect Human Sexuality,Smith,Nathan G,52,21,5,2,0,0,0,3.492
+Fall 2023,PSYC,7399,18,26163,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7399,19,26164,Masters Thesis,Babcock,Julia,0,0,0,0,0,1,0,
+Fall 2023,SYSE,3315,1,26166,Systems Architecture & Design,Diaz Martinez,Neil Orlando,3,2,2,0,0,0,0,3.237
+Fall 2023,SYSE,3301,1,26167,Fundamentals of Systems Engr,Diaz Martinez,Neil Orlando,3,3,0,0,1,0,0,3.094
+Fall 2023,PHLS,8399,2,26168,Doctoral Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8399,12,26169,Doctoral Dissertation,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8999,11,26171,Doctoral Dissertation,Khan,Shuhab D,2,0,0,0,0,0,0,4.0
+Fall 2023,CEA,3201,2,26175,Comp Program for Engineers,Hebert,Thomas James,0,1,0,1,0,0,0,1.67
+Fall 2023,GEOL,8999,12,26177,Doctoral Dissertation,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8398,3,26178,Graduate English Resrch,Berger,Jason,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7398,1,26179,Masters Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8398,4,26180,Graduate English Resrch,Womble,David Avari Patrick,0,0,0,0,0,3,0,
+Fall 2023,PSYC,6399,19,26181,Masters Thesis,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6359,8,26182,Directed Rsch in Clinical Psyc,Walker,Rheeda L,0,0,0,0,0,1,0,
+Fall 2023,HIST,3397,2,26185,Sel Tops-African History,Vijayalakshmi,Thangavel,2,0,0,0,0,0,1,4.0
+Fall 2023,ENGL,8398,5,26186,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2023,ARTH,4394,3,26187,Sel Tops in Art History,Volpe,Lisa Marie,2,4,1,1,0,0,0,2.916
+Fall 2023,ARTH,6394,6,26188,Sel Top in Art History,Volpe,Lisa Marie,8,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8398,6,26189,Graduate English Resrch,Shepley,Nathan,0,0,0,0,0,1,0,
+Fall 2023,CIVE,6335,1,26190,Advanced Concrete Design,Belarbi,Abdeldjelil,6,7,0,0,0,0,0,3.436
+Fall 2023,CIVE,6355,1,26191,Intro-Dynamics of Structures,Mo,Larry Yi-Lung,10,7,0,0,0,0,1,3.511
+Fall 2023,CIVE,7342,1,26192,Engineer Geographic Info. Syst,Xie,Surui,13,1,0,0,0,0,0,3.929
+Fall 2023,CIVE,5397,1,26193,Selected Topics,Ferdowsi,Behrooz,1,1,0,0,0,0,0,3.5
+Fall 2023,CIVE,6320,1,26195,Constitutive Modeling of Matls,Vipulanandan,Cumaraswamy,3,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,6320,2,26196,Constitutive Modeling of Matls,Vipulanandan,Cumaraswamy,5,0,0,0,0,0,0,3.934
+Fall 2023,CIVE,6337,1,26197,Matrix Analysis of Structures,Krakowiak,Konrad,0,3,5,2,0,0,1,2.067
+Fall 2023,CIVE,6337,2,26198,Matrix Analysis of Structures,Krakowiak,Konrad,4,1,1,0,1,0,3,2.906
+Fall 2023,CIVE,6358,1,26199,Deep Learning for Engineers,Hoskere,Vedhus,18,7,4,0,0,0,1,3.414
+Fall 2023,CIVE,6358,2,26201,Deep Learning for Engineers,Hoskere,Vedhus,3,1,0,0,0,0,0,3.75
+Fall 2023,CIVE,6381,1,26203,Applied Geospatial Computation,Milillo,Pietro,7,2,0,0,0,0,0,3.741
+Fall 2023,CIVE,6384,1,26207,Principles of satellite altime,Lee,Hyongki,5,3,0,0,0,0,0,3.46
+Fall 2023,CIVE,6390,1,26209,Municipal Drink Water Treatmen,Shaffer,Devin,3,3,1,0,0,0,0,3.097
+Fall 2023,CIVE,6390,2,26210,Municipal Drink Water Treatmen,Shaffer,Devin,3,1,0,0,0,0,0,3.585
+Fall 2023,CIVE,7350,1,26211,Adv. Behavior Struct Concrete,Belarbi,Abdeldjelil,3,6,3,0,0,0,0,3.0
+Fall 2023,CIVE,7397,3,26214,Selected Topics,Li,Hongyi,5,0,0,0,0,0,0,3.934
+Fall 2023,CIVE,7397,4,26215,Selected Topics,Li,Hongyi,3,1,0,0,0,0,1,3.668
+Fall 2023,CIVE,7397,5,26216,Selected Topics,Ferdowsi,Behrooz,7,7,1,0,0,0,0,3.334
+Fall 2023,CIVE,7397,6,26217,Selected Topics,Ferdowsi,Behrooz,3,0,0,0,0,0,0,3.67
+Fall 2023,GHL,6198,2,26218,Special Problems,Johnson,Tucker A,1,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,2314,16,26219,Human Dev and Interventions,Dunsmore,Julie C,10,11,7,0,2,0,5,2.812
+Fall 2023,ENGL,6398,5,26221,Rd&Research in Lang&Lit,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6260,1,26222,Applied Music,Hubley,Robert L,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,6398,6,26223,Rd&Research in Lang&Lit,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2023,COMM,6317,1,26224,Media Effects,Camaj,Lindita,9,3,0,0,2,0,1,3.261
+Fall 2023,MUSA,8243,7,26227,Doctoral Lecture Recital,Guez,Jonathan Charles,0,0,0,0,0,0,0,
+Fall 2023,MUSA,4189,7,26228,Senior Recital,Lo,Mann-Wen,0,0,0,0,0,0,0,
+Fall 2023,ENGL,8398,7,26229,Graduate English Resrch,Chatterjee,Sreya,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8399,13,26230,Doctoral Dissertation,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2023,MUSA,8320,33,26232,Doctoral Applied Music,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,8399,1,26235,Dissertation,Joshi,Ashwini,0,0,0,0,0,1,0,
+Fall 2023,COMD,8291,2,26236,COMD Research,Dial,Heather Raye,0,0,0,0,0,2,0,
+Fall 2023,ENGL,8398,8,26241,Graduate English Resrch,Flynn,Nicholas,0,0,0,0,0,1,0,
+Fall 2023,SCM,7325,3,26242,Process Analysis and Design,Robinson Jr,Powell Ersell,9,11,0,0,0,0,0,3.45
+Fall 2023,PSYC,3399,4,26245,Senior Honors Thesis,Atherton,Olivia Emile,0,0,0,0,0,0,0,
+Fall 2023,PSYC,4398,1,26246,Independent Study,Zvolensky,Michael J,12,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,3399,5,26247,Senior Honors Thesis,Fetterman,Adam Kent,0,0,0,0,0,0,0,
+Fall 2023,GHL,6190,2,26248,Hospitality Research Proposal,Maneethai,Dustin,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8398,9,26250,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2023,CIS,6397,21,26251,Selected Topics,Burke,Ross,26,6,0,0,0,0,0,3.771
+Fall 2023,CIS,6397,41,26252,Selected Topics,Burke,Ross,2,1,0,0,0,0,0,3.667
+Fall 2023,CIS,6397,1,26253,Selected Topics,Burke,Ross,4,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,7305,2,26255,Evaluation of SW Practice,Lucas,Virginia,3,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8399,8,26256,Doctoral Dissertation,Lekven,Arne,2,0,0,0,0,0,0,4.0
+Fall 2023,HIST,6398,1,26258,Special Problems,McNally,David Joseph,4,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,6344,2,26260,US Hispanic Literature,Kanellos,Nicolas,10,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,7399,24,26261,Masters Thesis,Do,Loi H,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8393,1,26265,Sel Top-Indstrl/Org Psy,Brummel,Bradley James,11,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,6398,7,26267,Rd&Research in Lang&Lit,Serpas,Martha R,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8398,10,26268,Graduate English Resrch,Prufer,Kevin D,0,0,0,0,0,1,0,
+Fall 2023,BTEC,6399,1,26269,Thesis,Balan,Venkatesh,0,0,0,0,0,2,0,
+Fall 2023,MUSA,6410,2,26270,Applied Piano,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2023,WGSS,3322,2,26271,Intersectionalities,Pegoda,Andrew Joseph,3,9,5,0,3,0,9,2.5
+Fall 2023,BZAN,6310,8,26272,Quant Analysis for Busn Dec,Hou,Jinghui,31,5,0,0,0,0,1,3.815
+Fall 2023,THEA,3322,1,26275,Musical Theatre for Actors,Wetzel,Molly Elizabeth,11,1,0,0,0,0,0,3.862
+Fall 2023,PHYS,3399,4,26277,Senior Honors Thesis,Cherdack,Daniel David,0,0,0,0,0,0,0,
+Fall 2023,COMD,8391,1,26278,COMD Research,Castilla-Earls,Anny,0,0,0,0,0,1,0,
+Fall 2023,NUTR,6218,1,26279,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,6,0,
+Fall 2023,ANTH,6399,7,26281,Masters Thesis,Hannaford,Dinah Rebecca,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8995,2,26283,Pre-Dissertation Research,Leung,Yuk-Hi Patrick,0,0,0,0,0,1,0,
+Fall 2023,SOCW,8995,3,26284,Pre-Dissertation Research,Narendorf,Sarah C,0,0,0,0,0,4,0,
+Fall 2023,FINA,4397,5,26285,Selected Topics in Finance,Susmel,Raul,1,0,0,0,1,0,0,2.0
+Fall 2023,ENGL,8398,11,26287,Graduate English Resrch,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Fall 2023,NUTR,6117,1,26288,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,1,0,
+Fall 2023,COSC,4398,10,26289,Independent Study,Bering,Edgar A,0,0,0,0,0,4,0,
+Fall 2023,MECE,8598,3,26294,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8998,1,26297,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8898,1,26298,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2023,PHLS,7398,1,26301,Candidacy Research,Correa-Fernandez,Virmarie,0,0,0,0,0,2,0,
+Fall 2023,PHLS,8199,10,26302,Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,2,0,
+Fall 2023,MUSA,2310,2,26303,Applied Piano,Morgulis,Tali,3,0,0,0,0,0,0,4.0
+Fall 2023,IDNS,4397,1,26304,Sel Tops-Natural Scien & Math,Manuel,Mariam A,1,0,0,0,0,0,0,3.67
+Fall 2023,CNST,6397,1,26305,Sel Tops-Construction Managemt,Chang,Chi Chung,49,0,0,0,0,0,1,3.886
+Fall 2023,CNST,6397,40,26306,Sel Tops-Construction Managemt,Chang,Chi Chung,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,7398,1,26307,Independent Graduate Study,Conrad,Jillian,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4380,1,26308,Professional Practices,Barrera,Debra,14,0,0,0,0,0,0,3.976
+Fall 2023,ARTS,6386,1,26309,Professional Practices,Barrera,Debra,6,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5397,9,26310,Selected Topics,Koehler,Michael,8,10,1,0,0,0,1,3.282
+Fall 2023,HDFS,2320,3,26311,Research Methods in HDFS,Kamdar-Sharif,Amber,25,8,2,1,0,0,0,3.501
+Fall 2023,HDFS,2320,4,26312,Research Methods in HDFS,Kamdar-Sharif,Amber,25,8,3,0,1,0,0,3.398
+Fall 2023,PSYC,6399,20,26313,Masters Thesis,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,8397,1,26314,Selected Topics in COMD,Castilla-Earls,Anny,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,3399,6,26315,Senior Honors Thesis,Capuozzo,Kristen Irene,0,0,0,0,0,0,0,
+Fall 2023,GEOL,6390,3,26316,3-D Seismic Exploration I,Zhou,Hua-Wei,5,2,0,0,0,0,0,3.809
+Fall 2023,ENGL,7399,8,26317,Essay,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,3317,3,26318,Prenatal and Infant Developmt,Fraser,Camille,30,19,1,0,0,0,0,3.521
+Fall 2023,ENGL,8398,12,26319,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2023,PSYC,3399,7,26326,Senior Honors Thesis,Walker,Rheeda L,1,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5662,4,26330,Academic Scholarship,Wollen,Joshua T,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,8999,13,26333,Doctoral Dissertation,Casellas,Jason,0,0,0,0,0,1,0,
+Fall 2023,POLS,8999,14,26334,Doctoral Dissertation,Aleman,Eduardo,0,0,0,0,0,1,0,
+Fall 2023,CORE,1101,6,26335,College Success,Dawson,Chrisdolyn Nesha,1,3,0,0,1,0,0,2.6
+Fall 2023,CORE,1101,9,26336,College Success,Osborn,Lori,5,1,1,0,1,0,0,3.166
+Fall 2023,POLS,8999,16,26337,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,2,0,
+Fall 2023,CORE,1101,17,26338,College Success,Hill,Megan,10,3,0,0,1,0,0,3.547
+Fall 2023,CORE,1101,19,26339,College Success,Yendell,Kialyn Beth,5,4,0,0,0,0,1,3.556
+Fall 2023,CORE,1101,20,26340,College Success,Lewis,Lateki,4,5,0,2,1,0,0,2.778
+Fall 2023,CORE,1101,29,26345,College Success,Dayton,Anne,7,1,0,0,1,0,0,3.371
+Fall 2023,MECE,6397,6,26347,Selected Topics,Zhao,Bo,0,1,0,0,0,0,0,3.33
+Fall 2023,MECE,6397,7,26348,Selected Topics,Zhao,Bo,0,1,0,0,0,0,0,3.33
+Fall 2023,CORE,1101,31,26349,College Success,Ware,Amanda Wynn,4,1,0,1,0,0,0,3.278
+Fall 2023,CORE,1101,33,26351,College Success,Williams,Kimberly,8,2,0,0,0,0,0,3.8
+Fall 2023,CHEE,6397,2,26352,Selected Topics,Zerze,Gul,8,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4397,5,26353,Sel Topics in Fine Arts,Chae,John,6,7,0,0,0,0,0,3.487
+Fall 2023,ARTS,6397,6,26354,Sel Topics/Studio Arts,Chae,John,2,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8399,17,26361,Doctoral Dissertation,Parsons,Alexander M,0,0,0,0,0,1,0,
+Fall 2023,ENGL,1301,178,26366,First Year Writing I,Yates,Kaitlyn,15,8,2,0,0,0,0,3.56
+Fall 2023,ENGL,1301,179,26367,First Year Writing I,Yates,Kaitlyn,17,4,1,1,1,0,0,3.335
+Fall 2023,ENGR,2301,5,26370,Mechanics I (Statics),Metrovich,Brian,2,3,1,0,0,0,0,3.112
+Fall 2023,ARLD,6395,1,26372,Sel Topics in Arts Leadership,Cachia,Amanda,7,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8199,1,26373,Dissertation,Robbins,Susan P,2,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8998,31,26374,Doctoral Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6498,3,26375,Special Problems,Statsyuk,Alexander V,2,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6498,4,26376,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,2,0,
+Fall 2023,ENGL,7399,9,26377,Essay,Berger,Jason,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6348,1,26383,Applied Euphonium,Fenske,Kevin,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6397,3,26384,Sel Top in Psychology,Kosten,Therese A,4,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,7397,7,26385,Selected Topics,Momen,Mostafa,5,1,0,0,0,0,0,3.778
+Fall 2023,CIVE,7397,8,26386,Selected Topics,Momen,Mostafa,1,0,0,0,0,0,0,3.67
+Fall 2023,HIST,6398,2,26390,Special Problems,Neumann,Kristina Marie,0,1,0,0,0,0,0,3.33
+Fall 2023,LAW,6226,1,26397,Advanced Oil & Gas Contracting,Borrego,Theodore R,3,3,0,0,0,1,0,3.61
+Fall 2023,GHL,8398,1,26398,Research Proposal in Hosp Adm,Kim,Jaewook,0,0,0,0,0,1,0,
+Fall 2023,GHL,8699,1,26399,Dissertation II in Hosp. Admin,Kim,Jaewook,0,0,0,0,0,1,0,
+Fall 2023,GHL,8699,2,26400,Dissertation II in Hosp. Admin,Legendre,Jungyoung Shin,0,0,0,0,0,1,0,
+Fall 2023,GHL,8699,3,26401,Dissertation II in Hosp. Admin,Madera,Juan Manuel,0,0,0,0,0,2,0,
+Fall 2023,GHL,8398,2,26402,Research Proposal in Hosp Adm,Legendre,Jungyoung Shin,0,0,0,0,0,1,0,
+Fall 2023,GHL,8398,3,26403,Research Proposal in Hosp Adm,Madera,Juan Manuel,0,0,0,0,0,2,0,
+Fall 2023,PHCA,6198,3,26405,Special Problems,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8199,2,26406,Dissertation,Leung,Yuk-Hi Patrick,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2350,3,26408,Applied Percussion,Hubley,Robert L,2,2,0,0,0,0,0,3.335
+Fall 2023,ENGL,7399,10,26421,Essay,Lecourt,Sebastian Joseph,0,0,0,0,0,0,0,
+Fall 2023,ENGL,8399,18,26428,Doctoral Dissertation,Boswell,Robert L,0,0,0,0,0,1,0,
+Fall 2023,NURS,4322,1,26432,Policy &Ethics in Prof Nursing,Anderson,Viia,6,4,0,0,0,0,0,3.6
+Fall 2023,NURS,3312,1,26433,Fundamental Concepts of Care,Smith,Deborah Ann,0,7,0,3,0,0,1,2.4
+Fall 2023,NURS,3313,1,26434,Fundamental Clinical,Kantala,Nadine,7,3,0,0,0,0,1,3.7
+Fall 2023,NURS,4213,1,26436,Mental Health Clinical,Emmanuel,Olatokunbo O,43,5,0,0,0,0,0,3.896
+Fall 2023,NURS,4211,1,26437,Mental Health Concepts of Care,Smith,Deborah Ann,11,35,0,2,0,0,0,3.146
+Fall 2023,NURS,3314,1,26438,Pharmacology,Kleinhans,Alicia Diane,3,5,0,4,0,0,0,2.583
+Fall 2023,NURS,6330,1,26439,Adv Diagnostic Physicl Examntn,Ecby,Chanique,3,1,0,0,0,0,1,3.75
+Fall 2023,NURS,6312,1,26440,Msrmt & Eval in Nur Edu,Schrader,Patricia K,3,0,0,0,0,0,0,4.0
+Fall 2023,NURS,6321,1,26441,Leadership Practicum,Brohard,Cheryl L,3,0,0,0,0,0,0,4.0
+Fall 2023,NURS,8301,1,26442,"Healthcare Project Design, Met",Love,Mary Frances,2,1,0,0,0,0,0,3.667
+Fall 2023,NURS,8302,1,26443,Advanced Practice Finance,Brohard,Cheryl L,3,0,0,0,0,0,0,4.0
+Fall 2023,NURS,8303,1,26444,Complex Systems and Leadership,Connelly,Linda K,6,0,0,0,0,0,0,4.0
+Fall 2023,NURS,8356,1,26445,Scholarly Project Development,Love,Mary Frances,0,0,0,0,0,6,0,
+Fall 2023,FINA,6A31,3,26446,Analyzing Financial Statements,Woods,James D,11,4,0,0,0,0,0,3.711
+Fall 2023,MUSA,6300,1,26448,Applied Voice,Clayton Vasquez,Cynthia L,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6300,2,26449,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6300,3,26450,Applied Voice,Sonnenberg,Melanie,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6310,1,26451,Applied Piano,Hester,Timothy E,5,1,0,0,0,0,0,3.833
+Fall 2023,MUSA,6310,2,26452,Applied Piano,Morgulis,Tali,5,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,8698,36,26455,Doctoral Research,Vovchenko,Volodymyr,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8198,5,26460,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7698,1,26469,Masters Research,Murphy,Michael,0,0,0,0,0,1,0,
+Fall 2023,MUSA,1300,6,26472,Applied Voice,Belcher,Daniel,7,0,0,0,0,0,0,3.953
+Fall 2023,MUSA,6410,3,26473,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,3340,3,26475,Intro. to Automata and Comp.,Das,Rathish,11,33,1,0,2,0,1,3.092
+Fall 2023,COSC,4368,1,26476,Artificial Intelligence,Lin,Sen,31,19,3,0,2,0,4,3.388
+Fall 2023,LAW,5339,2,26477,Trusts and Wills,Sanders,Pannal Alan,3,14,1,0,0,6,0,3.276
+Fall 2023,MUSA,3478,1,26479,Applied Jazz Guitar,Petito,Gregory Michael,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6300,4,26481,Applied Voice,Vasquez,Hector A,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,6300,5,26482,Applied Voice,Belcher,Daniel,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6300,6,26483,Applied Voice,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6204,4,26485,Conducting,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2023,CIS,4339,5,26486,Enterprise Appls Development,Lindner,Peggy,0,1,0,0,0,0,0,2.67
+Fall 2023,COMM,4398,1,26487,Independent Study,Liu,Wenlin,1,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,6397,3,26503,Selected Topics,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,3350,5,26506,Intro to Cognitive Psychology,Saiyed,Amna Shabbir,93,7,2,1,1,0,1,3.802
+Fall 2023,PSYC,3350,6,26507,Intro to Cognitive Psychology,Saiyed,Amna Shabbir,94,6,1,0,2,0,2,3.832
+Fall 2023,PSYC,3338,2,26508,Psychology of Older Adults,Saiyed,Amna Shabbir,63,11,1,1,2,0,2,3.684
+Fall 2023,COMD,8398,1,26509,Special Problems,Thiessen,Amber L,2,0,0,0,0,0,0,4.0
+Fall 2023,ENGI,1331,4,26523,Computing for Engineers,Kota,Venkata Krishna Tulasi,3,1,0,0,0,0,1,3.668
+Fall 2023,ENGI,1331,5,26524,Computing for Engineers,Kota,Venkata Krishna Tulasi,0,0,0,0,0,0,1,
+Fall 2023,CIVE,8198,6,26532,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Fall 2023,PSYC,6393,10,26533,Clinical Research Practicum,Venta,Amanda Cristina,0,0,0,0,0,2,0,
+Fall 2023,ELCS,8391,1,26534,Special Field Projects,Hernandez,Belkis Pamela,13,1,0,0,0,0,0,3.952
+Fall 2023,PSYC,3339,6,26546,Intro To Clinical Psychology,Szafranski,Derek D,64,6,5,4,0,0,0,3.629
+Fall 2023,PSYC,2301,9,26550,Introduction to Psychology,Babalola,Olusegun,52,42,4,8,3,0,6,3.278
+Fall 2023,PSYC,3310,5,26551,Indstrl-Orgnztnl Psy,Babalola,Olusegun,80,36,4,1,2,0,0,3.596
+Fall 2023,MUED,6398,1,26552,Research in Music Education,Meals,Cory Dewitt,4,1,0,0,0,0,0,3.734
+Fall 2023,PHLS,8399,4,26555,Doctoral Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,
+Fall 2023,MUSA,8242,6,26556,Doctoral Recital III,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,6397,3,26559,Selected Topics,Wen,Mingjian,35,2,0,0,0,0,0,3.875
+Fall 2023,MECE,6399,8,26563,Masters Thesis,Cescon,Marzia,0,0,0,0,0,3,0,
+Fall 2023,HIST,2371,2,26567,Latin America 1492-1820,Howard,Philip,2,12,9,6,3,0,0,2.115
+Fall 2023,ELCS,8699,1,26568,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6498,5,26569,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6498,6,26570,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2023,MUSI,1181,1,26572,Group Piano I,Van Kekerix,Todd Evan,11,2,0,0,0,0,1,3.821
+Fall 2023,PCEU,6298,4,26573,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Fall 2023,PHCA,8298,7,26583,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,0,0,0,0,0,1,0,
+Fall 2023,INDE,6361,1,26584,Prod Planning & Invent Control,Hu,Minxiang,15,0,0,0,0,0,0,3.868
+Fall 2023,SOC,3398,1,26585,Ind Study in Soc,Lee,Shayne,13,0,0,0,0,0,0,4.0
+Fall 2023,SOC,7399,3,26586,Masters Thesis,Baumle,Amanda K,1,0,0,0,0,0,0,4.0
+Fall 2023,MANA,4397,6,26594,Selected Topics in Mana,Thompson,Joseph Lee,40,2,1,0,1,0,1,3.811
+Fall 2023,PCEU,6198,1,26595,Special Problems,Liu,Xinli,0,0,0,0,0,0,0,
+Fall 2023,PSYC,4398,2,26596,Independent Study,Babcock,Julia,2,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,3300,4,26602,Advanced Drawing,Litos,Joshua David,18,2,0,0,0,0,0,3.867
+Fall 2023,ARTS,3374,4,26603,Computer Imaging,Ranjbarcheshmehsorkhi,Mandana,9,1,4,1,0,0,0,3.134
+Fall 2023,GEOL,1102,9,26604,Intro to Climate Change Lab,Zhang,Honghai,7,9,0,0,0,0,0,3.293
+Fall 2023,GEOL,1102,10,26605,Intro to Climate Change Lab,Zhang,Honghai,10,7,0,0,1,0,0,3.187
+Fall 2023,GEOL,8398,29,26611,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8399,19,26617,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,4,0,
+Fall 2023,BIOL,8998,2,26621,Doctoral Research,Sater,Amy,0,0,0,0,0,1,0,
+Fall 2023,SOC,6399,4,26622,Masters Thesis,Monserud,Maria Aleksandrovna,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1310,3,26623,Applied Piano,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6298,7,26625,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2023,SPAN,1507,5,26626,Intns Elem Span Heritage Learn,Hernandez,Yanina,8,8,3,1,4,0,1,2.584
+Fall 2023,HIST,6398,3,26634,Special Problems,Neumann,Kristina Marie,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,6193,1,26636,SW Generalist Practicum 1,Gonzales,Shelley A,0,0,0,0,0,138,3,
+Fall 2023,SOCW,7184,1,26637,SW Clinical Practicum 1,Gonzales,Shelley A,0,0,0,0,0,111,0,
+Fall 2023,SOCW,7188,1,26638,Social Work Macro Practicum 1,Gonzales,Shelley A,0,0,0,0,0,15,0,
+Fall 2023,SOCW,7185,1,26639,SW Clinical Practicum 2,Gonzales,Shelley A,0,0,0,0,0,6,0,
+Fall 2023,SOCW,7189,1,26640,Social Work Macro Practicum 2,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Fall 2023,RELS,3398,1,26643,Independent Study,Allen,Paul J,1,0,0,0,0,0,0,4.0
+Fall 2023,IART,3395,6,26644,Sel Topics in Interdis Arts,Wu,Cheng Hao,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,2397,1,26645,Sel Topics in Music,Wu,Cheng Hao,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,4399,1,26652,Senior Honors Thesis,Grigoriadis,Karolos,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6398,10,26653,Special Problems,McConnell,Bradley K,0,0,0,0,0,3,0,
+Fall 2023,LAW,5308,2,26655,Federal Courts,Kumar,Sapna,19,11,2,0,1,15,0,3.404
+Fall 2023,PSYC,7399,20,26656,Masters Thesis,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Fall 2023,IDNS,4397,2,26661,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,8,0,0,0,0,0,0,4.0
+Fall 2023,IDNS,4397,3,26662,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,7,0,0,0,0,0,0,4.0
+Fall 2023,ECE,4198,1,26664,Independent Study,Chen,Yuhua,2,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4398,2,26671,Independent Study,Trigg,Katishia Leonna,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEE,6398,3,26675,Research,Harold,Michael P,0,0,0,0,0,2,1,
+Fall 2023,PCOL,6298,5,26678,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Fall 2023,PHLS,8193,4,26680,Internship in Psychology,Smith,Bradley,0,0,0,0,0,8,0,
+Fall 2023,MECE,5397,3,26681,Selected Topics,Lee,Myoungkyu,14,18,5,0,0,0,3,3.27
+Fall 2023,BCHS,6229,2,26682,Protein Structure and Function,Yeo,Hye-Jeong,10,3,0,0,0,0,0,3.718
+Fall 2023,GEOL,8398,30,26683,Doctoral Research,Zhang,Honghai,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8399,26,26684,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2023,PSYC,4398,3,26685,Independent Study,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2023,POLC,4398,1,26686,Independent Study,Cross,Renee Danielle,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6356,2,26688,Clinical Assessment I,Cirino,Paul,8,4,0,0,0,0,0,3.612
+Fall 2023,MANA,7312,2,26690,Fundtls of Healthcare Business,Kroger,Edward John,3,0,0,0,0,0,0,3.89
+Fall 2023,HIST,1301,44,26692,The U.S. to 1877,McDonald,Eric John,61,17,9,1,2,0,2,3.427
+Fall 2023,PHYS,6698,1,26693,Special Problems,Chu,Ching Wu,0,0,0,0,0,1,0,
+Fall 2023,MECE,6399,9,26699,Masters Thesis,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2023,MECE,6398,4,26700,Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2023,CIVE,4311,3,26702,Prof Practice in Civil Engr,Herman,Reagan,3,20,8,0,0,0,0,2.743
+Fall 2023,CIVE,4332,1,26704,Hydrology,Saladi,Krishna Rishi Vijay,5,21,4,0,0,0,0,3.055
+Fall 2023,CIVE,4333,1,26705,Water and Wastewater Treatment,Saladi,Krishna Rishi Vijay,11,14,5,0,0,0,0,3.123
+Fall 2023,PHYS,1301,4,26706,College Physics I (lecture),Das,Mini,3,12,6,4,0,0,15,2.454
+Fall 2023,ECE,5330,2,26707,Introduction to Robotics,Becker,Aaron T,12,12,15,0,1,0,0,2.768
+Fall 2023,ECE,3337,3,26709,Signals and Systems Analysis,Shih,Wei-Chuan,13,33,13,0,0,0,0,2.989
+Fall 2023,PSYC,2317,12,26710,Intro to Psychology Statistics,Nguyen,My Viet Ha,17,18,12,3,16,0,11,2.248
+Fall 2023,ECE,3436,5,26711,Microprocessor Systems,Chen,Yuhua,49,6,0,0,0,0,0,3.831
+Fall 2023,MECE,4364,2,26714,Heat Transfer,Liu,Dong,9,4,15,1,0,0,0,2.724
+Fall 2023,MECE,3345,3,26716,Materials Science,Ryou,Jae-Hyun,14,22,12,0,0,0,0,3.007
+Fall 2023,MECE,3363,2,26722,Intro To Fluid Mechanics,Yang,Wenhua,6,20,15,2,0,0,0,2.636
+Fall 2023,ECE,2201,9,26724,Circuit Analysis I,Csutak,Sebastian,50,3,0,0,0,0,0,3.906
+Fall 2023,ENGR,1304,1,26730,Engineering Graphics,Ray,Kyle A,28,9,4,0,0,0,2,3.553
+Fall 2023,WCL,6398,1,26733,Special Problems,Majumder,Sarasij,2,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6498,2,26735,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8699,5,26736,Doctoral Dissertation,Castagna,John P,0,0,0,0,0,1,0,
+Fall 2023,SOCW,6194,1,26738,SW Generalist Practicum 2,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Fall 2023,MECE,6367,1,26746,Control System Analysis and De,Song,Gangbing,20,21,3,0,0,0,1,3.304
+Fall 2023,MECE,5367,1,26747,Control Systm Analysis & Desgn,Song,Gangbing,14,46,22,1,0,0,2,2.86
+Fall 2023,ECE,7399,7,26757,Masters Thesis,Prasad,Saurabh,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,8398,13,26759,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2023,GHL,6397,2,26760,Selected Topics,Padilla,Magdalena Manzano,3,1,0,0,0,0,0,3.75
+Fall 2023,THEA,6180,1,26762,Applying Methods Acting/Voice,Ferrarone,Jessica,8,0,0,0,0,0,0,3.918
+Fall 2023,COMD,7391,11,26763,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,1,0,0,0,0,3.333
+Fall 2023,COMD,7391,13,26764,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,1,0,0,0,0,0,3.557
+Fall 2023,COMD,7391,14,26765,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,0,0,0,0,0,3.835
+Fall 2023,COMD,7391,15,26766,Clinic in Speech Lang Disorder,Walker,Dionne A,1,1,0,0,0,0,0,3.5
+Fall 2023,POLS,3310,2,26768,Intro to Political Theory,Fumurescu,Alin,7,5,10,3,1,0,11,2.488
+Fall 2023,ENGL,6398,8,26775,Rd&Research in Lang&Lit,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2023,HIST,2313,1,26777,Global Civilization to 1500,Johnson,Michele R,12,12,20,4,2,0,2,2.58
+Fall 2023,PCOL,6498,7,26778,Special Problems,Boini,Krishna M,1,0,0,0,0,1,0,4.0
+Fall 2023,SGNL,2301,4,26780,Intermediate Sign Language I,Brittain,Terrell,1,6,5,0,0,0,0,2.584
+Fall 2023,OPTO,5298,1,26786,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,17,0,
+Fall 2023,HIST,2321,3,26791,Study of Early Civilizations,Cong,Xiaoping,8,22,1,0,4,0,0,2.782
+Fall 2023,HIST,2322,2,26792,Modern Civilizations,Al-Sowayel,Dina,21,10,0,0,2,0,2,3.415
+Fall 2023,INDE,6365,2,26793,Engineering Economy II,Wiggins,Nathanial David,60,0,0,0,0,0,0,4.0
+Fall 2023,INDE,6365,3,26796,Engineering Economy II,Wiggins,Nathanial David,5,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4398,3,26797,Independent Study,Huang,Yan,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4396,1,26798,Sel Topics in Studio Practice,Molina,Lorena Guadalupe,14,0,1,0,0,0,0,3.801
+Fall 2023,MUSA,6320,1,26801,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,4498,1,26802,Independent Study,Freelon,Byron Kendall,0,0,0,0,0,5,1,
+Fall 2023,COMM,4398,4,26803,Independent Study,Yamasaki,Jill S,0,1,0,0,0,0,0,3.0
+Fall 2023,BCIS,1305,5,26810,Business Computer Applications,Felvegi,Emese,170,38,23,6,10,0,3,3.405
+Fall 2023,POLS,6398,4,26813,Special Problems,Koganzon,Rita,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8698,1,26815,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8898,1,26817,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8199,9,26818,Doctoral Dissertation,Harrison,Wendy W,2,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8798,1,26819,Doctoral Research,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Fall 2023,MECT,4384,30,26825,Lean Manufacturing Systems,Rypien,David V,16,5,1,0,0,0,0,3.652
+Fall 2023,BUSI,4397,1,26829,Selected Topics in GENB,Bean,Gregory S,7,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6867,6,26830,Research Practicum A,Yoon,Geunyoung,3,0,0,0,0,0,0,3.67
+Fall 2023,PHOP,8798,2,26831,Doctoral Research,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6198,15,26832,Spec Prob-Physio Optics,Della Santina,Luca,2,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8998,1,26833,Doctoral Research,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6657,2,26834,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8898,2,26835,Doctoral Research,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6359,6,26840,Directed Rsch in Clinical Psyc,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Fall 2023,ELET,6396,3,26841,Master's Project,Merchant,Fatima Aziz,1,0,0,0,0,0,0,3.67
+Fall 2023,INDE,6365,4,26843,Engineering Economy II,Wiggins,Nathanial David,20,0,0,0,0,0,0,3.984
+Fall 2023,HIST,1302,8,26844,The U.S. Since 1877,Rector,Josiah John,19,11,2,0,3,0,0,3.229
+Fall 2023,COMM,4398,5,26845,Independent Study,Xiao,Zhiwen,2,0,0,0,0,0,0,3.835
+Fall 2023,PSYC,2319,8,26847,Intro to Social Psychology,Snead,Alexandra L,65,12,2,0,0,0,0,3.772
+Fall 2023,PSYC,2317,13,26848,Intro to Psychology Statistics,Alonso,Nicole,59,26,15,6,7,0,5,3.042
+Fall 2023,ELET,6308,20,26849,Mobile Computing,Lent,Marino Ricardo,4,1,0,0,0,0,0,3.866
+Fall 2023,ELET,6308,40,26850,Mobile Computing,Lent,Marino Ricardo,1,0,0,0,0,0,0,4.0
+Fall 2023,BTEC,6305,30,26860,Bioprocessing in Biotechnology,Lin,Yuheng,2,0,0,0,0,0,0,4.0
+Fall 2023,BTEC,6105,30,26862,Bioprocessing Laboratory,Lin,Yuheng,2,0,0,0,0,0,0,4.0
+Fall 2023,PHIL,6398,1,26887,Special Problems,Sommers,Tamler S,1,0,0,0,0,0,0,4.0
+Fall 2023,GENB,8397,1,26888,Selected Topics Gen Bus Admin,Patrick-Ralhan,Vanessa M,25,2,0,0,0,0,1,3.938
+Fall 2023,GENB,8397,2,26889,Selected Topics Gen Bus Admin,Johnson,Norman A,25,1,0,0,0,0,1,3.873
+Fall 2023,GENB,8397,3,26890,Selected Topics Gen Bus Admin,Celly,Nikhil,27,0,0,0,0,0,1,3.988
+Fall 2023,COMM,6395,1,26891,Comprehensive Examination,Liu,Wenlin,0,0,0,0,0,1,0,
+Fall 2023,CHEE,6397,4,26892,Selected Topics,Karim,Alamgir,19,6,0,0,0,0,0,3.747
+Fall 2023,PHOP,8398,4,26893,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,1111,79,26894,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,2,1,0,0,1,2.889
+Fall 2023,PHOP,6198,16,26895,Spec Prob-Physio Optics,Rump,Rachel,1,0,0,0,0,0,0,3.67
+Fall 2023,PHOP,6157,5,26896,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,1111,80,26897,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,12,1,0,0,0,0,3.024
+Fall 2023,PHOP,6157,6,26898,Research Practicum B,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,1111,81,26899,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,6,3,0,6,0,0,1.709
+Fall 2023,PHOP,8798,3,26901,Doctoral Research,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,8199,10,26902,Doctoral Dissertation,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6757,7,26903,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2023,PCEU,6698,5,26907,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8393,4,26909,Doctoral Practicum in Psy,Racine,Madeline D,0,0,0,0,0,10,0,
+Fall 2023,COMD,7391,16,26911,Clinic in Speech Lang Disorder,Cizek,Laura S,1,1,0,0,0,0,0,3.5
+Fall 2023,COMD,7391,17,26912,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,2,0,0,0,0,0,0,3.835
+Fall 2023,COMD,7391,18,26913,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,1,1,0,0,0,0,0,3.5
+Fall 2023,MECT,6394,30,26914,MET Special Topics with Lab,Wari,Ezra Tsegaye,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,7391,19,26916,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,2,0,0,0,0,0,0,3.67
+Fall 2023,COMD,7391,20,26917,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,1,1,0,0,0,0,0,3.665
+Fall 2023,COMD,7391,21,26918,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,2,0,0,0,0,0,0,3.835
+Fall 2023,COMD,7391,22,26919,Clinic in Speech Lang Disorder,Ross,Byron L,2,0,0,0,0,0,0,3.835
+Fall 2023,PHOP,6767,7,26921,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6267,6,26922,Research Practicum A,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,4315,5,26923,Culture and Diversity,Conston,Toya,44,2,0,1,1,0,0,3.799
+Fall 2023,HDFS,4315,7,26925,Culture and Diversity,Conston,Toya,36,2,2,1,5,0,1,3.391
+Fall 2023,PHOP,6557,5,26927,Research Practicum B,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,6198,2,26930,Special Problems in Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,6198,3,26931,Special Problems in Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,7398,2,26932,Candidacy Research,Smith,Nathan G,0,0,0,0,0,0,0,
+Fall 2023,BTEC,6399,2,26933,Thesis,Khan,Abdul Latif,2,0,0,0,0,0,0,4.0
+Fall 2023,LAW,5314,31,26935,Lawyering Skills & Strategy I,Esterholm,Melissa Hurter,9,7,0,0,0,0,0,3.398
+Fall 2023,ECE,6379,2,26936,Power Syst Oper and Modeling,Li,Xingpeng,3,2,1,0,2,0,4,2.376
+Fall 2023,MARK,4367,2,26937,Advertising and Promotion Mgt,Noriega,Jaime L,18,14,6,0,1,0,1,3.205
+Fall 2023,MARK,4389,8,26938,Marketing Strategy & Planning,Lish,Alan D,16,18,1,0,0,0,1,3.419
+Fall 2023,MARK,4397,2,26939,Selected Topics in Mkt,Richards,Sean Wesley,8,2,0,0,0,0,0,3.734
+Fall 2023,POLC,6311,3,26948,Leader and Prof Development,Witt,Lawrence A,11,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8356,2,26949,Program Policy Evaluation,Davis,Bradley,10,0,0,0,0,0,0,4.0
+Fall 2023,PHOP,6157,7,26950,Research Practicum B,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,8199,5,26951,Doctoral Dissertation Defense,Johnson,Michael L,1,0,0,0,0,0,0,4.0
+Fall 2023,DANC,1107,1,26953,Beginning Hip Hop Dance,Aguilera,Joel,12,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,4321,1,26957,Design of Construction Details,Story,Jon Kevin,2,6,3,0,0,0,0,2.879
+Fall 2023,GEOL,8698,22,26959,Doctoral Research,Beverly,Emily Jane,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8397,5,26960,Selected Topics in C&I,Hausmann,Robert Carl,7,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,6397,7,26961,Sel Tpcs-Arc/Urbn Desgn,Story,Jon Kevin,0,2,0,0,0,0,0,3.0
+Fall 2023,PSYC,6399,21,26962,Masters Thesis,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2023,DIGM,2325,30,26964,Info Tech Applications,Liao,Tony Chung-Li,5,10,4,0,1,0,0,2.933
+Fall 2023,BIOE,8598,30,26967,Doctoral Research,Li,Zhengwei,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,29,26969,Doctoral Research,Li,Zhengwei,0,0,0,0,0,1,0,
+Fall 2023,WCL,2352,3,26971,World Cinema,Choi,Jin Aeng,20,5,1,0,3,0,0,3.231
+Fall 2023,MUSA,1328,1,26972,Applied Harp,Cowan,Hope Kathleen,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8998,1,26973,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2023,FINA,4343,2,26974,Credit Analysis,Lara,Alexander J,11,2,0,0,0,0,0,3.821
+Fall 2023,PSYC,4399,2,26975,Senior Honors Thesis,Miciak,Jeremy Richard,1,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6182,1,26976,Applying Methods Light/Costume,Willson,Paige A,12,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,1111,82,26978,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,11,0,0,0,0,1,3.295
+Fall 2023,CHEM,1111,83,26979,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,3,4,0,1,0,2,2.566
+Fall 2023,CUIN,3316,5,26984,Prekindergarten Curr & Instr,Katz,Denise Annette,27,5,0,0,0,0,1,3.782
+Fall 2023,ELED,3322,3,26985,Elem Reading Phonics Instructn,Alba,Celeste,27,2,0,0,0,0,0,3.851
+Fall 2023,COSC,3360,801,26989,Operating Systems,Long,Kevin B,18,20,2,0,0,0,0,3.4
+Fall 2023,MECE,7399,14,26992,Masters Thesis,Ardebili,Haleh,0,0,0,0,0,2,0,
+Fall 2023,PHOP,8398,5,26996,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8698,5,27000,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,2,0,
+Fall 2023,COMD,8699,1,27004,Dissertation,Castilla-Earls,Anny,0,0,0,0,0,1,0,
+Fall 2023,OPTO,5298,3,27007,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,1,0,
+Fall 2023,COMM,4398,6,27008,Independent Study,Uhrick,Jan,2,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4398,7,27009,Independent Study,McCombs,Shawn,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8998,2,27011,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8399,14,27012,Doctoral Dissertation,Li,Aibing,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,8291,3,27014,COMD Research,Joshi,Ashwini,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8898,2,27016,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2023,COSC,8298,127,27018,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Fall 2023,MECE,6399,10,27019,Masters Thesis,Ardebili,Haleh,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6998,1,27025,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,2,0,
+Fall 2023,GEOL,8398,31,27027,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2023,PSYC,4398,4,27028,Independent Study,Yoshida,Hanako,0,0,0,0,0,2,0,
+Fall 2023,CHEE,8298,23,27029,Doctoral Research,Yao,Yan,0,0,0,0,0,3,0,
+Fall 2023,PSYC,2319,9,27030,Intro to Social Psychology,Bartlett,Brooke Ashley,19,37,36,14,7,0,2,2.425
+Fall 2023,GEOL,7398,2,27031,Masters Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Fall 2023,CIVE,6392,1,27034,Mass Transfer in Environ Syst,Rixey,William G,6,0,0,0,0,0,0,3.945
+Fall 2023,CIVE,6392,2,27035,Mass Transfer in Environ Syst,Rixey,William G,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8299,1,27036,Doctoral Dissertation,Babcock,Julia,0,0,0,0,0,1,0,
+Fall 2023,GEOL,6320,1,27037,Advanced Physical Geology,Sisson,Virginia B,2,0,0,0,0,0,0,3.67
+Fall 2023,HON,3396,1,27038,Senior Research Project,Rhoden,Brenda,3,0,0,0,0,0,0,4.0
+Fall 2023,HON,3396,2,27039,Senior Research Project,Deng,Liangzi,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,2317,14,27041,Intro to Psychology Statistics,Alonso,Nicole,29,30,7,2,8,0,2,2.925
+Fall 2023,OPTO,5198,1,27042,Spec Prob Phys Optics,Cheng,Han,0,0,0,0,0,6,0,
+Fall 2023,SOCW,8398,2,27044,Independent Study,Dettlaff,Alan J,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1344,2,27045,Applied Trombone,Freeman,Phillip I,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3444,2,27046,Applied Trombone,Freeman,Phillip I,0,1,0,0,0,0,0,3.0
+Fall 2023,COMM,6395,2,27048,Comprehensive Examination,Huang,Yan,0,0,0,0,0,1,0,
+Fall 2023,PCEU,6698,6,27049,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2023,PHOP,6767,8,27050,Research Practicum A,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,7998,1,27052,Masters Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Fall 2023,ARCH,6398,1,27053,Special Problems,Wienert,Ross George,1,0,0,0,0,0,0,3.67
+Fall 2023,CIVE,8699,1,27054,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6498,8,27055,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Fall 2023,PHLS,8399,5,27057,Doctoral Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Fall 2023,OPTO,5198,3,27058,Spec Prob Phys Optics,Garza,Janet,0,0,0,0,0,1,0,
+Fall 2023,MUSI,8296,6,27060,Doctoral Essay,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6332,1,27061,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8698,1,27062,Doctoral Research,Ott,William R,0,0,0,0,0,2,0,
+Fall 2023,MECE,8298,9,27064,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,5,0,
+Fall 2023,CIVE,8999,4,27065,Doctoral Dissertation,Lee,Hyongki,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8498,11,27066,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,2,0,
+Fall 2023,ECE,8298,29,27068,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,1,0,
+Fall 2023,ECE,8498,30,27069,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,1,0,
+Fall 2023,ELCS,8198,1,27071,Independent Study,Horn,Catherine Lynn,2,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8598,7,27072,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2023,MUSA,8243,1,27085,Doctoral Lecture Recital,Koozin,Timothy,1,0,0,0,0,0,0,3.67
+Fall 2023,MUSA,6310,4,27107,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,3310,6,27123,Indstrl-Orgnztnl Psy,Reyes,Denise Lucia,36,13,4,0,3,0,2,3.452
+Fall 2023,BIOE,8298,28,27124,Doctoral Research,An,Ran,0,0,0,0,0,2,0,
+Fall 2023,GEOL,7398,3,27125,Masters Research,Khan,Shuhab D,0,0,0,0,0,2,0,
+Fall 2023,PSYC,3399,8,27128,Senior Honors Thesis,Medina,Luis Daniel,0,0,0,0,0,0,0,
+Fall 2023,HIST,8388,4,27129,Dissertation Proposal,Klieman,Kairn,0,0,0,0,0,0,0,
+Fall 2023,PSYC,6398,22,27130,Independent Studies,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2023,HDFS,1311,3,27133,Personal Dev and College Succ,Sidwell,Jane Catherine,17,11,4,3,1,0,0,3.102
+Fall 2023,HDFS,1311,4,27134,Personal Dev and College Succ,Hall,Juanita J,29,5,1,0,0,0,1,3.753
+Fall 2023,WCL,4398,1,27139,Independent Study,El-Badawi,Emran,1,0,0,0,0,0,0,4.0
+Fall 2023,ECE,8498,31,27144,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2023,ECE,8298,30,27145,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2023,PEP,7398,1,27148,Adv Special Problem Human Perf,LaVoy,Emily Claire-Pyle,2,0,0,0,0,0,0,4.0
+Fall 2023,MATH,4399,1,27150,Senior Honors Thesis,Gao,Li,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6204,5,27153,Conducting,Koppel,Alexander,2,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8398,16,27155,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2023,CIVE,6398,1,27156,Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Fall 2023,MECE,8298,11,27158,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Fall 2023,SCLT,6399,30,27160,Master's Thesis,Bian,Zheyong,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8198,8,27163,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8598,8,27164,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Fall 2023,KIN,4398,2,27165,Independent Study,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6190,3,27166,Hospitality Research Proposal,Kim,Jaewook,0,0,0,0,0,1,0,
+Fall 2023,PHCA,6297,6,27167,Selected Topics,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,6397,4,27168,Selected Topics,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,6398,4,27170,Special Problems,Hopkins,Kelly Y,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8699,2,27171,Doctoral Dissertation,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8298,14,27175,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8699,3,27177,Doctoral Dissertation,Vipulanandan,Cumaraswamy,1,0,0,0,0,1,0,4.0
+Fall 2023,GEOL,8698,23,27180,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8298,15,27183,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,2,0,
+Fall 2023,PHLS,8398,2,27184,Special Problems,Hurt,Kara Marie,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8399,6,27185,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8298,16,27186,Doctoral Research,Momen,Mostafa,0,0,0,0,0,2,0,
+Fall 2023,COSC,4355,801,27187,Intro to Ubiquitous Computing,Pavlidis,Ioannis T,3,4,1,0,2,0,1,2.699
+Fall 2023,CNST,4345,1,27189,Reinforced Concrete Structures,Chang,Chi Chung,24,54,2,0,0,0,0,3.201
+Fall 2023,GEOL,7398,4,27192,Masters Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Fall 2023,ECON,8399,9,27194,Doctoral Dissertation,Nygaard,Vegard Mokleiv,0,0,0,0,0,1,0,
+Fall 2023,MECE,6353,1,27195,Intro Comp Fluid Dynam,Lee,Myoungkyu,4,2,2,0,0,0,0,3.168
+Fall 2023,MUSA,6141,3,27196,Graduate Recital II,Brooks,Wayne A,0,0,0,0,0,0,0,
+Fall 2023,CIVE,6399,2,27198,Master's Thesis,Kalliontzis,Dimitrios,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8598,9,27199,Doctoral Research,Lee,Hyongki,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6898,1,27200,Special Problems,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2023,BCHS,8998,3,27202,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8198,9,27204,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8398,2,27208,Independent Study,Gist,Conra D,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7398,2,27209,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6998,2,27210,Special Problems,Mohan,Chandra,0,0,0,0,0,2,0,
+Fall 2023,BCHS,8998,4,27211,Doctoral Research,Briggs,James M,0,0,0,0,0,1,0,
+Fall 2023,PHAR,5675,5,27213,Disease State Management,Ononogbu,Onyebuchi J,2,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5696,6,27214,Ambulatory Care - Primary Care,Ononogbu,Onyebuchi J,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,8399,1,27216,Dissertation I in Hosp. Admin,Boger Jr,Carl A,0,0,0,0,0,0,0,
+Fall 2023,PSYC,8699,5,27218,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8399,20,27224,Doctoral Dissertation,Shepley,Nathan,1,0,0,0,0,1,0,4.0
+Fall 2023,PHAR,5672,2,27225,Clinical Pharmaceutical Resch,Trivedi,Meghana,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6220,1,27227,Applied Violin,Austin,Alan S,1,0,0,0,0,0,0,3.67
+Fall 2023,ENGL,6398,9,27229,Rd&Research in Lang&Lit,Belieu,Erin Colleen,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8398,32,27231,Doctoral Research,Li,Aibing,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8397,10,27235,Selected Topics in C&I,Gist,Conra D,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8395,5,27238,Dissertation in practice,Hale,Margaret Ann,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6998,3,27239,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6898,2,27240,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2023,MECT,6317,30,27241,Application in Stress Analysis,Basaran,Burak,2,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8898,2,27242,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2023,BTEC,6398,30,27244,Special Problems in BTEC,Balan,Venkatesh,0,1,0,0,0,0,0,3.33
+Fall 2023,TLIM,3363,35,27247,Technical Communications,Tangeman,Anthony C,18,12,9,0,1,0,3,3.158
+Fall 2023,DANC,4298,1,27250,Independent Study,Chapman,Teresa Lynn,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8998,5,27251,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2023,BCHS,8998,6,27252,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2023,MUSA,4189,8,27254,Senior Recital,Vasquez,Hector A,1,1,0,0,0,0,0,3.5
+Fall 2023,MUSI,6261,1,27258,Intern in Piano Teaching II,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8898,3,27259,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Fall 2023,BCHS,8999,2,27260,Doctoral Dissertation,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8398,47,27264,Doctoral Research,Mondaini,Rubem,0,0,0,0,0,1,0,
+Fall 2023,PHYS,8698,37,27266,Doctoral Research,Mondaini,Rubem,0,0,0,0,0,1,0,
+Fall 2023,BZAN,6360,2,27268,Capstone Practicum in BZAN I,Lewis,Michael Joseph,13,4,0,0,0,0,0,3.765
+Fall 2023,BZAN,6361,2,27269,Capstone Practicum in BZAN II,Lewis,Michael Joseph,2,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,7398,5,27272,Masters Research,Carlson,Brandee Nicole,0,0,0,0,0,2,0,
+Fall 2023,COMD,8291,4,27273,COMD Research,Thiessen,Amber L,0,0,0,0,0,1,0,
+Fall 2023,PHLA,7199,1,27274,Masters Thesis,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2023,SOC,7399,5,27275,Masters Thesis,Lee,Shayne,0,0,0,0,0,0,0,
+Fall 2023,CIVE,8198,10,27276,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8498,12,27277,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8598,10,27278,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2023,HIST,1302,9,27282,The U.S. Since 1877,Amaral,Lindsay Nicole,45,47,24,5,17,0,7,2.66
+Fall 2023,HIST,3399,4,27283,Senior Honors Thesis,Clavin,Matthew J,0,0,0,0,0,0,1,
+Fall 2023,EDS,6398,1,27284,Research,Lendasse,Amaury,0,0,0,0,0,4,0,
+Fall 2023,SOC,7399,6,27285,Masters Thesis,Katz,Sheila,1,0,0,0,0,0,0,4.0
+Fall 2023,EDS,6342,2,27286,Intro to Machine Learning,Kulkarni,Yashashree,44,17,7,1,0,0,0,3.507
+Fall 2023,PEP,8699,6,27287,Doctoral Dissertation,Lee,Dong Hun,0,1,0,0,0,0,0,3.0
+Fall 2023,BIOL,6898,2,27331,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6498,10,27332,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Fall 2023,MARK,8336,1,27333,Marketing Research Methods,Ahearne,Michael,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,4398,2,27334,Independent Study,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Fall 2023,ECE,8298,31,27336,Doctoral Research,Pan,Miao,0,0,0,0,0,3,0,
+Fall 2023,ECE,8498,32,27337,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8999,15,27338,Doctoral Dissertation,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2023,TEPM,6304,3,27339,Quality Improvemnt in Proj Mgt,Kovach,Jamison,0,0,0,0,1,0,0,0.0
+Fall 2023,MECE,8298,12,27341,Doctoral Research,Chen,Yi-Chao,0,0,0,0,0,1,0,
+Fall 2023,MECE,8399,42,27342,Doctoral Dissertation,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8598,11,27349,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,2,0,
+Fall 2023,MUSI,6103,1,27351,Advanced Lyric Diction,Averyt,Zachary Benjamin,6,0,0,0,0,0,0,3.945
+Fall 2023,FINA,7397,10,27358,Selected Topics in Finance,Stewart,Marcus,4,0,0,0,0,0,0,3.918
+Fall 2023,PHLS,8399,7,27361,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8699,2,27362,Doctoral Dissertation,McNeil,Sara G,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8398,4,27364,Independent Study,McNeil,Sara G,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8398,12,27365,Independent Study,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8242,9,27366,Doctoral Recital III,Staupe,Andrew Paul,0,0,0,0,0,0,0,
+Fall 2023,ELCS,8311,12,27367,Lab of Practice-Lit Revw Devel,Shockley,Gerald,0,0,0,0,0,3,0,
+Fall 2023,ELCS,8311,14,27369,Lab of Practice-Lit Revw Devel,Davis,Bradley,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,1336,8,27370,Computer Science & Program,Subhlok,Jaspal,32,10,20,17,2,0,7,2.638
+Fall 2023,ELCS,8311,15,27371,Lab of Practice-Lit Revw Devel,Johnson,Detra DeVerne,0,0,0,0,0,3,0,
+Fall 2023,ELCS,8311,16,27373,Lab of Practice-Lit Revw Devel,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Fall 2023,ELCS,8311,18,27375,Lab of Practice-Lit Revw Devel,Snodgrass Rangel,Virginia Walker,2,0,0,0,0,0,0,3.835
+Fall 2023,FINA,7A97,7,27377,Selected Topics in Finance,Stewart,Marcus,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,4398,6,27378,Independent Study,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Fall 2023,MIS,7397,10,27379,Selected Topics in MIS,Messinger,Jacob Nelson,25,5,0,0,0,0,0,3.789
+Fall 2023,ARTS,1311,4,27380,Fundamentals of Graphic Design,Sawhney,Ashita,15,4,0,0,1,0,3,3.534
+Fall 2023,ECON,7390,1,27382,Research & Readings - Economic,Vollrath,Dietrich E,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,6399,2,27383,Masters Thesis,Song,Gangbing,0,0,0,0,0,0,0,
+Fall 2023,ACCT,8396,2,27384,Research Practicum,Chen,Xi,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,8396,1,27385,Research Practicum,Doshi,Hitesh B,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6324,1,27387,Bioinformatics,Stuckert,Adam,3,0,0,0,0,0,0,3.67
+Fall 2023,HIST,6383,2,27390,Topics in Public Hist,Rector,Josiah John,0,0,0,0,0,0,0,
+Fall 2023,ARTS,7398,2,27391,Independent Graduate Study,Hecker,Rachel G,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,7398,3,27392,Independent Graduate Study,Hillerbrand,Stephan C,2,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8398,24,27395,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6320,2,27396,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,7392,2,27398,Psychology Practicum,Atherton,Olivia Emile,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,8301,3,27399,Seminar in Perform Pedagogy,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,7392,1,27400,Internship,Gronseth,Susie L B,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7398,3,27401,Adv Special Problem Human Perf,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Fall 2023,BZAN,6350,3,27402,Quant Found for Busi Analytics,Venugopal,Kalyanaraman,23,3,0,0,1,0,0,3.655
+Fall 2023,CIVE,8298,17,27405,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,2,0,
+Fall 2023,ENGI,2304,17,27407,Technical Communications,Wilson,Chad A,2,2,1,0,0,0,1,3.134
+Fall 2023,FINA,7397,11,27408,Selected Topics in Finance,Bean,Gregory S,2,0,0,0,0,0,0,4.0
+Fall 2023,MECE,7399,3,27410,Masters Thesis,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2023,PCOL,8398,1,27414,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2023,CHEE,4198,1,27417,Independent Study,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8699,6,27418,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,1,0,
+Fall 2023,PSYC,7399,21,27419,Masters Thesis,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8699,7,27422,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8398,30,27423,Doctoral Research,Schultz,Jerome S,0,0,0,0,0,0,0,
+Fall 2023,BIOE,8598,31,27424,Doctoral Research,Schultz,Jerome S,0,0,0,0,0,0,0,
+Fall 2023,ELCS,8398,1,27425,Independent Study,McKinney,Lonnie Lyle,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8995,4,27426,Pre-Dissertation Research,Walton,Quenette,0,0,0,0,0,1,0,
+Fall 2023,HDFS,2314,18,27429,Human Dev and Interventions,Boykin,Jelisa Denae,96,33,13,4,7,0,7,3.316
+Fall 2023,ARTH,3399,2,27436,Senior Honors Thesis,Harren,Natilee O,0,0,0,0,0,0,0,
+Fall 2023,BIOL,6898,3,27437,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6398,9,27439,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Fall 2023,BIOL,4198,1,27440,Independent Study,Zufall,Rebecca A,1,0,0,0,0,0,0,4.0
+Fall 2023,MIS,7397,11,27441,Selected Topics in MIS,Jagtap,Pankaj,3,10,1,0,0,0,0,3.049
+Fall 2023,HIST,6398,5,27442,Special Problems,Cedillo,Adela Cedillo,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6498,11,27443,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6498,12,27444,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Fall 2023,MUSA,6142,3,27445,Graduate Recital III,Yon,Kirsten A,0,0,0,0,0,0,0,
+Fall 2023,PEP,7398,4,27449,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7398,5,27450,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,3.67
+Fall 2023,PEP,7398,6,27451,Adv Special Problem Human Perf,LaVoy,Emily Claire-Pyle,4,0,0,0,0,0,0,4.0
+Fall 2023,SPAN,7398,7,27452,Reading & Research,Fairclough,Marta A,0,0,0,0,0,2,0,
+Fall 2023,CUIN,8397,3,27454,Selected Topics in C&I,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,6335,2,27457,Advanced Concrete Design,Belarbi,Abdeldjelil,0,1,0,0,1,0,1,1.5
+Fall 2023,BIOE,8398,31,27458,Doctoral Research,An,Ran,0,0,0,0,0,2,0,
+Fall 2023,PSYC,6393,11,27459,Clinical Research Practicum,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6498,13,27461,Special Problems,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Fall 2023,DRAM,1310,16,27462,Introduction to Theatre,Young,Courtney Leigh,34,4,3,1,2,0,2,3.508
+Fall 2023,DRAM,1310,17,27464,Introduction to Theatre,Hinkel,Heidi Anne,32,10,5,0,2,0,0,3.388
+Fall 2023,BIOL,2101,25,27467,Anatomy & Physiology Lab I,Gill,Tejendra,1,14,2,1,1,0,1,2.684
+Fall 2023,BIOL,2101,26,27469,Anatomy & Physiology Lab I,Gill,Tejendra,2,14,3,0,2,0,2,2.651
+Fall 2023,MECE,8399,43,27471,Doctoral Dissertation,Sun,Li,1,0,0,0,0,0,0,4.0
+Fall 2023,PCOL,6298,9,27472,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2023,PCOL,6498,9,27473,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2023,COMM,7397,2,27475,Selected Topics - Comm,Yamasaki,Jill S,7,0,0,0,0,0,0,4.0
+Fall 2023,THEA,6398,2,27478,Independent Study,Webb,Matthew Clark,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8699,8,27479,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2023,BCHS,8498,2,27480,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2023,MUSI,1181,6,27481,Group Piano I,Van Kekerix,Todd Evan,3,1,0,0,1,0,1,3.066
+Fall 2023,BCHS,6898,3,27482,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6998,4,27483,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2023,IEEM,6360,2,27484,Data Analytics for Engr. Mgt,Hu,Minxiang,1,1,0,0,0,0,0,3.665
+Fall 2023,PHLS,7398,3,27485,Candidacy Research,Arbona,Consuelo,0,0,0,0,0,0,0,
+Fall 2023,MECE,8398,25,27488,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8690,4,27489,Dissertation in Practice,Hale,Margaret Ann,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,6303,1,27490,History of Science and Methods,Chakrabarti,Pratik,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6898,4,27491,Special Problems,Yi,Ping,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6998,5,27492,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6498,14,27493,Special Problems,Yi,Ping,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6698,1,27495,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,2,0,
+Fall 2023,BIOL,6598,11,27498,Special Problems,Khan,Abdul Latif,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8998,3,27500,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8498,13,27501,Doctoral Research,Momen,Mostafa,0,0,0,0,0,2,0,
+Fall 2023,PHCA,6397,5,27504,Selected Topics,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Fall 2023,PHCA,7310,2,27505,Teaching Practicum,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6598,12,27506,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8198,11,27507,Doctoral Research,Momen,Mostafa,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6598,13,27508,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Fall 2023,HDCS,4398,1,27510,Independent Study,Johnson,Olivia,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,6398,3,27514,Special Problems,Ashley,Laura B,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,6398,4,27515,Special Problems,Huang,Yan,1,0,0,0,0,0,0,3.67
+Fall 2023,PSYC,6393,12,27520,Clinical Research Practicum,Gallagher,Matthew Ward,2,0,0,0,0,0,0,4.0
+Fall 2023,COMD,8191,1,27522,COMD Research,Thiessen,Amber L,0,0,0,0,0,1,0,
+Fall 2023,PCEU,6198,2,27528,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6393,13,27529,Clinical Research Practicum,Williams,Michael W,0,0,0,0,0,1,0,
+Fall 2023,FINA,8396,2,27530,Research Practicum,Kumar,Praveen,0,0,0,0,0,2,0,
+Fall 2023,CIVE,8399,4,27531,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2023,PEP,7398,7,27532,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8298,29,27533,Doctoral Research,Li,Zhengwei,0,0,0,0,0,2,0,
+Fall 2023,PEP,7398,8,27534,Adv Special Problem Human Perf,Johnston,Craig Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,6305,1,27535,Histories of Capitalism,McNally,David Joseph,0,0,0,0,0,0,0,
+Fall 2023,MANA,8399,1,27536,Doctoral Dissertation,Ruggs,Enrica N,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,3399,1,27538,Senior Honors Thesis,Harth,Eva M,1,0,0,0,0,0,0,4.0
+Fall 2023,CHEM,3399,2,27539,Senior Honors Thesis,Czader,Arkadiusz,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7398,9,27540,Adv Special Problem Human Perf,Park,Yoonjung,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,7699,9,27544,Thesis,Prufer,Kevin D,0,0,0,0,0,1,0,
+Fall 2023,BIOL,8998,4,27548,Doctoral Research,Liu,Xinli,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6598,14,27549,Special Problems,Crawford,Kerri M,0,0,0,0,0,2,0,
+Fall 2023,BIOL,8898,5,27550,Doctoral Research,Feng,Qin,0,0,0,0,0,2,0,
+Fall 2023,HIST,8999,8,27551,Doctoral Dissertation,Mizelle Jr,Richard M,0,0,0,0,0,1,0,
+Fall 2023,HIST,6398,6,27552,Special Problems,Cedillo,Adela Cedillo,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8298,18,27553,Doctoral Research,Wang,Keh-Han,0,0,0,0,0,0,0,
+Fall 2023,CIVE,8498,14,27554,Doctoral Research,Wang,Keh-Han,0,0,0,0,0,0,0,
+Fall 2023,PEP,7398,10,27555,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8998,5,27559,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2023,ELCS,8399,8,27561,Doctoral Dissertation,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,6398,5,27564,Special Problems,Ni,Lan,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGL,6698,4,27567,Research,Kastely,James L,0,0,0,0,0,1,0,
+Fall 2023,HIST,6398,8,27568,Special Problems,Goldberg,Mark A,1,0,0,0,0,0,0,4.0
+Fall 2023,HLT,4310,5,27570,Program Planning for Hlt Prof,Haq,Arooba A,20,10,4,0,0,0,0,3.374
+Fall 2023,HLT,4310,6,27571,Program Planning for Hlt Prof,Haq,Arooba A,19,13,1,0,1,0,0,3.402
+Fall 2023,CNE,3310,3,27573,Construction Engr Project Mgmt,Safa,Mahdi,7,11,0,0,0,0,0,3.389
+Fall 2023,EDS,6398,2,27583,Research,Lindner,Peggy,0,0,0,0,0,1,0,
+Fall 2023,HLT,3306,3,27586,Environmental Health,Brown,Korey J,78,18,7,4,4,0,1,3.415
+Fall 2023,HLT,3306,4,27587,Environmental Health,Brown,Korey J,13,4,0,0,0,0,0,3.784
+Fall 2023,PHOP,6267,7,27588,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Fall 2023,PHOP,6198,17,27589,Spec Prob-Physio Optics,Stevenson,Scott Bailli,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8398,3,27591,Independent Study,Acquati,Chiara,0,0,0,0,0,0,0,
+Fall 2023,SOCW,8398,4,27592,Independent Study,Narendorf,Sarah C,0,0,0,0,0,0,0,
+Fall 2023,ELCS,8395,10,27594,Dissertation in practice,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Fall 2023,THEA,4398,1,27595,Independent Study,Romero,Gregory John,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6898,6,27596,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Fall 2023,PHLS,8398,3,27598,Special Problems,Smith,Bradley,2,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8995,5,27599,Pre-Dissertation Research,Ali,Samira Bano,0,0,0,0,0,2,0,
+Fall 2023,THEA,3372,1,27600,Digital Design Techniques,Willson,Paige A,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,8320,34,27601,Doctoral Applied Music,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6998,6,27602,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2023,BCHS,6898,4,27603,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Fall 2023,PSYC,4398,5,27605,Independent Study,Derrick,Jaye L,2,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7398,11,27606,Adv Special Problem Human Perf,Ogunrinde,Joyce,2,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6359,9,27607,Directed Rsch in Clinical Psyc,Alfano,Candice A,2,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,6898,7,27608,Special Problems,Fujita,Masaya,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7399,14,27609,Masters Thesis,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2023,MANA,8399,2,27610,Doctoral Dissertation,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8699,32,27611,Doctoral Dissertation,Joshi,Shailendra Pramod,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8398,26,27613,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Fall 2023,MECE,8298,20,27614,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,4,27615,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Fall 2023,BIOE,6298,3,27616,Research,Zhang,Yingchun,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6598,16,27618,Special Problems,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8998,32,27619,Doctoral Research,Curiale,Joseph A,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8398,33,27621,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,3,0,
+Fall 2023,PEP,7398,12,27622,Adv Special Problem Human Perf,Hawkins,Billy J,1,0,0,0,0,0,0,4.0
+Fall 2023,PCEU,6397,1,27623,PCEU Selected Topics,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2023,PCEU,6397,2,27624,PCEU Selected Topics,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,8399,44,27627,Doctoral Dissertation,Chen,Tian,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,1322,2,27628,Applied Viola,Archibald,Amber Cristina,1,1,0,0,0,0,0,3.5
+Fall 2023,BCHS,8898,3,27629,Doctoral Research,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6798,3,27630,Special Problems,O'Brien,John,0,0,0,0,0,1,0,
+Fall 2023,GEOL,8698,24,27632,Doctoral Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Fall 2023,COMD,8391,3,27633,COMD Research,Bunta,Ferenc,0,0,0,0,0,1,0,
+Fall 2023,COMD,8291,5,27635,COMD Research,Bunta,Ferenc,0,0,0,0,0,1,0,
+Fall 2023,ELED,7324,3,27637,Sci Instruction in Elem Grades,Rodriguez,Alberto J,1,0,0,0,0,0,0,4.0
+Fall 2023,EDS,6399,1,27638,Master?s Thesis,Lindner,Peggy,1,0,0,0,0,0,0,4.0
+Fall 2023,HON,3396,3,27639,Senior Research Project,Xu,Shoujun,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,8396,3,27644,Research Practicum,Susmel,Raul,0,0,0,0,0,1,0,
+Fall 2023,MUSI,8296,7,27645,Doctoral Essay,Snyder,John L,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8598,10,27646,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2023,SCM,8399,1,27647,Dissertation,Li,Meng,1,0,0,0,0,0,0,4.0
+Fall 2023,TLIM,4396,30,27657,Internship in TLIM,Burns,Maria,2,0,0,0,0,0,0,4.0
+Fall 2023,TLIM,4398,30,27659,Independent Study,Burns,Maria,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,8396,4,27660,Research Practicum,George,Thomas J,0,0,0,0,0,1,0,
+Fall 2023,BIOL,6498,15,27666,Special Problems,O'Brien,John,0,0,0,0,0,1,0,
+Fall 2023,PHLS,8396,5,27667,Doctoral Research,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Fall 2023,COMM,4398,8,27668,Independent Study,Crowe,Craig Warren,2,0,1,0,0,0,0,3.443
+Fall 2023,BIOL,8898,6,27670,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8399,5,27672,Doctoral Dissertation,Lee,Hyongki,1,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8995,6,27674,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,1,0,
+Fall 2023,BCHS,8898,4,27676,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Fall 2023,PSYC,4398,6,27677,Independent Study,Leasure,Jennifer Leigh,1,0,0,0,0,0,0,4.0
+Fall 2023,BCHS,8399,5,27678,Doctoral Dissertation,Briggs,James M,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,2334,3,27679,Applied Clarinet,Potiomkin,Alexander,3,0,0,0,0,0,0,4.0
+Fall 2023,COSC,4398,3,27680,Independent Study,Gnawali,Omprakash D,0,0,0,0,0,5,0,
+Fall 2023,COSC,4398,4,27681,Independent Study,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2023,ANTH,6398,1,27682,Special Problems,Sen,Debarati,1,0,0,0,0,0,0,4.0
+Fall 2023,MATH,8398,24,27684,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Fall 2023,MECE,8598,41,27687,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Fall 2023,KIN,4390,2,27690,Internship in PE,Walsh,David W,0,0,1,0,0,0,0,1.67
+Fall 2023,PSYC,6399,22,27691,Masters Thesis,Borjon,Jeremy Isaac,0,0,0,0,0,1,0,
+Fall 2023,ARTS,7398,4,27692,Independent Graduate Study,Meza,Abinadi,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,6340,2,27695,Applied Trumpet,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6365,9,27696,Dir Rsch in Dev Cog Beh Neuro,Borjon,Jeremy Isaac,0,0,0,0,0,1,0,
+Fall 2023,MECE,3399,4,27697,Senior Honors Thesis,Chen,Tian,0,0,1,0,0,0,0,2.0
+Fall 2023,INDE,6372,3,27698,Advanced Linear Optimization,Diaz Martinez,Neil Orlando,6,21,7,0,0,0,0,3.009
+Fall 2023,THEA,4398,2,27699,Independent Study,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Fall 2023,COMD,8291,6,27700,COMD Research,Castilla-Earls,Anny,0,0,0,0,0,2,0,
+Fall 2023,MUSA,6210,2,27702,Applied Piano,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8199,2,27704,Dissertation,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Fall 2023,BCHS,4398,1,27705,Independent Study,Widger,William R,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8198,12,27708,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,1,0,
+Fall 2023,ARTS,7398,5,27714,Independent Graduate Study,Giampietro,Francis A,2,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8998,33,27715,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,1,0,
+Fall 2023,HIST,6398,11,27718,Special Problems,Bhattacharya,Nandini Saradindu,0,0,0,0,0,0,0,
+Fall 2023,GEOL,8698,25,27719,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7399,15,27721,Masters Thesis,Wellner,Julia S,2,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,7398,4,27724,Candidacy Research,Wiesner,Margit F,1,0,0,0,0,0,0,3.67
+Fall 2023,MANA,8399,4,27730,Doctoral Dissertation,Sauerwald,Steve,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,7998,2,27732,Masters Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2023,BIOE,6298,4,27733,Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2023,SCM,8999,1,27734,Dissertation,Robinson Jr,Powell Ersell,0,0,0,0,0,1,0,
+Fall 2023,PHAR,5297,1,27736,Selected Topics in Pharmacy,Rosario,Natalie,1,0,0,0,0,0,0,4.0
+Fall 2023,PEP,7398,14,27742,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2023,PHAR,5397,1,27744,Selected Topics in Pharmacy,Rosario,Natalie,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,6398,2,27745,Special Problems,Maneethai,Dustin,1,0,0,0,0,0,0,4.0
+Fall 2023,PHLS,8198,1,27749,Special Problems,Smith,Bradley,1,0,0,0,0,0,0,4.0
+Fall 2023,CNST,6397,2,27750,Sel Tops-Construction Managemt,Chang,Chi Chung,15,0,0,0,0,0,0,3.978
+Fall 2023,COSC,4198,3,27753,Independent Study,Lin,Sen,0,0,0,0,0,1,0,
+Fall 2023,MUSI,4198,6,27758,Research in Chamber Music,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2023,CUIN,8390,1,27760,Dissertation in Practice,Hale,Margaret Ann,0,0,1,0,0,0,0,2.0
+Fall 2023,GENB,7297,1,27764,Selected Topics,Ahearne,Michael,4,0,0,0,0,0,0,4.0
+Fall 2023,PETR,6388,1,27765,Petroleum Engr Project,Farouq-Ali,Syed,0,1,0,0,0,0,0,3.0
+Fall 2023,SOCW,8995,7,27766,Pre-Dissertation Research,Cheung,Monit,0,0,0,0,0,1,0,
+Fall 2023,GEOL,6398,1,27767,Special Problems,Stewart,Robert R,2,0,0,0,0,0,0,4.0
+Fall 2023,SOCW,8995,8,27772,Pre-Dissertation Research,Jennings,Sheara Williams,0,0,0,0,0,1,0,
+Fall 2023,GEOL,6398,2,27773,Special Problems,Mann,Paul,0,1,0,0,0,0,0,3.0
+Fall 2023,PSYC,8199,6,27775,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2023,CIVE,8198,13,27776,Doctoral Research,Li,Hongyi,0,0,0,0,0,1,0,
+Fall 2023,GEOL,7698,2,27777,Masters Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2023,MIS,8399,1,27778,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Fall 2023,MUSI,6298,1,27779,Research,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2023,MECE,4198,1,27781,Independent Study,Love,Holley Carole,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,6398,23,27782,Independent Studies,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2023,PSYC,6359,10,27783,Directed Rsch in Clinical Psyc,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2023,MATH,6698,1,27784,Special Problems,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Fall 2023,ECE,6498,1,27785,Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Fall 2023,ECE,6598,1,27786,Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Fall 2023,ECON,6693,2,27787,Master's Research Project,Zhivan,Natalia A,1,0,0,0,0,0,0,4.0
+Fall 2023,DIGM,2325,32,27788,Info Tech Applications,Liao,Tony Chung-Li,0,1,0,0,0,0,0,3.0
+Fall 2023,FORE,6395,40,27791,Master's Project in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Fall 2023,FORE,6398,40,27792,Special Problems in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOE,8298,30,27797,Doctoral Research,Nurminen,Lauri Oskari,0,0,0,0,0,1,0,
+Fall 2023,IDNS,2197,3,27798,Top-Natrl Sci & Mth,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2023,ELED,7320,3,27804,Foundations of Literacy Instru,Alba,Celeste,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,7398,9,27805,Masters Research,Sager,William W,0,0,0,0,0,1,0,
+Fall 2023,CUIN,8397,4,27807,Selected Topics in C&I,Lee,Mimi Miyoung,0,0,0,0,0,0,0,
+Fall 2023,COMD,8391,4,27808,COMD Research,Mills,Monique T,0,0,0,0,0,1,0,
+Fall 2023,ENGL,8698,14,27809,Graduate Research,Duran,Chatwara,0,0,0,0,0,1,0,
+Fall 2023,ARCH,6398,2,27811,Special Problems,Diehl,Tom,0,0,0,0,0,0,0,
+Fall 2023,BCHS,6898,6,27812,Special Problems,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8498,25,27818,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2023,MECE,6399,11,27819,Masters Thesis,Franchek,Matthew,0,0,0,0,0,1,0,
+Fall 2023,POLC,4398,2,27820,Independent Study,Buttorff,Gail J,1,0,0,0,0,0,0,4.0
+Fall 2023,BIOL,8798,1,27829,Doctoral Research,Graur,Dan,0,0,0,0,0,1,0,
+Fall 2023,PCEU,8698,1,27830,Doctoral Research,Tam,Vincent H,0,0,0,0,0,1,0,
+Fall 2023,BIOE,8598,33,27831,Doctoral Research,Du,Yuncheng,0,0,0,0,0,2,0,
+Fall 2023,BIOE,8398,32,27832,Doctoral Research,Du,Yuncheng,0,0,0,0,0,2,0,
+Fall 2023,GHL,3155,2,27834,Event Planning,Haskell,Rebecca Erin,1,0,0,0,0,0,0,4.0
+Fall 2023,KIN,4398,4,27835,Independent Study,Johnston,Craig Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,POLS,8399,13,27836,Doctoral Dissertation,Raychaudhuri,Tanika,1,0,0,0,0,0,0,4.0
+Fall 2023,GEOL,8698,26,27837,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Fall 2023,ELET,6350,2,27838,Overview Com Health Informatic,Pollonini,Luca,2,0,0,0,0,0,0,3.835
+Fall 2023,MUSA,1330,3,27840,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSA,3430,3,27842,Applied Flute,Martin,Tyler Craig,2,0,0,0,0,0,0,3.835
+Fall 2023,ARTS,4398,5,27843,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Fall 2023,DIGM,1376,31,27848,User Experience (UX)Principles,Rodwell,Elizabeth Ann,0,0,0,0,1,0,0,0.0
+Fall 2023,MUSI,6100,2,27851,Chamber Music,Suits,Brian J,5,1,0,0,0,0,0,3.888
+Fall 2023,MUSI,6198,5,27853,Research in Chamber Music,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6198,6,27854,Research in Chamber Music,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6198,7,27855,Research in Chamber Music,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,7,27856,Research in Chamber Music,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,8,27857,Research in Chamber Music,Archibald,Amber Cristina,3,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,9,27858,Research in Chamber Music,Larson,Eric Amery,4,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,10,27859,Research in Chamber Music,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,11,27860,Research in Chamber Music,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4198,12,27861,Research in Chamber Music,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,6198,8,27862,Research in Chamber Music,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,8999,2,27863,Doctoral Dissertation,Golubev,Alexey Valeryevich,0,0,0,0,0,0,0,
+Fall 2023,POLS,6398,1,27866,Special Problems,Kistner,Michael,0,1,0,0,0,0,0,3.33
+Fall 2023,BIOL,3396,1,27868,Senior Research Project,Daane,Jacob,1,0,0,0,0,0,0,4.0
+Fall 2023,GHL,3155,3,27870,Event Planning,Haskell,Rebecca Erin,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4398,9,27871,Independent Study,Camaj,Lindita,1,0,0,0,0,0,0,4.0
+Fall 2023,FINA,7A23,2,27896,Portfolio Theory and Practice,Jacobs,Kris,3,0,0,0,0,0,0,3.78
+Fall 2023,COMM,4398,10,27898,Independent Study,Houk,Keith R,1,0,0,0,0,0,0,4.0
+Fall 2023,ELCS,8311,25,27899,Lab of Practice-Lit Revw Devel,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4398,11,27902,Independent Study,Choi,Ho Joon,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8399,425,27907,Doctoral Dissertation,Shi,Weidong,0,0,0,0,0,1,0,
+Fall 2023,FINA,7A97,8,27908,Selected Topics in Finance,George,Thomas J,1,0,0,0,0,0,0,4.0
+Fall 2023,PHYS,8399,45,27912,Doctoral Dissertation,Varghese,Oomman K,1,0,0,0,0,0,0,4.0
+Fall 2023,COSC,8398,414,27913,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2023,MUSI,6399,1,27923,Masters Thesis,Caton,Kathryn L.,1,0,0,0,0,0,0,4.0
+Fall 2023,DRAM,1310,24,27928,Introduction to Theatre,Hinkel,Heidi Anne,21,5,0,1,1,0,1,3.571
+Fall 2023,MUSI,4197,5,27929,Selected Topics in Music,Fernando,Fleurette S,6,0,0,0,0,0,0,4.0
+Fall 2023,MUSI,4197,4,27930,Selected Topics in Music,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Fall 2023,ARTS,4390,1,27931,Blaffer Museum Internship,Veneman,Katherine A,1,0,0,0,0,0,0,4.0
+Fall 2023,COMM,4398,12,27933,Independent Study,Uhrick,Jan,1,0,0,0,0,0,0,4.0
+Fall 2023,ENGI,4398,25,27934,Independent Study,Claydon,Frank J,0,0,0,0,0,1,0,
+Fall 2023,HDCS,4398,3,27936,Independent Study,Greer,Tomika,1,0,0,0,0,0,0,4.0
+Fall 2023,HIST,8399,6,27940,Doctoral Dissertation,Romero,Todd,0,0,0,0,0,1,0,
+Fall 2023,HIST,3394,1,27941,Sel Tops-Us History,Goldberg,Mark A,1,0,0,0,0,0,0,4.0
+Fall 2023,HON,3396,50,27943,Senior Research Project,Rhoden,Brenda,0,0,0,0,0,0,0,
+Fall 2023,POLC,6391,2,27947,Public Policy Internship,Bronk,Robert C,1,0,0,0,0,0,0,4.0
+Fall 2023,SOC,3398,2,27952,Ind Study in Soc,Lee,Shayne,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,8199,7,27955,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2023,COMM,4398,13,27956,Independent Study,Houk,Keith R,1,0,0,0,0,0,0,4.0
+Fall 2023,PSYC,4398,7,27957,Independent Study,Ng,Vincent,0,0,0,0,0,1,0,
+Fall 2023,MUSA,3310,1,27959,Applied Piano,Norian,Gary,1,0,0,0,0,0,0,4.0
+Fall 2023,ARCH,1198,1,27968,Special Problems,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Fall 2023,CIVE,8398,19,27969,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Fall 2023,ECE,6398,30,27973,Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Fall 2023,BTEC,6396,40,27976,Masters Project in BTEC,Khan,Abdul Latif,2,0,0,0,0,0,0,4.0

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2024-01 (Spring 2024).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2024-01 (Spring 2024).csv
@@ -1,0 +1,6937 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Spring 2024,SOCW,7325,1,10340,Individuals: Adv Clinical Prac,Amtsberg,Donna K,20,1,0,0,0,0,1,3.952
+Spring 2024,PHIL,1301,1,10341,Intro To Philosophy,Aiman,Edwin E,49,13,5,1,4,0,1,3.325
+Spring 2024,PHIL,1301,3,10342,Intro To Philosophy,Haaga,Curtis W,59,33,2,2,3,0,1,3.411
+Spring 2024,PHIL,1301,4,10343,Intro To Philosophy,Oliveira,Luis RG,119,73,11,2,5,0,10,3.378
+Spring 2024,PHIL,1305,1,10344,Intro To Ethics,Coates,Daniel J,55,48,4,0,2,0,7,3.443
+Spring 2024,PHIL,1305,2,10345,Intro To Ethics,Aiman,Edwin E,37,24,4,1,5,0,3,3.188
+Spring 2024,PHIL,1305,3,10346,Intro To Ethics,Sommers,Tamler S,86,17,8,0,4,0,3,3.554
+Spring 2024,PHIL,1321,2,10347,Logic I,Buckner,Cameron J,28,16,17,0,7,0,16,2.775
+Spring 2024,PHIL,1321,3,10348,Logic I,Haaga,Curtis W,28,13,13,10,2,0,9,2.793
+Spring 2024,PHIL,1321,5,10350,Logic I,Haaga,Curtis W,24,17,17,2,3,0,9,2.847
+Spring 2024,PHIL,1361,1,10351,Philosophy and the Arts,Drapela,Nick Gerard,13,17,6,4,1,0,8,2.854
+Spring 2024,PHIL,1361,2,10352,Philosophy and the Arts,Drapela,Nick Gerard,11,21,6,2,2,0,7,2.842
+Spring 2024,PHIL,1361,3,10353,Philosophy and the Arts,Drapela,Nick Gerard,8,15,13,5,0,0,8,2.626
+Spring 2024,PHIL,1361,4,10354,Philosophy and the Arts,Drapela,Nick Gerard,16,14,7,1,2,0,9,2.967
+Spring 2024,PHIL,3386,1,10355,19th Century Philosophy,Werner,Andrew Timothy,19,8,2,0,1,0,1,3.401
+Spring 2024,PHIL,3358,1,10356,Classics in Hist of Ethics,Phillips,David K,16,13,4,1,1,0,1,3.172
+Spring 2024,ARCH,4324,1,10357,High-Rise Structures,Colaco,Joseph P,1,3,6,0,0,0,0,2.401
+Spring 2024,ARCH,6324,1,10358,High Rise Structures,Colaco,Joseph P,7,2,0,0,0,0,0,3.594
+Spring 2024,AAS,2320,2,10360,Intro To African American Stdy,Shakir,Ameenah,15,11,9,0,4,0,1,2.787
+Spring 2024,ACCT,2301,1,10362,Prin of Financial Accounting,Zhu,Limin,17,28,19,11,1,0,9,2.784
+Spring 2024,ACCT,3368,1,10364,Intermediate Accounting II,Sun,Xue,9,13,11,1,0,0,1,2.911
+Spring 2024,ACCT,4331,1,10365,Federal Income Tax,Fernandez,Ramon,13,21,12,1,0,0,1,3.084
+Spring 2024,ACCT,4331,2,10366,Federal Income Tax,Small,Randolph Christopher,17,8,1,0,0,0,0,3.615
+Spring 2024,ACCT,4396,1,10367,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,25,0,
+Spring 2024,ACCT,5330,1,10368,Advanced Accounting,Ramaswamy,Vinita,2,0,0,0,0,0,0,3.835
+Spring 2024,ACCT,5337,1,10369,Management Accounting,Serrato,Darlene Marie  Bohac,6,1,2,0,0,0,1,3.444
+Spring 2024,ACCT,5368,1,10370,Intermediate Accounting II,Kraten,Michael,6,5,0,0,0,0,0,3.545
+Spring 2024,ACCT,6331,1,10371,Financial Accounting,Li,Bin,18,8,1,0,0,0,0,3.581
+Spring 2024,ACCT,7330,1,10372,Advanced Accounting,Ramaswamy,Vinita,6,3,0,0,0,0,0,3.74
+Spring 2024,ACCT,7330,2,10373,Advanced Accounting,Ramaswamy,Vinita,1,1,0,0,0,0,0,3.665
+Spring 2024,ACCT,7340,1,10374,Financial Statement Analysis,Crawford,Steven,4,8,0,0,0,0,0,3.443
+Spring 2024,ACCT,7340,2,10375,Financial Statement Analysis,Crawford,Steven,7,3,0,0,1,0,0,3.394
+Spring 2024,ACCT,8699,1,10376,Doctoral Dissertation,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Spring 2024,AFSC,1202,1,10378,Foundations of the USAF II,Bolarinwa,Feyisade,10,1,0,0,0,0,1,3.849
+Spring 2024,AFSC,1202,2,10379,Foundations of the USAF II,Bolarinwa,Feyisade,9,0,0,0,0,0,2,3.963
+Spring 2024,AFSC,2202,1,10381,Evolution of Air Power II,O'Connor,Anthony,4,0,0,0,0,0,1,3.918
+Spring 2024,AFSC,2202,2,10382,Evolution of Air Power II,O'Connor,Anthony,6,0,0,0,0,0,2,3.835
+Spring 2024,AFSC,3302,1,10384,Air Force Leadership II,Williams,Randi,5,1,0,0,0,0,0,3.833
+Spring 2024,ANTH,2346,1,10386,Introduction to Anthropology,Routon,Erin Danielle,65,13,2,3,0,0,6,3.659
+Spring 2024,ANTH,2351,1,10387,Intro to Cultural Anthropology,Hannaford,Dinah Rebecca,19,8,3,0,1,0,1,3.366
+Spring 2024,ANTH,2302,1,10388,Introduction to Archeology,Raymond,Amy Lynn,13,16,8,1,3,0,3,2.83
+Spring 2024,ANTH,4310,1,10389,Theories of Culture,Small,Ivan Victor,18,7,1,0,0,0,0,3.628
+Spring 2024,ANTH,7399,4,10393,Masters Thesis,Hannaford,Dinah Rebecca,1,0,0,0,0,0,0,4.0
+Spring 2024,ARAB,1502,1,10394,Beginning Arabic II,Hefter,Thomas H,2,3,3,0,0,0,0,2.916
+Spring 2024,ARAB,2312,1,10395,Intermediate Arabic II,Sayyid,Huda,9,1,1,0,0,0,1,3.697
+Spring 2024,ARCH,1501,1,10396,Arc/Int Arc Design Studio II,Gonzales,Michael A,8,4,1,0,0,0,1,3.462
+Spring 2024,ARCH,1501,5,10398,Arc/Int Arc Design Studio II,Plauche',Roya,6,8,0,0,0,0,0,3.476
+Spring 2024,ARCH,1501,7,10400,Arc/Int Arc Design Studio II,Wienert,Ross George,9,2,2,1,0,0,0,3.31
+Spring 2024,ARCH,1501,9,10402,Arc/Int Arc Design Studio II,Lutz,Shawn M,6,4,3,0,0,0,0,3.307
+Spring 2024,ARCH,2351,1,10404,Hist of the Built Environmt II,Ramaswamy,Deepa,68,59,8,7,2,0,4,3.195
+Spring 2024,ARCH,2501,1,10411,Architecture Design Studio IV,Perez Lopez,Elena Maria,5,3,4,0,0,0,1,2.973
+Spring 2024,ARCH,2501,3,10413,Architecture Design Studio IV,Jacobs,Daniel,6,5,2,0,1,0,0,3.048
+Spring 2024,ARCH,3347,1,10417,Evolution of Arch Interiors,Thomas,James B,18,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,3501,1,10418,Architecture Design Studio VI,Self,Ronnie L,10,4,0,0,1,0,0,3.357
+Spring 2024,ARCH,3501,5,10420,Architecture Design Studio VI,Lutz,Shawn M,8,6,0,2,0,0,0,3.209
+Spring 2024,ARCH,4351,1,10424,Readings & Criticism in Arch,Turner,Drexel,10,3,2,0,0,0,0,3.445
+Spring 2024,ARCH,4355,1,10425,Houston Architecture,Fox,Stephen,9,4,0,0,0,0,2,3.565
+Spring 2024,ARCH,4367,1,10426,Case Studies in Sustain Design,Taylor,Rives,11,6,0,0,0,0,0,3.569
+Spring 2024,ARCH,6341,1,10429,Architectural Hist Survey II,Ramaswamy,Deepa,6,4,0,0,0,0,0,3.567
+Spring 2024,ARCH,6351,1,10431,Criticism in Architecture,Turner,Drexel,3,0,0,0,0,0,0,3.89
+Spring 2024,ARCH,6360,1,10432,Practice of Arch,Jacobs,Daniel,7,16,0,0,0,0,0,3.405
+Spring 2024,ARCH,6604,1,10433,Architecture Design Studio IV,Zamore,Brett Elliot,7,4,0,0,0,0,0,3.576
+Spring 2024,ARCH,6604,3,10435,Architecture Design Studio IV,Hager,Jesse,5,4,0,0,1,0,0,3.2
+Spring 2024,ARCH,7601,1,10437,Architecture Design Studio VI,Borden,Gail,7,1,0,0,0,0,0,3.834
+Spring 2024,BCHS,3201,1,10439,Biochemistry I Laboratory,Pattison,Donna,13,10,1,0,0,0,0,3.459
+Spring 2024,BCHS,3201,2,10440,Biochemistry I Laboratory,Pattison,Donna,9,3,1,0,0,0,0,3.565
+Spring 2024,BCHS,3201,3,10441,Biochemistry I Laboratory,Pattison,Donna,6,5,5,0,1,0,4,2.844
+Spring 2024,BCHS,3305,1,10443,General Biochemistry II,Fujita,Masaya,14,12,5,1,0,0,4,3.208
+Spring 2024,BCHS,4399,1,10446,Senior Honors Thesis,Widger,William R,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,6113,1,10447,Graduate Biochemistry Seminar,Amaral Antunes,Dinler,0,0,0,0,0,27,0,
+Spring 2024,BCHS,6231,1,10448,Grad Biochem Lab Rotation II,Widger,William R,3,1,0,0,0,0,0,3.833
+Spring 2024,BIOE,6111,1,10452,Grad Bioengineering Seminar,Larin,Kirill,0,0,0,0,0,59,0,
+Spring 2024,BIOL,2102,1,10453,Anatomy & Physiology II (lab),Gill,Tejendra,6,15,3,0,0,0,0,3.153
+Spring 2024,BIOL,2102,2,10454,Anatomy & Physiology II (lab),Gill,Tejendra,10,11,2,1,0,0,0,3.278
+Spring 2024,BIOL,2102,3,10455,Anatomy & Physiology II (lab),Gill,Tejendra,5,19,0,0,0,0,0,3.291
+Spring 2024,BIOL,2102,4,10456,Anatomy & Physiology II (lab),Gill,Tejendra,10,8,3,0,1,0,1,3.197
+Spring 2024,BIOL,2102,5,10457,Anatomy & Physiology II (lab),Gill,Tejendra,7,14,1,0,0,0,1,3.408
+Spring 2024,BIOL,2102,6,10458,Anatomy & Physiology II (lab),Gill,Tejendra,7,14,2,0,0,0,0,3.203
+Spring 2024,BIOL,2102,7,10459,Anatomy & Physiology II (lab),Gill,Tejendra,12,6,3,1,0,0,1,3.303
+Spring 2024,BIOL,2102,8,10460,Anatomy & Physiology II (lab),Gill,Tejendra,7,13,2,0,0,0,2,3.197
+Spring 2024,BIOL,2102,9,10461,Anatomy & Physiology II (lab),Gill,Tejendra,11,8,3,1,0,0,1,3.29
+Spring 2024,BIOL,2102,10,10462,Anatomy & Physiology II (lab),Gill,Tejendra,6,12,4,0,1,0,1,2.913
+Spring 2024,BIOL,1107,1,10463,Biology for Science Majors II,Medrano,Ana I,18,4,1,0,0,0,0,3.768
+Spring 2024,BIOL,1107,2,10464,Biology for Science Majors II,Medrano,Ana I,18,2,2,0,0,0,1,3.727
+Spring 2024,BIOL,1107,3,10465,Biology for Science Majors II,Medrano,Ana I,19,2,2,1,0,0,0,3.639
+Spring 2024,BIOL,1107,4,10466,Biology for Science Majors II,Medrano,Ana I,18,4,0,0,2,0,0,3.514
+Spring 2024,BIOL,1107,5,10467,Biology for Science Majors II,Medrano,Ana I,21,1,0,0,1,0,0,3.783
+Spring 2024,BIOL,1107,6,10468,Biology for Science Majors II,Medrano,Ana I,16,6,0,0,0,0,2,3.742
+Spring 2024,BIOL,1107,7,10469,Biology for Science Majors II,Medrano,Ana I,18,3,0,1,1,0,1,3.479
+Spring 2024,BIOL,1107,8,10470,Biology for Science Majors II,Medrano,Ana I,9,12,1,0,1,0,1,3.203
+Spring 2024,BIOL,1107,9,10471,Biology for Science Majors II,Medrano,Ana I,22,1,0,0,0,0,1,3.971
+Spring 2024,BIOL,1107,10,10472,Biology for Science Majors II,Medrano,Ana I,18,1,1,0,2,0,1,3.485
+Spring 2024,BIOL,1107,11,10473,Biology for Science Majors II,Medrano,Ana I,21,3,0,0,0,0,0,3.875
+Spring 2024,BIOL,1107,12,10474,Biology for Science Majors II,Medrano,Ana I,20,1,2,0,0,0,1,3.754
+Spring 2024,BIOL,1107,13,10475,Biology for Science Majors II,Medrano,Ana I,19,1,0,0,0,0,1,3.917
+Spring 2024,BIOL,1107,14,10476,Biology for Science Majors II,Medrano,Ana I,22,0,0,0,0,0,1,4.0
+Spring 2024,BIOL,1107,15,10477,Biology for Science Majors II,Medrano,Ana I,22,1,1,0,0,0,0,3.889
+Spring 2024,BIOL,1107,16,10478,Biology for Science Majors II,Medrano,Ana I,19,4,0,0,0,0,1,3.826
+Spring 2024,BIOL,1107,17,10479,Biology for Science Majors II,Medrano,Ana I,18,5,1,0,0,0,0,3.695
+Spring 2024,BIOL,1107,18,10480,Biology for Science Majors II,Medrano,Ana I,21,2,0,1,0,0,0,3.778
+Spring 2024,BIOL,1107,19,10481,Biology for Science Majors II,Medrano,Ana I,17,3,3,1,0,0,0,3.459
+Spring 2024,BIOL,1107,20,10482,Biology for Science Majors II,Medrano,Ana I,11,8,2,1,1,0,1,3.131
+Spring 2024,BIOL,1107,21,10483,Biology for Science Majors II,Medrano,Ana I,17,2,2,1,1,0,1,3.406
+Spring 2024,BIOL,1107,22,10484,Biology for Science Majors II,Medrano,Ana I,22,2,0,0,0,0,0,3.903
+Spring 2024,BIOL,2301,1,10485,Anatomy & Physiology I (lect),Wayne,Chad M,35,75,101,15,32,0,78,2.243
+Spring 2024,BIOL,2302,1,10486,Anatomy & Physiology II (lect),Gill,Tejendra,70,198,72,3,8,0,13,2.879
+Spring 2024,BIOL,1307,1,10487,Biology for Science Majors II,Medrano,Ana I,28,36,29,15,6,0,17,2.596
+Spring 2024,BIOL,1307,2,10488,Biology for Science Majors II,Cheek,Ann Oliver,122,111,30,11,6,0,3,3.226
+Spring 2024,BIOL,1307,4,10489,Biology for Science Majors II,Farmer,Lisa M,61,113,67,28,11,0,4,2.637
+Spring 2024,BIOL,3306,1,10490,Evolutionary Biology,Frankino,William A,45,64,39,14,5,0,7,2.769
+Spring 2024,BIOL,3324,1,10491,Human Physiology,Ogletree-Hughes,Monique L,41,32,32,15,8,0,17,2.669
+Spring 2024,BIOL,3341,1,10492,Human Genetics,Feng,Qin,55,15,4,0,0,0,2,3.694
+Spring 2024,BIOL,4347,1,10502,Animal Behavior,Cole,Blaine J,14,12,20,5,0,0,5,2.622
+Spring 2024,BIOL,6110,1,10505,Biology Seminar,Sater,Amy,0,0,0,0,0,10,0,
+Spring 2024,BIOL,7167,1,10506,Population Biology Seminar,Stuckert,Adam,0,0,0,0,0,16,0,
+Spring 2024,CHEE,2332,1,10509,Chem Engr Thermodyn I,Palmer,Jeremy,19,13,3,1,0,0,5,3.361
+Spring 2024,CHEE,3300,1,10510,Materials Science & Engr I,Karim,Alamgir,31,9,1,0,0,0,0,3.643
+Spring 2024,CHEE,3367,1,10511,Process Modeling and Control,Kaspar,Michael,10,23,7,0,0,0,1,3.1
+Spring 2024,CHEE,3369,1,10512,Chemical Engr Transport Proc,Bollini,Praveen P,18,18,6,0,0,0,1,3.309
+Spring 2024,CHEE,3466,1,10513,Bio & Physical Chemistry,Orman,Mehmet,38,4,1,0,0,0,0,3.761
+Spring 2024,CHEE,4361,1,10514,Chemical Engineering Practices,Cirino,Patrick C,10,28,2,0,0,0,0,3.184
+Spring 2024,CHEE,6111,1,10517,Graduate Seminar,Mountziaris,Triantafillos John,0,0,0,0,0,87,0,
+Spring 2024,CHEE,6337,1,10518,Advanced Reactor Engr,Mountziaris,Triantafillos John,15,5,0,0,0,0,0,3.734
+Spring 2024,CHEE,8399,1,10520,Doctoral Dissertation,Balakotaiah,Vemuri,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8399,2,10521,Doctoral Dissertation,Bollini,Praveen P,5,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8399,3,10522,Doctoral Dissertation,Cirino,Patrick C,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8399,4,10523,Doctoral Dissertation,Conrad,Jacinta C,0,0,0,0,0,4,0,
+Spring 2024,CHEE,8399,5,10524,Doctoral Dissertation,Donnelly,Vincent M,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8399,7,10526,Doctoral Dissertation,Grabow,Lars C,0,0,0,0,0,4,0,
+Spring 2024,CHEE,8399,8,10527,Doctoral Dissertation,Harold,Michael P,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8399,9,10528,Doctoral Dissertation,Karim,Alamgir,5,0,0,0,0,1,0,4.0
+Spring 2024,CHEE,8399,10,10529,Doctoral Dissertation,Krishnamoorti,Ramanan,1,0,0,0,0,1,0,4.0
+Spring 2024,CHEE,8399,12,10531,Doctoral Dissertation,Orman,Mehmet,4,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8399,13,10532,Doctoral Dissertation,Palmer,Jeremy,3,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8399,14,10533,Doctoral Dissertation,Rimer,Jeffrey,0,0,0,0,0,9,0,
+Spring 2024,CHEM,1105,1,10534,Foundations of Chem Lab,Zaitsev,Vladimir G,4,11,3,0,0,0,0,3.056
+Spring 2024,CHEM,1105,2,10535,Foundations of Chem Lab,Zaitsev,Vladimir G,3,13,1,0,0,0,0,3.118
+Spring 2024,CHEM,1111,1,10536,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,3,0,0,0,1,3.098
+Spring 2024,CHEM,1111,3,10537,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,16,1,0,0,0,0,3.199
+Spring 2024,CHEM,1111,4,10538,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,2,0,0,0,1,3.158
+Spring 2024,CHEM,1111,5,10539,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,2,0,0,0,1,3.196
+Spring 2024,CHEM,1111,6,10540,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,1,0,0,0,0,3.277
+Spring 2024,CHEM,1111,7,10541,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,0,0,1,0,1,3.052
+Spring 2024,CHEM,1111,9,10542,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,12,4,0,0,0,2,2.921
+Spring 2024,CHEM,1111,10,10543,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,2,0,0,0,2,3.188
+Spring 2024,CHEM,1111,11,10544,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,2,0,0,0,2,3.089
+Spring 2024,CHEM,1111,17,10545,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,2,0,2,0,3,2.667
+Spring 2024,CHEM,1112,1,10546,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,16,2,0,0,0,1,2.999
+Spring 2024,CHEM,1112,2,10547,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,14,2,0,0,0,0,3.087
+Spring 2024,CHEM,1112,3,10548,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,2,0,0,0,3,3.178
+Spring 2024,CHEM,1112,4,10549,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,9,2,0,1,0,2,3.053
+Spring 2024,CHEM,1112,7,10550,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,1,0,0,1,3.122
+Spring 2024,CHEM,1112,8,10551,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,11,0,0,0,0,1,3.261
+Spring 2024,CHEM,1112,9,10552,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,1,0,1,0,1,2.982
+Spring 2024,CHEM,1112,10,10553,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,14,2,0,1,0,0,2.917
+Spring 2024,CHEM,1112,12,10554,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,16,1,0,0,0,2,3.092
+Spring 2024,CHEM,1112,13,10555,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,3,0,0,0,1,3.098
+Spring 2024,CHEM,1112,14,10556,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,11,1,0,0,0,0,3.316
+Spring 2024,CHEM,1112,15,10557,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,1,0,0,0,1,3.259
+Spring 2024,CHEM,1112,16,10558,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,7,3,2,0,0,3,2.854
+Spring 2024,CHEM,1112,17,10559,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,9,3,0,0,0,1,2.976
+Spring 2024,CHEM,1112,18,10560,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,11,0,0,0,0,1,3.295
+Spring 2024,CHEM,1112,19,10561,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,15,0,0,0,0,0,3.234
+Spring 2024,CHEM,1112,20,10562,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,2,0,0,0,1,3.227
+Spring 2024,CHEM,1112,22,10563,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,13,1,0,0,0,1,3.245
+Spring 2024,CHEM,1112,23,10564,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,6,3,1,0,0,2,3.098
+Spring 2024,CHEM,1112,25,10565,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,1,0,1,0,2,2.999
+Spring 2024,CHEM,1311,2,10566,Fundamentals of Chemistry,Larsen,Russell Gene,52,74,102,7,24,0,41,2.451
+Spring 2024,CHEM,1312,1,10567,Fundamentals of Chemistry 2,Halasyamani,P Shiv,17,24,25,9,14,0,26,2.203
+Spring 2024,CHEM,1312,2,10568,Fundamentals of Chemistry 2,Larsen,Russell Gene,134,144,138,24,42,0,54,2.615
+Spring 2024,CHEM,3119,1,10569,Anlytical Chemistry Lab,Czader,Arkadiusz,4,2,1,0,1,0,0,2.918
+Spring 2024,CHEM,2123,1,10570,Organic Chemistry Lab I,Bean,Mary B,4,8,9,1,0,0,2,2.712
+Spring 2024,CHEM,2123,2,10571,Organic Chemistry Lab I,Bean,Mary B,2,10,9,1,0,0,1,2.516
+Spring 2024,CHEM,2123,4,10572,Organic Chemistry Lab I,Bean,Mary B,4,12,5,0,0,0,2,2.89
+Spring 2024,CHEM,2123,5,10573,Organic Chemistry Lab I,Bean,Mary B,4,4,7,4,0,0,3,2.473
+Spring 2024,CHEM,2123,6,10574,Organic Chemistry Lab I,Bean,Mary B,6,9,4,1,0,0,1,2.967
+Spring 2024,CHEM,2123,7,10575,Organic Chemistry Lab I,Bean,Mary B,4,11,7,2,0,0,0,2.681
+Spring 2024,CHEM,2123,10,10576,Organic Chemistry Lab I,Bean,Mary B,1,10,8,0,0,0,0,2.493
+Spring 2024,CHEM,2123,11,10577,Organic Chemistry Lab I,Bean,Mary B,1,5,12,0,0,0,1,2.426
+Spring 2024,CHEM,2123,12,10578,Organic Chemistry Lab I,Bean,Mary B,1,9,5,0,0,0,4,2.755
+Spring 2024,CHEM,2123,14,10579,Organic Chemistry Lab I,Bean,Mary B,3,10,1,1,1,0,6,2.833
+Spring 2024,CHEM,2125,1,10580,Organic Chemistry Lab II,Bean,Mary B,3,8,12,0,0,0,1,2.666
+Spring 2024,CHEM,2125,2,10581,Organic Chemistry Lab II,Bean,Mary B,5,9,8,0,0,0,0,2.819
+Spring 2024,CHEM,2125,3,10582,Organic Chemistry Lab II,Bean,Mary B,5,4,8,1,0,0,3,2.686
+Spring 2024,CHEM,2125,4,10583,Organic Chemistry Lab II,Bean,Mary B,5,7,5,4,0,0,2,2.572
+Spring 2024,CHEM,2125,6,10584,Organic Chemistry Lab II,Bean,Mary B,3,9,9,1,0,0,1,2.726
+Spring 2024,CHEM,2125,8,10585,Organic Chemistry Lab II,Bean,Mary B,5,7,8,2,0,0,1,2.667
+Spring 2024,CHEM,2125,9,10586,Organic Chemistry Lab II,Bean,Mary B,8,7,6,2,1,0,0,2.75
+Spring 2024,CHEM,2125,10,10587,Organic Chemistry Lab II,Bean,Mary B,6,9,5,1,0,0,1,2.795
+Spring 2024,CHEM,2125,11,10588,Organic Chemistry Lab II,Bean,Mary B,4,6,8,1,0,0,1,2.667
+Spring 2024,CHEM,2125,13,10589,Organic Chemistry Lab II,Bean,Mary B,4,8,7,2,0,0,2,2.698
+Spring 2024,CHEM,2125,14,10590,Organic Chemistry Lab II,Bean,Mary B,3,12,8,0,0,0,0,2.74
+Spring 2024,CHEM,2125,15,10591,Organic Chemistry Lab II,Bean,Mary B,3,9,8,0,0,0,0,2.668
+Spring 2024,CHEM,2125,16,10592,Organic Chemistry Lab II,Bean,Mary B,7,9,6,0,0,0,1,2.94
+Spring 2024,CHEM,2125,17,10593,Organic Chemistry Lab II,Bean,Mary B,4,11,7,1,0,0,0,2.725
+Spring 2024,CHEM,2323,1,10594,Organic Chemistry I,Daugulis,Olafs,52,49,53,60,25,0,63,2.161
+Spring 2024,CHEM,2323,2,10595,Organic Chemistry I,Cai,Chengzhi,28,26,30,30,18,0,40,2.064
+Spring 2024,CHEM,2325,2,10596,Organic Chemistry II,Bean,Mary B,29,46,70,23,15,0,33,2.243
+Spring 2024,CHEM,2325,1,10597,Organic Chemistry II,Bean,Mary B,45,69,99,31,16,0,39,2.353
+Spring 2024,CHEM,3369,1,10598,Analytical Chemistry 1,Czader,Arkadiusz,5,11,4,3,3,0,0,2.423
+Spring 2024,CHEM,3396,1,10599,Senior Research Project,Daugulis,Olafs,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,6111,1,10602,Graduate Colloquium,Chiang,Naihao,0,0,0,0,0,26,0,
+Spring 2024,CHEM,6112,1,10603,Graduate Seminar,Brgoch,Jakoah,0,0,0,0,0,10,0,
+Spring 2024,CHEM,6112,2,10604,Graduate Seminar,Chiang,Naihao,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6112,3,10605,Graduate Seminar,Gilbertson,Scott R,0,0,0,0,0,13,0,
+Spring 2024,CHEM,6115,1,10606,Sem in Chm Lab Instruct,Zaitsev,Vladimir G,0,0,0,0,0,6,0,
+Spring 2024,CHEM,6115,2,10607,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,2,0,
+Spring 2024,CHEM,8399,3,10647,Doctoral Dissertation,May,Jeremy A,0,0,0,0,0,1,0,
+Spring 2024,CHEM,8999,6,10688,Doctoral Dissertation,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,8999,13,10695,Doctoral Dissertation,Lee,T Randall,0,0,0,0,0,2,0,
+Spring 2024,CHEM,8999,15,10697,Doctoral Dissertation,May,Jeremy A,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,8999,17,10699,Doctoral Dissertation,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Spring 2024,CIVE,3337,1,10703,Structural Analysis,Herman,Reagan,6,3,7,0,0,0,0,2.814
+Spring 2024,CIVE,4369,1,10704,Foundation Engineering,Vipulanandan,Cumaraswamy,18,42,2,0,0,0,0,3.247
+Spring 2024,CIVE,8399,4,10705,Doctoral Dissertation,Rodrigues,Debora Frigi,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8399,8,10706,Doctoral Dissertation,Wang,Keh-Han,0,0,0,0,0,1,0,
+Spring 2024,COMD,6321,1,10708,Swallowing Disorders,Daniels,Stephanie K,15,26,8,0,0,0,0,3.129
+Spring 2024,COMD,7391,1,10710,Clinic in Speech Lang Disorder,Chapman,Amanda,3,0,0,0,0,0,0,3.67
+Spring 2024,COMD,7391,7,10711,Clinic in Speech Lang Disorder,Hoppe,Martha Ann,3,0,0,0,0,0,0,3.78
+Spring 2024,COMD,7391,9,10713,Clinic in Speech Lang Disorder,Devore,Danielle R,3,0,0,0,0,0,0,3.67
+Spring 2024,COMD,7391,10,10714,Clinic in Speech Lang Disorder,Devore,Danielle R,3,0,0,0,0,0,0,3.89
+Spring 2024,COMD,7391,11,10715,Clinic in Speech Lang Disorder,Devore,Danielle R,3,0,0,0,0,0,0,3.78
+Spring 2024,COMD,7392,8,10716,Adv Pract Sp & Lang Dis,Townsend,Alayna,2,1,0,0,0,0,0,3.777
+Spring 2024,COMD,7392,2,10717,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,2,1,0,0,0,0,0,3.667
+Spring 2024,COMM,1302,1,10720,Intro To Comm Theory,Lee,Jaesub,9,16,17,0,6,0,3,2.451
+Spring 2024,COMM,2300,1,10721,Communication Research Methods,Lyn,Robyn,15,5,3,3,4,0,5,2.866
+Spring 2024,COMM,3311,1,10723,Editing Print & Digital Media,Crixell,Charles A,13,11,1,0,0,0,0,3.546
+Spring 2024,COMM,3314,1,10724,Intermediate Reporting,Roth,Geoffrey,23,3,1,0,0,0,1,3.741
+Spring 2024,COMM,3316,1,10726,Electronic News,Platenburg,Gheni Nicole,9,4,3,1,0,0,3,3.196
+Spring 2024,COMM,3326,1,10728,Graphics Applications,Economou-Clarke,Ann M,27,7,0,0,0,0,0,3.784
+Spring 2024,COMM,3361,1,10730,Advertising Copywriting,Tinnel,Jason Wayne,13,17,4,0,0,0,1,3.245
+Spring 2024,COMM,3369,1,10731,Strategic Comm. Writing,Williams,Uniqua Janae,23,9,3,0,0,0,1,3.496
+Spring 2024,COMM,3370,1,10732,History of Cinema,Houk,Keith R,42,16,5,1,2,0,0,3.399
+Spring 2024,COMM,3380,1,10733,Electronic Field Production,Crowe,Craig Warren,7,9,4,0,0,0,1,3.101
+Spring 2024,COMM,3382,1,10735,TV II & Sports Production,Crowe,Craig Warren,4,8,6,0,0,0,1,2.962
+Spring 2024,COMM,4303,2,10739,Communication Law and Ethics,Kirkland,Steven Earl,76,8,1,0,4,0,0,3.7
+Spring 2024,COMM,4361,1,10740,Adv. Campaign Competition,Tinnel,Jason Wayne,19,0,0,0,0,0,0,3.931
+Spring 2024,COMM,6371,1,10742,Public Relations Theory,Vardeman,Jennifer E,6,0,0,0,0,0,0,3.835
+Spring 2024,COSC,3340,1,10750,Intro. to Automata and Comp.,Leiss,Ernst L,25,94,25,8,4,0,13,2.831
+Spring 2024,COSC,3360,2,10751,Operating Systems,Paris,Jehan-Francois,32,45,20,5,5,0,11,2.801
+Spring 2024,COSC,4351,1,10752,Fundamentals of Software Engr,Hilford,Victoria,70,34,14,0,0,0,1,3.438
+Spring 2024,COSC,6110,1,10753,Graduate Colloquium,Leiss,Ernst L,0,0,0,0,0,3,0,
+Spring 2024,CUIN,3310,1,10754,Bilingual Education,Leon,Maredil Josefina,10,2,0,0,0,0,0,3.778
+Spring 2024,CUIN,7337,1,10755,Current Issues/Soc Stud,Brower,Samuel Richard,6,0,0,0,1,0,0,3.429
+Spring 2024,ECE,2100,2,10757,Circuit Analysis Laboratory,Trombetta,Leonard P,16,12,3,1,0,0,1,3.364
+Spring 2024,ECE,2201,1,10758,Circuit Analysis I,Shattuck,David P,8,11,20,4,1,0,11,2.492
+Spring 2024,ECE,3318,1,10759,Applied Elec & Magnetism,Jackson,David R,11,9,5,1,0,0,1,3.052
+Spring 2024,ECE,3331,1,10760,Program Appl in Elec Comp Engr,Hebert,Thomas James,15,22,24,4,0,0,15,2.764
+Spring 2024,ECE,3364,1,10761,Circuits and Systems,Hebert,Thomas James,11,12,15,0,0,0,5,2.886
+Spring 2024,ECE,3456,1,10762,Analog Electronics,Aksu,Gulin Tulunay,13,12,10,0,0,0,1,2.973
+Spring 2024,ECE,4115,1,10763,Control Systems Laboratory I,Provence,Robert S,4,10,5,0,0,0,1,2.878
+Spring 2024,ECE,4375,1,10764,Automatic Control Systems,Provence,Robert S,7,6,12,0,0,0,0,2.708
+Spring 2024,ECE,5318,1,10765,Antenna Engineering,Long,Stuart A,1,2,0,0,0,0,1,3.333
+Spring 2024,ECE,5440,1,10766,Advanced Digital Design,Chen,Yuhua,41,1,0,0,0,0,0,3.953
+Spring 2024,ECE,6111,1,10767,Graduate Research Seminar,Shan,Xiaonan,0,0,0,0,0,0,1,
+Spring 2024,ECE,6352,1,10769,Antenna Engineering,Long,Stuart A,3,1,0,0,0,0,0,3.503
+Spring 2024,ECE,6364,1,10770,Digital Imag Processing,Hebert,Thomas James,3,0,0,0,0,0,0,3.89
+Spring 2024,ECE,6370,1,10771,Advanced Digital Design,Chen,Yuhua,27,1,1,0,0,0,1,3.862
+Spring 2024,ECE,6399,13,10784,Masters Thesis,Li,Xingpeng,0,0,0,0,0,1,0,
+Spring 2024,ECE,6399,26,10797,Masters Thesis,Krishnamoorthy,Harish Sarma,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8399,2,10804,Doctoral Dissertation,Litvinov,Dmitri,0,0,0,0,0,0,0,
+Spring 2024,ECE,8399,10,10812,Doctoral Dissertation,Han,Zhu,3,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8399,12,10814,Doctoral Dissertation,Fu,Xin,2,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8399,13,10815,Doctoral Dissertation,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2024,ECE,8399,15,10817,Doctoral Dissertation,Roysam,Badrinath,0,0,0,0,0,0,0,
+Spring 2024,ECE,8399,17,10819,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Spring 2024,ECE,8399,19,10821,Doctoral Dissertation,Shih,Wei-Chuan,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8399,21,10823,Doctoral Dissertation,Le,Hung Quang,0,0,0,0,0,1,0,
+Spring 2024,ECE,8399,24,10826,Doctoral Dissertation,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2024,ECE,8399,25,10827,Doctoral Dissertation,Li,Xingpeng,0,0,0,0,0,1,0,
+Spring 2024,ECE,8399,27,10829,Doctoral Dissertation,Mayerich,David Matthew,1,0,0,0,0,1,0,4.0
+Spring 2024,ECE,8399,29,10831,Doctoral Dissertation,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2024,ECE,8399,30,10832,Doctoral Dissertation,Brankovic,Stanko R,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8399,31,10833,Doctoral Dissertation,Contreras-Vidal,Jose Luis,2,0,0,0,0,2,0,4.0
+Spring 2024,ECE,8399,32,10834,Doctoral Dissertation,Chen,Ji,2,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8399,34,10835,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,2,0,
+Spring 2024,ECE,8399,35,10836,Doctoral Dissertation,Shireen,Wajiha,2,0,0,0,0,0,0,3.835
+Spring 2024,ECE,8699,3,10839,Doctoral Dissertation,Shih,Wei-Chuan,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8699,7,10843,Doctoral Dissertation,Rajashekara,Kaushik,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8999,1,10844,Doctoral Dissertation,Pan,Miao,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,2302,1,10845,Principles of Microeconomics,Hossain,Md Shahadath,198,198,41,0,4,0,5,3.282
+Spring 2024,ECON,2301,3,10848,Principles of Macroeconomics,Vidogbena,Yabo Gwladys,11,24,14,2,2,0,2,2.692
+Spring 2024,ECON,3332,2,10849,Intermediate Microeconomics,Saboury,Piruz,8,11,7,2,2,0,3,2.645
+Spring 2024,ECON,3334,1,10850,Intermediate Macroeconomics,Thornton,Rebecca Achee,6,10,7,7,4,0,5,2.138
+Spring 2024,ECON,3370,1,10851,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,9,7,7,2,1,0,3,2.77
+Spring 2024,ECON,7342,1,10852,Microeconomic Theory II,Maheshri,Vikram,3,7,0,0,0,0,0,3.333
+Spring 2024,ECON,8362,1,10853,Workshop Research Methods IV,Juhn,Chinhui,7,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8399,2,10854,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,1,0,
+Spring 2024,ECON,8399,3,10855,Doctoral Dissertation,Cubas Norando,German,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8399,4,10856,Doctoral Dissertation,Nygaard,Vegard Mokleiv,0,0,0,0,0,1,0,
+Spring 2024,ECON,8399,6,10858,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,3,0,
+Spring 2024,EDUC,4315,1,10859,Student Teaching Sec,Culpepper,Shea Mosley,13,0,0,0,0,0,1,3.949
+Spring 2024,EDUC,4317,1,10860,Student Tch Art Sec,Culpepper,Shea Mosley,4,0,0,0,0,0,0,4.0
+Spring 2024,EDUC,4318,1,10861,Student Tch Music Elem,McGinnis,Emily Jane,19,2,1,0,0,0,0,3.863
+Spring 2024,EDUC,4319,1,10862,Student Tch Music Sec,McGinnis,Emily Jane,19,2,1,0,0,0,0,3.863
+Spring 2024,EDUC,4324,1,10863,Student Teaching Tech Middle,Thompson,Amber M,17,3,0,0,1,0,0,3.667
+Spring 2024,EDUC,4325,1,10864,Student Teaching 4-8 2Nd 7 Wks,Culpepper,Shea Mosley,27,0,0,0,0,0,0,3.963
+Spring 2024,ELED,3322,2,10865,Elem Reading Phonics Instructn,Alba,Celeste,17,0,0,0,0,0,0,3.922
+Spring 2024,ENGI,2304,11,10866,Technical Communications,Wilson,Chad A,17,2,0,0,0,0,0,3.895
+Spring 2024,ENGI,2304,1,10867,Technical Communications,Wilson,Chad A,10,2,1,1,0,0,0,3.453
+Spring 2024,ENGL,1301,11,10868,First Year Writing I,Bradley,Jari,3,2,4,2,7,0,6,1.464
+Spring 2024,ENGL,1301,12,10869,First Year Writing I,Abdelwahab,Maha Ahmed Ibraheem,13,2,0,0,3,0,3,3.222
+Spring 2024,ENGL,1302,1,10870,First Year Writing II,Anderson,Claire F,14,2,0,1,2,0,0,3.229
+Spring 2024,ENGL,1302,2,10871,First Year Writing II,Islam,Muhammad Nurul,18,1,0,0,0,0,0,3.861
+Spring 2024,ENGL,1302,3,10872,First Year Writing II,Niaz,Zarlasht,8,3,1,3,3,0,0,2.611
+Spring 2024,ENGL,1302,7,10873,First Year Writing II,Ornell,Colby,4,5,1,2,7,0,0,1.721
+Spring 2024,ENGL,1302,8,10874,First Year Writing II,Pogue,Donovan A,8,11,1,0,2,0,2,3.075
+Spring 2024,ENGL,1302,9,10875,First Year Writing II,Niaz,Zarlasht,1,4,3,2,5,0,1,1.6
+Spring 2024,ENGL,1302,10,10876,First Year Writing II,Woodward,Marshall B,7,4,1,0,0,0,5,3.473
+Spring 2024,ENGL,1302,14,10877,First Year Writing II,Downey,Carlton M,19,0,0,0,0,0,0,3.948
+Spring 2024,ENGL,1302,16,10878,First Year Writing II,Downey,Carlton M,15,1,1,1,1,0,0,3.491
+Spring 2024,ENGL,1302,23,10879,First Year Writing II,Lopez,Reese D,9,5,4,0,0,0,1,3.223
+Spring 2024,ENGL,1302,26,10880,First Year Writing II,Salome,Melanie Rebecca,3,9,5,0,1,0,1,2.741
+Spring 2024,ENGL,1302,27,10881,First Year Writing II,Colchado,Lea,7,5,2,2,3,0,0,2.596
+Spring 2024,ENGL,1302,28,10882,First Year Writing II,Khalil,Rand Omar,15,1,2,0,0,0,1,3.704
+Spring 2024,ENGL,1302,30,10883,First Year Writing II,Khalil,Rand Omar,15,2,1,0,1,0,0,3.562
+Spring 2024,ENGL,1302,57,10884,First Year Writing II,Rajkumar,Nidhi,16,2,1,1,3,0,2,3.131
+Spring 2024,ENGL,1302,60,10885,First Year Writing II,Mandia,Christopher Peter,15,3,3,2,1,0,1,3.14
+Spring 2024,ENGL,1302,77,10886,First Year Writing II,Garcia,Serena Mari,15,6,3,0,0,0,1,3.486
+Spring 2024,ENGL,1302,86,10887,First Year Writing II,Cervantes,Kimberly Ann,15,1,0,1,0,0,1,3.687
+Spring 2024,ENGL,1302,88,10888,First Year Writing II,Horton,Lara,8,4,6,0,1,0,0,2.791
+Spring 2024,ENGL,1302,91,10889,First Year Writing II,Bass,Kasey Dawn,17,0,0,0,1,0,0,3.631
+Spring 2024,ENGL,1302,98,10890,First Year Writing II,Moore,Kelly L,6,9,4,0,0,0,0,3.018
+Spring 2024,ENGL,1302,99,10891,First Year Writing II,Moore,Kelly L,10,8,0,0,0,0,0,3.556
+Spring 2024,ENGL,2307,2,10893,Intro To Drama,Singh,Kavita Ashana,6,5,3,2,1,0,10,2.804
+Spring 2024,ENGL,2361,1,10894,Western World Lit II--Honors,Barnes,Michael,5,2,0,0,0,0,0,3.667
+Spring 2024,ENGL,2361,2,10895,Western World Lit II--Honors,Barnes,Michael,3,1,0,0,0,0,0,3.75
+Spring 2024,ENGL,3330,1,10896,Beg Creative Writing-Fiction,Fretwell,Leah M,16,2,0,0,1,0,1,3.684
+Spring 2024,ENGL,4390,1,10897,Professional Internship,Zentz,Lauren R,0,0,0,0,0,4,0,
+Spring 2024,ENGL,4399,1,10898,Senior Honors Thesis,Lecourt,Sebastian Joseph,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8399,1,10899,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,2,0,
+Spring 2024,ENTR,3310,1,10900,Entrepreneurship,Ortega,Carlos Alberto,173,19,2,0,1,0,2,3.819
+Spring 2024,ENTR,3310,2,10901,Entrepreneurship,Ortega,Carlos Alberto,166,22,4,0,4,0,2,3.735
+Spring 2024,ENTR,3310,3,10902,Entrepreneurship,Wilbur,Stephen,125,113,29,8,1,0,3,3.235
+Spring 2024,ENTR,3312,1,10903,Corporate Entrepreneurship,Karonika,John R,35,10,1,0,2,0,1,3.473
+Spring 2024,ENTR,3312,3,10904,Corporate Entrepreneurship,Karonika,John R,27,11,5,0,1,0,4,3.364
+Spring 2024,ENTR,4320,1,10905,Entrepreneurial Revenue,Nordby,Jonathan,24,4,0,0,0,0,0,3.893
+Spring 2024,ENTR,4330,1,10906,Entrepreneurial Costs/Budgets,Blair,Edward A,10,18,0,0,0,0,0,3.263
+Spring 2024,ENTR,4360,1,10907,Business Plan & Implementation,Rassin,Keith David,24,3,0,0,0,0,1,3.901
+Spring 2024,FINA,3332,2,10908,Prin of Financial Management,Chisholm,Darla,30,47,56,37,13,0,23,2.199
+Spring 2024,FINA,3332,4,10909,Prin of Financial Management,Chisholm,Darla,12,23,25,17,14,0,17,2.007
+Spring 2024,FINA,4320,1,10910,Investment Management,Pederzoli,Paola,34,9,1,0,0,0,1,3.728
+Spring 2024,FINA,4350,1,10911,Derivatives I: Options,Rabinovitch,Ramon,8,5,2,1,1,0,1,3.078
+Spring 2024,FINA,4354,1,10912,Risk Management,Kapatos,Nick Gus,15,21,16,4,0,0,2,2.763
+Spring 2024,FINA,4358,1,10914,Commercial Property,Kapatos,Nick Gus,16,13,11,3,0,0,7,2.961
+Spring 2024,FINA,4359,1,10915,Energy Insurance and Risk Mgmt,Hughes,James F,23,10,1,1,0,0,0,3.543
+Spring 2024,FINA,8999,5,10925,Doctoral Dissertation,Yerramilli,Vijay,1,0,0,0,0,0,0,4.0
+Spring 2024,FREN,1501,1,10926,Elementary French I,Chalhoub,Rania Maria,5,3,3,1,0,0,2,2.918
+Spring 2024,FREN,1502,1,10930,Elementary French II,Gnanwo Hounfodji,Raymond,4,8,5,4,1,0,1,2.41
+Spring 2024,FREN,1502,7,10932,Elementary French II,Chalhoub,Rania Maria,6,7,5,1,0,0,0,2.861
+Spring 2024,FREN,2311,1,10934,Intermediate French I,Green,Viola V,3,3,0,0,1,0,2,2.764
+Spring 2024,FREN,2312,1,10935,Intermediate French II,Green,Viola V,3,6,4,1,0,0,0,2.809
+Spring 2024,GEOL,1103,2,10936,Physical Geology Lab,Hauptvogel,Daniel William,17,0,3,0,0,0,0,3.7
+Spring 2024,GEOL,1103,3,10937,Physical Geology Lab,Hauptvogel,Daniel William,11,6,1,1,1,0,0,3.217
+Spring 2024,GEOL,1103,4,10938,Physical Geology Lab,Hauptvogel,Daniel William,9,6,2,3,0,0,0,2.968
+Spring 2024,GEOL,1103,5,10939,Physical Geology Lab,Hauptvogel,Daniel William,7,6,0,0,0,0,0,3.361
+Spring 2024,GEOL,1103,6,10940,Physical Geology Lab,Hauptvogel,Daniel William,12,2,2,0,2,0,1,3.149
+Spring 2024,GEOL,3345,1,10941,Structural Geology,Murphy,Michael,11,8,1,0,0,0,0,3.451
+Spring 2024,GERM,1502,1,10943,Beginning German II,Bandmann,Tanya,8,7,1,0,1,0,2,3.235
+Spring 2024,GERM,2312,2,10945,Intermediate German II,Kleinheider,Julia D,3,4,5,0,0,0,0,2.861
+Spring 2024,HDFS,1300,1,10946,Dev of Contemporary Families,Jordan,Erica F,77,64,7,2,7,0,2,3.295
+Spring 2024,HDFS,3350,1,10950,Observation and Assessment,Schroder,Kathleen Anne,32,2,1,0,0,0,0,3.829
+Spring 2024,HDFS,4393,1,10952,Internship in HDFS,Conston,Toya,24,3,2,0,0,0,0,3.736
+Spring 2024,HIST,1302,50,10954,The U.S. Since 1877,Modaff,Abigail,22,2,0,1,1,0,0,3.565
+Spring 2024,HIST,3378,1,10955,The Modern Middle East,Al-Sowayel,Dina,18,4,3,4,4,0,3,2.828
+Spring 2024,HIST,8399,3,10957,Doctoral Dissertation,Young,Nancy Beck,0,0,0,0,0,1,0,
+Spring 2024,HIST,8699,2,10959,Doctoral Dissertation,Mizelle Jr,Richard M,0,0,0,0,0,1,0,
+Spring 2024,HIST,8999,2,10961,Doctoral Dissertation,Goldberg,Mark A,0,0,0,0,0,2,0,
+Spring 2024,HIST,8999,4,10963,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Spring 2024,HIST,8999,8,10965,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,3,0,
+Spring 2024,HIST,8999,12,10966,Doctoral Dissertation,Clavin,Matthew J,0,0,0,0,0,1,0,
+Spring 2024,HLT,1353,1,10967,Personal Health,Rafique,Kiran Sajid,108,12,1,0,0,0,0,3.843
+Spring 2024,HLT,3300,1,10968,Social Health and Wellness,Farmer,Jennifer,72,19,5,1,1,0,1,3.609
+Spring 2024,HLT,3301,1,10969,Health Behavior Theories,Correa-Fernandez,Virmarie,49,14,2,0,0,0,0,3.652
+Spring 2024,HON,2101,1,10972,The Human Situation:Modernity,Ferguson,Jamie H,201,85,8,0,3,0,4,3.556
+Spring 2024,HON,2101,2,10973,The Human Situation:Modernity,Mikics,David,132,74,12,0,4,0,8,3.445
+Spring 2024,HON,4399,1,10976,Senior Honors Thesis,Ventura,Gabriela Baeza,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,1301,1,10977,Hospitality Technology,Hernandez Calderon,Araceli,28,3,2,0,1,0,0,3.657
+Spring 2024,GHL,1337,1,10978,Intro To Hospitality Industry,Doudna,Simone P,26,3,0,0,3,0,2,3.511
+Spring 2024,GHL,2340,1,10979,System of Accts in Hospitality,DeFranco,Agnes L,18,18,10,3,0,0,1,3.014
+Spring 2024,GHL,1345,1,10980,"Safety, Sanitation in Hosp Ind",Beiza,Alberto,32,17,4,0,2,0,1,3.382
+Spring 2024,GHL,1367,1,10981,Lodging Management,Theis,Iuliana,17,9,5,3,0,0,2,3.176
+Spring 2024,GHL,3336,1,10983,Beverage Management,Rinck,Kristen Ann,27,5,2,0,0,0,1,3.677
+Spring 2024,GHL,3341,1,10984,Hospitality Managerial Acct,Johnson,Tucker A,13,7,1,1,0,0,0,3.305
+Spring 2024,GHL,3341,2,10985,Hospitality Managerial Acct,Johnson,Tucker A,11,13,7,1,0,0,1,2.99
+Spring 2024,GHL,2343,1,10986,Hospitality Cost Controls,Haskell,Rebecca Erin,23,13,5,3,0,0,0,3.25
+Spring 2024,GHL,3345,1,10987,Wine Appreciation,Taylor,David C,31,4,3,1,0,0,2,3.65
+Spring 2024,GHL,3352,1,10989,Human Resource Management,Madera,Juan Manuel,26,9,5,1,0,0,0,3.383
+Spring 2024,GHL,3352,2,10990,Human Resource Management,Guchait,Priyanko,10,9,2,1,0,0,1,3.303
+Spring 2024,GHL,3358,1,10991,Hospitality Industry Law,Abbott,Jeanna L,20,1,2,0,1,0,1,3.653
+Spring 2024,GHL,3364,1,10992,Hotel Sales,Kenyan,Erin Oeser,25,23,4,2,1,0,0,3.237
+Spring 2024,GHL,4353,1,10993,Leadership in Hospitality Ind,Maneethai,Dustin,24,9,5,0,1,0,0,3.351
+Spring 2024,GHL,6360,1,10994,Graduate Directed Practicum,Back,KiJoon,10,0,0,0,0,0,0,4.0
+Spring 2024,INDE,2333,1,10995,Engineering Statistics I,Wang,Yaping,29,33,15,12,1,0,1,2.841
+Spring 2024,INDE,3333,1,10996,Engineering Economy I,Wiggins,Nathanial David,85,5,0,0,0,0,0,3.911
+Spring 2024,INDE,3362,1,10997,Cad/Cam,Kamrani,Ali K,4,11,12,0,0,0,0,2.557
+Spring 2024,INDE,3381,1,10999,Linear Optimization,Lim,Gino Jinho,12,12,14,0,0,0,2,2.817
+Spring 2024,INDE,4331,1,11000,Anlysis-Ind Activties I,Schulze,Lawrence John Henry,1,24,2,0,0,0,1,2.951
+Spring 2024,INDE,4334,1,11001,Engineering Systems Design,Wiggins,Nathanial David,31,0,0,0,0,0,0,3.883
+Spring 2024,INDE,4369,1,11002,Facilities Planning & Design,Wang,Yaping,13,13,2,0,0,0,1,3.44
+Spring 2024,INDE,4372,1,11003,Operation Control,Hu,Minxiang,16,0,0,0,0,0,0,3.897
+Spring 2024,INDE,6111,1,11004,Graduate Seminar,Peng,Jiming Ouyang,0,0,0,0,0,56,0,
+Spring 2024,INDE,8198,1,11009,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Spring 2024,INDE,8298,2,11013,Doctoral Research,Xiang,Yisha,0,0,0,0,0,2,0,
+Spring 2024,INDE,8298,3,11014,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Spring 2024,INDE,8398,2,11016,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Spring 2024,INDE,8398,3,11017,Doctoral Research,Peng,Jiming Ouyang,0,0,0,0,0,2,0,
+Spring 2024,INDE,8398,4,11018,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,2,0,
+Spring 2024,INDE,8598,1,11024,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,6,0,
+Spring 2024,INDE,8598,3,11026,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Spring 2024,INDE,8598,4,11027,Doctoral Research,Xiang,Yisha,0,0,0,0,0,2,0,
+Spring 2024,INDS,2341,1,11036,Computer Aided Indus Design I,Chow,George K,3,11,0,0,0,0,0,3.356
+Spring 2024,INDS,2356,1,11037,Design History II,Ramirez,Enrique,18,6,0,0,0,0,0,3.681
+Spring 2024,INDS,2501,1,11038,Industrial Design Studio IV,Wells,Adam C,5,9,0,0,0,0,0,3.381
+Spring 2024,INDS,3501,1,11040,Industrial Design Studio VI,Chow,George K,4,6,1,1,0,0,0,3.111
+Spring 2024,INDS,4501,1,11043,Industrial Design Studio VIII,Kimbrough,Mark S,9,9,2,0,0,0,0,3.334
+Spring 2024,ITAL,2312,1,11045,Intermediate Italian II,Nicosia,Alda,11,9,2,0,0,0,1,3.334
+Spring 2024,KIN,3305,3,11048,Sport Sociology,Graham,Marilynn Hadassah,187,27,6,3,0,0,2,3.746
+Spring 2024,KIN,3350,1,11049,Psych Aspects Sport Exercise,Ferrara,Morgan Paige,161,62,18,3,5,0,1,3.485
+Spring 2024,KIN,4310,1,11050,Measurement Tech Human Perf,Thrasher,Timothy Adam,35,38,14,6,5,0,6,2.919
+Spring 2024,KIN,4355,1,11052,Adm of Sport & Phys Activity,Walsh,David W,10,39,14,2,0,0,2,2.887
+Spring 2024,KIN,4365,1,11053,Legal/Ethical Aspects of Sport,Cottingham,Michael,13,12,10,5,2,0,7,2.675
+Spring 2024,KIN,4390,1,11054,Internship in PE,Betts,Randi Jill,9,0,0,0,0,0,0,3.927
+Spring 2024,LAW,5103,1,11055,Health Law Journal,Mantel,Jessica,0,0,0,0,0,8,0,
+Spring 2024,LAW,5104,1,11056,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,3,0,
+Spring 2024,LAW,5110,1,11057,Law Review,Sanders,Joseph,0,0,0,0,0,8,0,
+Spring 2024,LAW,5147,1,11058,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,5,0,
+Spring 2024,LAW,5198,1,11059,Special Rsch & Writing,Vetter,Greg R,2,1,0,0,0,0,0,3.667
+Spring 2024,LAW,5210,1,11060,Law Review,Sanders,Joseph,0,0,0,0,0,12,0,
+Spring 2024,LAW,5247,1,11061,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,8,0,
+Spring 2024,LAW,5298,1,11062,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,3.67
+Spring 2024,LAW,5303,1,11063,Criminal Law,Thompson,Sandra Guerra,28,49,0,0,0,0,0,3.376
+Spring 2024,LAW,5303,2,11064,Criminal Law,Kwok,David Y,30,47,2,0,0,0,0,3.371
+Spring 2024,LAW,5303,4,11065,Criminal Law,Ten Cate,Irene,29,43,2,0,0,0,1,3.392
+Spring 2024,LAW,5322,2,11066,Pretrial Litigation,Goranson,Mark D,1,12,0,0,0,1,0,3.356
+Spring 2024,LAW,5339,1,11068,Trusts and Wills,Sanders,Pannal Alan,9,11,1,0,0,17,0,3.381
+Spring 2024,LAW,5381,1,11069,Legal Negotiation,Abbott,Jeanna L,18,24,0,0,0,4,0,3.374
+Spring 2024,LAW,5386,1,11070,Trial Advocacy,Baldassano,Steven L,15,16,0,0,0,8,1,3.399
+Spring 2024,LAW,5398,2,11071,Special Research and Writing,Vetter,Greg R,2,2,0,0,0,0,0,3.665
+Spring 2024,LAW,5400,1,11072,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,1,0,
+Spring 2024,LAW,5407,1,11074,Judicial Externship I,Powers,William,0,0,0,0,0,2,0,
+Spring 2024,LAW,5408,1,11075,Property,Warren,Gina S,34,40,4,0,0,0,0,3.402
+Spring 2024,LAW,5408,2,11076,Property,Zale,Kellen B,20,54,3,0,0,0,0,3.216
+Spring 2024,LAW,5410,1,11077,Law Review,Sanders,Joseph,0,0,0,0,0,13,0,
+Spring 2024,LAW,5414,1,11078,Immigration Clinic II,Cabot,Jessica Anna,1,2,0,0,0,0,0,3.333
+Spring 2024,LAW,5421,1,11080,Business Organizations,Moll,Douglas Keith,17,32,0,0,0,11,0,3.394
+Spring 2024,LAW,5488,1,11081,Constitutional Law,Portuondo,Laura,38,40,1,0,0,0,0,3.402
+Spring 2024,LAW,5488,2,11082,Constitutional Law,Morales,Daniel I,25,44,4,1,0,0,1,3.252
+Spring 2024,LAW,5488,3,11083,Constitutional Law,Berman,Emily,14,64,0,0,0,0,0,3.277
+Spring 2024,LAW,6209,2,11084,Health Law Journal,Mantel,Jessica,0,0,0,0,0,9,0,
+Spring 2024,LAW,6211,1,11085,Houston Buiness/Tax Journal,Wells,Douglas,0,0,0,0,0,17,0,
+Spring 2024,LAW,6300,1,11086,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,6,0,
+Spring 2024,LAW,6318,1,11089,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,14,0,
+Spring 2024,LAW,6354,1,11090,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,17,0,
+Spring 2024,LAW,6355,1,11091,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,3,0,
+Spring 2024,LAW,6356,1,11092,Law Review,Sanders,Joseph,0,0,0,0,0,20,0,
+Spring 2024,LAW,6358,1,11093,Health Law Journal,Mantel,Jessica,0,0,0,0,0,17,0,
+Spring 2024,MANA,3335,1,11094,Intro Org Behavior and Mgmt,Rude,Dale,11,7,0,0,0,0,0,3.593
+Spring 2024,MANA,3335,3,11096,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,175,83,5,2,2,0,1,3.562
+Spring 2024,MANA,4330,1,11097,Intro to Strategic HR Mgt,Phillips,James S,85,109,21,7,2,0,1,3.111
+Spring 2024,MANA,4353,1,11098,Mgmt Training and Career Devel,Bozeman,Dennis,12,24,7,1,0,0,0,3.181
+Spring 2024,MANA,8399,1,11100,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,0,0,
+Spring 2024,MANA,8399,2,11101,Doctoral Dissertation,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Spring 2024,MANA,8699,2,11102,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,1,0,
+Spring 2024,MANA,8999,1,11105,Doctoral Dissertation,Ruggs,Enrica N,1,0,0,0,0,0,0,4.0
+Spring 2024,MANA,8999,3,11107,Doctoral Dissertation,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Spring 2024,MARK,3336,1,11108,Introduction to Marketing,Patrick-Ralhan,Vanessa M,492,36,9,4,2,0,1,3.843
+Spring 2024,MARK,3336,2,11109,Introduction to Marketing,Patrick-Ralhan,Vanessa M,451,46,17,12,0,0,5,3.744
+Spring 2024,MARK,3336,3,11110,Introduction to Marketing,Koch,Steven F,11,8,0,0,0,0,1,3.562
+Spring 2024,MARK,3336,4,11111,Introduction to Marketing,Koch,Steven F,45,86,46,20,4,0,1,2.717
+Spring 2024,MARK,4373,1,11112,Advanced Professional Selling,Bremer,Justin,30,2,0,0,0,0,0,3.886
+Spring 2024,MARK,4374,1,11113,Sales Management,Webb,James R,28,1,0,0,0,0,0,3.954
+Spring 2024,MARK,4374,2,11114,Sales Management,Webb,James R,24,2,0,0,0,0,0,3.885
+Spring 2024,MARK,4375,1,11115,Key Account Selling,Webb,James R,19,1,0,0,0,0,0,3.934
+Spring 2024,MARK,4376,1,11116,Sales CRM,Herman,Carl,29,3,0,0,0,0,0,3.875
+Spring 2024,MARK,4376,2,11117,Sales CRM,Suki,Yara D,27,6,0,0,0,0,0,3.818
+Spring 2024,MAS,2340,1,11119,Intro Mexican American Studies,Pino,Diana,4,9,4,0,0,0,0,2.942
+Spring 2024,MAS,3340,1,11120,Mexican Amer Urban Communities,Pino,Diana,7,8,4,1,1,0,1,2.826
+Spring 2024,MATH,1314,8,11121,College Algebra,Hafeez,Shahinda,13,20,48,11,49,0,45,1.546
+Spring 2024,MATH,1324,1,11122,Finite Math with Applications,Sosa,Moses,124,88,72,12,36,0,64,2.711
+Spring 2024,MATH,1324,4,11123,Finite Math with Applications,Sosa,Moses,156,108,118,34,64,0,56,2.471
+Spring 2024,MATH,1324,7,11124,Finite Math with Applications,Hong,Yuqi,14,8,6,0,4,0,10,2.772
+Spring 2024,MATH,1324,5,11125,Finite Math with Applications,Kim,Jae Youn,84,96,70,26,52,0,66,2.358
+Spring 2024,MATH,1325,2,11126,Calc for Bus & Social Sciences,Constante,Beatrice,130,114,42,12,32,0,48,2.881
+Spring 2024,MATH,2312,3,11127,Precalculus,Manavalan Varghese,Shyla,60,84,82,20,38,0,56,2.348
+Spring 2024,MATH,2312,4,11128,Precalculus,Perepelitsa,Irina,118,96,66,16,44,0,48,2.632
+Spring 2024,MATH,2312,7,11130,Precalculus,Douglas,Casey,92,80,72,8,34,0,88,2.611
+Spring 2024,MATH,2451,1,11131,Accelerated Calculus II,Nicol,Matthew J,16,4,7,0,1,0,0,3.155
+Spring 2024,MATH,1342,3,11132,Elementary Statistical Methods,Kim,Jae Youn,132,122,58,18,28,0,38,2.857
+Spring 2024,MATH,1342,5,11133,Elementary Statistical Methods,Ryan,John M,84,94,116,18,56,0,40,2.312
+Spring 2024,MATH,3304,1,11134,Mathematical Analysis,George,Rebecca Ann,16,18,4,1,0,0,2,3.29
+Spring 2024,MATH,3321,1,11135,Engineering Mathematics,Etgen,Garret J,26,29,25,15,23,0,29,2.144
+Spring 2024,MATH,3321,4,11136,Engineering Mathematics,Torok,Andrei S,5,8,13,7,9,0,6,1.802
+Spring 2024,MATH,3331,2,11137,Intermediate Diff Equations,Sanders,Richard,9,21,13,6,6,0,1,2.364
+Spring 2024,MATH,2305,1,11138,Discrete Mathematics,Ru,Min,17,24,7,3,7,0,12,2.707
+Spring 2024,MATH,2305,2,11139,Discrete Mathematics,Douglas,Casey,123,23,12,1,7,0,10,3.484
+Spring 2024,MATH,4332,1,11140,Intro to Real Analysis II,Bodmann,Bernhard G,3,2,1,0,0,0,0,3.333
+Spring 2024,MATH,4378,1,11141,Advanced Linear Algebra II,Mamonov,Alexander V,2,1,2,2,3,0,1,1.601
+Spring 2024,MATH,4380,1,11142,Mathematical Intro To Options,Papadakis,Emanuel Ioannis,17,6,0,1,1,0,0,3.454
+Spring 2024,MATH,4389,1,11143,Survey of Undergraduate Math,Blecher,David P,8,14,1,4,0,0,2,3.0
+Spring 2024,MATH,5332,1,11150,Differential Equations,Etgen,Garret J,11,6,0,0,0,0,0,3.647
+Spring 2024,MATH,6303,1,11151,Modern Algebra,Kalantar,Mehrdad,11,2,0,0,0,0,0,3.821
+Spring 2024,MATH,6315,1,11152,Masters Tutorial,Etgen,Garret J,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6315,3,11154,Masters Tutorial,Ji,Shanyu,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6321,1,11156,Func Real Variable,Climenhaga,Vaughn,4,3,1,0,0,0,0,3.169
+Spring 2024,MATH,6371,1,11157,Numerical Analysis,Cappanera,Loic,22,4,0,0,0,0,2,3.783
+Spring 2024,MATH,6383,1,11158,Statistics,Jun,Mikyoung,6,1,0,0,0,0,0,3.716
+Spring 2024,MATH,6398,3,11160,Special Problems,Blecher,David P,0,0,0,0,0,1,0,
+Spring 2024,MATH,6398,5,11162,Special Problems,Timofeyev,Ilya,0,0,0,0,0,3,0,
+Spring 2024,MATH,6398,7,11164,Special Problems,Ott,William R,0,0,0,0,0,2,0,
+Spring 2024,MATH,6398,9,11166,Special Problems,Mang,Andreas,0,0,0,0,0,1,0,
+Spring 2024,MATH,6398,10,11167,Special Problems,Ru,Min,0,0,0,0,0,2,0,
+Spring 2024,MATH,6398,14,11170,Special Problems,Josic,Kresimir,0,0,0,0,0,2,0,
+Spring 2024,MATH,6398,17,11173,Special Problems,Quaini,Annalisa,0,0,0,0,0,1,0,
+Spring 2024,MATH,6398,18,11174,Special Problems,Wu,Yingying,0,0,0,0,0,3,0,
+Spring 2024,MATH,6398,19,11175,Special Problems,Charon,Nicolas,0,0,0,0,0,1,0,
+Spring 2024,MATH,7315,8,11186,Masters Tutorial,Nicol,Matthew J,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8398,2,11189,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Spring 2024,MATH,8398,3,11190,Doctoral Research,Blecher,David P,0,0,0,0,0,1,0,
+Spring 2024,MECE,2361,1,11197,Intro Mechanical Design,Chang,Christiana,17,36,23,3,1,0,1,2.804
+Spring 2024,MECE,3245,1,11200,Materials Science Laboratory,Chen,Xuemei,35,51,14,2,0,0,2,3.131
+Spring 2024,MECE,3336,1,11201,Mechanics II,Franchek,Matthew,4,11,0,0,0,0,0,3.267
+Spring 2024,MECE,3360,1,11202,Experimental Methods,Chen,Xuemei,21,32,23,1,1,0,2,2.906
+Spring 2024,MECE,3400,1,11204,Intro To Mechanics,Wang,Su Su,7,4,6,1,2,0,11,2.601
+Spring 2024,MECE,4364,1,11205,Heat Transfer,Xu,Ben,8,27,35,8,0,0,1,2.406
+Spring 2024,MECE,4371,1,11206,Thermal-Fluids Laboratory,Love,Holley Carole,67,10,0,0,0,0,0,3.849
+Spring 2024,MECE,8111,1,11209,Graduate Seminar,Grigoriadis,Karolos,0,0,0,0,0,55,0,
+Spring 2024,MSCI,1126,1,11210,Phys Readiness Training,Comiskey,Melissa C,13,1,0,0,1,0,0,3.645
+Spring 2024,MSCI,1131,1,11211,Intermediate Physical Fitness,Comiskey,Melissa C,3,1,0,0,0,0,0,3.75
+Spring 2024,MSCI,2220,1,11212,Doctrine & Team Development,Comiskey,Melissa C,6,2,0,0,0,0,0,3.709
+Spring 2024,MSCI,2220,2,11213,Doctrine & Team Development,Comiskey,Melissa C,1,1,0,0,0,0,0,3.5
+Spring 2024,MSCI,3320,1,11214,Applied Leadership,Comiskey,Melissa C,2,0,0,0,0,0,0,4.0
+Spring 2024,MSCI,4320,2,11216,Company Grade Leadership,Comiskey,Melissa C,5,0,0,0,0,0,0,4.0
+Spring 2024,MSCI,4398,1,11218,Independent Study,Comiskey,Melissa C,7,2,0,0,0,0,1,3.778
+Spring 2024,NUTR,2133,1,11219,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,8,8,0,1,0,0,1,3.314
+Spring 2024,NUTR,2133,2,11220,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,2,2,1,1,1,0,0,2.429
+Spring 2024,NUTR,2332,1,11221,Intro To Human Nutrition,Hughes,Lindsay,39,32,12,1,1,0,12,3.177
+Spring 2024,NUTR,2333,1,11222,Comm Food Prod I,Svendsen-Sanchez,Ann Carol,6,15,3,1,0,0,1,2.934
+Spring 2024,NUTR,3334,1,11223,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,97,42,9,1,8,0,5,3.353
+Spring 2024,NUTR,4347,1,11224,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,12,18,3,3,0,0,1,3.001
+Spring 2024,OPTO,5112,1,11225,Optics Lab II,Cheng,Han,18,6,0,0,0,0,0,3.75
+Spring 2024,OPTO,5112,2,11226,Optics Lab II,Cheng,Han,19,6,0,0,0,0,0,3.76
+Spring 2024,OPTO,5112,3,11227,Optics Lab II,Cheng,Han,17,6,1,0,0,0,0,3.667
+Spring 2024,OPTO,5112,4,11228,Optics Lab II,Cheng,Han,21,1,0,0,0,0,0,3.955
+Spring 2024,OPTO,5135,1,11229,Ocular Anatomy Lab,Ostrin,Lisa,23,2,0,0,0,0,0,3.92
+Spring 2024,OPTO,5135,2,11230,Ocular Anatomy Lab,Ostrin,Lisa,22,3,0,0,0,0,0,3.88
+Spring 2024,OPTO,5135,3,11231,Ocular Anatomy Lab,Ostrin,Lisa,19,4,0,0,0,0,0,3.826
+Spring 2024,OPTO,5135,4,11232,Ocular Anatomy Lab,Ostrin,Lisa,22,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,5172,1,11233,Clinic Practicum II,Berntsen,David A,11,10,1,0,0,0,0,3.455
+Spring 2024,OPTO,5172,2,11234,Clinic Practicum II,Kehinde,Lucy,9,8,6,0,1,0,0,3.0
+Spring 2024,OPTO,5172,3,11235,Clinic Practicum II,Kehinde,Lucy,7,16,2,0,0,0,0,3.2
+Spring 2024,OPTO,5172,4,11236,Clinic Practicum II,Kehinde,Lucy,3,15,5,0,2,0,0,2.68
+Spring 2024,OPTO,5194,1,11237,Ophthalmic Optics Lab,Tucker,Ashley,18,5,1,0,0,0,0,3.708
+Spring 2024,OPTO,5194,2,11238,Ophthalmic Optics Lab,Tucker,Ashley,21,2,1,0,0,0,0,3.833
+Spring 2024,OPTO,5194,3,11239,Ophthalmic Optics Lab,Tucker,Ashley,19,6,0,0,0,0,0,3.76
+Spring 2024,OPTO,5194,4,11240,Ophthalmic Optics Lab,Tucker,Ashley,19,3,0,0,0,0,0,3.864
+Spring 2024,OPTO,5221,1,11241,Vision Science II,Applegate,Raymond A,25,43,25,2,0,0,0,2.958
+Spring 2024,OPTO,5272,1,11243,Optometry II,Kehinde,Lucy,63,25,6,0,0,0,0,3.606
+Spring 2024,OPTO,5282,1,11244,Community Health Optometry,Fitta,Meron Almaz,94,1,0,0,0,0,0,3.989
+Spring 2024,OPTO,5315,1,11245,Optics II,Porter,Jason,28,38,25,5,2,0,0,2.867
+Spring 2024,OPTO,5331,1,11246,General Pathology & Medicine,Frishman,Laura J,38,42,15,1,0,0,0,3.312
+Spring 2024,OPTO,5335,1,11247,Ocular Anatomy and Physiology,Ostrin,Lisa,46,36,12,3,0,0,0,3.289
+Spring 2024,OPTO,6151,1,11248,Pediatric Optometry I Lab,Ho,Hong Dieu,19,4,0,0,0,0,0,3.826
+Spring 2024,OPTO,6151,2,11249,Pediatric Optometry I Lab,Ho,Hong Dieu,18,4,0,0,0,0,0,3.818
+Spring 2024,OPTO,6151,3,11250,Pediatric Optometry I Lab,Ho,Hong Dieu,22,2,0,0,0,0,0,3.917
+Spring 2024,OPTO,6151,5,11251,Pediatric Optometry I Lab,Ho,Hong Dieu,21,3,0,0,0,0,0,3.875
+Spring 2024,OPTO,6174,1,11252,Contact Lens Lab,Giannoni,Amber Gaume,22,2,0,0,0,0,0,3.917
+Spring 2024,OPTO,6174,3,11253,Contact Lens Lab,Giannoni,Amber Gaume,17,5,0,0,0,0,0,3.773
+Spring 2024,OPTO,6174,4,11254,Contact Lens Lab,Giannoni,Amber Gaume,22,2,0,0,0,0,0,3.917
+Spring 2024,OPTO,6174,5,11255,Contact Lens Lab,Giannoni,Amber Gaume,20,2,0,0,0,0,0,3.909
+Spring 2024,OPTO,6251,1,11256,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,19,0,
+Spring 2024,OPTO,6291,1,11257,General Clinic II,Kim,Jung-Sun,0,0,0,0,0,93,0,
+Spring 2024,OPTO,6312,1,11258,Optics IV,Ritchey,Eric R,80,13,1,0,0,0,0,3.84
+Spring 2024,OPTO,6333,1,11259,Ocular Pharm and Therapeutics,Marrelli,Danica J,24,54,16,0,0,0,0,3.032
+Spring 2024,OPTO,6335,1,11260,Ocular Pathology II,Harrison,Wendy W,39,45,9,0,0,0,0,3.308
+Spring 2024,OPTO,6351,1,11261,Pediatric Optometry I,Martinez,Muriel L,61,27,5,0,0,0,0,3.602
+Spring 2024,OPTO,6374,1,11262,Contact Lens I,Walker,Maria Kelly,40,44,8,0,0,0,0,3.348
+Spring 2024,OPTO,7120,1,11263,Opt III Rounds/Case Discussn,Marrelli,Danica J,92,6,0,0,1,0,0,3.899
+Spring 2024,OPTO,7130,1,11264,"Laser, Refract & Surg Lab",Patel,Nimesh Bhikhu,28,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7130,2,11265,"Laser, Refract & Surg Lab",Patel,Nimesh Bhikhu,22,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7130,5,11266,"Laser, Refract & Surg Lab",Patel,Nimesh Bhikhu,25,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7130,6,11267,"Laser, Refract & Surg Lab",Patel,Nimesh Bhikhu,23,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7162,1,11268,Vision Rehabilitative Lab,Hooper,Nicole,27,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7162,2,11269,Vision Rehabilitative Lab,Modi,Swati,23,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7162,3,11270,Vision Rehabilitative Lab,Modi,Swati,24,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7162,4,11271,Vision Rehabilitative Lab,Hooper,Nicole,23,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,7253,1,11272,Pediatric Optometry III,Manny,Ruth,3,40,53,0,2,0,0,2.429
+Spring 2024,OPTO,7262,1,11273,Rehabilitative Optometry,Modi,Swati,39,47,12,0,0,0,0,3.276
+Spring 2024,OPTO,7330,1,11274,"Lasers, Refract Proced, Surg",Patel,Nimesh Bhikhu,82,17,0,0,0,0,0,3.802
+Spring 2024,OPTO,7337,1,11275,Ocular Pathology IV,Johnston,Kassaundra Lee,28,59,14,0,0,0,0,3.139
+Spring 2024,OPTO,7383,1,11276,Practice Management I,Cass,Peter John,90,8,0,0,0,0,0,3.844
+Spring 2024,OPTO,7495,1,11277,General Clinic IIIc,Herring,Ralph Jay,0,0,0,0,0,93,0,
+Spring 2024,OPTO,8992,1,11278,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,57,0,
+Spring 2024,OPTO,8993,1,11279,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,57,0,
+Spring 2024,PCOL,7142,1,11280,Pharmacological Lit Review,Bond,Richard A,0,0,0,0,0,14,0,
+Spring 2024,PETR,6302,1,11281,Reservoir Engineering II,Thakur,Ganesh Chandra,13,6,2,0,0,0,0,3.508
+Spring 2024,PHAR,5642,1,11282,Emergency Medicine,Truong,Mabel,7,2,0,0,0,0,0,3.778
+Spring 2024,PHAR,5663,1,11284,Pharmacy Management,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5670,1,11286,Community Pharmaceutical Care,Tolleson,Shane Russell,5,1,0,0,0,0,0,3.833
+Spring 2024,PHAR,5675,1,11287,Disease State Management,Tolleson,Shane Russell,22,3,0,0,0,0,0,3.88
+Spring 2024,PHAR,5678,1,11288,Transplant Therapeutics,Truong,Mabel,1,1,0,0,0,0,0,3.5
+Spring 2024,PHAR,5680,1,11289,Oncology,Truong,Mabel,3,0,0,0,1,0,0,3.0
+Spring 2024,PHAR,5683,1,11291,Cardiology,Truong,Mabel,4,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5685,1,11292,Critical Care,Truong,Mabel,6,2,0,0,0,0,0,3.75
+Spring 2024,PHAR,5686,1,11293,Psychiatry,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5690,1,11294,Internal Medicine,Truong,Mabel,14,8,1,0,0,0,0,3.565
+Spring 2024,PHAR,5690,3,11295,Internal Medicine,Sherer,Jeffrey T,2,2,0,0,0,0,0,3.5
+Spring 2024,PHAR,5691,1,11296,Drug Information,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5692,1,11297,Advanced Hospital Pharmacy,Truong,Mabel,25,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5693,1,11298,Advanced Community Pharmacy,Tolleson,Shane Russell,37,3,0,0,0,0,0,3.925
+Spring 2024,PHAR,5695,1,11300,Geriatrics,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5696,1,11301,Ambulatory Care - Primary Care,Tolleson,Shane Russell,6,0,1,0,0,0,0,3.714
+Spring 2024,PHCA,6298,1,11302,Special Problems,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8398,6,11310,Doctoral Research,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8398,12,11316,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8699,1,11349,Doctoral Dissertation,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,2125,1,11364,University Physics Lab I,Wood,Lowell T,2,9,10,0,0,0,2,2.635
+Spring 2024,PHYS,2125,2,11365,University Physics Lab I,Wood,Lowell T,2,10,6,0,0,0,3,2.723
+Spring 2024,PHYS,2126,1,11366,University Physics Lab II,Wood,Lowell T,2,13,7,0,0,0,0,2.788
+Spring 2024,PHYS,2126,2,11367,University Physics Lab II,Wood,Lowell T,1,10,7,1,0,0,1,2.614
+Spring 2024,PHYS,1301,1,11368,College Physics I (lecture),Cardoso Barato,Andre,8,11,17,2,4,0,23,2.35
+Spring 2024,PHYS,1301,2,11369,College Physics I (lecture),Chu,Wei-Kan,6,7,5,3,2,0,10,2.421
+Spring 2024,PHYS,1302,1,11370,College Physics II (lecture),Portillo Vazquez,Israel,40,40,64,28,12,0,38,2.334
+Spring 2024,PHYS,1302,2,11371,College Physics II (lecture),Maric,Sladjana,12,22,27,4,3,0,11,2.539
+Spring 2024,PHYS,2325,1,11372,University Physics I (lecture),Chen,Xiaojia,9,13,12,3,3,0,15,2.492
+Spring 2024,PHYS,6327,1,11384,Statistical Physics,Morrison,Gregory C,12,7,0,0,0,0,1,3.632
+Spring 2024,PHYS,8398,3,11394,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,5,11396,Doctoral Research,Chen,Shuo,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8398,6,11397,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,16,11402,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,17,11403,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,20,11405,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,30,11412,Doctoral Research,Ratti,Claudia,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,31,11413,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8398,32,11414,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,35,11416,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8399,3,11419,Doctoral Dissertation,Bellwied,Rene,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8399,4,11420,Doctoral Dissertation,Bering,Edgar A,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8399,14,11425,Doctoral Dissertation,Das,Mini,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8399,15,11426,Doctoral Dissertation,Freelon,Byron Kendall,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8399,20,11430,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8399,26,11435,Doctoral Dissertation,Ordonez,Carlos,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8399,29,11438,Doctoral Dissertation,Ren,Zhifeng,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8399,32,11441,Doctoral Dissertation,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Spring 2024,POLS,4198,1,11473,Independent Study,Cross,Renee Danielle,0,0,0,0,0,1,0,
+Spring 2024,POLS,4298,7,11474,Independent Study,Cross,Renee Danielle,0,0,0,0,0,2,0,
+Spring 2024,POLS,4390,1,11475,Government Internship,Cross,Renee Danielle,19,2,0,0,0,0,0,3.92
+Spring 2024,POLS,8399,2,11476,Doctoral Dissertation,Church,Jeffrey,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8699,1,11477,Doctoral Dissertation,Soules,Michael,0,0,0,0,0,1,0,
+Spring 2024,PSYC,2301,2,11479,Introduction to Psychology,Agan,Herb W,121,93,13,7,5,0,2,3.303
+Spring 2024,PSYC,2317,1,11480,Intro to Psychology Statistics,Litson,Kaylee,27,28,12,1,5,0,6,2.905
+Spring 2024,PSYC,2320,1,11481,Abnormal Psychology,Babcock,Julia,6,18,11,5,4,0,6,2.364
+Spring 2024,PSYC,6357,1,11483,Clinical Assessment II,Williams,Michael W,12,0,0,0,0,0,0,3.945
+Spring 2024,PSYC,6393,2,11484,Clinical Research Practicum,Alfano,Candice A,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7392,2,11485,Psychology Practicum,Tamber-Rosenau,Benjamin J,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8121,1,11487,Clinical Psychology Internship,Woods,Steven Paul,0,0,0,0,0,4,0,
+Spring 2024,PSYC,8321,1,11489,Clinical Psyc Internship,Woods,Steven Paul,0,0,0,0,0,5,0,
+Spring 2024,PSYC,8390,1,11490,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8399,1,11491,Doctoral Dissertation,Zvolensky,Michael J,2,0,0,0,0,2,0,4.0
+Spring 2024,PSYC,8399,2,11492,Doctoral Dissertation,Alfano,Candice A,0,0,0,0,0,3,0,
+Spring 2024,PSYC,8399,3,11493,Doctoral Dissertation,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8399,14,11494,Doctoral Dissertation,Babcock,Julia,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8699,2,11495,Doctoral Dissertation,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Spring 2024,RELS,1301,1,11497,Intro To Religious Studies,Dawson,Cindy,23,14,6,0,2,0,2,3.23
+Spring 2024,SOC,6311,1,11498,Qualitative Soc Methods,Katz,Sheila,11,3,0,0,0,0,0,3.786
+Spring 2024,SOCW,3330,1,11499,Nonprofit Financial Management,Crespo,Deysi M,6,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7330,1,11500,Nonprofit Fiscal Mgmt & Budget,Crespo,Deysi M,17,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7366,1,11501,Grief/Bereave Therapy,Rodgers,Beverly J,23,4,0,0,0,0,0,3.852
+Spring 2024,SOCW,7384,1,11502,SW Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Spring 2024,SOCW,7385,1,11503,SW Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,19,0,
+Spring 2024,SOCW,7391,1,11505,Social Work Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,23,0,
+Spring 2024,SOCW,8322,1,11506,Research Methods II,Acquati,Chiara,6,1,0,0,0,0,0,3.857
+Spring 2024,SOCW,8333,1,11507,Social Science Theories,Borja,Sharon G,5,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,8395,1,11508,Pre-Dissertation Research,Walton,Quenette,0,0,0,0,0,1,0,
+Spring 2024,SPAN,1501,1,11509,Elementary Spanish I,Naderi,Cina Oscar,6,6,3,1,1,0,2,2.902
+Spring 2024,SPAN,1501,3,11511,Elementary Spanish I,Lumbierres,M Pilar,6,6,1,0,1,0,6,3.166
+Spring 2024,SPAN,1501,13,11513,Elementary Spanish I,Jouannet De La Jara,Sebastian Nicolas,13,10,1,0,1,0,0,3.347
+Spring 2024,SPAN,1502,11,11515,Elementary Spanish II,Javierre Londono,Juliana,10,10,6,0,0,0,1,3.116
+Spring 2024,SPAN,1502,19,11517,Elementary Spanish II,Brave,Ivan,5,10,7,1,1,0,3,2.695
+Spring 2024,SPAN,1502,21,11519,Elementary Spanish II,Nieves Cabrera,Wendy,9,8,6,1,1,0,2,2.96
+Spring 2024,SPAN,2311,1,11523,Intermediate Spanish I,Pena Loyola,Jose Francisco,12,7,2,0,3,0,3,3.0
+Spring 2024,SPAN,2311,3,11524,Intermediate Spanish I,Pena Loyola,Jose Francisco,8,4,6,0,0,0,2,3.074
+Spring 2024,SPAN,2311,6,11525,Intermediate Spanish I,del Castillo Garza,Alejandro,1,11,6,1,2,0,2,2.412
+Spring 2024,SPAN,2312,3,11526,Intermediate Spanish II,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,3,9,9,2,1,0,0,2.417
+Spring 2024,SPAN,2312,9,11527,Intermediate Spanish II,Scalzo,Dillon S,11,13,1,0,0,0,1,3.413
+Spring 2024,SPAN,3301,1,11529,Span Oral Comm for Crit Think,Ruisanchez Serra,Jose Ramon,11,2,0,0,0,0,1,3.846
+Spring 2024,SPAN,3307,1,11531,Public Speaking in Spanish,Cuesta,Mabel,12,3,1,0,1,0,1,3.509
+Spring 2024,SPAN,3308,2,11532,Written Com-Hisp Herit Learner,Hasbun,Rodrigo,9,8,2,0,0,0,0,3.403
+Spring 2024,SPAN,3384,3,11534,Intro To Hispanic Literature,Sisk,Christina L,8,10,1,0,0,0,1,3.386
+Spring 2024,SPAN,6398,1,11535,Special Problems,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,6398,4,11538,Special Problems,Gutierrez,Manuel J,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,7398,3,11544,Reading & Research,Gutierrez,Manuel J,0,0,0,0,0,2,0,
+Spring 2024,SPAN,8399,1,11547,Dissertation,Rivera Garza,Cristina,3,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,8399,2,11548,Dissertation,Fairclough,Marta A,0,0,0,0,0,1,0,
+Spring 2024,SPAN,8399,3,11549,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,2,0,
+Spring 2024,SPAN,8399,4,11550,Dissertation,Gutierrez,Manuel J,2,0,0,0,0,1,0,4.0
+Spring 2024,SPAN,8399,6,11552,Dissertation,Solino,Maria Elena,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,8399,8,11554,Dissertation,Kanellos,Nicolas,1,0,0,0,0,2,0,4.0
+Spring 2024,SPAN,8699,1,11555,Dissertation,Rivera Garza,Cristina,3,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,8699,2,11556,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,2,0,
+Spring 2024,SPAN,8699,3,11557,Dissertation,Fairclough,Marta A,0,0,0,0,0,1,0,
+Spring 2024,VIET,1502,1,11559,Elementary Vietnamese II,Dang,Thong Q,9,0,0,0,0,0,0,4.0
+Spring 2024,VIET,2302,1,11561,Intermediate Vietnamese II,Dang,Thong Q,20,0,0,0,0,0,0,4.0
+Spring 2024,MATH,2318,1,11562,Linear Algebra,Sanders,Richard,25,12,17,0,2,0,2,3.006
+Spring 2024,PHYS,4322,1,11563,Int Electromagnetic Theory II,Cherdack,Daniel David,10,6,2,2,1,0,1,3.048
+Spring 2024,PHYS,1101,1,11564,College Physics I (lab),Wood,Lowell T,3,11,7,0,0,0,2,2.81
+Spring 2024,PHYS,1101,2,11565,College Physics I (lab),Wood,Lowell T,0,11,3,1,0,0,0,2.601
+Spring 2024,PHYS,1101,3,11566,College Physics I (lab),Wood,Lowell T,3,10,11,0,0,0,0,2.735
+Spring 2024,PHYS,1101,4,11567,College Physics I (lab),Wood,Lowell T,2,9,3,0,1,0,1,2.711
+Spring 2024,PHYS,1101,5,11568,College Physics I (lab),Wood,Lowell T,0,16,2,0,1,0,3,2.789
+Spring 2024,PHYS,1101,6,11569,College Physics I (lab),Wood,Lowell T,3,3,5,1,0,0,3,2.584
+Spring 2024,GEOL,3372,1,11570,Petrography,Copeland,Peter,4,11,12,0,0,0,0,2.581
+Spring 2024,GEOL,3374,1,11571,Sedimentary Petrogenesis,Voarintsoa,Ny Riavo Gilbertinie,5,10,3,1,1,0,0,2.817
+Spring 2024,PHYS,1101,7,11572,College Physics I (lab),Wood,Lowell T,2,12,4,1,1,0,2,2.601
+Spring 2024,PHYS,1101,8,11573,College Physics I (lab),Wood,Lowell T,0,13,8,0,0,0,2,2.745
+Spring 2024,PHYS,1101,9,11574,College Physics I (lab),Wood,Lowell T,1,9,5,0,0,0,1,2.733
+Spring 2024,PHYS,1101,10,11575,College Physics I (lab),Wood,Lowell T,0,13,5,0,0,0,5,2.704
+Spring 2024,PHYS,1101,11,11576,College Physics I (lab),Wood,Lowell T,1,15,5,0,0,0,0,2.668
+Spring 2024,PHYS,1102,1,11577,College Physics II (lab),Wood,Lowell T,8,6,7,1,0,0,1,2.895
+Spring 2024,PHYS,1102,2,11578,College Physics II (lab),Wood,Lowell T,2,13,7,1,0,0,0,2.595
+Spring 2024,PHYS,1102,3,11579,College Physics II (lab),Wood,Lowell T,1,14,6,0,1,0,1,2.771
+Spring 2024,PHYS,1102,4,11580,College Physics II (lab),Wood,Lowell T,3,13,7,0,1,0,0,2.626
+Spring 2024,PHYS,1102,5,11581,College Physics II (lab),Wood,Lowell T,3,13,5,0,0,0,2,2.732
+Spring 2024,PHYS,1102,6,11582,College Physics II (lab),Wood,Lowell T,3,12,6,0,0,0,2,2.81
+Spring 2024,PHYS,1102,7,11583,College Physics II (lab),Wood,Lowell T,1,12,7,0,0,0,2,2.667
+Spring 2024,PHYS,1102,8,11584,College Physics II (lab),Wood,Lowell T,5,13,6,0,0,0,0,2.931
+Spring 2024,PHYS,1102,9,11585,College Physics II (lab),Wood,Lowell T,5,12,5,0,1,0,0,2.712
+Spring 2024,PHYS,1102,10,11586,College Physics II (lab),Wood,Lowell T,3,13,8,0,0,0,0,2.819
+Spring 2024,SPAN,3305,1,11587,Spanish Grammar Review,Gutierrez,Manuel J,10,5,2,0,1,0,0,3.241
+Spring 2024,ENTR,3312,4,11588,Corporate Entrepreneurship,Lish,Alan D,18,62,11,1,3,0,4,2.944
+Spring 2024,MARK,4389,1,11589,Marketing Strategy & Planning,Beveridge,Ivana,24,6,0,0,0,0,0,3.756
+Spring 2024,MARK,4389,3,11590,Marketing Strategy & Planning,Randazzo,Gary W,24,7,0,0,0,0,0,3.657
+Spring 2024,COMM,4331,1,11591,Persuasion,Huang,Yan,24,5,0,0,0,0,1,3.748
+Spring 2024,GHL,4343,1,11593,Financial Admin for Hosp.Ind.,DeFranco,Agnes L,14,11,2,1,0,0,1,3.322
+Spring 2024,BIOE,3341,1,11594,Biothermodynamics,Aglyamov,Salavat,7,4,2,0,0,0,0,3.41
+Spring 2024,BCHS,4304,1,11595,Biophysics,Fox,Robert O,16,15,10,0,0,0,1,3.146
+Spring 2024,NUTR,3101,1,11596,Dietetics As a Profession,Scott,Claudia W,33,4,0,0,0,0,0,3.865
+Spring 2024,ENGI,2304,2,11597,Technical Communications,Contos,Ashlie Meghan,22,2,1,0,0,0,0,3.774
+Spring 2024,PSYC,4344,1,11598,Cultural Psychology,Murphy,Elijah Rayvon,68,6,1,1,2,0,1,3.765
+Spring 2024,KIN,4391,2,11599,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,5330,1,11601,Abstract Algebra,Haynes,Alan K,9,1,0,0,0,0,0,3.933
+Spring 2024,CHEE,3333,1,11602,Chem Engr Thermodyn II,Zerze,Gul,14,21,7,0,0,0,3,3.127
+Spring 2024,LAW,5408,3,11603,Property,Bregant,Jessica Lynn,27,46,0,0,0,0,1,3.402
+Spring 2024,HDFS,4394,1,11606,Internship in HDFS,Conston,Toya,27,3,0,0,0,0,0,3.889
+Spring 2024,ACCT,4330,1,11607,Advanced Accounting,Ramaswamy,Vinita,6,4,1,0,0,0,0,3.575
+Spring 2024,COSC,6309,1,11608,Intro Automata & Computability,Leiss,Ernst L,1,0,0,0,0,0,0,3.67
+Spring 2024,COSC,6310,1,11609,Fundamentals of Operating Syst,Rincon Castro,Carlos Alberto,1,0,0,0,0,0,1,3.67
+Spring 2024,BCHS,4311,1,11611,Biochemistry Lab II,Pattison,Donna,46,26,2,2,0,0,0,3.505
+Spring 2024,CHEM,4270,1,11612,Physical Chemistry Lab I,Czader,Arkadiusz,4,11,0,0,0,0,0,3.245
+Spring 2024,CHEM,4270,2,11613,Physical Chemistry Lab I,Czader,Arkadiusz,4,4,1,1,1,0,0,2.698
+Spring 2024,MARK,4373,2,11614,Advanced Professional Selling,Pingel,John W,23,10,0,0,0,0,0,3.697
+Spring 2024,MECE,3345,1,11615,Materials Science,Chen,Tian,36,40,6,0,0,0,3,3.318
+Spring 2024,ACCT,4330,2,11616,Advanced Accounting,Ramaswamy,Vinita,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,3201,5,11617,Biochemistry I Laboratory,Pattison,Donna,8,13,2,0,0,0,0,3.247
+Spring 2024,BCHS,3201,6,11618,Biochemistry I Laboratory,Pattison,Donna,7,12,2,0,0,0,0,3.191
+Spring 2024,BCHS,3201,7,11621,Biochemistry I Laboratory,Pattison,Donna,4,5,1,1,0,0,0,3.091
+Spring 2024,BCHS,3201,8,11622,Biochemistry I Laboratory,Pattison,Donna,4,8,4,0,0,0,1,3.083
+Spring 2024,SPAN,8699,5,11623,Dissertation,Ventura,Gabriela Baeza,2,0,0,0,0,0,0,4.0
+Spring 2024,GHL,2365,1,11629,Tourism,Draper,Jason A,17,13,3,2,0,0,0,3.229
+Spring 2024,PHOP,8699,8,11631,Doctoral Dissertation,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8399,18,11632,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2024,SPAN,1502,5,11633,Elementary Spanish II,Hernandez,Stephanie,6,5,2,2,3,0,1,2.445
+Spring 2024,INDE,6332,1,11635,Egr Project Mgt,Chung,Christopher,34,3,0,0,0,0,0,3.937
+Spring 2024,MATH,8398,4,11638,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Spring 2024,MATH,8398,5,11639,Doctoral Research,Cappanera,Loic,0,0,0,0,0,2,0,
+Spring 2024,MATH,6313,1,11642,Introduction to Real Analysis,Bodmann,Bernhard G,3,2,0,0,0,0,0,3.666
+Spring 2024,MATH,6309,1,11643,Advanced Linear Algebra II,Mamonov,Alexander V,3,2,1,1,0,0,0,2.953
+Spring 2024,BIOL,3306,2,11644,Evolutionary Biology,Frankino,William A,56,49,49,10,4,0,1,2.835
+Spring 2024,BIOL,3311,1,11645,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,52,13,9,4,3,0,3,3.272
+Spring 2024,BIOL,3311,2,11646,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,32,13,4,1,2,0,3,3.347
+Spring 2024,BCHS,4307,1,11655,Proteins,Widger,William R,21,31,3,5,1,0,3,3.033
+Spring 2024,GEOL,1103,7,11656,Physical Geology Lab,Hauptvogel,Daniel William,18,1,0,0,0,0,0,3.861
+Spring 2024,GEOL,3340,1,11657,Geologic Field Methods,Robinson,Alexander C,18,14,9,1,1,0,0,3.047
+Spring 2024,FINA,4370,1,11659,Energy Trading,Smith III,Edwin A,4,5,1,3,0,0,2,2.769
+Spring 2024,MARK,4389,4,11660,Marketing Strategy & Planning,Lish,Alan D,18,10,3,2,0,0,0,3.213
+Spring 2024,CIVE,8198,2,11664,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Spring 2024,ACCT,2302,2,11665,Prin of Managerial Accounting,Newman,Michael Ray,19,5,1,0,0,0,1,3.694
+Spring 2024,ACCT,6331,2,11666,Financial Accounting,Kuruvilla,Mohan,11,11,3,0,1,0,1,3.192
+Spring 2024,CIVE,8298,1,11667,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8298,2,11668,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8298,3,11669,Doctoral Research,Lee,Hyongki,0,0,0,0,0,5,0,
+Spring 2024,CIVE,8298,4,11670,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8298,5,11671,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Spring 2024,CIVE,8398,1,11672,Doctoral Research,Milillo,Pietro,0,0,0,0,0,7,0,
+Spring 2024,CIVE,8398,2,11673,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8398,3,11674,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8398,4,11675,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Spring 2024,CIVE,8398,5,11676,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,3,0,
+Spring 2024,CIVE,8398,6,11677,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8398,7,11678,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,4,0,
+Spring 2024,CIVE,8498,1,11679,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8498,2,11680,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8598,1,11681,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Spring 2024,CIVE,8598,2,11682,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,3,0,
+Spring 2024,CIVE,8598,3,11683,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Spring 2024,GHL,2350,2,11686,Mgmt Principles in Hospitality,Boger Jr,Carl A,25,8,3,0,2,0,1,3.369
+Spring 2024,MIS,3370,1,11687,Info Systems Development Tools,Zamarripa,Ivan,16,14,16,4,1,0,10,2.784
+Spring 2024,MIS,3371,1,11688,Transaction Processing Sys I,Messinger,Jacob Nelson,118,76,4,0,1,0,1,3.531
+Spring 2024,MIS,4374,1,11689,Info Technology Project Mgmt,Scott,Carl P,37,4,0,0,0,0,0,3.83
+Spring 2024,MIS,4378,1,11690,Admin of Computer-Based MIS,Porra,Jaana,42,4,0,0,0,0,0,3.913
+Spring 2024,STAT,3331,1,11691,Statistical Anal Bus Appl I,Wiley,Briceon C,5,6,7,11,1,0,7,2.089
+Spring 2024,SCM,3301,1,11692,SCM Fundamentals,Anderson Fletcher,Elizabeth,12,9,0,0,0,0,0,3.587
+Spring 2024,SCM,3301,2,11693,SCM Fundamentals,Miller,Bradley D,241,252,45,5,1,0,5,3.318
+Spring 2024,GHL,6345,1,11694,Wine Appreciation,Taylor,David C,13,2,0,0,0,0,1,3.779
+Spring 2024,NUTR,4312,1,11696,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,11,13,9,0,0,0,1,3.051
+Spring 2024,NUTR,4346,1,11697,Research in Nutrition,Ledoux,Tracey A,20,17,0,0,0,0,1,3.549
+Spring 2024,NUTR,4348,1,11698,Intro to NUTR Counseling,Honig,Caryn A,13,6,1,1,0,0,0,3.398
+Spring 2024,FREN,2311,2,11699,Intermediate French I,Green,Viola V,4,4,4,3,0,0,3,2.578
+Spring 2024,WCL,2352,2,11700,World Cinema,Zaretsky,Robert D,5,2,1,3,1,0,3,2.501
+Spring 2024,WCL,2351,2,11701,World Cultures Thru Lit & Arts,Ambikaipaker,Mohan,11,5,4,0,3,0,1,2.827
+Spring 2024,LAW,5409,1,11704,Contracts,Bush,Darren,12,16,0,0,0,0,0,3.405
+Spring 2024,GHL,4132,1,11705,Bev Mgmt & Mktg Internship,Taylor,David C,0,0,0,0,1,0,0,0.0
+Spring 2024,CHEE,8198,1,11707,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,1,11708,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8298,2,11709,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,6,0,
+Spring 2024,CHEE,8298,4,11711,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8298,5,11712,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,8,11715,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,9,11716,Doctoral Research,Karim,Alamgir,0,0,0,0,0,10,0,
+Spring 2024,CHEE,8298,10,11717,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,11,11718,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,12,11719,Doctoral Research,Orman,Mehmet,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8298,13,11720,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8298,14,11721,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,5,0,
+Spring 2024,CHEE,8298,16,11722,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8399,15,11723,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,3,0,
+Spring 2024,LAW,5301,1,11724,Immigration Clinic II,Cabot,Jessica Anna,1,0,0,0,0,0,0,3.67
+Spring 2024,CHEE,8398,6,11730,Doctoral Research,Economou,Demetre J,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8398,7,11731,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8398,8,11732,Doctoral Research,Harold,Michael P,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8398,9,11733,Doctoral Research,Karim,Alamgir,0,0,0,0,0,7,0,
+Spring 2024,CHEE,8398,12,11736,Doctoral Research,Orman,Mehmet,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8398,14,11738,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8398,15,11739,Doctoral Research,Robertson,Megan L,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8498,9,11748,Doctoral Research,Karim,Alamgir,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8598,1,11755,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8598,4,11758,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8598,5,11759,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8598,7,11761,Doctoral Research,Grabow,Lars C,0,0,0,0,0,5,0,
+Spring 2024,CHEE,8598,8,11762,Doctoral Research,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8598,9,11763,Doctoral Research,Karim,Alamgir,0,0,0,0,0,4,0,
+Spring 2024,CHEE,8598,12,11766,Doctoral Research,Orman,Mehmet,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8598,13,11767,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8598,14,11768,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,8,0,
+Spring 2024,CHEE,8598,15,11769,Doctoral Research,Robertson,Megan L,0,0,0,0,0,2,0,
+Spring 2024,POLS,4398,1,11770,Independent Study,Cross,Renee Danielle,10,0,2,0,0,2,0,3.612
+Spring 2024,ARCH,6367,1,11771,Case Studies Sustainable Arch,Taylor,Rives,3,2,0,0,0,0,0,3.6
+Spring 2024,ECE,6398,1,11772,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Spring 2024,ECE,6398,5,11776,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Spring 2024,ECE,6398,7,11778,Research,Chen,Ji,0,0,0,0,0,3,0,
+Spring 2024,ECE,6398,9,11780,Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Spring 2024,ECE,6398,10,11781,Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Spring 2024,ECE,6398,11,11782,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Spring 2024,ECE,6398,14,11785,Research,Han,Zhu,0,0,0,0,0,2,0,
+Spring 2024,ECE,6398,18,11789,Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Spring 2024,ECE,6398,20,11790,Research,Pan,Miao,0,0,0,0,0,2,0,
+Spring 2024,ECE,6398,27,11797,Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Spring 2024,ECE,8198,4,11806,Doctoral Research,Chen,Jiefu,0,0,0,0,0,2,0,
+Spring 2024,ECE,8198,11,11811,Doctoral Research,Han,Zhu,0,0,0,0,0,1,0,
+Spring 2024,ECE,8198,13,11813,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Spring 2024,ECE,8198,14,11814,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Spring 2024,ECE,8198,20,11819,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2024,ECE,8198,21,11820,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2024,ECE,8198,28,11827,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,0,0,
+Spring 2024,ECE,8198,31,11830,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Spring 2024,ECE,8198,32,11831,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,1,11838,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,3,0,
+Spring 2024,ECE,8298,2,11839,Doctoral Research,Chen,Ji,0,0,0,0,0,4,0,
+Spring 2024,ECE,8298,3,11840,Doctoral Research,Chen,Jiefu,0,0,0,0,0,2,0,
+Spring 2024,ECE,8298,5,11842,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,4,0,
+Spring 2024,ECE,8298,6,11843,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,7,11844,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,8,11845,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Spring 2024,ECE,8298,10,11847,Doctoral Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Spring 2024,ECE,8298,11,11848,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Spring 2024,ECE,8298,12,11849,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,13,11850,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Spring 2024,ECE,8298,15,11852,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,16,11853,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,3,0,
+Spring 2024,ECE,8298,17,11854,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,27,11862,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,29,11864,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2024,ECE,8398,1,11874,Doctoral Research,Li,Xingpeng,0,0,0,0,0,2,0,
+Spring 2024,ECE,8398,5,11878,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Spring 2024,ECE,8398,7,11880,Doctoral Research,Chen,Ji,0,0,0,0,0,4,1,
+Spring 2024,ECE,8398,8,11881,Doctoral Research,Chen,Jiefu,0,0,0,0,0,1,0,
+Spring 2024,ECE,8398,9,11882,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Spring 2024,ECE,8398,10,11883,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2024,ECE,8398,11,11884,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Spring 2024,ECE,8398,13,11886,Doctoral Research,Fu,Xin,0,0,0,0,0,3,0,
+Spring 2024,ECE,8398,14,11887,Doctoral Research,Han,Zhu,0,0,0,0,0,6,0,
+Spring 2024,ECE,8398,15,11888,Doctoral Research,Jackson,David R,0,0,0,0,0,2,0,
+Spring 2024,ECE,8398,16,11889,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Spring 2024,ECE,8398,18,11891,Doctoral Research,Pan,Miao,0,0,0,0,0,3,0,
+Spring 2024,ECE,8398,20,11893,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,2,0,
+Spring 2024,ECE,8398,21,11894,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,2,0,
+Spring 2024,ECE,8398,25,11898,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Spring 2024,ECE,8398,27,11900,Doctoral Research,Yao,Yan,0,0,0,0,0,5,0,
+Spring 2024,ECE,8398,28,11901,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,
+Spring 2024,ECE,8398,30,11902,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Spring 2024,ECE,8498,1,11903,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Spring 2024,ECE,8498,3,11905,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,4,11906,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,1,
+Spring 2024,ECE,8498,5,11907,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,3,0,
+Spring 2024,ECE,8498,6,11908,Doctoral Research,Chen,Ji,0,0,0,0,0,5,0,
+Spring 2024,ECE,8498,7,11909,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Spring 2024,ECE,8498,9,11911,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,10,11912,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Spring 2024,ECE,8498,11,11913,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Spring 2024,ECE,8498,12,11914,Doctoral Research,Fu,Xin,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,13,11915,Doctoral Research,Han,Zhu,0,0,0,0,0,2,0,
+Spring 2024,ECE,8498,14,11916,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,15,11917,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,4,0,
+Spring 2024,ECE,8498,17,11919,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,18,11920,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,3,0,
+Spring 2024,ECE,8498,19,11921,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,22,11924,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,24,11926,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,0,0,
+Spring 2024,ECE,8498,25,11927,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,5,0,
+Spring 2024,ECE,8498,27,11929,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,28,11930,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,1,11931,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,2,11932,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,3,11933,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,4,11934,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,5,11935,Doctoral Research,Chen,Ji,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,7,11936,Doctoral Research,Chen,Jiefu,0,0,0,0,0,3,0,
+Spring 2024,ECE,8598,10,11939,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,12,11941,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Spring 2024,ECE,8598,13,11942,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Spring 2024,ECE,8598,15,11944,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Spring 2024,ECE,8598,17,11946,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,0,0,
+Spring 2024,ECE,8598,18,11947,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,19,11948,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,3,0,
+Spring 2024,ECE,8598,22,11951,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,23,11952,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,26,11955,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,27,11956,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Spring 2024,ECE,8598,30,11958,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Spring 2024,COMM,4382,1,11959,Narrative Non-Linear Editing,Houk,Keith R,22,6,0,0,0,0,0,3.774
+Spring 2024,BIOL,4206,1,11960,Ecology & Evolution Laboratory,Cheek,Ann Oliver,20,2,0,0,1,0,0,3.739
+Spring 2024,BIOL,4206,2,11961,Ecology & Evolution Laboratory,Cheek,Ann Oliver,13,8,0,0,1,0,2,3.47
+Spring 2024,PHCA,6298,3,11963,Special Problems,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6398,1,11970,Special Problems,Chung,Sanghyuk,0,0,0,0,0,2,0,
+Spring 2024,BIOL,6198,1,11971,Special Problems,Nunez,Martin A,0,0,0,0,0,2,0,
+Spring 2024,BIOL,6498,1,11973,Special Problems,Chung,Sanghyuk,0,0,0,0,0,3,0,
+Spring 2024,CHEM,6198,1,11976,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6198,2,11977,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6198,4,11978,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6198,8,11982,Special Problems,Teets,Thomas,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6198,11,11985,Special Problems,Carrow,Bradley,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6198,13,11987,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6198,15,11989,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6698,2,12013,Special Problems,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6698,3,12014,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6698,4,12015,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,5,12016,Special Problems,Teets,Thomas,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6698,6,12017,Special Problems,May,Jeremy A,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6698,7,12018,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,9,12020,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,10,12021,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6698,11,12022,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,15,12026,Special Problems,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,17,12028,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,18,12029,Special Problems,Carrow,Bradley,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6698,20,12031,Special Problems,Comito,Robert Joseph,0,0,0,0,0,3,0,
+Spring 2024,CHEM,6998,7,12037,Special Problems,Comito,Robert Joseph,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6998,12,12042,Special Problems,Lubchenko,Vassiliy,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6998,15,12045,Special Problems,Carrow,Bradley,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6998,18,12048,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Spring 2024,CHEM,6998,20,12050,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Spring 2024,CHEM,8998,2,12089,Doctoral Research,Harth,Eva M,0,0,0,0,0,5,0,
+Spring 2024,CHEM,8998,4,12091,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,2,0,
+Spring 2024,CHEM,8998,5,12092,Doctoral Research,Teets,Thomas,0,0,0,0,0,1,0,
+Spring 2024,CHEM,8998,6,12093,Doctoral Research,Lee,T Randall,0,0,0,0,0,6,0,
+Spring 2024,CHEM,8998,7,12094,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,4,0,
+Spring 2024,CHEM,8998,9,12096,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Spring 2024,CHEM,8998,13,12100,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,3,0,
+Spring 2024,CHEM,8998,14,12101,Doctoral Research,Baldelli,Steve,0,0,0,0,0,2,0,
+Spring 2024,CHEM,8998,16,12103,Doctoral Research,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Spring 2024,CHEM,8998,17,12104,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Spring 2024,CHEM,8998,20,12107,Doctoral Research,May,Jeremy A,0,0,0,0,0,2,0,
+Spring 2024,PSYC,2316,1,12108,Psychology of Personality,Inman,Tonya N,61,33,13,5,1,0,3,3.278
+Spring 2024,PSYC,4344,2,12109,Cultural Psychology,Hernandez Ortiz,Jessica G,49,21,7,1,0,0,0,3.576
+Spring 2024,PSYC,3331,1,12110,Psychology of Gender,Jaramillo,Kristen,65,9,3,0,2,0,0,3.663
+Spring 2024,PCEU,6498,2,12112,Special Problems,Hu,Ming,0,0,0,0,0,2,0,
+Spring 2024,ENGL,7398,1,12113,Special Problems,Turchi,Peter D,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,6376,1,12115,Organometallic Chemistry,Daugulis,Olafs,5,13,0,0,0,0,0,3.296
+Spring 2024,CUIN,8398,9,12116,Independent Study,Hale,Margaret Ann,1,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,8398,1,12117,Special Problems,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5681,1,12118,Infectious Diseases,Truong,Mabel,11,2,0,0,0,0,0,3.846
+Spring 2024,HON,3399,1,12119,Senior Honors Thesis,Belco,Michelle Helene,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,4498,1,12120,Independent Study,Cross,Renee Danielle,0,0,0,0,0,5,0,
+Spring 2024,ENGL,4398,1,12121,Independent Study,Lee,Eunjeong,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8598,16,12122,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,3,0,
+Spring 2024,CHEE,8498,16,12123,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,1,0,
+Spring 2024,BCHS,6298,1,12124,Special Problems,Briggs,James M,0,0,0,0,0,2,0,
+Spring 2024,POLS,4598,1,12127,Independent Study,Cross,Renee Danielle,0,0,0,0,0,4,0,
+Spring 2024,ENGI,2304,3,12128,Technical Communications,Estrada,Carl,13,10,2,0,0,0,0,3.308
+Spring 2024,NUTR,3336,2,12129,Nutritional Pathophysiology,Vollrath,Kirstin,28,12,5,2,0,0,1,3.383
+Spring 2024,COSC,4354,1,12131,Software Development Practices,Subramaniam,Venkat,20,7,1,2,0,0,1,3.412
+Spring 2024,ECON,3332,1,12132,Intermediate Microeconomics,Craig,Steven G,12,17,8,2,1,0,2,2.942
+Spring 2024,GEOL,6396,1,12134,Graduate Seminar,Choi,Yunsoo,0,0,0,0,0,18,0,
+Spring 2024,MATH,1351,3,12135,Intro to Geometric Reasoning,Douglas,Casey,92,102,86,32,40,0,36,2.432
+Spring 2024,MATH,1342,6,12136,Elementary Statistical Methods,Chern,Haley Nicole,82,128,124,18,26,0,34,2.559
+Spring 2024,MATH,3338,3,12137,Probability,Papadakis,Emanuel Ioannis,16,8,2,2,2,0,3,3.089
+Spring 2024,KIN,4190,1,12138,Sport Administration Seminar,Walsh,David W,27,6,2,0,1,0,4,3.556
+Spring 2024,FINA,4330,2,12139,Corporate Finance,Liu,Zesong,21,12,6,3,0,0,1,3.191
+Spring 2024,GEOL,1347,1,12140,Introduction To Meteorology,Rappenglueck,Bernhard,56,12,7,4,3,0,11,3.314
+Spring 2024,ARCH,6355,1,12141,Houston Architecture,Fox,Stephen,2,3,0,0,0,0,0,3.334
+Spring 2024,ARCH,6347,1,12142,Evolution of Arch Interiors,Thomas,James B,2,0,0,0,0,0,0,4.0
+Spring 2024,COMM,4366,1,12145,Advertising Account Planning,Tinnel,Jason Wayne,14,6,4,0,0,0,1,3.403
+Spring 2024,COSC,6385,1,12146,Computer Architecture,Shi,Weidong,29,7,0,0,0,0,1,3.714
+Spring 2024,KIN,4690,1,12147,Internship in Sport Admin 1,Walsh,David W,10,1,2,1,1,0,0,3.244
+Spring 2024,KIN,4691,1,12148,Internship in Sport Admin 2,Walsh,David W,12,1,1,1,1,0,0,3.334
+Spring 2024,BIOL,4103,1,12149,Integration Biol Knowledge,Wayne,Chad M,59,27,5,0,2,0,0,3.52
+Spring 2024,ENTR,3310,4,12150,Entrepreneurship,Ortega,Carlos Alberto,162,24,6,1,4,0,2,3.691
+Spring 2024,ACCT,2302,3,12152,Prin of Managerial Accounting,Weber,Catherine K,36,62,38,5,1,0,6,2.948
+Spring 2024,CUIN,4350,1,12153,Multiple Teaching Strategies,Segura,Perri F,6,0,0,0,0,0,0,3.945
+Spring 2024,ECE,5114,1,12154,Antenna Engineering Laboratory,Long,Stuart A,0,0,0,0,0,0,1,
+Spring 2024,PSYC,3310,1,12155,Indstrl-Orgnztnl Psy,Reyes,Denise Lucia,42,12,4,1,0,0,0,3.666
+Spring 2024,PSYC,3350,1,12156,Intro to Cognitive Psychology,Hernandez,Arturo E,9,65,40,5,8,0,12,2.483
+Spring 2024,CHEE,3363,1,12157,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,7,12,10,3,0,0,4,2.739
+Spring 2024,LAW,5418,1,12158,Torts,Koch,Valerie Gutmann,11,14,2,0,0,0,0,3.333
+Spring 2024,COMD,3385,1,12159,Speech Science,Bunta,Ferenc,8,16,2,1,0,0,1,3.16
+Spring 2024,HDFS,1300,7,12162,Dev of Contemporary Families,Jordan,Erica F,70,39,10,2,2,0,3,3.39
+Spring 2024,MANA,4338,1,12163,Performance Management Systems,Sullivan,David Walter,51,8,0,1,0,0,0,3.85
+Spring 2024,CUIN,3350,1,12164,Knowing/Learning Science-Math,Latiolais,Cheryl S,9,1,0,0,0,0,0,3.768
+Spring 2024,CUIN,3350,2,12165,Knowing/Learning Science-Math,Segura,Perri F,15,1,0,1,1,0,1,3.519
+Spring 2024,MIS,3360,1,12166,Systems Analysis and Design,Harkness,Carol Louise,14,32,15,1,0,0,2,2.952
+Spring 2024,GERM,3381,1,12168,German Cinema,Glass,Hildegard,6,5,4,3,9,0,5,1.815
+Spring 2024,ACCT,7385,1,12169,Forensic Accounting,Ramey,Dan T,12,7,1,0,0,0,0,3.6
+Spring 2024,FINA,6387,2,12170,Managerial Analysis,Basu,Swati,32,18,0,0,0,0,1,3.64
+Spring 2024,PHYS,3327,1,12172,Thermal Physics,Chen,Shuo,3,9,2,0,1,0,3,2.845
+Spring 2024,KIN,4340,1,12173,Sport Governance,Hawkins,Billy J,38,21,2,0,0,0,0,3.65
+Spring 2024,MIS,7378,1,12174,Info.Tech Management & Control,Porra,Jaana,26,1,0,0,1,0,0,3.774
+Spring 2024,SOCW,7389,1,12175,SW Practicum IV- Macro,Gonzales,Shelley A,0,0,0,0,0,4,0,
+Spring 2024,PSYC,8399,6,12179,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,2102,11,12180,Anatomy & Physiology II (lab),Gill,Tejendra,11,9,2,1,0,0,1,3.304
+Spring 2024,BIOL,2102,12,12182,Anatomy & Physiology II (lab),Gill,Tejendra,4,16,2,1,0,0,1,3.043
+Spring 2024,EDUC,4314,1,12185,Student Teaching Sec,Thompson,Amber M,14,2,0,1,0,0,0,3.706
+Spring 2024,HDFS,3350,3,12186,Observation and Assessment,Schroder,Kathleen Anne,25,2,1,2,0,0,0,3.623
+Spring 2024,BIOL,2102,13,12189,Anatomy & Physiology II (lab),Gill,Tejendra,10,8,4,1,0,0,0,3.203
+Spring 2024,PCEU,7142,1,12191,Pharmaceutic Literature Review,Bond,Richard A,0,0,0,0,0,5,0,
+Spring 2024,BIOL,2102,15,12192,Anatomy & Physiology II (lab),Gill,Tejendra,8,14,2,0,0,0,0,3.236
+Spring 2024,COMD,7692,1,12195,Advanced Practicum,Blake,Margaret T,3,3,0,0,0,0,0,3.39
+Spring 2024,PSYC,6392,1,12201,Intervention Practicum,Vincent,John P,0,0,0,0,0,14,0,
+Spring 2024,SOCW,8699,1,12202,Dissertation,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Spring 2024,ARCH,3342,1,12204,Shape of the City,Turner,Drexel,6,6,0,0,0,0,0,3.583
+Spring 2024,ARCH,6342,1,12205,Shape of the City,Turner,Drexel,2,1,0,0,0,0,0,3.557
+Spring 2024,FREN,1501,5,12207,Elementary French I,Gnanwo Hounfodji,Raymond,5,10,3,0,1,0,2,2.947
+Spring 2024,BCHS,6198,1,12212,Special Problems,Widger,William R,0,0,0,0,0,3,0,
+Spring 2024,FINA,8398,2,12213,Special Problems,Yerramilli,Vijay,1,0,0,0,0,0,0,3.67
+Spring 2024,FINA,8398,4,12214,Special Problems,Susmel,Raul,1,0,0,0,0,0,0,4.0
+Spring 2024,MSCI,1220,1,12215,Agile & Adaptive Leadership,Comiskey,Melissa C,8,1,0,0,0,0,0,3.816
+Spring 2024,MSCI,1220,3,12217,Agile & Adaptive Leadership,Comiskey,Melissa C,4,1,0,0,1,0,0,3.112
+Spring 2024,ECON,6340,1,12218,Health Economics,Zhivan,Natalia A,6,4,0,0,0,0,0,3.567
+Spring 2024,ECON,6345,1,12219,Energy Economics,Kelly,Robert C,5,0,0,0,0,0,0,3.736
+Spring 2024,MATH,4309,1,12220,Mathematical Biology,Azevedo,Ricardo,3,3,1,0,0,0,2,3.191
+Spring 2024,MIS,4374,2,12221,Info Technology Project Mgmt,Campbell,Phillip James,24,8,0,1,0,0,0,3.697
+Spring 2024,GEOL,1103,8,12222,Physical Geology Lab,Hauptvogel,Daniel William,13,2,2,2,2,0,0,3.016
+Spring 2024,KIN,3370,1,12223,Sport Facility Management,Cho,Minseok,21,19,1,0,0,0,1,3.488
+Spring 2024,FINA,7352,1,12224,Energy Derivatives,Pirrong,Stephen Craig,11,5,0,0,0,0,0,3.646
+Spring 2024,CHEE,3321,1,12225,Analytical Methods Chem Engr,Conrad,Jacinta C,13,10,7,2,1,0,5,2.9
+Spring 2024,CHEM,4340,1,12227,Research Methods,Ekeoba,Jacqueline Njideka,2,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,4309,1,12228,Mathematical Biology,Azevedo,Ricardo,5,1,0,0,0,0,0,3.723
+Spring 2024,COSC,4359,1,12229,Intermediate Game Development,Yun,Changhoon,20,0,0,0,0,0,0,3.901
+Spring 2024,COSC,6359,1,12230,Intermediate Game Development,Yun,Changhoon,5,0,0,0,0,0,0,3.934
+Spring 2024,PSYC,2305,2,12231,Intro to Methods in Psychology,Foss,Donald J,12,11,9,1,5,0,6,2.675
+Spring 2024,PSYC,6337,1,12233,Grant Writing,Neighbors,Clayton T,10,0,0,0,0,0,0,3.967
+Spring 2024,COMM,3319,1,12234,Preproduction Management,Houk,Keith R,27,0,0,0,0,0,0,4.0
+Spring 2024,MARK,6361,1,12235,Marketing Administration,Koch,Steven F,14,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,6115,3,12236,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,8,0,
+Spring 2024,ITAL,1502,1,12237,Elementary Italian II,Ercolani,Monica,6,4,0,0,0,0,1,3.567
+Spring 2024,ITAL,1502,3,12239,Elementary Italian II,Ercolani,Monica,11,3,0,0,1,0,1,3.401
+Spring 2024,PSYC,2305,4,12241,Intro to Methods in Psychology,Foss,Donald J,14,9,6,2,1,0,12,3.011
+Spring 2024,BIOL,3368,1,12243,Ecology,Pennings,Steven C,14,17,42,1,4,0,3,2.449
+Spring 2024,BIOL,4354,1,12244,Endocrinology,Warner,Margaret,80,21,4,3,0,0,4,3.648
+Spring 2024,HDFS,2320,1,12245,Research Methods in HDFS,Kamdar-Sharif,Amber,24,13,3,0,0,0,1,3.418
+Spring 2024,ACCT,3366,1,12249,Financial Reporting Frameworks,Harris,Kathleen L,12,4,10,3,2,0,14,2.72
+Spring 2024,ACCT,3366,2,12250,Financial Reporting Frameworks,Harris,Kathleen L,14,1,4,0,1,0,12,3.35
+Spring 2024,KIN,3360,1,12252,Professional Prep for Sp Admin,Pearson,Demetrius W,8,15,19,7,6,0,5,2.218
+Spring 2024,ACCT,5331,1,12253,Federal Income Tax,Fernandez,Ramon,2,8,4,0,0,0,3,2.975
+Spring 2024,ENGL,1302,24,12254,First Year Writing II,Koulen,Marisa Theresa,17,2,0,0,0,0,0,3.808
+Spring 2024,MECE,4341,1,12255,Mechanical Engr Capstone II,Agrawal,Ashutosh,64,54,9,0,0,0,0,3.43
+Spring 2024,LAW,5200,1,12256,Depositions,Morfey,Michael D,4,5,0,0,0,3,0,3.371
+Spring 2024,GHL,6330,1,12257,Statistical Analysis in Hosp.,Shin,Min Jung,2,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6364,1,12258,Hosp. Managerial Accounting,Johnson,Tucker A,8,2,0,0,0,0,0,3.767
+Spring 2024,NUTR,4334,1,12259,Community Nutrition,Hughes,Lindsay,83,45,14,1,1,0,2,3.438
+Spring 2024,PEP,6321,2,12260,Sport in Cont Society,Pearson,Demetrius W,1,10,6,1,0,0,0,2.648
+Spring 2024,BIOL,1307,5,12261,Biology for Science Majors II,Gifford,Jenifer,111,104,49,11,4,0,5,3.073
+Spring 2024,MECE,4372,1,12262,Mechs-Cntrls-Vibrtn Lab,Chen,Zheng,20,25,33,0,0,0,0,2.736
+Spring 2024,CHEE,2331,1,12264,Chemical Processes,Henderson,Jerrod A,8,5,4,4,1,0,6,2.562
+Spring 2024,AFSC,4302,1,12265,National Security Affairs II,Manning,Matthew,2,0,0,0,0,0,0,4.0
+Spring 2024,MARK,7368,1,12267,Integrated Marketng Commncatns,Morabito,Philip A,26,0,0,0,0,0,0,3.784
+Spring 2024,POLS,3311,1,12268,Intro Compar Politics,Hanna,Tom Leard,25,8,2,0,1,0,3,3.583
+Spring 2024,FINA,3332,1,12269,Prin of Financial Management,Suleymanov,Masim,12,10,1,2,0,0,0,3.28
+Spring 2024,ACCT,3366,3,12270,Financial Reporting Frameworks,Parthasarathy,Kiran M,42,13,25,4,2,0,11,3.008
+Spring 2024,MECE,4331,1,12271,Design of Machine Elements,Wang,Su Su,17,24,16,2,2,0,4,2.825
+Spring 2024,FINA,4320,2,12273,Investment Management,Gargano,Antonio,9,2,0,0,0,0,0,3.848
+Spring 2024,ENGL,2306,1,12274,Intro To Poetry,Guajardo,Paul,10,12,2,0,1,0,0,3.213
+Spring 2024,BCHS,3201,10,12275,Biochemistry I Laboratory,Pattison,Donna,9,10,2,0,1,0,1,3.152
+Spring 2024,ELED,3322,3,12280,Elem Reading Phonics Instructn,Alba,Celeste,9,0,1,0,0,0,0,3.701
+Spring 2024,PHYS,1101,12,12290,College Physics I (lab),Wood,Lowell T,3,6,10,0,0,0,4,2.718
+Spring 2024,PHYS,1101,13,12291,College Physics I (lab),Wood,Lowell T,3,11,7,1,0,0,1,2.697
+Spring 2024,ENGI,2304,4,12297,Technical Communications,Estrada,Carl,5,6,3,1,3,0,5,2.408
+Spring 2024,ARCH,5500,11,12301,Architecture Design Studio IX,Plauche',Roya,8,6,0,0,0,0,0,3.548
+Spring 2024,PHAR,5668,1,12303,Managed Care Pharmacy,Tolleson,Shane Russell,7,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8361,1,12305,Workshop Research Methods III,Ujhelyi,Gergely,0,0,0,0,0,5,0,
+Spring 2024,MATH,3339,3,12306,Statistics for the Sciences,Fu,Wenjiang,29,11,4,7,4,0,5,2.97
+Spring 2024,ARCH,5500,5,12307,Architecture Design Studio IX,Wienert,Ross George,6,5,2,0,0,0,1,3.333
+Spring 2024,INDS,4180,1,12308,Design Internship,Kimbrough,Mark S,4,0,0,0,1,0,0,3.2
+Spring 2024,INDE,6361,1,12309,Prod Planning & Invent Control,Hu,Minxiang,68,0,0,0,0,0,0,3.845
+Spring 2024,SPAN,1502,9,12310,Elementary Spanish II,Jager Lopezllera,Valentina Kathe,4,10,6,0,3,0,3,2.522
+Spring 2024,FREN,2312,2,12312,Intermediate French II,Green,Viola V,5,7,5,2,2,0,3,2.43
+Spring 2024,PHAR,5660,1,12314,Pharmaceutical Industry,Tolleson,Shane Russell,1,0,1,0,0,0,0,3.0
+Spring 2024,PHAR,5663,2,12315,Pharmacy Management,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,1302,1,12318,Intro To Global Climate Change,Wang,Yuxuan,107,234,80,4,2,0,15,3.028
+Spring 2024,SCM,4301,1,12319,Logistics Management,Tibodeau,Dale,21,22,9,1,0,0,0,3.182
+Spring 2024,SCM,4330,1,12320,Bus Modeling and Dec Analysis,Cossick,Kathy L,4,4,3,1,0,0,3,2.889
+Spring 2024,SCM,4330,2,12321,Bus Modeling and Dec Analysis,Cossick,Kathy L,24,12,6,3,1,0,3,3.167
+Spring 2024,SCM,4351,1,12322,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,24,8,4,0,0,0,0,3.556
+Spring 2024,SCM,4351,2,12323,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,14,10,1,0,0,0,0,3.507
+Spring 2024,GEOL,4331,1,12324,Geospatial Analysis & App.,Khan,Shuhab D,11,15,11,0,1,0,1,2.878
+Spring 2024,GEOL,6388,1,12325,Geospatial Analysis,Khan,Shuhab D,4,4,0,0,1,0,0,3.148
+Spring 2024,BIOL,4340,1,12326,Research Methods,Ekeoba,Jacqueline Njideka,5,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,3347,2,12328,Reading in the Content Area,Schorzman,Emma,22,0,0,0,1,0,0,3.826
+Spring 2024,CUIN,4361,1,12330,Second Language Methodology,Burgess,Miguel,28,2,0,0,0,0,0,3.933
+Spring 2024,CUIN,4375,5,12331,Classroom Management,Castillo,Bernadette Marie,17,0,0,0,0,0,1,3.903
+Spring 2024,BIOL,2321,1,12332,Microbiology for Science Major,Knapp,Richard D,23,24,33,14,9,0,8,2.388
+Spring 2024,INTB,3355,1,12333,Global Environment of Business,Thompson,Joseph Lee,22,0,0,0,0,0,0,3.985
+Spring 2024,ELED,4310,1,12334,Reading/Language in Elementary,Tyson,Eleanore S,30,0,0,0,0,0,0,3.989
+Spring 2024,SOCW,8327,1,12335,Grant Writing,Gearing,Robin Edward,4,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2301,2,12336,Prin of Financial Accounting,Bhakthavachalam,Aimee Tara,8,13,20,9,2,0,3,2.428
+Spring 2024,BIOL,1307,3,12337,Biology for Science Majors II,Farmer,Lisa M,54,86,82,31,14,0,13,2.511
+Spring 2024,MIS,3370,2,12340,Info Systems Development Tools,Zamarripa,Ivan,12,22,8,5,0,0,13,2.872
+Spring 2024,GEOL,1103,1,12341,Physical Geology Lab,Hauptvogel,Daniel William,9,3,1,0,3,0,2,2.938
+Spring 2024,EDUC,1301,2,12342,Intro to Teaching Profession,Ronduen,Lionnel Ganir,19,4,2,0,1,0,1,3.526
+Spring 2024,SOCW,7325,2,12343,Individuals: Adv Clinical Prac,Amtsberg,Donna K,26,1,0,0,0,0,1,3.963
+Spring 2024,SOCW,7334,1,12344,Social Work Leadership,Pang,Melanie Espinosa,25,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2302,4,12345,Prin of Managerial Accounting,Seltz,Joe D,34,43,19,5,1,0,3,3.084
+Spring 2024,NUTR,4333,1,12346,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,11,12,4,0,0,0,0,3.296
+Spring 2024,ECE,3155,1,12347,Electronics Laboratory,Wolfe,John C,44,0,0,0,0,0,0,3.985
+Spring 2024,PHYS,2326,1,12348,University Physics II(lecture),Curran,Seamus A,33,48,34,9,4,0,15,2.732
+Spring 2024,MATH,1314,10,12350,College Algebra,Caglar,Atife,8,9,3,5,4,0,2,2.357
+Spring 2024,MATH,1324,10,12351,Finite Math with Applications,Sosa,Moses,42,22,26,22,28,0,36,2.172
+Spring 2024,MATH,1342,7,12353,Elementary Statistical Methods,Hafeez,Shahinda,26,34,28,16,22,0,28,2.222
+Spring 2024,PSYC,2305,6,12354,Intro to Methods in Psychology,Merrill,Livia Christine,37,16,9,3,5,0,9,3.086
+Spring 2024,PETR,2313,1,12355,Reservoir Fluids,Dindoruk,Birol,3,6,2,0,0,0,0,3.121
+Spring 2024,PETR,3321,1,12356,Petr Pressure Trans Testing,Hatzignatiou,Dimitrios Georgios,1,2,4,0,0,0,2,2.477
+Spring 2024,BIOE,6298,1,12359,Research,Akay,Metin,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8198,2,12365,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8298,1,12366,Doctoral Research,Akay,Metin,0,0,0,0,0,4,0,
+Spring 2024,BIOE,8298,2,12367,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8398,1,12368,Doctoral Research,Akay,Metin,0,0,0,0,0,4,1,
+Spring 2024,BIOE,8399,1,12370,Doctoral Dissertation,Akay,Metin,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8399,2,12371,Doctoral Dissertation,Wu,Tianfu,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,1,12373,Doctoral Research,Akay,Metin,0,0,0,0,0,3,0,
+Spring 2024,BIOE,8598,2,12374,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8699,1,12375,Doctoral Dissertation,Akay,Metin,1,0,0,0,0,1,0,4.0
+Spring 2024,BIOE,8699,2,12376,Doctoral Dissertation,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Spring 2024,COMD,4382,2,12378,Aural Rehabilitation,Andrews,Chereece N,48,6,0,0,0,0,1,3.828
+Spring 2024,CHEE,8498,18,12380,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,17,12381,Doctoral Research,Vekilov,Peter,0,0,0,0,0,4,0,
+Spring 2024,GHL,2350,1,12382,Mgmt Principles in Hospitality,Liu,Wenfang,25,9,5,1,0,0,0,3.401
+Spring 2024,HON,4315,1,12384,Artists at Work,Cremins,Robert Paul,17,0,0,0,1,0,0,3.704
+Spring 2024,ENGL,2305,1,12385,Intro To Fiction,Singh,Kavita Ashana,15,4,3,0,3,0,4,3.067
+Spring 2024,MIS,4378,2,12386,Admin of Computer-Based MIS,Porra,Jaana,40,4,0,0,0,0,0,3.909
+Spring 2024,ENGL,1302,4,12387,First Year Writing II,Downey,Carlton M,20,0,0,0,1,0,3,3.81
+Spring 2024,COMM,3321,1,12388,Single Camera Studio Productn,Houk,Keith R,20,2,0,0,0,0,0,3.939
+Spring 2024,PHYS,1101,14,12391,College Physics I (lab),Wood,Lowell T,0,15,7,0,0,0,1,2.682
+Spring 2024,PHYS,1101,15,12392,College Physics I (lab),Wood,Lowell T,2,15,4,0,0,0,3,2.826
+Spring 2024,PHYS,1101,16,12393,College Physics I (lab),Wood,Lowell T,3,5,9,1,0,0,3,2.666
+Spring 2024,BIOL,4103,2,12394,Integration Biol Knowledge,Wayne,Chad M,63,18,11,0,2,0,0,3.517
+Spring 2024,BIOL,2121,1,12395,Microbiol for Science Maj(lab),Knapp,Richard D,6,7,2,0,0,0,0,3.311
+Spring 2024,BIOL,2121,2,12396,Microbiol for Science Maj(lab),Knapp,Richard D,14,9,0,1,0,0,0,3.459
+Spring 2024,BIOL,2121,3,12397,Microbiol for Science Maj(lab),Knapp,Richard D,11,9,3,0,1,0,0,3.222
+Spring 2024,BIOL,2121,4,12398,Microbiol for Science Maj(lab),Knapp,Richard D,6,13,3,1,1,0,0,2.972
+Spring 2024,BIOL,2121,5,12399,Microbiol for Science Maj(lab),Knapp,Richard D,8,7,2,5,0,0,1,2.788
+Spring 2024,BIOL,2121,6,12400,Microbiol for Science Maj(lab),Knapp,Richard D,7,5,7,0,0,0,1,3.104
+Spring 2024,BIOL,2121,7,12401,Microbiol for Science Maj(lab),Knapp,Richard D,9,5,2,0,0,0,0,3.417
+Spring 2024,BIOL,2121,8,12402,Microbiol for Science Maj(lab),Knapp,Richard D,10,6,2,1,0,0,3,3.316
+Spring 2024,CHEM,2123,8,12403,Organic Chemistry Lab I,Bean,Mary B,3,9,7,3,0,0,0,2.485
+Spring 2024,CHEM,1112,27,12404,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,3,0,1,0,1,2.863
+Spring 2024,PHOP,8199,4,12405,Doctoral Dissertation,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,3119,2,12406,Anlytical Chemistry Lab,Czader,Arkadiusz,1,10,0,0,0,0,0,3.211
+Spring 2024,BIOL,1107,23,12407,Biology for Science Majors II,Medrano,Ana I,14,7,1,0,1,0,1,3.478
+Spring 2024,BIOL,1107,24,12408,Biology for Science Majors II,Medrano,Ana I,21,2,0,0,0,0,0,3.913
+Spring 2024,BIOL,1107,25,12409,Biology for Science Majors II,Medrano,Ana I,13,9,1,0,0,0,1,3.565
+Spring 2024,BIOL,1107,26,12410,Biology for Science Majors II,Medrano,Ana I,20,1,1,0,1,0,0,3.667
+Spring 2024,BIOL,1107,27,12411,Biology for Science Majors II,Medrano,Ana I,20,2,1,0,0,0,1,3.826
+Spring 2024,BIOL,1107,28,12412,Biology for Science Majors II,Medrano,Ana I,23,0,1,0,0,0,0,3.862
+Spring 2024,BIOL,1107,29,12413,Biology for Science Majors II,Medrano,Ana I,21,2,0,0,0,0,1,3.884
+Spring 2024,BIOL,1107,30,12414,Biology for Science Majors II,Medrano,Ana I,21,3,0,0,0,0,0,3.875
+Spring 2024,BIOL,1107,31,12415,Biology for Science Majors II,Medrano,Ana I,15,2,3,2,1,0,0,3.174
+Spring 2024,BIOL,1107,32,12416,Biology for Science Majors II,Medrano,Ana I,19,1,0,0,0,0,2,3.917
+Spring 2024,CHEM,1105,3,12417,Foundations of Chem Lab,Zaitsev,Vladimir G,3,16,1,0,0,0,0,3.232
+Spring 2024,CHEM,1105,4,12418,Foundations of Chem Lab,Zaitsev,Vladimir G,7,12,0,0,0,0,0,3.368
+Spring 2024,ACCT,5367,1,12419,Intermediate Accounting I,Noland,Thomas R,5,2,3,0,1,0,0,2.969
+Spring 2024,CHEM,1111,12,12420,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,12,3,0,0,0,1,3.019
+Spring 2024,CHEM,1111,13,12421,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,0,0,0,0,3,3.311
+Spring 2024,CHEM,1111,15,12422,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,3,0,1,0,2,2.815
+Spring 2024,CHEM,1112,28,12423,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,11,1,0,0,0,2,3.314
+Spring 2024,CHEM,1112,29,12424,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,14,0,0,0,0,1,3.194
+Spring 2024,CHEM,1112,30,12425,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,6,1,0,0,0,5,3.313
+Spring 2024,CHEM,1112,31,12426,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,14,1,0,0,0,0,3.254
+Spring 2024,CHEM,1112,34,12427,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,2,0,0,0,1,3.146
+Spring 2024,BIOL,1107,33,12428,Biology for Science Majors II,Medrano,Ana I,12,3,3,0,1,0,4,3.298
+Spring 2024,BIOL,1107,34,12429,Biology for Science Majors II,Medrano,Ana I,21,1,0,1,0,0,1,3.826
+Spring 2024,BIOL,1107,35,12430,Biology for Science Majors II,Medrano,Ana I,18,3,3,0,0,0,0,3.639
+Spring 2024,BIOL,1107,36,12431,Biology for Science Majors II,Medrano,Ana I,18,3,0,1,0,0,1,3.742
+Spring 2024,BIOL,2102,14,12432,Anatomy & Physiology II (lab),Gill,Tejendra,8,8,2,3,0,0,3,3.047
+Spring 2024,BIOL,2102,16,12433,Anatomy & Physiology II (lab),Gill,Tejendra,8,13,3,0,0,0,0,3.126
+Spring 2024,BIOL,1107,37,12434,Biology for Science Majors II,Medrano,Ana I,16,5,2,0,0,0,0,3.594
+Spring 2024,BIOL,1107,38,12435,Biology for Science Majors II,Medrano,Ana I,21,1,2,0,0,0,0,3.778
+Spring 2024,BIOL,1107,40,12436,Biology for Science Majors II,Medrano,Ana I,19,5,0,0,0,0,0,3.805
+Spring 2024,BIOL,1107,39,12437,Biology for Science Majors II,Medrano,Ana I,20,3,0,0,0,0,1,3.798
+Spring 2024,PHCA,8398,2,12438,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8698,2,12440,Doctoral Dissertation Research,Aparasu,Rajender R,2,0,0,0,0,0,0,4.0
+Spring 2024,HON,3361,1,12443,Global Engagement and Research,Miljanic,Andra Olivia,4,3,0,0,0,0,0,3.477
+Spring 2024,BIOL,1107,41,12444,Biology for Science Majors II,Medrano,Ana I,15,7,2,0,0,0,0,3.528
+Spring 2024,BIOL,1107,42,12445,Biology for Science Majors II,Medrano,Ana I,18,4,0,0,2,0,0,3.514
+Spring 2024,BIOL,1107,43,12446,Biology for Science Majors II,Medrano,Ana I,13,9,1,0,0,0,1,3.507
+Spring 2024,BIOL,1107,44,12447,Biology for Science Majors II,Medrano,Ana I,18,4,1,0,0,0,0,3.768
+Spring 2024,ENGL,1302,5,12450,First Year Writing II,Anderson,Claire F,8,6,2,0,2,0,1,2.927
+Spring 2024,ENGL,1302,6,12451,First Year Writing II,Jones,Baylea,12,4,2,0,1,0,0,3.299
+Spring 2024,ENGL,1302,13,12452,First Year Writing II,Brinkley,Paola Garcia,9,5,2,0,1,0,2,3.235
+Spring 2024,ENGL,1302,29,12453,First Year Writing II,Colchado,Lea,5,3,6,3,0,0,1,2.588
+Spring 2024,SPAN,1501,17,12455,Elementary Spanish I,Carrion Rivera,Lydiette,8,11,2,1,1,0,1,3.015
+Spring 2024,ECE,2201,2,12459,Circuit Analysis I,Shattuck,David P,5,14,11,9,3,0,13,2.23
+Spring 2024,KIN,4398,3,12464,Independent Study,Cottingham,Michael,2,0,0,0,0,0,0,4.0
+Spring 2024,EDUC,4314,2,12467,Student Teaching Sec,Evans,Paige K,11,1,0,0,0,0,0,3.917
+Spring 2024,PHYS,8398,36,12469,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Spring 2024,ENGL,1301,2,12472,First Year Writing I,Bradley,Jari,5,3,6,0,6,0,5,1.984
+Spring 2024,ENGL,1302,31,12473,First Year Writing II,Coleman,Quintin,12,2,1,1,2,0,1,3.093
+Spring 2024,BIOE,8398,3,12477,Doctoral Research,Abidian,Mohammad Reza,0,0,0,0,0,0,0,
+Spring 2024,BIOE,8399,3,12478,Doctoral Dissertation,Shevkoplyas,Sergey,2,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8598,3,12479,Doctoral Research,Abidian,Mohammad Reza,0,0,0,0,0,0,0,
+Spring 2024,PHYS,3399,3,12481,Senior Honors Thesis,Bering,Edgar A,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,3363,1,12485,Introduction To PDE,Caglar,Atife,16,14,12,6,6,0,4,2.512
+Spring 2024,ECON,3370,2,12486,Introduction To Econometrics,Zhivan,Natalia A,8,12,10,4,3,0,4,2.531
+Spring 2024,ECON,3371,1,12487,Economics of Money & Banking,Troncoso,Pablo A,26,34,18,12,2,0,3,2.754
+Spring 2024,ECON,7301,1,12488,Seminar in Microecon Research,Juhn,Chinhui,0,0,0,0,0,9,0,
+Spring 2024,ECON,7302,1,12489,Seminar in Macroecon Research,Paluszynski,Radoslaw,0,0,0,0,0,9,0,
+Spring 2024,ECON,8363,1,12490,Workshop in Research Methods V,Paluszynski,Radoslaw,11,0,1,0,0,0,0,3.833
+Spring 2024,SPAN,3306,2,12491,Intro Study Span Language,Fairclough,Marta A,6,3,2,0,0,0,0,3.334
+Spring 2024,ARCH,5500,7,12492,Architecture Design Studio IX,Beneytez-Duran,Rafael,21,8,1,0,0,0,0,3.7
+Spring 2024,BIOL,4374,1,12494,Cell Biology,Farmer,Lisa M,18,25,18,0,0,0,3,2.978
+Spring 2024,ITAL,3304,1,12495,Culture Italy,Nicosia,Alda,6,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,1112,35,12496,Fundamentals of Chm Lab,Zaitsev,Vladimir G,10,8,1,0,0,0,1,3.387
+Spring 2024,CHEM,1112,37,12497,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,3,0,0,0,4,2.956
+Spring 2024,CHEM,1112,40,12498,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,2,0,0,0,3,3.271
+Spring 2024,CHEM,1112,42,12499,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,14,0,0,1,0,2,3.037
+Spring 2024,CHEM,1112,43,12500,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,15,0,0,1,0,1,3.035
+Spring 2024,CHEM,6332,1,12501,Inorganic Material Analysis,Meen,James K,5,10,0,0,0,0,0,3.377
+Spring 2024,ARAB,3302,1,12502,Adv Modern Standard Arabic II,Hefter,Thomas H,5,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,2317,2,12503,Intro to Psychology Statistics,Mehta,Paras D,6,9,5,3,1,0,6,2.653
+Spring 2024,PSYC,3350,2,12504,Intro to Cognitive Psychology,Yoshida,Hanako,37,28,8,4,0,0,1,3.273
+Spring 2024,CHEM,2123,13,12505,Organic Chemistry Lab I,Bean,Mary B,1,12,5,1,0,0,3,2.597
+Spring 2024,CHEM,2123,15,12506,Organic Chemistry Lab I,Bean,Mary B,2,8,9,1,0,0,1,2.633
+Spring 2024,CHEM,2123,16,12507,Organic Chemistry Lab I,Bean,Mary B,1,6,7,0,0,0,1,2.524
+Spring 2024,CHEM,2123,17,12508,Organic Chemistry Lab I,Bean,Mary B,1,9,3,2,0,0,0,2.6
+Spring 2024,BIOL,4315,1,12509,Neuroscience,Ziburkus,Jokubas,56,16,18,0,0,0,7,3.393
+Spring 2024,COSC,4368,1,12510,Artificial Intelligence,Eick,Christoph F,21,42,19,4,0,0,8,2.957
+Spring 2024,BIOL,1307,50,12511,Biology for Science Majors II,Cheek,Ann Oliver,19,6,3,0,1,0,0,3.482
+Spring 2024,PHAR,5644,1,12512,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5645,1,12513,Pharmacy Informatics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Spring 2024,INDE,4315,1,12515,Supply Chain Design Management,Wang,Yaping,17,14,3,0,0,0,0,3.451
+Spring 2024,SCM,4350,1,12517,Strategic Supply Management,Wayhan,Victor Brian,15,45,4,2,0,0,1,3.091
+Spring 2024,SCM,4390,1,12518,Supply Chain Strategy,Smith,Gordon D,14,32,17,1,0,0,0,2.901
+Spring 2024,RELS,1301,2,12519,Intro To Religious Studies,Dawson,Cindy,20,10,4,0,0,0,3,3.432
+Spring 2024,FINA,4320,3,12520,Investment Management,Gargano,Antonio,32,7,0,0,0,0,2,3.804
+Spring 2024,FINA,4357,1,12521,Commercial Liability,Kapatos,Nick Gus,8,6,3,1,0,0,0,3.112
+Spring 2024,FINA,7376,1,12522,Energy Trading,Smith III,Edwin A,8,1,1,0,0,0,0,3.601
+Spring 2024,MIS,4381,1,12523,Mgmt of Information Security,Cooper,Randolph B,2,7,7,1,2,0,0,2.316
+Spring 2024,MIS,4390,1,12524,Energy Trading Systems,Pena,Juan F,188,25,2,0,0,0,2,3.831
+Spring 2024,MIS,7381,1,12526,Management of Info Security,Cooper,Randolph B,2,6,0,1,0,0,0,3.0
+Spring 2024,MANA,4356,1,12527,Managing Diversity,Ruggs,Enrica N,25,14,10,2,1,0,5,3.205
+Spring 2024,HDFS,3318,2,12529,Human Ecol of Adult Developmt,Schoger,Kimberly,26,7,2,0,3,0,1,3.377
+Spring 2024,HLT,3381,2,12531,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,94,13,1,0,0,0,0,3.8
+Spring 2024,HLT,4302,1,12532,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,53,26,9,3,3,0,6,3.284
+Spring 2024,ILAS,2350,1,12534,Knowledge and Methods,Oliva,Luca,17,14,2,0,7,0,3,2.817
+Spring 2024,PSYC,6316,1,12535,Interventions-Clinical Psyc II,Walker,Rheeda L,6,0,0,0,0,0,0,3.945
+Spring 2024,COMD,4333,1,12537,Neuroscience for COMD,Blake,Margaret T,11,12,7,0,0,0,3,3.122
+Spring 2024,ASLI,4368,1,12539,ASL and English Linguistics,Gietz,Merrilee Ruth,5,3,0,0,0,0,0,3.584
+Spring 2024,HIST,3367,1,12540,Japan Since 1600,Cong,Xiaoping,6,15,6,1,2,0,4,2.634
+Spring 2024,SPAN,3339,1,12542,Span for Global Professions,Zubiate,Maria Laura,6,6,2,1,1,0,2,2.958
+Spring 2024,HON,3301,1,12543,Readings in Medicine & Society,Macdonald,Arlene,17,1,0,0,0,0,0,3.853
+Spring 2024,SOCW,7367,2,12545,Social Policy Analysis,Sereno,Alba Donajhi,10,5,1,0,0,0,0,3.563
+Spring 2024,RELS,2311,1,12546,Bible and Western Culture II,Eberhart,Christian,8,3,0,0,1,0,2,3.362
+Spring 2024,PHAR,5662,1,12547,Academic Scholarship,Wallace,David A,1,1,0,0,0,0,0,3.5
+Spring 2024,PHAR,5675,2,12549,Disease State Management,Asias-Dinh,Bernadette De Leon,3,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,3315,1,12550,Modern Physics,Wood,Lowell T,7,10,10,0,1,0,0,2.644
+Spring 2024,PHYS,2326,3,12551,University Physics II(lecture),Su,Wu-Pei,7,17,34,2,1,0,10,2.334
+Spring 2024,POLS,3313,1,12553,Intro Internatl Relatns,Chatagnier,John Tyson,29,8,2,1,0,0,0,3.625
+Spring 2024,CHEM,2131,1,12554,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,5,0,
+Spring 2024,COMD,6326,1,12555,Motor Speech Disorders,Wynn,Camille Jane,29,19,0,0,0,0,0,3.59
+Spring 2024,CHEM,2132,1,12556,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,1,2,
+Spring 2024,CHEM,2132,2,12557,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,6,0,
+Spring 2024,ASLI,2335,1,12558,Privilege & Equity in ASLI,Sheneman,Naomi,5,4,0,1,0,0,1,3.201
+Spring 2024,ASLI,3433,1,12559,Simultaneous Interpreting I,Hill,Sharon Grigsby,5,2,1,0,0,0,0,3.335
+Spring 2024,ASLI,4489,1,12560,Service Learning - Internship,Hill,Sharon Grigsby,8,2,0,0,0,0,0,3.602
+Spring 2024,LAW,5254,1,12561,Tax Controversy & Litigation,Lowy,Peter A,4,3,0,0,0,2,0,3.524
+Spring 2024,SOCW,7329,2,12563,SW Practice for Policy Change,Ortiz,Lillian Aguirre,16,0,0,0,0,0,0,4.0
+Spring 2024,COMM,3353,1,12564,Information & Comm Tech I,Liu,Youmei,44,5,1,0,1,0,1,3.784
+Spring 2024,CUIN,6375,2,12567,Classroom Mgt,Thompson,Alan M,0,1,0,0,0,0,1,3.33
+Spring 2024,ENGL,7699,1,12570,Thesis,Divakaruni,Chitra B,1,0,0,0,0,1,0,4.0
+Spring 2024,SPAN,8699,6,12571,Dissertation,Solino,Maria Elena,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,3351,2,12576,Class Interact Science-Math,Latiolais,Cheryl S,9,1,1,0,0,0,0,3.697
+Spring 2024,MTLS,6111,1,12577,Materials Engineering Seminar,Shan,Xiaonan,0,0,0,0,0,31,0,
+Spring 2024,PSYC,8399,26,12579,Doctoral Dissertation,Williams,Michael W,0,0,0,0,0,1,0,
+Spring 2024,POLS,8999,25,12581,Doctoral Dissertation,Basinger,Scott J,0,0,0,0,0,1,0,
+Spring 2024,POLS,8999,22,12582,Doctoral Dissertation,Fumurescu,Alin,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8398,38,12584,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Spring 2024,PHCA,8298,4,12598,Doctoral Dissertation Research,Chen,Hua,0,0,0,0,0,0,0,
+Spring 2024,BCHS,6230,1,12601,Grad Biochem Lab Rotation I,Widger,William R,6,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8398,12,12602,Doctoral Research,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Spring 2024,MATH,8398,13,12604,Doctoral Research,Josic,Kresimir,0,0,0,0,0,1,0,
+Spring 2024,MATH,8398,14,12605,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Spring 2024,MATH,8398,15,12606,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,2,0,
+Spring 2024,MATH,4365,1,12608,Numerical Methods for Diff Equ,Wang,Min,3,3,4,0,0,0,1,2.9
+Spring 2024,CUIN,3317,1,12609,Kindergarten/Elem Curr & Instr,Wilson,Jahnette,19,10,1,0,0,0,0,3.567
+Spring 2024,CUIN,3317,2,12610,Kindergarten/Elem Curr & Instr,Katz,Denise Annette,20,6,0,0,0,0,0,3.706
+Spring 2024,CUIN,3317,4,12611,Kindergarten/Elem Curr & Instr,Henderson,Linda Fay,20,4,3,0,0,0,0,3.544
+Spring 2024,CUIN,3346,1,12612,Teaching the Writing Process,Pauloski,Gwendolyn Jordan,25,2,0,0,0,0,0,3.877
+Spring 2024,CUIN,4315,1,12613,Assessment of Children,Siller Escudero,Patricia,24,5,1,0,0,0,0,3.646
+Spring 2024,CUIN,4315,2,12614,Assessment of Children,Siller Escudero,Patricia,18,8,0,0,0,0,0,3.629
+Spring 2024,CUIN,4315,3,12615,Assessment of Children,Hernandez,Berky,24,2,0,0,1,0,1,3.741
+Spring 2024,CUIN,4315,4,12616,Assessment of Children,Siller Escudero,Patricia,8,5,1,0,0,0,0,3.547
+Spring 2024,CUIN,3316,1,12617,Prekindergarten Curr & Instr,Katz,Denise Annette,13,0,0,0,0,0,1,3.848
+Spring 2024,CUIN,3316,2,12618,Prekindergarten Curr & Instr,Katz,Denise Annette,16,1,0,0,0,0,0,3.844
+Spring 2024,CUIN,4375,4,12619,Classroom Management,Castillo,Bernadette Marie,18,0,0,0,0,0,0,3.982
+Spring 2024,MATH,3364,1,12620,Intro Complex Analysis,Onofrei,Daniel T,8,2,1,0,2,0,5,2.95
+Spring 2024,ENGL,6320,1,12621,Poetic Forms,Harris,Francine Julia,9,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,3342,1,12622,Principles of Air Pollution,Wang,Yuxuan,11,12,1,0,0,0,1,3.444
+Spring 2024,MATH,3325,2,12623,Transition to Advanced Math,Leger,Nicholas M,10,12,11,2,2,0,3,2.694
+Spring 2024,PSYC,2330,1,12625,Biological Psychology,Kosten,Therese A,32,16,1,0,0,0,0,3.586
+Spring 2024,ECON,2302,4,12627,Principles of Microeconomics,Hossain,Md Shahadath,144,186,49,0,9,0,18,3.169
+Spring 2024,GEOL,4330,1,12629,Intro To Geophysics,Sager,William W,1,2,6,1,1,0,0,2.091
+Spring 2024,CUIN,7304,1,12630,Professional Seminar II,Leon,Maredil Josefina,18,3,0,0,0,0,0,3.873
+Spring 2024,CUIN,7304,2,12631,Professional Seminar II,Katz,Denise Annette,16,2,0,0,0,0,1,3.834
+Spring 2024,CUIN,7304,3,12632,Professional Seminar II,Boyce,Stephanie,13,2,0,0,2,0,1,3.392
+Spring 2024,GEOL,1303,7,12634,Physical Geology,Lytwyn,Jennifer N,57,86,43,17,18,0,15,2.626
+Spring 2024,GEOL,1340,3,12635,Earth Systems,Lytwyn,Jennifer N,63,85,59,25,8,0,13,2.7
+Spring 2024,CHEM,1305,1,12639,Foundations of Chemistry,Czernuszewicz,Roman S,23,37,58,12,15,0,30,2.235
+Spring 2024,PSYC,4344,3,12640,Cultural Psychology,Jewell,Rebecca D,48,21,3,1,3,0,2,3.504
+Spring 2024,PSYC,2317,4,12641,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,36,21,10,2,7,0,1,2.952
+Spring 2024,PHYS,6316,1,12642,Quantum Mechanics II,Hosur,Pavan R,10,5,0,0,0,0,0,3.623
+Spring 2024,BIOL,3301,1,12644,Mendelian and Pop Genetics,Lekven,Arne,52,58,32,2,6,0,5,2.967
+Spring 2024,PHYS,1301,4,12645,College Physics I (lecture),Portillo Vazquez,Israel,7,18,17,15,3,0,13,2.172
+Spring 2024,LAW,5378,1,12646,Statutory Interpretation & Rea,Bush,Darren,32,45,0,0,0,0,0,3.403
+Spring 2024,LAW,5378,2,12647,Statutory Interpretation & Rea,Michaels,Andrew Charles,31,47,0,0,0,0,0,3.402
+Spring 2024,LAW,5378,3,12648,Statutory Interpretation & Rea,Blevins,John F,6,9,0,0,0,0,0,3.334
+Spring 2024,PSYC,3339,1,12649,Intro To Clinical Psychology,Szafranski,Derek D,109,8,0,1,0,0,0,3.879
+Spring 2024,COSC,3380,1,12651,Database Systems,Ramamurthy,Uma,17,23,18,9,5,0,7,2.5
+Spring 2024,HIST,1302,1,12652,The U.S. Since 1877,Amaral,Lindsay Nicole,183,84,23,6,15,0,13,3.296
+Spring 2024,ASLI,4335,1,12653,Advanced ASL Interpreting,Sheneman,Naomi,7,3,0,0,0,0,0,3.667
+Spring 2024,COMD,2338,2,12654,Phonetics,Schaff,Carrie Allyson,18,8,3,0,0,0,1,3.506
+Spring 2024,PHYS,8399,39,12655,Doctoral Dissertation,Stokes,Donna,0,0,0,0,0,0,0,
+Spring 2024,MANA,4355,1,12658,Selection and Staffing,Phillips,James S,37,17,4,1,0,0,1,3.43
+Spring 2024,MANA,7332,1,12659,Effective Negotiating,Miller,Carl Chet,20,20,4,0,0,0,0,3.386
+Spring 2024,MANA,6A25,1,12660,Ethical Leadrshp & Crit Reason,Celly,Nikhil,10,0,0,0,0,0,0,3.967
+Spring 2024,MANA,6A32,1,12661,Organizational Behavior & Mgt,Rude,Dale,5,2,1,0,0,0,0,3.418
+Spring 2024,MANA,6A32,2,12662,Organizational Behavior & Mgt,Krylova,Ksenia O,21,2,0,1,0,0,0,3.682
+Spring 2024,SCM,6A01,1,12663,SCM Concepts,Hossain,Md Mahbub,18,0,0,0,0,0,1,3.963
+Spring 2024,SCM,3301,3,12664,SCM Fundamentals,Anderson Fletcher,Elizabeth,8,9,2,0,0,0,1,3.42
+Spring 2024,SCM,4362,1,12665,Demand and Supply Integration,Li,Meng,25,30,8,0,0,0,2,3.259
+Spring 2024,SCM,4367,1,12666,Process and Quality Management,Miller,Bradley D,10,10,11,4,0,0,0,2.658
+Spring 2024,FINA,6387,3,12670,Managerial Analysis,Basu,Swati,10,4,0,0,0,0,0,3.738
+Spring 2024,FINA,7373,1,12671,Petrochem and Refining Econ,Singh,Rajiv,6,1,0,0,0,0,0,3.716
+Spring 2024,MARK,4396,1,12672,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,11,0,
+Spring 2024,MANA,4396,1,12673,Management Internship,Carlin,Barbara A,0,0,0,0,0,5,1,
+Spring 2024,FINA,4396,1,12674,Finance Internship,Kumar,Praveen,0,0,0,0,0,3,0,
+Spring 2024,HIST,3390,1,12675,Middle East: Pictures & Words,Al-Sowayel,Dina,12,8,6,2,2,0,3,2.834
+Spring 2024,INTB,3355,2,12676,Global Environment of Business,Thompson,Joseph Lee,245,3,0,0,1,0,0,3.963
+Spring 2024,INTB,3355,3,12677,Global Environment of Business,Carvalho,Emilia Barreto,208,27,12,0,2,0,0,3.752
+Spring 2024,ACCT,2301,3,12678,Prin of Financial Accounting,Sykes,Mary Reeves,38,24,9,5,1,0,8,3.302
+Spring 2024,LAW,6207,1,12679,Lawyering Skills & Strategy II,Swift,Kenneth Richard,5,10,0,0,0,0,0,3.399
+Spring 2024,LAW,6207,2,12680,Lawyering Skills & Strategy II,Gomez,Alissa R,6,10,0,0,0,0,0,3.354
+Spring 2024,LAW,6207,3,12681,Lawyering Skills & Strategy II,Reed,Hilary S,7,8,0,0,0,0,0,3.401
+Spring 2024,LAW,6207,4,12682,Lawyering Skills & Strategy II,Brantley,Maikieta Antoinette,6,7,0,0,0,0,0,3.385
+Spring 2024,LAW,6207,5,12683,Lawyering Skills & Strategy II,Brantley,Maikieta Antoinette,8,7,1,0,0,0,0,3.396
+Spring 2024,LAW,6207,6,12684,Lawyering Skills & Strategy II,Gomez,Alissa R,7,7,1,0,0,0,0,3.378
+Spring 2024,LAW,6207,7,12685,Lawyering Skills & Strategy II,Heard,Whitney W,10,5,2,0,0,0,0,3.374
+Spring 2024,LAW,6207,8,12686,Lawyering Skills & Strategy II,Brem,Katherine B,6,10,0,0,0,0,0,3.396
+Spring 2024,LAW,6207,9,12687,Lawyering Skills & Strategy II,Esterholm,Melissa Hurter,7,9,0,0,0,0,0,3.396
+Spring 2024,LAW,6207,10,12688,Lawyering Skills & Strategy II,Heard,Whitney W,7,8,0,0,0,0,1,3.401
+Spring 2024,LAW,6207,11,12689,Lawyering Skills & Strategy II,Reed,Hilary S,6,9,0,0,0,0,0,3.4
+Spring 2024,ENGL,4386,1,12690,Short Story Writing,Peynado,Brenda,12,2,0,0,1,0,1,3.556
+Spring 2024,ACCT,2302,5,12692,Prin of Managerial Accounting,Newman,Michael Ray,21,4,0,0,0,0,0,3.866
+Spring 2024,ECE,2100,3,12694,Circuit Analysis Laboratory,Trombetta,Leonard P,5,2,1,0,0,0,1,3.376
+Spring 2024,ACCT,4105,1,12695,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,3,0,
+Spring 2024,ACCT,4106,1,12696,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,1,0,
+Spring 2024,ECE,4335,2,12699,Electrical Comp Engr Design I,Trombetta,Leonard P,37,6,0,0,1,0,0,3.78
+Spring 2024,ECE,4336,1,12700,Electrical Comp Engr Design II,Contreras-Vidal,Jose Luis,28,25,7,0,0,0,0,3.35
+Spring 2024,MARK,6A61,1,12702,Marketing Administration,Hess,James D,10,2,0,0,0,0,0,3.833
+Spring 2024,MARK,6A61,2,12703,Marketing Administration,Lish,Alan D,7,9,3,0,1,0,0,3.083
+Spring 2024,MANA,6A32,3,12705,Organizational Behavior & Mgt,Rude,Dale,3,3,0,0,0,0,0,3.61
+Spring 2024,MIS,4477,1,12706,Network & Security Infrastruct,Messinger,Jacob Nelson,23,12,4,0,0,0,1,3.411
+Spring 2024,MIS,6A41,1,12708,Information Systems,Silva,Leiser O,9,1,0,0,0,0,0,3.933
+Spring 2024,MIS,6A41,2,12709,Information Systems,Silva,Leiser O,29,0,0,0,0,0,0,3.943
+Spring 2024,GENB,7334,1,12710,Brainstorming to Bankrolling,Khumawala,Saleha B,0,1,0,0,0,0,0,2.67
+Spring 2024,GENB,5303,1,12711,Prof Acct Communication,Newman,Michael Ray,6,1,1,0,0,0,0,3.625
+Spring 2024,GENB,7303,1,12712,Prof Accounting Communication,Newman,Michael Ray,17,7,0,0,0,0,0,3.791
+Spring 2024,INAR,3501,1,12713,Interior Arch Studio VI,Tucker de Vazquez,Sheryl,8,11,0,0,0,0,0,3.508
+Spring 2024,INAR,3310,1,12715,Materials/Methods of Int Arch,Mantz,Ophelia,8,9,2,1,0,0,0,3.233
+Spring 2024,ARCH,7601,3,12716,Architecture Design Studio VI,Longoria,Rafael R,6,2,0,0,0,0,0,3.668
+Spring 2024,KIN,4301,1,12718,Workplace Wellness,Alastuey,Lisa L,15,11,7,0,1,0,0,3.069
+Spring 2024,HON,3330,1,12719,Leadership Theory and Practice,Rhoden,Brenda,8,2,0,0,0,0,0,3.866
+Spring 2024,HON,4130,1,12720,E-Portfolio,Rayder,Benjamin Taylor,7,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2302,6,12721,Prin of Managerial Accounting,Seltz,Joe D,12,20,6,8,0,0,2,2.826
+Spring 2024,ENGL,3301,2,12722,Intro To Literary Studies,Mazella,David S,9,4,0,0,1,0,2,3.499
+Spring 2024,NUTR,4349,1,12723,Public Policy in Nutrition,Vollrath,Kirstin,27,32,6,1,0,0,0,3.278
+Spring 2024,ENGL,2307,1,12724,Intro To Drama,Lee,Nathanael D,17,6,0,0,1,0,5,3.542
+Spring 2024,ENGL,1301,13,12725,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,9,5,4,0,3,0,4,2.794
+Spring 2024,ENGL,1302,15,12726,First Year Writing II,Kozma,Andrew,10,7,3,1,1,0,3,3.031
+Spring 2024,IRW,1300,1,12727,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,11,0,
+Spring 2024,KIN,1352,3,12728,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,249,33,16,1,1,0,0,3.737
+Spring 2024,KIN,1352,4,12729,"Foundations of KIN, HLT, FIT",Gray,Jon Phillip,211,48,18,3,9,0,7,3.555
+Spring 2024,KIN,1352,5,12730,"Foundations of KIN, HLT, FIT",Alastuey,Lisa L,10,3,6,3,3,0,1,2.534
+Spring 2024,BIOE,4366,1,12731,Biomolecular Engr Fundamentals,Varadarajan,Navin,2,4,3,0,0,0,0,2.999
+Spring 2024,PSYC,2301,4,12732,Introduction to Psychology,Silva,Karina,38,26,11,4,2,0,0,3.144
+Spring 2024,FINA,4373,1,12733,Petrochem & Refining Economics,Singh,Rajiv,0,1,0,0,0,0,0,3.0
+Spring 2024,PSYC,2330,2,12734,Biological Psychology,Alward,Beau Andrew,28,12,0,0,0,0,0,3.692
+Spring 2024,CIVE,3339,3,12735,Geotechnical Engineering,Ferdowsi,Behrooz,18,5,1,0,0,0,1,3.695
+Spring 2024,CHEM,1111,18,12737,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,0,0,0,0,2,3.255
+Spring 2024,CHEM,1111,19,12738,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,12,2,0,0,0,1,3.021
+Spring 2024,CHEM,1111,22,12739,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,9,4,0,0,0,3,2.855
+Spring 2024,MSCI,3320,3,12740,Applied Leadership,Comiskey,Melissa C,16,1,0,0,0,0,0,3.941
+Spring 2024,EDUC,4316,1,12741,Student Teach Art Elem,Thompson,Amber M,3,0,1,0,0,0,0,3.5
+Spring 2024,PHOP,6367,2,12744,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,4337,1,12745,Soc Stud in Middle Grades Gen,Brower,Samuel Richard,11,1,0,0,0,0,1,3.917
+Spring 2024,CHEM,8998,21,12759,Doctoral Research,Wu,Judy,0,0,0,0,0,1,0,
+Spring 2024,POLS,8999,10,12761,Doctoral Dissertation,Kennedy,Ryan P,0,0,0,0,0,1,0,
+Spring 2024,HIST,8999,10,12766,Doctoral Dissertation,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8598,4,12770,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Spring 2024,COSC,4353,1,12771,Software Design,Singh,Raj Kumar,141,8,1,0,0,0,1,3.896
+Spring 2024,BIOE,8298,4,12772,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8298,11,12776,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8398,4,12779,Doctoral Research,Das,Mini,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8398,5,12780,Doctoral Research,Li,Zhengwei,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,8,12783,Doctoral Research,Du,Yuncheng,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,10,12785,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,11,12786,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Spring 2024,BIOE,8398,12,12787,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,5,12789,Doctoral Research,Li,Zhengwei,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,8,12792,Doctoral Research,Du,Yuncheng,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8598,10,12794,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Spring 2024,BIOE,8598,11,12795,Doctoral Research,Gifford,Howard,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,13,12797,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,1,0,
+Spring 2024,BIOE,7399,1,12802,Masters Thesis,Akay,Metin,3,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8999,11,12803,Doctoral Dissertation,Scarrow,Susan E,0,0,0,0,0,2,0,
+Spring 2024,MATH,8398,18,12815,Doctoral Research,Labate,Demetrio,0,0,0,0,0,1,0,
+Spring 2024,ENGL,2305,2,12816,Intro To Fiction,Bass,Kasey Dawn,23,0,0,0,2,0,0,3.68
+Spring 2024,BCHS,3396,1,12817,Senior Research Project,Gunaratne,Preethi H,2,0,0,0,0,0,0,3.67
+Spring 2024,ECE,4398,1,12819,Independent Study,Bering,Edgar A,1,1,0,0,0,0,0,3.5
+Spring 2024,PSYC,2301,1,12828,Introduction to Psychology,Agan,Herb W,78,49,17,2,12,0,5,3.095
+Spring 2024,INDS,1501,1,12829,Industrial Design Studio II,Jamjoom,Zain Ahmed,2,7,1,0,1,0,0,2.728
+Spring 2024,ARCH,2328,1,12831,Technology 2,Taylor,Rives,56,26,7,4,2,0,2,3.355
+Spring 2024,ARCH,3328,1,12833,Technology 4,Kyropoulou,Amygdalia,70,39,9,0,3,0,0,3.383
+Spring 2024,ARCH,3501,9,12835,Architecture Design Studio VI,Kacmar,Donna,12,2,2,0,0,0,0,3.563
+Spring 2024,ARCH,4328,1,12837,Technology 6 Practice of ARCH,Jacobs,Daniel,56,55,0,0,1,0,0,3.432
+Spring 2024,INAR,2501,1,12838,Interior Arch Design Studio IV,Rodriguez Fernandez,Marta,13,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,4354,1,12840,Ideas and Buildings,Self,Ronnie L,8,6,1,0,0,0,0,3.489
+Spring 2024,ARCH,4321,1,12841,Design of Construction Details,Story,Jon Kevin,6,14,2,0,1,0,1,3.0
+Spring 2024,INAR,4360,1,12842,Practice of Interior Arch,Yu,Maria H,11,10,0,0,0,0,0,3.508
+Spring 2024,INAR,4501,1,12843,Interior Arch Studio VIII,Handanovic,Dijana,6,2,1,0,0,0,1,3.482
+Spring 2024,MATH,4377,3,12846,Advanced Linear Algebra I,Quaini,Annalisa,7,6,8,0,1,0,3,2.728
+Spring 2024,MATH,6308,2,12847,Advanced Linear Algebra I,Quaini,Annalisa,5,5,1,0,0,0,1,3.334
+Spring 2024,BCHS,3304,2,12848,General Biochemistry I,Frankino,William A,52,40,38,4,2,0,14,3.01
+Spring 2024,BIOL,4374,3,12849,Cell Biology,Rea,Michael A,43,20,21,3,0,0,8,3.195
+Spring 2024,BIOL,6374,2,12850,Cell Biology,Gifford,Jenifer,3,0,0,0,0,0,0,3.78
+Spring 2024,BIOL,6374,3,12851,Cell Biology,Rea,Michael A,6,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,4313,1,12852,Cell Biochemistry,Farmer,Lisa M,3,4,1,0,0,0,0,3.333
+Spring 2024,BCHS,4313,2,12853,Cell Biochemistry,Gifford,Jenifer,5,7,2,1,1,0,0,2.896
+Spring 2024,LAW,6207,12,12854,Lawyering Skills & Strategy II,Swift,Kenneth Richard,8,7,0,0,0,0,0,3.401
+Spring 2024,LAW,6207,15,12855,Lawyering Skills & Strategy II,Simpson,Lauren J,5,8,0,0,0,0,0,3.385
+Spring 2024,LAW,6207,16,12856,Lawyering Skills & Strategy II,Simpson,Lauren J,6,7,1,0,0,0,0,3.381
+Spring 2024,INDE,6363,1,12857,Statistical Process Control,Keedy,Elias,23,30,12,0,0,0,0,3.129
+Spring 2024,CUIN,3316,3,12858,Prekindergarten Curr & Instr,Siller Escudero,Patricia,16,2,0,0,0,0,0,3.852
+Spring 2024,CUIN,3317,3,12860,Kindergarten/Elem Curr & Instr,Nurre,Irma Linda,11,2,1,0,0,0,0,3.714
+Spring 2024,INDE,4111,1,12861,Industrial Engineering Seminar,Peng,Jiming Ouyang,6,0,0,1,0,0,1,3.524
+Spring 2024,HDFS,3310,1,12863,Introduction to Child Life,Fraser,Camille,18,3,3,0,0,0,1,3.57
+Spring 2024,COMM,3315,1,12864,News and Social Media,Lee,Taeyoung,12,6,2,0,0,0,0,3.517
+Spring 2024,LAW,6218,1,12866,Client Interviewng & Counselng,Dao,Andrew,7,9,0,0,0,8,0,3.396
+Spring 2024,CUIN,4332,4,12870,Literacy Assess Rdg Writing,Reis,Nancy,24,0,0,0,0,0,0,3.986
+Spring 2024,ELED,4314,3,12871,Mathematics in Elem School I,Burris,Justin T,17,2,1,0,0,0,0,3.8
+Spring 2024,BIOE,6342,1,12872,Biomedical Signal Processing,Singh,Manmohan,14,0,0,0,0,0,0,3.929
+Spring 2024,BIOE,4336,1,12874,Capstone Design II,Schultz,Jerome S,53,0,0,0,0,0,0,3.875
+Spring 2024,BIOE,6346,1,12876,Advanced Medical Imaging,Gifford,Howard,0,1,0,0,0,0,0,3.0
+Spring 2024,PSYC,2319,1,12877,Intro to Social Psychology,Fetterman,Adam Kent,15,17,7,3,1,0,0,3.053
+Spring 2024,PSYC,3310,2,12878,Indstrl-Orgnztnl Psy,Reyes,Denise Lucia,40,10,5,0,1,0,3,3.583
+Spring 2024,PSYC,2316,2,12879,Psychology of Personality,Inman,Tonya N,76,22,13,0,0,0,10,3.529
+Spring 2024,PSYC,2316,3,12880,Psychology of Personality,Liu,Tingshu,55,17,3,2,1,0,1,3.547
+Spring 2024,SPAN,3302,1,12882,Adv Span for Non-Heritage,Cuesta,Mabel,21,2,2,0,0,0,0,3.76
+Spring 2024,LAW,5362,1,12883,Employment Discrimination,Areheart,Bradley Allan,15,14,1,0,0,14,0,3.401
+Spring 2024,BIOL,2121,9,12884,Microbiol for Science Maj(lab),Knapp,Richard D,12,7,2,2,0,0,0,3.203
+Spring 2024,BIOL,2121,10,12886,Microbiol for Science Maj(lab),Knapp,Richard D,8,11,4,0,0,0,1,3.131
+Spring 2024,LAW,5459,1,12887,Federal Income Tax,Wilson,John Marshall,6,6,0,0,0,9,0,3.39
+Spring 2024,BIOL,2102,17,12888,Anatomy & Physiology II (lab),Gill,Tejendra,8,10,3,0,1,0,2,3.166
+Spring 2024,BIOL,2102,18,12889,Anatomy & Physiology II (lab),Gill,Tejendra,8,6,4,1,2,0,2,2.888
+Spring 2024,POLS,3316,1,12890,Stats for Political Scientists,Zhu,Ling,9,4,1,1,0,0,5,3.466
+Spring 2024,CHEE,3321,2,12891,Analytical Methods Chem Engr,Conrad,Jacinta C,0,0,0,0,0,0,1,
+Spring 2024,COSC,6364,1,12892,Adv Numerical Analysis,Tsekos,Nikolaos V,58,12,0,0,0,0,0,3.81
+Spring 2024,HIST,3389,1,12893,China Since 1600,Cong,Xiaoping,8,19,1,3,2,0,1,2.848
+Spring 2024,POLS,4343,1,12894,Causes and Politics of War,Zwald,Zachary J,9,14,5,0,0,0,1,3.06
+Spring 2024,MANA,3335,4,12896,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,151,82,8,3,3,0,4,3.466
+Spring 2024,ENGL,3349,1,12897,Native American Literature,Wood,Barry Albert,24,10,1,0,0,0,0,3.544
+Spring 2024,MANA,7336,1,12898,Strategic Human Resource Mgt,Fernandez,Alejandro,35,0,0,0,0,0,0,3.991
+Spring 2024,MIS,3360,3,12899,Systems Analysis and Design,Ruff,Eniscia R,60,2,0,0,0,0,1,3.978
+Spring 2024,BZAN,7320,1,12900,Bus Modeling For Comp Adv,Hess,James D,16,2,0,0,0,0,0,3.816
+Spring 2024,ECE,3340,1,12902,Numerical Methods for ECE,Mayerich,David Matthew,47,10,2,0,0,0,2,3.752
+Spring 2024,ECE,3337,2,12903,Signals and Systems Analysis,Roysam,Badrinath,1,0,0,0,0,0,0,4.0
+Spring 2024,BZAN,6310,1,12904,Quant Analysis for Busn Dec,Wiley,Briceon C,5,6,0,0,0,0,0,3.455
+Spring 2024,BZAN,6310,2,12905,Quant Analysis for Busn Dec,Wiley,Briceon C,12,4,3,0,1,0,0,3.234
+Spring 2024,CUIN,7369,1,12906,Affective Learning and Instru,Snead,Lauren Oropeza,5,1,0,0,0,0,1,3.888
+Spring 2024,POLS,3358,1,12907,Judicial Behavior,Badas,Alex,4,6,5,1,1,0,5,2.511
+Spring 2024,BZAN,7320,2,12908,Bus Modeling For Comp Adv,Murray,Michael J,2,4,1,0,0,0,0,3.19
+Spring 2024,ELED,3320,2,12910,Survey Literature Child Adol,Black,Misty Paul,13,0,0,0,0,0,0,3.975
+Spring 2024,PHYS,3312,1,12912,Modern Optics,Forrest,Rebecca L,7,6,3,1,0,0,1,3.098
+Spring 2024,PHYS,3110,1,12913,Sem-Adv Lab Analysis,Timmins,Anthony Robert,12,2,0,0,0,0,2,3.857
+Spring 2024,GEOL,1102,2,12914,Intro to Climate Change Lab,Wang,Yuxuan,16,8,0,0,0,0,0,3.653
+Spring 2024,ACCT,3366,4,12915,Financial Reporting Frameworks,Harris,Kathleen L,12,14,4,1,5,0,4,2.778
+Spring 2024,FINA,7A23,2,12916,Portfolio Theory and Practice,Wu,Guojun,35,1,0,0,0,0,0,3.981
+Spring 2024,FINA,7A30,1,12917,Advanced Corporate Finance,Povel,Paul,17,6,1,0,0,0,0,3.529
+Spring 2024,MECE,3381,1,12919,Finite Elements for Mech Engr,Rao,Jagannatha R,39,45,23,2,1,0,2,2.992
+Spring 2024,COMM,6300,1,12926,Quantitative Research Methods,Jin,Eunjoo,10,2,0,0,1,0,0,3.488
+Spring 2024,HON,3305,1,12928,Medicine in Performance,Lambeth,Laurie Regine Clements,11,4,2,1,1,0,0,3.228
+Spring 2024,SCM,4390,2,12929,Supply Chain Strategy,Smith,Gordon D,14,30,11,2,0,0,1,2.982
+Spring 2024,ELED,4315,5,12930,Mathematics in Elem School II,Cutler,Carrie Sybil,31,2,0,0,0,0,0,3.869
+Spring 2024,MARK,4338,1,12932,Marketing Research,Wang,Yu,38,11,1,0,0,0,0,3.621
+Spring 2024,MIS,3360,4,12933,Systems Analysis and Design,Knighton,William B,36,19,10,0,0,0,0,3.4
+Spring 2024,MECE,3336,2,12934,Mechanics II,Chen,Yi-Chao,8,18,20,3,6,0,13,2.309
+Spring 2024,GHL,2160,1,12936,Hospitality Internship,Shepherd,Ashley,23,3,0,0,4,0,2,3.334
+Spring 2024,FINA,7A20,2,12937,Capital Markets,Wu,Guojun,17,0,0,0,0,0,0,4.0
+Spring 2024,KIN,3303,1,12938,Sports Communication,Hawkins,Billy J,2,20,13,0,0,0,0,2.582
+Spring 2024,CHEM,1112,41,12941,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,16,1,0,0,0,0,3.133
+Spring 2024,CHEM,1112,50,12942,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,3,0,0,0,4,3.071
+Spring 2024,CHEM,1112,52,12943,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,2,0,0,0,2,3.118
+Spring 2024,CHEM,1112,54,12944,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,1,0,0,0,3,3.333
+Spring 2024,CHEM,1111,14,12945,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,1,0,2,0,0,2.876
+Spring 2024,IDNS,1101,1,12946,Physics 1301 Workshop,Pattison,Donna,7,8,1,0,0,0,0,3.354
+Spring 2024,IDNS,1102,1,12947,Physics 1302 Workshop,Pattison,Donna,13,2,3,0,1,0,2,3.316
+Spring 2024,ENGL,4371,1,12948,Literature and Medicine,Liddell,Robert B,22,3,0,0,0,0,0,3.827
+Spring 2024,ENGL,3301,1,12949,Intro To Literary Studies,Voskuil,Lynn M,13,2,5,0,0,0,0,3.334
+Spring 2024,MATH,3339,1,12950,Statistics for the Sciences,Jun,Mikyoung,24,10,10,3,3,0,9,2.921
+Spring 2024,HLT,3325,1,12951,Medical Terminology,Bloom,Joel A,143,2,4,0,0,0,0,3.917
+Spring 2024,PEP,7307,1,12953,Implmtng Leg Strat Sprts/Fit,Cottingham,Michael,10,5,3,0,2,0,0,3.067
+Spring 2024,PHYS,1101,17,12956,College Physics I (lab),Wood,Lowell T,1,15,5,0,0,0,1,2.7
+Spring 2024,PHYS,1101,18,12957,College Physics I (lab),Wood,Lowell T,0,14,7,0,0,0,2,2.62
+Spring 2024,PHYS,1102,11,12958,College Physics II (lab),Wood,Lowell T,1,15,5,0,0,0,2,2.857
+Spring 2024,PHYS,1102,12,12959,College Physics II (lab),Wood,Lowell T,1,15,6,0,0,0,1,2.788
+Spring 2024,PHYS,1102,13,12960,College Physics II (lab),Wood,Lowell T,5,11,7,0,0,0,0,2.87
+Spring 2024,PHYS,2125,3,12961,University Physics Lab I,Wood,Lowell T,2,10,8,0,0,0,2,2.75
+Spring 2024,PHYS,2125,4,12962,University Physics Lab I,Wood,Lowell T,0,16,4,1,1,0,1,2.681
+Spring 2024,PHYS,2125,5,12963,University Physics Lab I,Wood,Lowell T,3,10,7,1,0,0,2,2.714
+Spring 2024,PHYS,2125,6,12964,University Physics Lab I,Wood,Lowell T,0,15,5,1,0,0,1,2.651
+Spring 2024,PHYS,2126,3,12965,University Physics Lab II,Wood,Lowell T,1,14,7,1,0,0,1,2.652
+Spring 2024,PHYS,2126,4,12966,University Physics Lab II,Wood,Lowell T,0,18,4,0,0,0,0,2.713
+Spring 2024,CIVE,6111,2,12972,Graduate Seminar,Momen,Mostafa,0,0,0,0,0,3,0,
+Spring 2024,MECE,3363,1,12974,Intro To Fluid Mechanics,Yang,Di,18,30,6,0,0,0,1,3.179
+Spring 2024,ENGL,1301,15,12977,First Year Writing I,Fretwell,Leah M,10,8,1,0,4,0,2,2.783
+Spring 2024,PSYC,6393,1,12978,Clinical Research Practicum,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Spring 2024,ATP,6293,1,12979,Clinical Experience III,Harrison,Layci,13,1,1,0,0,0,0,3.8
+Spring 2024,SCM,4367,2,12980,Process and Quality Management,Miller,Bradley D,27,35,10,2,0,0,0,3.131
+Spring 2024,ATP,6123,1,12981,Upper Extremity Evaluation Lab,Harrison,Layci,12,3,0,0,0,0,0,3.8
+Spring 2024,ATP,6323,1,12982,Upper Extremity Evaluation,Harrison,Layci,8,7,0,0,0,0,0,3.533
+Spring 2024,PCOL,6345,1,12983,Drug Design and Discovery,Cuny,Gregory D,17,7,0,0,0,0,0,3.626
+Spring 2024,BIOE,8699,4,12986,Doctoral Dissertation,Al-Ubaidi,Muayyad,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,8998,22,12989,Doctoral Research,Xu,Shoujun,0,0,0,0,0,3,0,
+Spring 2024,NAVY,1302,1,12990,Seapower and Maritime Affairs,Konoza,Emily M,6,0,0,0,0,0,0,3.835
+Spring 2024,NAVY,3301,1,12991,Navigation,Davis,Danyelle,1,2,1,0,0,0,0,2.67
+Spring 2024,NAVY,4301,1,12992,Naval Weapons- Ship Systems II,Konoza,Emily M,2,0,0,0,0,0,0,3.67
+Spring 2024,NAVY,4302,1,12993,Leadership and Ethics,Konoza,Emily M,3,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,8998,23,12996,Doctoral Research,Chiang,Naihao,0,0,0,0,0,1,0,
+Spring 2024,MATH,8698,3,12999,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,5,0,
+Spring 2024,SPAN,2308,4,13001,Span for Heritage Learners II,Zubiate,Maria Laura,17,9,2,1,0,0,0,3.369
+Spring 2024,ENGL,1301,16,13014,First Year Writing I,Campese,Kathleen Ann,15,5,0,0,4,0,1,3.015
+Spring 2024,BIOE,8598,14,13028,Doctoral Research,Larin,Kirill,0,0,0,0,0,9,1,
+Spring 2024,MECE,6364,1,13030,Phase Transform in Materials,Selvamanickam,Venkat,3,8,0,0,0,0,1,3.153
+Spring 2024,ENGL,1301,17,13032,First Year Writing I,Campese,Kathleen Ann,18,5,1,0,0,0,1,3.736
+Spring 2024,ENGL,1302,32,13033,First Year Writing II,Nee,Kelan,9,4,1,0,2,0,2,3.084
+Spring 2024,PHCA,8398,7,13034,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,1301,18,13035,First Year Writing I,Pogue,Donovan A,11,0,2,2,3,0,5,2.759
+Spring 2024,ENGI,2304,5,13036,Technical Communications,Contos,Ashlie Meghan,17,5,1,0,1,0,1,3.418
+Spring 2024,CHEE,8298,15,13038,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,
+Spring 2024,MATH,8398,19,13039,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,
+Spring 2024,PHYS,1101,19,13041,College Physics I (lab),Wood,Lowell T,2,11,4,1,1,0,3,2.632
+Spring 2024,GEOL,3145,1,13042,Strctrl Geology Lab,Murphy,Michael,6,7,0,0,1,0,0,3.191
+Spring 2024,CHEM,1111,27,13044,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,15,0,0,0,0,1,3.332
+Spring 2024,CHEM,1111,28,13045,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,3,0,1,0,0,2.941
+Spring 2024,CHEE,8298,18,13046,Doctoral Research,Willson,Richard,0,0,0,0,0,2,0,
+Spring 2024,FINA,6398,2,13047,Research,Bean,Gregory S,5,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8698,5,13048,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,1,0,
+Spring 2024,ENGL,1301,19,13050,First Year Writing I,Williams,Adele E,13,6,4,0,0,0,2,3.363
+Spring 2024,BIOE,8398,14,13051,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,15,13052,Doctoral Research,Larin,Kirill,0,0,0,0,0,8,0,
+Spring 2024,ENGI,2304,6,13054,Technical Communications,Estrada,Carl,5,9,4,1,2,0,4,2.698
+Spring 2024,ENGL,1302,35,13056,First Year Writing II,Kozma,Andrew,12,9,2,0,0,0,2,3.406
+Spring 2024,MATH,8698,9,13062,Doctoral Research,Ott,William R,0,0,0,0,0,2,0,
+Spring 2024,MATH,1314,9,13065,College Algebra,Caglar,Atife,8,10,8,7,19,0,15,1.635
+Spring 2024,MATH,1324,11,13066,Finite Math with Applications,Sosa,Moses,24,32,10,30,62,0,32,1.519
+Spring 2024,MATH,1342,8,13067,Elementary Statistical Methods,Wang,Wenshuang,38,50,40,30,12,0,12,2.424
+Spring 2024,MATH,2312,9,13068,Precalculus,Almus,Melahat,28,8,26,8,14,0,16,2.278
+Spring 2024,MATH,4364,1,13069,Intro to Numerical Analysis,Pan,Tsorng-Whay,29,21,8,0,1,0,0,3.232
+Spring 2024,ECON,2301,2,13070,Principles of Macroeconomics,Maden,Bitaran Jang,53,133,111,39,15,0,18,2.487
+Spring 2024,GEOL,1102,3,13072,Intro to Climate Change Lab,Wang,Yuxuan,16,7,1,0,0,0,0,3.584
+Spring 2024,ARCH,1501,13,13074,Arc/Int Arc Design Studio II,Olwi,Asmaa,6,3,0,0,1,0,3,3.3
+Spring 2024,ARCH,2501,11,13076,Architecture Design Studio IV,Lee,Seo Hee,3,7,3,0,0,0,2,3.025
+Spring 2024,PSYC,2330,4,13078,Biological Psychology,Rech,Megan Elizabeth,46,17,8,3,1,0,4,3.312
+Spring 2024,GEOL,1303,8,13079,Physical Geology,Lytwyn,Jennifer N,48,80,52,9,18,0,24,2.622
+Spring 2024,PSYC,7393,1,13080,Field Practicum in Psychology,Woods,Steven Paul,0,0,0,0,0,31,0,
+Spring 2024,ARCH,6A23,1,13081,Construction Technology 2,Thaddeus,David J,5,4,0,1,0,0,0,3.234
+Spring 2024,ARCH,6A21,1,13082,Environmental Technology 2,Kyropoulou,Amygdalia,6,4,0,0,0,0,0,3.633
+Spring 2024,ARCH,6A51,1,13083,Construction Technology 4,Thaddeus,David J,11,17,0,2,0,0,0,3.222
+Spring 2024,ARCH,6A49,1,13084,Environmental Technology 4,Kyropoulou,Amygdalia,23,6,0,0,0,0,0,3.713
+Spring 2024,GEOL,1340,2,13085,Earth Systems,Lytwyn,Jennifer N,77,85,41,8,4,0,10,3.03
+Spring 2024,BIOL,2102,19,13087,Anatomy & Physiology II (lab),Gill,Tejendra,7,16,0,1,0,0,0,3.291
+Spring 2024,BIOL,2102,20,13088,Anatomy & Physiology II (lab),Gill,Tejendra,7,14,2,1,0,0,0,3.166
+Spring 2024,CHEM,1311,1,13089,Fundamentals of Chemistry,Guloy,Arnold M,11,32,74,18,22,0,41,1.966
+Spring 2024,PHYS,4340,1,13090,Research Methods,Ekeoba,Jacqueline Njideka,5,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,2610,1,13092,Intensive Intermediate Spanish,Said,Erika,0,11,4,1,3,0,0,2.263
+Spring 2024,SPAN,2610,4,13093,Intensive Intermediate Spanish,Monarrez Martinez,Sendy Patricia,2,11,3,0,2,0,1,2.629
+Spring 2024,INDS,7301,1,13095,Design Thesis II,Morshedzadeh,Elham,2,0,0,0,0,0,0,4.0
+Spring 2024,SOC,4394,1,13097,Internship in Sociology,Karner,Tracy Xavia,5,2,0,0,0,0,1,3.62
+Spring 2024,MATH,1314,3,13098,College Algebra,Campos,Marco,19,20,36,16,35,0,19,1.738
+Spring 2024,COMM,1307,1,13100,Media and Society,Lyn,Robyn,30,4,2,0,2,0,5,3.562
+Spring 2024,ELCS,6334,1,13101,Assessment & Eval in Higher Ed,Hernandez,Belkis Pamela,5,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,2320,3,13102,Abnormal Psychology,Ridgely,Natalie,33,30,9,1,5,0,1,3.039
+Spring 2024,FINA,3332,3,13103,Prin of Financial Management,Lopez,John C,39,74,66,34,6,0,6,2.614
+Spring 2024,COMM,3360,1,13104,Principles of Strategic Comm,Ashley,Laura B,91,20,8,0,2,0,0,3.625
+Spring 2024,FINA,4330,3,13105,Corporate Finance,Allena,Rohit,11,8,2,1,0,0,0,3.348
+Spring 2024,FINA,4356,1,13106,Insurance Operations,Hughes,James F,20,24,3,0,0,0,0,3.355
+Spring 2024,GENB,6A50,2,13107,Business Communications,Pettiette,Michael R,8,1,0,0,0,0,1,3.632
+Spring 2024,GENB,6A50,3,13108,Business Communications,Pettiette,Michael R,10,1,0,0,0,0,0,3.789
+Spring 2024,PSYC,3350,3,13109,Intro to Cognitive Psychology,Racioppo,Keith,41,32,5,0,1,0,0,3.363
+Spring 2024,BIOL,6374,1,13110,Cell Biology,Farmer,Lisa M,0,2,1,0,0,0,0,2.777
+Spring 2024,MANA,4346,1,13111,Leadership Development,Evans,Klavdia Markelova,24,0,0,0,0,0,0,4.0
+Spring 2024,MANA,7339,1,13112,Leadership Development,Witt,Lawrence A,35,0,0,0,0,0,0,3.991
+Spring 2024,SCM,3301,4,13113,SCM Fundamentals,Miller,Bradley D,188,212,60,11,2,0,6,3.177
+Spring 2024,COMM,4357,1,13114,Intercultural Communication,Liu,Wenlin,22,5,0,0,1,0,1,3.561
+Spring 2024,COSC,4353,2,13115,Software Design,Singh,Raj Kumar,139,7,1,0,0,0,1,3.874
+Spring 2024,MIS,3376,1,13116,Busn Appls Database Mgmt I,Dimoka,Angelika,14,13,5,0,1,0,1,3.092
+Spring 2024,MIS,3376,2,13117,Busn Appls Database Mgmt I,Scamell,Richard W,18,19,12,4,1,0,4,2.932
+Spring 2024,SCM,7390,1,13118,Global Supply Chain Strategy,Smith,Gordon D,0,2,1,0,0,0,0,2.887
+Spring 2024,PHYS,1301,5,13119,College Physics I (lecture),McElhenny,Brian Patrick,31,55,59,12,13,0,43,2.397
+Spring 2024,FINA,4342,1,13120,Financial Eval Corp Reports,Disch,Chad Alan,16,10,1,0,0,0,2,3.446
+Spring 2024,FINA,4329,1,13121,Life Insurance and Annuities,Hong,James,18,31,1,0,0,0,0,3.287
+Spring 2024,FINA,4343,1,13122,Credit Analysis,Lara,Alexander J,12,0,0,0,0,0,0,3.945
+Spring 2024,HDFS,2314,1,13123,Human Dev and Interventions,Boykin,Jelisa Denae,99,26,10,9,10,0,6,3.262
+Spring 2024,HDFS,3318,1,13124,Human Ecol of Adult Developmt,Schoger,Kimberly,35,3,0,1,0,0,0,3.795
+Spring 2024,ENGL,1302,36,13126,First Year Writing II,Kozma,Andrew,14,4,3,0,0,0,4,3.492
+Spring 2024,ELED,4315,1,13127,Mathematics in Elem School II,Burris,Justin T,20,2,1,0,0,0,0,3.826
+Spring 2024,COMM,2320,1,13130,Fundamentals Media Production,Crowe,Craig Warren,70,10,2,0,0,0,0,3.765
+Spring 2024,ENGI,1331,3,13135,Computing for Engineers,Landon,Alexandra Maley,26,4,2,0,0,0,1,3.698
+Spring 2024,COMD,3371,1,13137,Speech Devel & Dis in Children,Cizek,Laura S,5,12,3,0,0,0,0,2.985
+Spring 2024,HDFS,2314,6,13142,Human Dev and Interventions,Dunsmore,Julie C,20,12,4,3,3,0,3,2.969
+Spring 2024,PETR,1111,1,13144,Intro to Petroleum Engineering,Hathon,Lori A,2,5,2,1,0,0,0,2.8
+Spring 2024,WGSS,2350,1,13145,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,3,1,0,0,0,0,3.833
+Spring 2024,WGSS,2350,3,13146,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,30,0,1,1,0,0,1,3.854
+Spring 2024,WGSS,2350,5,13147,Intro To Women's Studies,Martinez,Itzel Areli,23,5,0,1,1,0,0,3.633
+Spring 2024,WGSS,2350,6,13148,Intro To Women's Studies,Slatton,Brittany Chevon,24,1,2,2,0,0,1,3.609
+Spring 2024,PSYC,2319,2,13149,Intro to Social Psychology,Fetterman,Adam Kent,18,16,10,0,0,0,1,3.264
+Spring 2024,LAW,5227,1,13150,Procedure of Patent Litigation,Barcelo,Bryce,3,4,0,0,0,0,0,3.429
+Spring 2024,LAW,5271,1,13151,Advanced Negotiation,Daic,Megan Ashley,2,4,0,0,0,3,0,3.388
+Spring 2024,LAW,5421,2,13152,Business Organizations,Ragazzo,Robert A,12,21,0,0,0,0,0,3.384
+Spring 2024,LAW,5218,1,13157,Human Trafficking Law,Zack,Sherri Lynn,11,5,0,0,0,0,0,3.419
+Spring 2024,ACCT,2302,7,13161,Prin of Managerial Accounting,Newman,Michael Ray,20,5,0,0,0,0,0,3.826
+Spring 2024,POLS,3376,1,13162,Black Political Thought,LeVeaux,Christine,15,5,3,0,0,0,2,3.493
+Spring 2024,COMM,4303,4,13163,Communication Law and Ethics,Payne,Latosha Lewis Terrell,68,27,2,0,0,0,2,3.663
+Spring 2024,ACCT,7372,1,13164,Multijurisdictional Taxation,Evetts,Nancy Zalmanek,23,4,1,0,0,0,0,3.798
+Spring 2024,HIST,1302,52,13165,The U.S. Since 1877,Modaff,Abigail,21,2,0,0,0,0,1,3.899
+Spring 2024,SOCW,8425,1,13167,Statistics & Data Analysis II,Torres,Isabel,7,0,0,0,0,0,0,4.0
+Spring 2024,GHL,3361,1,13168,Hospitality Marketing,Park,Yunna,17,2,1,0,0,0,0,3.784
+Spring 2024,GHL,3348,1,13169,Principles of Hosp Revenue Mgt,Cheatham,Cathy A,43,14,4,1,0,0,0,3.65
+Spring 2024,GHL,6101,1,13170,Colloquium,Back,KiJoon,18,1,0,0,1,0,0,3.75
+Spring 2024,GHL,8304,1,13171,Qualitative Design in Hosp Adm,Madera,Juan Manuel,4,0,0,0,0,0,0,3.918
+Spring 2024,GHL,3348,2,13172,Principles of Hosp Revenue Mgt,Kazemi Zarkouei,Mohammad Sadegh,3,9,6,1,2,0,8,2.523
+Spring 2024,BIOE,3340,1,13173,Quantitative Physiology,Roh,Jinsook,6,8,9,1,0,0,0,2.847
+Spring 2024,PSYC,7305,1,13174,Structural Equations,Mehta,Paras D,4,2,0,0,0,0,0,3.612
+Spring 2024,MAS,3343,1,13176,Latino Psychology,Pino,Diana,8,15,9,4,2,0,1,2.544
+Spring 2024,MECE,2334,1,13177,Thermodynamics,Love,Holley Carole,21,27,14,0,0,0,5,3.065
+Spring 2024,PHYS,6321,1,13178,Electrodynamics,Koerner,Lisa Whitehead,13,9,0,0,0,0,1,3.591
+Spring 2024,WGSS,2360,1,13180,Introduction to LGBT Studies,Pegoda,Andrew Joseph,7,5,12,1,1,0,4,2.514
+Spring 2024,WGSS,6301,1,13181,Feminist Theory & Methodology,Gregory,Elizabeth,12,0,0,0,0,0,0,4.0
+Spring 2024,ECON,2302,3,13182,Principles of Microeconomics,Patwardhan,Ashutosh Anant,11,13,5,0,1,0,0,3.21
+Spring 2024,ENTR,7339,1,13186,Venture Fund,Rassin,Keith David,3,0,0,0,0,0,0,4.0
+Spring 2024,WGSS,2350,7,13187,Intro To Women's Studies,Slatton,Brittany Chevon,22,5,0,0,0,0,2,3.79
+Spring 2024,KIN,3301,1,13188,Design/Eval Phys Activity Prog,Betts,Charles Raphael,33,8,5,1,2,0,1,3.354
+Spring 2024,PETR,3372,1,13189,Petroleum Production Operation,Wong,George K,2,4,1,0,0,0,0,3.049
+Spring 2024,KIN,3306,3,13190,Physiology-Human Performance,Breslin,Whitney L,46,55,16,1,1,0,1,3.166
+Spring 2024,PHYS,1102,14,13191,College Physics II (lab),Wood,Lowell T,4,13,4,1,0,0,0,2.744
+Spring 2024,WGSS,3360,1,13192,Sexuality and Queer Theory,Harrell,Haylee C,3,0,0,0,0,0,1,3.89
+Spring 2024,WGSS,2350,8,13193,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,31,4,0,1,0,0,0,3.815
+Spring 2024,WGSS,2350,4,13194,Intro To Women's Studies,Slatton,Brittany Chevon,26,0,2,0,2,0,0,3.6
+Spring 2024,BIOE,3140,1,13195,Quantitative Physiology Lab,Roh,Jinsook,8,2,0,0,0,0,0,3.767
+Spring 2024,MIS,7376,1,13196,Systems Analysis and Design,Johnson,Glynn L,16,9,1,0,0,0,2,3.577
+Spring 2024,ACCT,4380,1,13197,Contro & Sec Intern Fin Inform,Brant Jr,Robert Edward,1,2,1,0,0,0,0,3.0
+Spring 2024,CIVE,3434,3,13198,Fluid Mech and Hydraulic Engr,Momen,Mostafa,18,26,9,2,0,0,1,3.067
+Spring 2024,CIVE,4311,1,13200,Prof Practice in Civil Engr,Herman,Reagan,4,7,3,0,0,0,0,3.166
+Spring 2024,ATP,7196,1,13201,Clinical Experience VI,Gililland,Darrell Jon,15,0,0,0,0,0,0,4.0
+Spring 2024,ATP,7321,1,13202,Behavioral Health in AT,Gililland,Darrell Jon,11,4,0,0,0,0,0,3.733
+Spring 2024,ATP,7322,1,13203,Seminar in Athletic Training,Knoblauch,Mark Alan,15,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,2312,13,13204,Intermediate Spanish II,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,2,12,7,1,1,0,0,2.493
+Spring 2024,SPAN,2312,14,13205,Intermediate Spanish II,Morales Utria,Yordanis,9,11,5,0,1,0,0,2.924
+Spring 2024,ACCT,4331,3,13206,Federal Income Tax,Small,Randolph Christopher,19,8,0,0,0,0,0,3.704
+Spring 2024,POLS,8999,14,13207,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,2,0,
+Spring 2024,PETR,4312,1,13209,Petroleum Capstone Project II,Zargar,Zeinab,3,8,0,0,0,0,0,3.513
+Spring 2024,PETR,6312,1,13210,Well Log Eval of Petr Formatn,Hathon,Lori A,9,5,1,0,0,0,0,3.511
+Spring 2024,SPAC,6203,1,13212,Spacecraft/Habitat Design,Toups,Larry David,22,0,0,0,0,0,1,4.0
+Spring 2024,SPAC,6403,1,13213,Mission Planning and Analysis,Bannova,Olga,13,6,4,0,0,0,0,3.32
+Spring 2024,SPAC,6405,1,13214,Advanced Design and Analysis,Bannova,Olga,1,0,0,0,0,0,0,3.67
+Spring 2024,SPAC,7410,1,13215,Master's Project: Space Arch,Bell,Larry S,1,1,0,0,0,0,0,3.5
+Spring 2024,CHEM,1111,2,13219,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,11,1,0,0,0,0,3.314
+Spring 2024,CHEM,1111,8,13220,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,5,5,0,1,0,2,2.488
+Spring 2024,MANA,4355,2,13223,Selection and Staffing,Bozeman,Dennis,10,7,3,0,0,0,2,3.416
+Spring 2024,CHEM,1112,60,13224,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,1,2,0,0,1,2.983
+Spring 2024,CHEM,1112,61,13225,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,11,1,0,0,0,1,3.158
+Spring 2024,CHEM,1112,62,13226,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,0,0,0,0,3,3.208
+Spring 2024,CHEM,1112,63,13227,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,5,0,0,0,2,3.0
+Spring 2024,ARCH,5500,3,13228,Architecture Design Studio IX,Woodfill,Celeste Ponce,3,2,7,1,1,0,0,2.475
+Spring 2024,CHEM,1111,24,13230,Fundamentals of Chm Lab,Zaitsev,Vladimir G,9,8,2,0,0,0,1,3.351
+Spring 2024,CHEM,1111,25,13231,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,0,0,0,0,4,3.288
+Spring 2024,CHEM,1111,26,13232,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,11,3,0,1,0,1,2.881
+Spring 2024,CHEM,1111,29,13233,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,10,2,0,0,0,1,3.001
+Spring 2024,CHEM,1111,30,13234,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,4,5,0,0,0,5,2.833
+Spring 2024,CHEM,1111,31,13235,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,3,0,0,0,0,2.945
+Spring 2024,CHEM,1111,32,13236,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,0,0,0,0,1,3.333
+Spring 2024,CHEM,1111,33,13237,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,9,4,0,1,0,0,2.877
+Spring 2024,CHEM,1111,34,13238,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,1,0,0,0,2,3.261
+Spring 2024,CHEM,1111,37,13239,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,2,0,0,0,4,3.042
+Spring 2024,PSYC,2307,1,13241,Psychology of Adolescence,Anderson,Jill Annette,21,27,7,3,1,0,1,3.04
+Spring 2024,CHEM,8998,24,13244,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Spring 2024,MARK,4379,1,13245,Personal Branding,Vandaveer,Amy L,45,20,0,0,0,0,0,3.657
+Spring 2024,PHOP,6198,28,13246,Spec Prob-Physio Optics,Marsack,Jason,2,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8698,12,13251,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Spring 2024,PHOP,6257,3,13252,Research Practicum B,Ostrin,Lisa,4,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6198,29,13259,Spec Prob-Physio Optics,Ostrin,Lisa,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,2330,1,13261,Writing Discipline English,Coleman,Quintin,10,3,4,0,2,0,1,2.931
+Spring 2024,COMD,7391,14,13264,Clinic in Speech Lang Disorder,Jacobson,Shannon,1,2,0,0,0,0,0,3.553
+Spring 2024,COMD,7391,13,13265,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,2,0,0,0,0,0,0,3.835
+Spring 2024,PETR,7399,3,13271,Masters Thesis,Myers,Michael Tolbert,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8398,16,13289,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Spring 2024,GHL,4343,2,13290,Financial Admin for Hosp.Ind.,Koh,Yoon,19,13,8,1,1,0,1,3.088
+Spring 2024,OPTO,7494,1,13291,General Clinic IIIb,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8399,6,13296,Doctoral Dissertation,Larin,Kirill,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,7350,1,13298,Cellular Pharmacology I,Ruan,Ke-He,0,0,0,0,0,0,0,
+Spring 2024,ENGL,7399,1,13299,Essay,Prufer,Kevin D,2,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,3334,1,13303,Stat/Num Tchqs for Chem Engrs,Zerze,Hasan,12,19,3,1,0,0,2,3.219
+Spring 2024,CUIN,8699,10,13304,Doctoral Dissertation,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8999,15,13313,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,2,0,
+Spring 2024,MECE,3336,3,13314,Mechanics II,Chen,Xuemei,10,16,11,1,1,0,10,2.855
+Spring 2024,CHEE,8399,16,13315,Doctoral Dissertation,Varadarajan,Navin,7,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8398,16,13317,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Spring 2024,PETR,8398,3,13319,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,2,0,
+Spring 2024,ACCT,5378,1,13325,Control & Security of Fin Info,Brant Jr,Robert Edward,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8999,1,13330,Doctoral Dissertation,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,7399,6,13332,Masters Thesis,Rasmussen,Susan J,0,0,0,0,0,1,0,
+Spring 2024,MATH,8698,14,13336,Doctoral Research,Mang,Andreas,0,0,0,0,0,2,0,
+Spring 2024,WGSS,4360,1,13338,Capstone Internship Course,Gregory,Elizabeth,2,0,0,0,0,0,0,4.0
+Spring 2024,MANA,4396,2,13345,Management Internship,Carlin,Barbara A,0,0,0,0,0,2,0,
+Spring 2024,ECON,3344,1,13346,History of Economic Doctrine,Saboury,Piruz,12,12,1,0,1,0,2,3.333
+Spring 2024,MATH,2318,3,13347,Linear Algebra,Perepelitsa,Mikhail Antolyevic,23,26,15,2,1,0,12,3.005
+Spring 2024,MATH,2131,1,13348,Linear Alg Labs w/MATLAB,Vu,An Thuy,23,6,4,0,1,0,3,3.461
+Spring 2024,CUIN,8372,1,13349,Introduction to Qual Research,Qiu,Tairan,8,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,4306,1,13352,Nucleic Acids,Bawa-Khalfe,Tasneem,9,9,5,0,1,0,0,3.138
+Spring 2024,BIOL,6240,1,13353,Molecular Genetics 1,Dauwalder,Brigitte,10,1,0,0,0,0,0,3.939
+Spring 2024,BIOL,6241,1,13354,Molecular Genetics 2,McKeon,Frank D,11,0,0,0,0,0,0,4.0
+Spring 2024,FINA,3332,6,13355,Prin of Financial Management,Suleymanov,Masim,93,61,40,17,4,0,4,3.033
+Spring 2024,MIS,3370,3,13356,Info Systems Development Tools,Cooper,Randolph B,6,10,14,6,7,0,14,2.047
+Spring 2024,BIOL,2121,11,13357,Microbiol for Science Maj(lab),Knapp,Richard D,9,9,3,0,1,0,1,3.076
+Spring 2024,PSYC,2316,4,13358,Psychology of Personality,Inman,Tonya N,40,18,7,0,1,0,8,3.46
+Spring 2024,PSYC,2330,5,13359,Biological Psychology,Jackson,Lillian Reed,40,31,6,0,1,0,2,3.338
+Spring 2024,CUIN,4361,10,13360,Second Language Methodology,Latiolais,Cheryl S,9,0,0,0,0,0,0,4.0
+Spring 2024,COMM,3369,3,13362,Strategic Comm. Writing,Emery II,Philip M,25,0,1,0,0,0,2,3.923
+Spring 2024,COMM,4378,1,13364,Social Impact of Info Tech,Ashley,Laura B,56,2,2,0,0,0,0,3.906
+Spring 2024,PSYC,6332,1,13365,CDLNeuropsych: Assess/App I,Woods,Steven Paul,7,0,0,0,0,0,0,3.953
+Spring 2024,GEOL,3377,1,13366,Oceanography,Maddocks,Rosalie F,4,1,9,2,0,0,0,2.355
+Spring 2024,PETR,4311,1,13367,Petroleum Capstone Project I,Zargar,Zeinab,0,5,0,0,0,0,0,3.33
+Spring 2024,PHYS,3316,1,13368,Quantum Mechanics,Gunaratne,Gemunu,5,4,1,0,1,0,3,3.061
+Spring 2024,ELED,4314,2,13369,Mathematics in Elem School I,Burris,Justin T,21,2,1,0,0,0,0,3.847
+Spring 2024,CUIN,4332,2,13370,Literacy Assess Rdg Writing,Black,Misty Paul,16,1,0,0,0,0,0,3.883
+Spring 2024,BIOE,3140,2,13371,Quantitative Physiology Lab,Roh,Jinsook,14,1,0,0,0,0,0,3.889
+Spring 2024,EDRS,8381,1,13372,Rsch Mthds in Educ,Johnson,Detra DeVerne,5,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,2321,2,13373,Microbiology for Science Major,Knapp,Richard D,69,71,66,36,8,0,12,2.631
+Spring 2024,SCM,4385,1,13393,Supply Chain Analytics,Murray,Michael J,9,3,0,0,0,0,3,3.53
+Spring 2024,COMM,3340,1,13394,Health Campaigns,Xiao,Zhiwen,6,10,1,1,0,0,0,3.258
+Spring 2024,COMM,3377,1,13395,Strategic PR Planning,Uhrick,Jan,23,2,0,0,0,0,0,3.92
+Spring 2024,ARED,3305,1,13396,Art in Elementary Schools,Boyaki Wilson,Amanda R,21,3,1,0,0,0,0,3.787
+Spring 2024,ELED,4310,2,13397,Reading/Language in Elementary,Stubbs,Susan,15,0,0,0,0,0,0,4.0
+Spring 2024,ENTR,3311,1,13398,Technology Entrepreneurship,Chatterji,Tanushree,9,0,0,1,1,0,3,3.304
+Spring 2024,MARK,4332,1,13399,Social Media Marketing,Zahn,William J,36,27,5,1,0,0,0,3.406
+Spring 2024,MARK,7332,1,13400,Social Media Marketing,Gavin,Daniel Yaakov,17,1,2,0,0,0,0,3.75
+Spring 2024,CUIN,3333,1,13401,Differentiating Diverse Learn,Larry,Frederick,21,6,0,0,0,0,0,3.827
+Spring 2024,CUIN,4315,5,13402,Assessment of Children,Henderson,Linda Fay,16,7,4,0,0,0,0,3.322
+Spring 2024,ENGI,1100,2,13404,Introduction To Engineering,Metrovich,Brian,21,19,6,1,4,0,6,3.013
+Spring 2024,ENGI,1100,3,13405,Introduction To Engineering,Aksu,Gulin Tulunay,21,18,10,5,0,0,4,3.019
+Spring 2024,CHEE,2332,2,13408,Chem Engr Thermodyn I,Palmer,Jeremy,0,2,0,0,0,0,0,2.835
+Spring 2024,BIOE,4342,1,13409,Biomedical Signal Processing,Singh,Manmohan,3,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,4349,1,13410,Biomedical Microdevices,Majd,Sheereen,2,0,0,0,0,0,1,3.67
+Spring 2024,BIOE,6349,1,13411,Biomedical Microdevices,Majd,Sheereen,9,2,0,0,0,0,0,3.668
+Spring 2024,BIOE,4150,1,13412,Genomic & Proteomic Lab,Akay,Yasemin M,8,3,1,0,0,0,0,3.583
+Spring 2024,BIOE,4350,1,13414,Genomic & Proteomic Engr,Wu,Tianfu,31,4,0,0,0,0,0,3.905
+Spring 2024,BIOE,4302,1,13415,Numerical Analysis for BME,An,Ran,24,0,0,0,0,0,0,3.945
+Spring 2024,BIOE,6300,1,13416,Mathematical Methods in BME,Wang,Lu,16,14,0,0,0,0,2,3.445
+Spring 2024,HLT,2320,1,13417,Introduction to Public Health,Solari Williams,Kayce D,102,14,2,0,1,0,1,3.776
+Spring 2024,ENTR,7390,1,13418,Technology Entrepreneurship,Chatterji,Tanushree,7,1,0,0,0,0,0,3.875
+Spring 2024,MECE,4340,1,13419,Mechanical Engr Capstone I,Chang,Christiana,16,39,5,0,0,0,0,3.2
+Spring 2024,COSC,6373,1,13420,Computer Vision,Kakadiaris,Ioannis A,7,6,0,0,0,0,0,3.412
+Spring 2024,MANA,3335,5,13421,Intro Org Behavior and Mgmt,Currie,Daniel David,205,46,10,3,0,0,3,3.691
+Spring 2024,COSC,6323,1,13422,Statistical Method in Research,Pavlidis,Ioannis T,9,23,11,4,1,0,0,2.791
+Spring 2024,MANA,6A83,2,13423,Strategic Analysis,Sauerwald,Steve,31,2,0,0,0,0,0,3.889
+Spring 2024,PETR,8399,1,13424,Doctoral Dissertation,Soliman,Mohamed Yousef,1,0,0,0,0,0,0,4.0
+Spring 2024,PETR,8399,3,13425,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,4,0,
+Spring 2024,PETR,8399,5,13427,Doctoral Dissertation,Ehlig-Economides,Christine A,0,0,0,0,0,2,0,
+Spring 2024,PETR,8399,9,13431,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,2,0,
+Spring 2024,ENGL,3331,1,13432,Beg Creative Writing-Poetry,Nee,Kelan,13,4,1,0,1,0,0,3.456
+Spring 2024,PETR,8699,1,13433,Doctoral Dissertation,Soliman,Mohamed Yousef,0,0,0,0,0,1,0,
+Spring 2024,PETR,8699,3,13434,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,2,0,
+Spring 2024,PETR,8699,4,13435,Doctoral Dissertation,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Spring 2024,PETR,8699,7,13438,Doctoral Dissertation,Wong,George K,0,0,0,0,0,0,0,
+Spring 2024,PETR,8699,8,13439,Doctoral Dissertation,Lee,Kyung Jae,1,0,0,0,0,0,0,4.0
+Spring 2024,PETR,8699,9,13440,Doctoral Dissertation,Sakhaee Pour,Ahmad,1,0,0,0,0,0,0,3.67
+Spring 2024,PETR,8298,1,13444,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,2,0,
+Spring 2024,PETR,8999,8,13452,Doctoral Dissertation,Lee,Kyung Jae,1,0,0,0,0,0,0,4.0
+Spring 2024,PETR,8999,9,13453,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Spring 2024,PETR,8298,3,13454,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,3,0,
+Spring 2024,PETR,8298,5,13456,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Spring 2024,PETR,8298,7,13458,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Spring 2024,PETR,8298,8,13459,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Spring 2024,PETR,8298,9,13460,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Spring 2024,PETR,8598,3,13470,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,3,0,
+Spring 2024,PETR,8598,5,13472,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,2,0,
+Spring 2024,PETR,8598,8,13475,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Spring 2024,MANA,4336,1,13477,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,9,29,6,2,4,0,2,2.694
+Spring 2024,MANA,4348,1,13478,Global Leadership,Tabesh,Pooya,30,20,5,1,2,0,1,3.31
+Spring 2024,ECE,2202,1,13479,Circuit Analysis II,Shan,Xiaonan,51,12,6,1,0,0,3,3.548
+Spring 2024,PHLS,6352,1,13480,Assessmnt in Educ Psych,Lee,Jungeun,11,4,0,0,0,0,0,3.711
+Spring 2024,PHLS,8300,1,13482,Advanced Educ/Psy Measurement,Fan,Weihua,10,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8305,1,13483,Supervisn in Counseling,Reyna,Ronda,10,1,0,0,0,0,0,3.939
+Spring 2024,PHLS,8347,1,13485,Assessment Cog Abilities,Matta,Michael,4,3,0,0,0,0,1,3.571
+Spring 2024,PHLS,8367,1,13486,Behavioral Consultation,Gonzalez,Jorge E,6,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,1350,1,13488,Mathematics for Teachers 1,Burris,Justin T,18,8,1,0,0,0,2,3.581
+Spring 2024,SOCW,7325,3,13489,Individuals: Adv Clinical Prac,Mayes,Kimberly,26,2,0,0,0,0,0,3.929
+Spring 2024,INDE,6333,1,13491,Probability Stat For Engineers,Feng,Qianmei,19,22,11,5,3,0,8,2.811
+Spring 2024,INDE,6372,1,13492,Advanced Linear Optimization,Peng,Jiming Ouyang,5,8,10,1,0,0,10,2.708
+Spring 2024,HDFS,4315,1,13493,Culture and Diversity,Conston,Toya,31,3,0,1,0,0,0,3.8
+Spring 2024,HLT,3325,2,13494,Medical Terminology,Bloom,Joel A,140,3,1,1,0,0,1,3.933
+Spring 2024,SOCW,8395,2,13495,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8395,3,13496,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Spring 2024,CUIN,3347,1,13497,Reading in the Content Area,Morris,Alana,26,3,0,0,0,0,1,3.908
+Spring 2024,PEP,7393,1,13498,Internship & Practicum,Walsh,David W,1,2,0,0,0,0,0,3.553
+Spring 2024,POLS,3356,1,13500,Intro-Constitutionl Law,Wall,Kenneth S,4,7,5,8,0,0,3,2.195
+Spring 2024,MECE,6384,1,13502,Methods of Applied Math I,Baxevanis,Theocharis,8,5,2,0,1,0,1,3.064
+Spring 2024,ACCT,2301,4,13503,Prin of Financial Accounting,Sykes,Mary Reeves,37,22,10,6,1,0,8,3.24
+Spring 2024,FINA,6387,1,13504,Managerial Analysis,Basu,Swati,6,3,0,0,0,0,0,3.667
+Spring 2024,ACCT,6331,3,13505,Financial Accounting,Li,Bin,11,2,1,0,0,0,0,3.714
+Spring 2024,MATH,2318,6,13506,Linear Algebra,Vershynina,Anna,6,13,11,2,1,0,8,2.646
+Spring 2024,MATH,3321,2,13507,Engineering Mathematics,West,James David,11,12,18,14,17,0,15,1.796
+Spring 2024,MARK,4362,1,13508,Applied Buyer Behavior,Noriega,Jaime L,24,18,9,2,0,0,0,3.046
+Spring 2024,MANA,6A25,2,13509,Ethical Leadrshp & Crit Reason,Celly,Nikhil,38,0,0,0,0,0,0,3.991
+Spring 2024,CORE,1101,1,13510,College Success,Harrell II,Clifford E,23,2,0,1,0,0,0,3.808
+Spring 2024,CORE,1101,2,13511,College Success,Harrell II,Clifford E,11,6,1,0,3,0,3,3.048
+Spring 2024,BIOL,3301,2,13512,Mendelian and Pop Genetics,Lekven,Arne,41,63,37,6,4,0,7,2.868
+Spring 2024,PHYS,1304,1,13513,Solar System,Li,Liming,71,69,13,3,1,0,2,3.245
+Spring 2024,LAW,5328,1,13514,Judicial Externship I,Powers,William,0,0,0,0,0,3,0,
+Spring 2024,LAW,5378,4,13515,Statutory Interpretation & Rea,Hester,Tracy,33,40,2,0,0,0,1,3.378
+Spring 2024,LAW,7328,1,13516,WRC: Writing Criminal Defense,Maselli,Jani,6,5,0,0,0,0,0,3.395
+Spring 2024,LAW,5375,1,13517,Admin Estates & Guardianship,Akers,Georgia Lee Hinkle,4,8,5,0,0,0,0,2.941
+Spring 2024,MUSA,6204,1,13521,Conducting,Krager,Franz A,4,0,0,0,0,0,0,4.0
+Spring 2024,THEA,1111,1,13522,Production,Davis,Lauren E,21,0,0,1,0,0,0,3.864
+Spring 2024,THEA,1111,2,13523,Production,Gardecki,Samantha Lauren,26,5,0,0,0,0,0,3.754
+Spring 2024,THEA,1112,1,13524,Production,Vlahos,Kalliope,13,0,0,0,0,0,1,3.975
+Spring 2024,THEA,1340,1,13525,Fundamentals of Acting,Hanna,Austin Essa,8,1,1,0,0,0,1,3.601
+Spring 2024,LAW,5376,1,13526,Colloquium,Knake,Renee N,3,3,0,0,0,9,0,3.39
+Spring 2024,THEA,2321,1,13527,Acting IV,Pistorius,Allison Marie,7,3,0,0,0,0,0,3.667
+Spring 2024,THEA,2350,1,13528,Movement for the Actor II,Bronfenbrenner,Skye,9,1,0,0,0,0,0,3.9
+Spring 2024,THEA,2380,1,13529,Voice for the Actor II,Johnson,James B,9,1,0,0,0,0,0,3.834
+Spring 2024,THEA,2382,1,13530,Stage Management I,Bush,Rachel R,10,9,2,0,0,0,0,3.35
+Spring 2024,THEA,3321,1,13531,Acting VI,Wetzel,Molly Elizabeth,7,4,0,0,0,0,0,3.516
+Spring 2024,THEA,3332,1,13532,Directing I,Holm,Eric Powell,7,0,0,0,0,0,0,4.0
+Spring 2024,THEA,3333,1,13533,Directing II,Holm,Eric Powell,6,0,0,0,0,0,0,4.0
+Spring 2024,THEA,3336,1,13534,History of the Theatre II,Romero,Gregory John,20,1,0,0,1,0,0,3.728
+Spring 2024,THEA,3364,1,13535,Costume History,Willson,Paige A,7,3,0,0,1,0,1,3.244
+Spring 2024,THEA,3371,1,13536,"Hist of Arch, Int & Decor Arts",Willson,Paige A,8,4,1,1,0,0,0,3.263
+Spring 2024,THEA,3372,1,13537,Digital Design Techniques,Vintu,Tatiana,6,0,1,0,0,0,0,3.761
+Spring 2024,THEA,3385,1,13538,Scenic Design,Vintu,Tatiana,6,1,0,0,0,0,0,3.716
+Spring 2024,THEA,3393,1,13539,Applied Stage Management,Bush,Rachel R,2,0,0,0,0,0,0,4.0
+Spring 2024,THEA,4283,1,13540,Seminar in Stage Management,Bush,Rachel R,1,0,0,0,0,0,0,4.0
+Spring 2024,THEA,4321,1,13541,Acting VIII,Pistorius,Allison Marie,8,1,3,0,0,0,0,3.472
+Spring 2024,THEA,4350,1,13542,Movement for the Actor IV,Bronfenbrenner,Skye,10,1,0,0,0,0,0,3.849
+Spring 2024,THEA,4352,1,13543,Senior Project:Capstone,Damour,Lisa Jane,0,0,0,0,0,0,0,
+Spring 2024,THEA,4380,1,13544,Voice for the Actor IV,Johnson,James B,11,0,0,0,0,0,0,3.85
+Spring 2024,THEA,4390,1,13545,Acting Showcase: Capstone,Pistorius,Allison Marie,11,0,1,0,0,0,0,3.806
+Spring 2024,THEA,4600,1,13546,Adv Thea Education Internship,Hickman,Margo Louise,7,0,0,0,0,0,0,4.0
+Spring 2024,THEA,6294,1,13547,Design and Production Studio,Willson,Paige A,2,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5354,1,13549,Environmental Law Practicum,Hill,Jason A,5,7,0,0,0,0,0,3.417
+Spring 2024,LAW,5361,1,13550,Financial Statement Analysis,Brennan,Daniel,2,3,0,0,0,0,0,3.4
+Spring 2024,LAW,5203,1,13551,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,7,0,
+Spring 2024,LAW,5206,1,13552,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,4,0,
+Spring 2024,THEA,4313,1,13553,Advanced Playwriting,Damour,Lisa Jane,2,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5392,1,13554,Int Business Trans,Foteh,Samir Jabra,4,2,0,0,0,0,0,3.557
+Spring 2024,LAW,5228,1,13555,Judicial Externship I,Powers,William,0,0,0,0,0,4,0,
+Spring 2024,THEA,7141,1,13557,Grad Direct/Design Collaboratn,Willson,Paige A,2,0,0,0,0,0,0,4.0
+Spring 2024,THEA,7212,1,13558,Graduate Movement II,Noble,Adam S,7,0,0,0,0,0,0,3.764
+Spring 2024,THEA,7222,1,13560,Graduate Voice II,Johnson,James B,7,0,0,0,0,0,0,3.953
+Spring 2024,THEA,7252,1,13562,Graduate Speech II,Wetzel,Molly Elizabeth,4,3,0,0,0,0,0,3.524
+Spring 2024,THEA,7302,1,13564,Graduate Acting II,Young,John M,0,7,0,0,0,0,0,3.094
+Spring 2024,THEA,7304,1,13565,Graduate Acting IV,Young,John M,1,6,0,0,0,0,0,3.331
+Spring 2024,THEA,7305,1,13566,Acting Creative Project,Noble,Adam S,7,0,0,0,0,0,0,3.859
+Spring 2024,THEA,7314,1,13567,Graduate Movement IV,Noble,Adam S,6,1,0,0,0,0,0,3.763
+Spring 2024,THEA,7324,1,13568,Graduate Voice/Speech IV,Wetzel,Molly Elizabeth,5,0,2,0,0,0,0,3.287
+Spring 2024,THEA,7355,1,13569,Design Portfolio,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Spring 2024,ARLD,6300,1,13570,Fndmntals & Planning for Arts,Cachia,Amanda,12,0,0,0,0,0,0,4.0
+Spring 2024,ARLD,6691,1,13571,Internship in Arts Organizatn,Fernando,Fleurette S,0,0,0,0,0,0,0,
+Spring 2024,LAW,6321,1,13572,Professional Responsibility,Schwartz,Richard Austin,30,7,5,3,0,0,0,3.364
+Spring 2024,LAW,5320,1,13573,Pretrial Procedure,Schwartz,Charles W,22,11,3,3,0,0,0,3.198
+Spring 2024,ARTH,4383,1,13575,Contemporary Painting,Barrera,Debra,20,12,1,1,1,0,0,3.343
+Spring 2024,ARTH,6331,1,13577,Contemporary Painting,Barrera,Debra,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,3331,2,13578,Program Appl in Elec Comp Engr,Sheth,Bhavin R,14,1,0,0,0,0,4,3.845
+Spring 2024,ECE,3355,3,13579,Electronics,Litvinov,Dmitri,6,11,8,2,2,0,0,2.484
+Spring 2024,ECE,3337,3,13582,Signals and Systems Analysis,Roysam,Badrinath,1,2,0,0,1,0,0,2.583
+Spring 2024,MUSA,6410,1,13583,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8241,1,13585,Doctoral Recital II,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6100,1,13587,Chamber Music,Archibald,Amber Cristina,16,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1176,1,13588,Applied Jazz Percussion,Hubley,Robert L,4,0,0,0,0,0,0,3.753
+Spring 2024,MUSA,1300,1,13589,Applied Voice,Averyt,Zachary Benjamin,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1300,2,13590,Applied Voice,Clayton Vasquez,Cynthia L,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1300,4,13591,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1320,1,13593,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1320,2,13594,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1322,1,13595,Applied Viola,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1326,1,13596,Applied Double Bass,Larson,Eric Amery,4,1,0,0,0,0,0,3.866
+Spring 2024,MUSA,1330,1,13597,Applied Flute,Russell,Peggy,6,0,0,0,0,0,0,3.945
+Spring 2024,MUSA,1336,1,13599,Applied Bassoon,Wagner,Elise L,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1338,1,13600,Saxophone,Witt,Woodrow W,6,0,0,0,0,0,0,3.945
+Spring 2024,MUSA,1340,2,13601,Applied Trumpet,Vassallo,Jim Cates,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1342,1,13602,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1344,1,13603,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1346,1,13604,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1348,1,13605,Applied Euphonium,Fenske,Kevin,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1350,1,13606,Applied Percussion,Warren,Paul Alexander,8,1,0,0,0,0,0,3.779
+Spring 2024,MUSA,2202,1,13607,Applied Composition,Maroney,Marcus K,1,2,0,0,0,0,0,3.333
+Spring 2024,MUSA,2202,2,13608,Applied Composition,Smith,Robert Thomas,1,3,0,0,0,0,0,3.168
+Spring 2024,MUSA,2300,1,13609,Applied Voice,Clayton Vasquez,Cynthia L,2,1,0,0,0,0,0,3.777
+Spring 2024,MUSA,2300,2,13610,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,3.89
+Spring 2024,MUSA,2300,4,13611,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2300,5,13612,Applied Voice,Averyt,Zachary Benjamin,1,1,0,0,0,0,0,3.335
+Spring 2024,MUSA,2310,2,13614,Applied Piano,Morgulis,Tali,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2320,1,13615,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2322,1,13616,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2330,1,13617,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2334,1,13618,Applied Clarinet,Griffin,Randall S,0,1,0,0,0,0,0,3.0
+Spring 2024,MUSA,2336,1,13619,Applied Bassoon,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2338,1,13620,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2344,1,13622,Applied Trombone,Kauk,Brian Keith,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2348,1,13623,Applied Euphonium,Fenske,Kevin,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3400,1,13624,Applied Voice,Averyt,Zachary Benjamin,2,0,0,0,0,0,0,3.67
+Spring 2024,MUSA,3400,2,13625,Applied Voice,Clayton Vasquez,Cynthia L,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3400,3,13626,Applied Voice,Jones,Timothy J,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3420,2,13629,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,3.835
+Spring 2024,MUSA,3434,1,13631,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3436,1,13632,Applied Bassoon,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3438,1,13633,Applied Saxophone,Witt,Woodrow W,3,0,0,0,0,0,0,3.89
+Spring 2024,MUSA,3444,1,13634,Applied Trombone,Kauk,Brian Keith,4,0,1,0,0,0,0,3.666
+Spring 2024,MUSA,3446,1,13635,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3448,1,13636,Applied Euphonium,Fenske,Kevin,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4400,1,13637,Applied Voice,Sonnenberg,Melanie,4,0,0,0,0,0,0,3.918
+Spring 2024,MUSA,4400,2,13638,Applied Voice,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,3.67
+Spring 2024,MUSA,4400,3,13639,Applied Voice,Clayton Vasquez,Cynthia L,4,0,0,0,0,0,0,3.918
+Spring 2024,MUSA,4420,2,13641,Applied Violin,Lo,Mann-Wen,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4430,1,13642,Applied Flute,Russell,Peggy,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4434,1,13643,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4440,1,13645,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4444,1,13647,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4446,1,13648,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4448,1,13649,Applied Euphonium,Fenske,Kevin,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4450,1,13650,Applied Percussion,Wilkins,Blake M,3,0,0,0,0,0,0,3.89
+Spring 2024,MUSI,6104,1,13651,New Music Ensemble,Smith,Robert Thomas,10,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6300,1,13652,Intro Res Method in Musicology,Caton,Kathryn L.,6,1,1,0,0,0,0,3.584
+Spring 2024,MUSI,6300,2,13653,Intro Res Method in Musicology,Dirst,Matthew C,2,3,3,0,0,0,0,2.793
+Spring 2024,MUSI,8300,1,13654,Doct Research Seminar,Pollack,Howard J,0,4,0,0,0,0,0,3.0
+Spring 2024,MUED,3320,1,13656,Intro To Education in Music,McGinnis,Emily Jane,7,9,1,1,0,0,0,3.241
+Spring 2024,MUED,4305,1,13658,General Music/Elem & Sec Schls,Derges,Julie D,7,9,2,0,0,0,1,3.314
+Spring 2024,MUSI,1102,2,13660,Wind Ensemble,Bertman,David Garry,64,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,1102,3,13661,Wind Ensemble,Bertman,David Garry,12,0,0,0,0,0,1,4.0
+Spring 2024,MUSI,1103,1,13662,Cougar Brass,Kubos,Cameron Kade,37,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,1110,1,13663,Jazz Orchestra,Marmolejo,Noe J,19,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,1121,1,13665,Concert Chorus,Koppel,Alexander,27,1,0,0,0,0,0,3.941
+Spring 2024,MUSI,1140,1,13666,Orchestra,Krager,Franz A,54,3,0,0,0,0,0,3.918
+Spring 2024,MUSI,1182,1,13668,Group Piano II,Van Kekerix,Todd Evan,9,2,2,0,0,0,1,3.564
+Spring 2024,MUSI,1182,2,13669,Group Piano II,Van Kekerix,Todd Evan,10,4,0,0,0,0,0,3.691
+Spring 2024,MUSI,1182,3,13670,Group Piano II,Van Kekerix,Todd Evan,9,4,0,0,0,0,1,3.591
+Spring 2024,MUSI,1116,1,13671,Aural Skills I,Brake,Austin S,3,8,7,0,2,0,2,2.451
+Spring 2024,MUSI,1117,1,13672,Aural Skills II,Snyder,John L,6,6,1,0,3,0,4,2.709
+Spring 2024,MUSI,1117,2,13673,Aural Skills II,Snyder,John L,11,8,0,0,0,0,2,3.544
+Spring 2024,MUSI,1117,3,13674,Aural Skills II,Snyder,John L,6,12,1,0,0,0,0,3.315
+Spring 2024,MUSI,1311,1,13675,Music Theory I,Brake,Austin S,5,12,6,4,1,0,2,2.571
+Spring 2024,MUSI,1312,1,13676,Music Theory II,Snyder,John L,7,4,2,0,2,0,3,2.867
+Spring 2024,MUSI,1312,2,13677,Music Theory II,Snyder,John L,12,8,0,0,0,0,1,3.633
+Spring 2024,MUSI,1312,3,13678,Music Theory II,Snyder,John L,8,7,4,0,0,0,1,3.245
+Spring 2024,MUSI,2182,1,13679,Group Piano IV,Van Kekerix,Todd Evan,6,3,1,0,0,0,0,3.434
+Spring 2024,MUSI,2182,2,13680,Group Piano IV,Van Kekerix,Todd Evan,3,5,4,0,1,0,0,2.819
+Spring 2024,MUSI,2182,3,13681,Group Piano IV,Van Kekerix,Todd Evan,11,1,0,0,1,0,1,3.565
+Spring 2024,MUSI,2117,1,13682,Aural Skills IV,Lee,Ji Yeon,8,5,2,0,1,0,1,3.126
+Spring 2024,MUSI,2117,3,13683,Aural Skills IV,Lee,Ji Yeon,3,11,1,0,1,0,0,2.938
+Spring 2024,MUSI,2117,4,13684,Aural Skills IV,Lee,Ji Yeon,8,7,2,0,0,0,0,3.353
+Spring 2024,MUSI,2214,1,13685,Techniques of Music Since 1900,Lee,Ji Yeon,5,7,6,3,0,0,0,2.73
+Spring 2024,MUSI,2214,3,13686,Techniques of Music Since 1900,Lee,Ji Yeon,8,3,1,0,2,0,0,3.001
+Spring 2024,MUSI,2214,4,13687,Techniques of Music Since 1900,Lee,Ji Yeon,10,5,3,0,0,0,0,3.297
+Spring 2024,MUSI,2302,1,13688,Listening to Jazz,Hubley,Robert L,33,29,17,1,4,0,13,3.016
+Spring 2024,MUSI,2362,1,13689,History of Music I,Dirst,Matthew C,6,23,39,1,4,0,2,2.361
+Spring 2024,MUSI,3216,1,13690,Analysis,Snyder,John L,5,2,0,0,0,0,0,3.714
+Spring 2024,MUSI,1307,1,13691,Listening to Classical Music,Smerud,Aidan J,53,14,2,0,1,0,4,3.662
+Spring 2024,MUSI,1307,2,13692,Listening to Classical Music,Engle,Nicholas Paul,46,9,6,0,1,0,3,3.618
+Spring 2024,MUSI,3301,1,13693,Listening To World Music,Hubley,Robert L,43,17,6,0,3,0,6,3.329
+Spring 2024,MUSI,3303,1,13694,Pop Music of Americas Sn 1840,Vansteenburg,Jessica N,44,21,4,0,4,0,1,3.379
+Spring 2024,MUSI,3364,1,13695,History of Music III,Caton,Kathryn L.,13,22,8,4,0,0,0,2.908
+Spring 2024,MUSI,4120,1,13696,Percussion Ensemble,Wilkins,Blake M,12,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4120,2,13697,Percussion Ensemble,Warren,Paul Alexander,13,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6106,1,13698,Grad Large Ensemble,Bertman,David Garry,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6106,2,13699,Grad Large Ensemble,Marmolejo,Noe J,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6106,3,13700,Grad Large Ensemble,Krager,Franz A,19,1,0,0,0,0,0,3.917
+Spring 2024,MUSI,6112,1,13701,Chamber Music - Woodwind,Bertman,David Garry,6,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6114,1,13702,Chamber Music - Brass,Bertman,David Garry,7,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6330,1,13703,Adv Instrumental Conducting,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8106,2,13704,Doctoral Large Ensemble,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8106,3,13705,Doctoral Large Ensemble,Krager,Franz A,14,1,0,0,0,0,0,3.911
+Spring 2024,MUSI,1102,1,13706,Wind Ensemble,Bertman,David Garry,49,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,4351,1,13709,Develop Proportional Reasoning,Gallagher,Melissa Ann,16,6,1,0,0,0,0,3.623
+Spring 2024,LAW,5199,2,13712,Special Problems,Vetter,Greg R,0,0,0,0,0,13,0,
+Spring 2024,LAW,5199,3,13713,Special Problems,Alderman,Richard M,0,0,0,0,0,3,0,
+Spring 2024,LAW,5199,11,13714,Special Problems,Vetter,Greg R,0,0,0,0,0,7,0,
+Spring 2024,LAW,5199,10,13715,Special Problems,Alderman,Richard M,0,0,0,0,0,1,0,
+Spring 2024,LAW,5299,2,13717,Special Problems,Vetter,Greg R,0,0,0,0,0,28,0,
+Spring 2024,LAW,5299,3,13718,Special Problems,Alderman,Richard M,0,0,0,0,0,2,0,
+Spring 2024,RELS,2360,1,13722,Introduction to Buddhism,Huynh,Trung,14,7,1,3,2,0,6,3.061
+Spring 2024,RELS,3355,1,13723,Yoga and Philosophy,Borkataky-Varma,Sravana,10,5,0,0,0,0,2,3.557
+Spring 2024,WGSS,2360,2,13725,Introduction to LGBT Studies,Pegoda,Andrew Joseph,3,10,8,1,0,0,5,2.637
+Spring 2024,NURS,3631,1,13726,Nur Process Symptom Mgmt,Schrader,Patricia K,4,44,0,1,0,0,8,3.041
+Spring 2024,NURS,3633,1,13727,Clinical Nursing Practice I,Quintana,Danielle,41,8,0,0,0,0,8,3.837
+Spring 2024,NURS,3247,1,13728,Pharm for Collbrtv Nurs Prac,Schrader,Patricia K,4,43,0,0,0,0,6,3.085
+Spring 2024,EDUC,4322,1,13729,Student Teaching:Theater Elem,Hickman,Margo Louise,7,0,0,0,0,0,0,4.0
+Spring 2024,EDUC,4323,1,13730,Student Teaching: Theater Sec,Hickman,Margo Louise,7,0,0,0,0,0,0,4.0
+Spring 2024,IDNS,2115,1,13731,Physics 2325 SEP Workshop,Pattison,Donna,8,8,0,0,0,0,4,3.521
+Spring 2024,IDNS,2115,2,13732,Physics 2325 SEP Workshop,Pattison,Donna,10,4,0,0,0,0,3,3.691
+Spring 2024,IDNS,2116,1,13733,Physics 2326 SEP Workshop,Pattison,Donna,13,10,1,1,0,0,2,3.347
+Spring 2024,MUSI,2188,1,13735,Keybd Skills & Collab Technqs,Hester,Timothy E,6,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,3216,2,13737,Analysis,Lee,Ji Yeon,5,2,0,1,0,0,0,3.293
+Spring 2024,MUSI,4102,1,13739,Acting for Opera,Belcher,Kathleen,1,3,0,0,0,0,0,3.168
+Spring 2024,MUSI,4250,1,13740,Performance Pedagogy,Averyt,Zachary Benjamin,11,5,0,0,1,0,0,3.412
+Spring 2024,MUSI,6351,1,13741,Applied Music Pedagogy,Sonnenberg,Melanie,3,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,8998,25,13743,Doctoral Research,Carrow,Bradley,0,0,0,0,0,3,0,
+Spring 2024,PSYC,3350,4,13744,Intro to Cognitive Psychology,Perkovich,Elizabeth Susan,66,9,3,0,2,0,0,3.675
+Spring 2024,MUSA,6141,2,13746,Graduate Recital II,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Spring 2024,ENTR,4110,2,13747,Entrepren Values & Leadership,Cook,David B,21,7,0,0,0,0,0,3.715
+Spring 2024,MUSA,1342,2,13748,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,3.835
+Spring 2024,MUSA,3440,1,13749,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2024,MSCI,1220,4,13750,Agile & Adaptive Leadership,Comiskey,Melissa C,0,2,0,0,0,0,0,3.0
+Spring 2024,HON,4399,2,13752,Senior Honors Thesis,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,2306,1,13753,Psychology of Human Sexuality,Keo-Meier,Colton Lawrence,38,36,23,6,7,0,9,2.827
+Spring 2024,PSYC,2317,6,13755,Intro to Psychology Statistics,Penheiro,Romeo Alex,16,36,14,2,4,0,4,2.851
+Spring 2024,ENTR,4110,1,13758,Entrepren Values & Leadership,Cook,David B,12,15,0,0,0,0,1,3.224
+Spring 2024,MUSI,6261,1,13759,Intern in Piano Teaching II,Van Kekerix,Todd Evan,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8699,2,13761,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8999,1,13762,Doctoral Dissertation,Smith,Nathan G,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8398,18,13763,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2024,MUSA,2324,1,13766,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,2123,18,13767,Organic Chemistry Lab I,Bean,Mary B,2,12,5,1,0,0,2,2.734
+Spring 2024,PSYC,3399,1,13769,Senior Honors Thesis,Sharp,Carla,0,0,0,0,0,0,0,
+Spring 2024,THEA,4323,1,13770,Dramaturgy,Romero,Gregory John,4,0,0,0,1,0,0,3.2
+Spring 2024,THEA,6323,1,13771,Dramaturgy for 21st Century,Romero,Gregory John,9,1,0,0,0,0,0,3.9
+Spring 2024,ENGL,2315,1,13772,Literature and Film,Sicinski,Michael J,21,2,0,0,2,0,0,3.481
+Spring 2024,MUSA,1300,7,13773,Applied Voice,Ceres,Emily Margaret,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7399,2,13774,Masters Thesis,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8699,3,13775,Doctoral Dissertation,Tejada,Roberto Jose,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,4380,1,13776,R E Fin & Investment,Picazo,Cindy Lee,24,9,4,0,0,0,0,3.505
+Spring 2024,ENGL,8699,5,13778,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6399,1,13779,Masters Thesis,Sharp,Carla,0,0,0,0,0,2,0,
+Spring 2024,MUSI,6101,1,13783,Opera Role Performance,Belcher,Kathleen,19,0,0,0,1,0,0,3.8
+Spring 2024,ENGL,8699,6,13785,Doctoral Dissertation,Nelson,Antonya,0,0,0,0,0,1,0,
+Spring 2024,ARCH,6604,7,13786,Architecture Design Studio IV,Schuster,Kristin,3,5,1,0,0,0,0,3.259
+Spring 2024,PSYC,6399,2,13788,Masters Thesis,Woods,Steven Paul,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6398,1,13790,Independent Studies,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6352,1,13791,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,0,0,0,0,0,5,0,
+Spring 2024,MUSA,4402,2,13793,Applied Composition,Maroney,Marcus K,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6393,3,13795,Clinical Research Practicum,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,7399,6,13798,Masters Thesis,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6298,1,13815,Spec Prob-Physio Optics,Schill,Alexander W,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,3,13822,Masters Thesis,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Spring 2024,POLS,8999,16,13826,Doctoral Dissertation,Badas,Alex,0,0,0,0,0,1,0,
+Spring 2024,HLT,3380,1,13828,Culture and Health,Fedor Amador,Theresa Marie,38,16,5,2,1,0,0,3.313
+Spring 2024,ELCS,8191,1,13833,Special Field Projects,Davis,Bradley,7,2,0,0,0,0,0,3.778
+Spring 2024,CHEE,8399,17,13836,Doctoral Dissertation,Vekilov,Peter,2,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6257,6,13837,Research Practicum B,Twa,Michael D,0,1,0,0,0,0,0,3.0
+Spring 2024,MIS,4374,3,13839,Info Technology Project Mgmt,Scott,Carl P,35,6,0,0,0,0,0,3.813
+Spring 2024,CHEE,8399,18,13840,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,4,13842,Masters Thesis,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2024,PSYC,7390,1,13843,Clin Neuropsychology Practicum,Woods,Steven Paul,0,0,0,0,0,7,0,
+Spring 2024,PSYC,7399,3,13844,Masters Thesis,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Spring 2024,MARK,4389,6,13848,Marketing Strategy & Planning,Muschalik,Monica Harper,23,3,0,0,1,0,0,3.619
+Spring 2024,PSYC,6398,2,13849,Independent Studies,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2024,PSYC,4399,2,13854,Senior Honors Thesis,Atherton,Olivia Emile,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6198,2,13855,Spec Prob-Physio Optics,Frishman,Laura J,0,1,0,0,0,0,0,3.33
+Spring 2024,INDS,4380,1,13858,Design Internship,Kimbrough,Mark S,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7392,1,13859,Psychology Practicum,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,8399,10,13860,Dissertation,Ventura,Gabriela Baeza,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6352,2,13862,Directed Rsch in I/O Psyc,Ng,Vincent,4,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8388,2,13864,Dissertation Proposal,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2024,PHCA,7181,1,13865,Sem in Phrm Hlth Outcomes &Pol,Chen,Hua,15,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7399,4,13867,Masters Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Spring 2024,MECE,3338,1,13869,Dynamic & Control of Mech Syst,Hammami,Farah,20,31,28,8,1,0,10,2.656
+Spring 2024,PSYC,6352,3,13870,Directed Rsch in I/O Psyc,Brummel,Bradley James,1,0,0,0,0,0,0,4.0
+Spring 2024,EGRP,1141,1,13871,Engineering Applications IV,Luna Singh,Jennifer Austin,0,0,0,0,0,5,0,
+Spring 2024,POLS,8999,17,13873,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,4,0,
+Spring 2024,PSYC,8399,4,13874,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8399,5,13875,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,
+Spring 2024,COMM,6398,1,13877,Special Problems,Yamasaki,Jill S,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8298,19,13878,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8398,21,13882,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,20,13886,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,3,0,
+Spring 2024,BIOE,8399,10,13891,Doctoral Dissertation,Akay,Yasemin M,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8399,11,13892,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8399,12,13893,Doctoral Dissertation,Al-Ubaidi,Muayyad,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8699,13,13897,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8699,16,13900,Doctoral Dissertation,Wu,Tianfu,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8699,20,13904,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,5367,1,13907,Intro To Computer Arch & Dsgn,Baker,Abu M,61,21,0,0,0,0,0,3.684
+Spring 2024,PSYC,7399,6,13911,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Spring 2024,BIOL,2102,21,13912,Anatomy & Physiology II (lab),Gill,Tejendra,5,13,4,1,0,0,1,3.086
+Spring 2024,BIOL,2102,22,13913,Anatomy & Physiology II (lab),Gill,Tejendra,5,14,4,0,0,0,0,3.101
+Spring 2024,PSYC,2308,1,13916,Child Development,Yoshida,Hanako,47,17,5,6,0,0,3,3.4
+Spring 2024,CHEM,1312,4,13917,Fundamentals of Chemistry 2,Young,Crystal Ann,12,8,17,5,15,0,13,1.953
+Spring 2024,MATH,8698,15,13918,Doctoral Research,Labate,Demetrio,0,0,0,0,0,5,0,
+Spring 2024,COMM,4384,1,13919,Strategic Comm Applications,Williams,Uniqua Janae,29,0,0,0,0,0,0,3.989
+Spring 2024,SPAN,2312,6,13921,Intermediate Spanish II,Scalzo,Dillon S,14,9,3,0,0,0,0,3.461
+Spring 2024,COMD,2338,1,13922,Phonetics,Bunta,Ferenc,13,7,2,1,3,0,4,2.975
+Spring 2024,PSYC,7399,8,13924,Masters Thesis,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Spring 2024,PSYC,4399,3,13925,Senior Honors Thesis,Fetterman,Adam Kent,3,0,0,0,0,0,0,4.0
+Spring 2024,HLT,1353,2,13926,Personal Health,Rafique,Kiran Sajid,106,13,1,0,0,0,0,3.809
+Spring 2024,ECON,8399,1,13927,Doctoral Dissertation,Yi,Kei-Mu,1,0,0,0,0,4,0,4.0
+Spring 2024,PSYC,6398,9,13934,Independent Studies,Kosten,Therese A,0,0,0,0,0,0,0,
+Spring 2024,PSYC,6398,11,13936,Independent Studies,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8698,17,13943,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Spring 2024,MATH,8398,24,13944,Doctoral Research,Ru,Min,0,0,0,0,0,2,0,
+Spring 2024,PSYC,6398,12,13945,Independent Studies,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,7,13947,Masters Thesis,Cirino,Paul,0,0,0,0,0,1,0,
+Spring 2024,ECON,3334,4,13948,Intermediate Macroeconomics,Musaico,Erika Michelle,6,11,7,6,4,0,13,2.216
+Spring 2024,LAW,5309,1,13949,Advanced Trial Advocacy,Draper,Genesis Elaine,4,6,0,0,0,0,1,3.334
+Spring 2024,LAW,5311,1,13950,Product Liability,Sanders,Joseph,5,6,0,0,0,4,0,3.395
+Spring 2024,LAW,7307,1,13951,WRS: Advanced Topics in IP,Janicke,Paul,4,5,0,0,0,0,0,3.371
+Spring 2024,PSYC,7399,9,13952,Masters Thesis,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,2501,17,13958,Architecture Design Studio IV,Sen,Ozan,11,2,1,0,0,0,0,3.644
+Spring 2024,ARCH,3501,3,13960,Architecture Design Studio VI,Truitt,William C,9,6,0,0,0,0,0,3.666
+Spring 2024,ARCH,6601,1,13962,Architecture Design Studio II,Peters,Patrick A,6,4,0,0,0,0,0,3.633
+Spring 2024,GEOL,1102,1,13964,Intro to Climate Change Lab,Wang,Yuxuan,8,3,2,0,0,0,0,3.436
+Spring 2024,BCHS,3304,4,13965,General Biochemistry I,Wang,Yuhong,47,39,11,0,0,0,3,3.371
+Spring 2024,BIOL,7124,1,13966,Cell Biology Seminar,Lin,Chin-Yo,0,0,0,0,0,11,0,
+Spring 2024,MATH,1314,1,13967,College Algebra,Caglar,Atife,28,34,48,12,48,0,29,1.875
+Spring 2024,MATH,2305,4,13968,Discrete Mathematics,Winkle,James J,14,20,25,14,4,0,2,2.372
+Spring 2024,MATH,3339,5,13969,Statistics for the Sciences,Wang,Wenshuang,120,27,24,7,8,0,10,3.298
+Spring 2024,PSYC,4344,4,13970,Cultural Psychology,Bautista,Ashley,50,14,7,2,6,0,0,3.308
+Spring 2024,PSYC,4344,5,13971,Cultural Psychology,Kilani,Mohamed Hechmi,33,29,7,2,2,0,5,3.197
+Spring 2024,PSYC,2317,3,13973,Intro to Psychology Statistics,Griep,Christina Diaz,39,28,3,1,2,0,4,3.347
+Spring 2024,PSYC,3339,2,13975,Intro To Clinical Psychology,Szafranski,Derek D,102,11,1,1,1,0,2,3.799
+Spring 2024,PSYC,2330,3,13976,Biological Psychology,Leonard,Samuel J,60,16,1,0,0,0,2,3.801
+Spring 2024,PSYC,2330,6,13977,Biological Psychology,Myers,Annika Mariah,31,36,10,1,1,0,1,3.19
+Spring 2024,MATH,2413,1,13979,Calculus I,Constante,Beatrice,92,74,76,24,46,0,34,2.402
+Spring 2024,MATH,2413,11,13985,Calculus I,Perepelitsa,Irina,140,72,82,20,32,0,28,2.736
+Spring 2024,MATH,2413,41,13987,Calculus I,May,Jennifer Ruhnow,44,50,54,38,82,0,64,1.719
+Spring 2024,MATH,2414,1,13989,Calculus II,Almus,Melahat,138,50,28,9,10,0,12,3.244
+Spring 2024,MATH,2414,11,13993,Calculus II,Xhabli,Blerina,86,54,34,19,23,0,29,2.736
+Spring 2024,MATH,2414,21,13996,Calculus II,Xhabli,Blerina,112,50,33,15,18,0,21,2.959
+Spring 2024,MATH,2414,31,14000,Calculus II,West,James David,20,25,23,13,23,0,20,2.061
+Spring 2024,MATH,2415,21,14003,Calculus III,West,James David,39,39,29,12,25,0,41,2.38
+Spring 2024,MATH,2413,31,14006,Calculus I,Sosa,Moses,72,58,50,14,34,0,22,2.474
+Spring 2024,MATH,2413,61,14008,Calculus I,Perepelitsa,Irina,52,22,34,10,12,0,10,2.698
+Spring 2024,MATH,2414,61,14010,Calculus II,West,James David,5,2,5,5,9,0,12,1.526
+Spring 2024,PSYC,2319,4,14021,Intro to Social Psychology,Browne,Lindsay J,56,18,2,1,2,0,2,3.536
+Spring 2024,PSYC,2305,8,14022,Intro to Methods in Psychology,Kennedy,Caitlin Grace,18,28,6,6,12,0,10,2.481
+Spring 2024,PSYC,7307,1,14025,Applied PSYC Measurement,Steinberg,Lynne,6,2,0,0,0,0,0,3.668
+Spring 2024,PSYC,2301,3,14026,Introduction to Psychology,Cirino,Paul,9,14,9,3,3,0,2,2.64
+Spring 2024,WCL,3372,1,14027,Indian Film:Bollywood & Beyond,Tiwari,Bhavya,4,3,1,0,0,0,1,3.334
+Spring 2024,HON,3301,2,14028,Readings in Medicine & Society,Macdonald,Arlene,13,2,0,0,0,0,0,3.779
+Spring 2024,POLS,3322,1,14030,Intro Latin-Am Politics,Aleman,Eduardo,16,17,6,0,1,0,0,3.167
+Spring 2024,MANA,4347,1,14034,Ethics and Corp Soc Respon.,Salaiz,Ashley,46,8,1,0,0,0,4,3.83
+Spring 2024,MANA,4385,1,14035,Intro to Strategic Management,Tabesh,Pooya,40,15,2,2,1,0,0,3.462
+Spring 2024,CHEM,3333,1,14036,Inorganic Chemistry I,Zastrow,Melissa L,16,19,15,2,2,0,0,2.803
+Spring 2024,BIOL,2121,12,14037,Microbiol for Science Maj(lab),Knapp,Richard D,8,10,3,1,0,0,1,3.091
+Spring 2024,BIOL,1107,45,14038,Biology for Science Majors II,Medrano,Ana I,6,12,2,0,1,0,3,3.048
+Spring 2024,BIOL,1107,46,14039,Biology for Science Majors II,Medrano,Ana I,14,4,2,0,1,0,3,3.381
+Spring 2024,BIOL,1107,47,14040,Biology for Science Majors II,Medrano,Ana I,12,9,0,0,1,0,2,3.409
+Spring 2024,BIOL,1107,48,14041,Biology for Science Majors II,Medrano,Ana I,16,3,0,1,2,0,0,3.319
+Spring 2024,FINA,4328,1,14043,Principles of Personal Finance,Coleman,Alfred G,38,10,5,1,1,0,0,3.443
+Spring 2024,PHLS,8322,2,14044,Intermed Stats in Psy/Educ Res,Wiesner,Margit F,13,5,0,0,0,0,0,3.631
+Spring 2024,FINA,6A35,1,14045,Managerial Finance,Povel,Paul,17,10,5,0,0,0,1,3.303
+Spring 2024,ENTR,3310,5,14046,Entrepreneurship,Ortega,Carlos Alberto,152,29,6,1,3,0,4,3.691
+Spring 2024,ENTR,3312,5,14047,Corporate Entrepreneurship,Karonika,John R,12,10,3,0,3,0,3,2.929
+Spring 2024,MARK,4389,2,14048,Marketing Strategy & Planning,Suki,Yara D,21,11,0,0,0,0,0,3.563
+Spring 2024,MARK,4389,5,14049,Marketing Strategy & Planning,Suki,Yara D,13,18,1,0,0,0,0,3.323
+Spring 2024,ENGL,1301,22,14050,First Year Writing I,Denton,Amy,7,3,1,1,3,0,1,2.645
+Spring 2024,COMM,3304,1,14051,Multicultural Health Comm,Xiao,Zhiwen,20,8,1,0,0,0,0,3.667
+Spring 2024,PHLS,8393,1,14052,Doctoral Practicum in Psy,Racine,Madeline D,0,0,0,0,0,9,0,
+Spring 2024,PHLS,8393,2,14053,Doctoral Practicum in Psy,Smith,Nathan G,0,0,0,0,0,7,0,
+Spring 2024,PHLS,8393,3,14054,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,4,0,
+Spring 2024,COSC,2425,1,14055,Computer Org & Architecture,Long,Kevin B,24,23,10,3,4,0,3,2.938
+Spring 2024,COMM,4392,1,14056,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,45,1,
+Spring 2024,COSC,3380,2,14057,Database Systems,Ramamurthy,Uma,13,22,22,9,7,0,6,2.324
+Spring 2024,FINA,4381,1,14058,Essentials of Real Estate,Madison,Necitha,18,16,2,0,0,0,2,3.371
+Spring 2024,KIN,3309,4,14061,Biomechanics,Lee,Beom Chan,74,18,6,0,0,0,3,3.691
+Spring 2024,COSC,2436,5,14063,Programming and Data Structure,Rizk,Nouhad J,25,21,23,7,14,0,28,2.429
+Spring 2024,COSC,1437,1,14065,Introduction to Programming,Rincon Castro,Carlos Alberto,43,14,15,6,15,0,24,2.678
+Spring 2024,POLS,3311,3,14066,Intro Compar Politics,Aleman,Eduardo,11,16,7,3,0,0,2,2.91
+Spring 2024,COSC,1437,3,14068,Introduction to Programming,Chen,Guoning,42,13,13,2,18,0,26,2.648
+Spring 2024,CUIN,1350,2,14069,Mathematics for Teachers 1,Burris,Justin T,25,5,0,0,0,0,0,3.811
+Spring 2024,COSC,1437,5,14071,Introduction to Programming,Biediger,Daniel Edward,52,16,9,6,10,0,28,3.021
+Spring 2024,KIN,4360,1,14072,Adaptive Athletics Management,Cottingham,Michael,16,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,2331,1,14074,Biomedical Processes,Shevkoplyas,Sergey,14,7,1,1,1,0,0,3.278
+Spring 2024,NUTR,4352,1,14075,Child and Adolescent Nutrition,Vollrath,Kirstin,33,22,8,3,1,0,2,3.229
+Spring 2024,HDFS,3317,2,14076,Prenatal and Infant Developmt,Fraser,Camille,30,7,3,0,0,0,0,3.576
+Spring 2024,MECE,6334,1,14078,Convection Heat Transfr,Prosperetti,Andrea,4,2,0,0,0,0,0,3.502
+Spring 2024,ECE,6348,1,14079,Material Science of Thin Films,Wolfe,John C,62,2,0,0,0,0,0,3.979
+Spring 2024,HLT,4309,1,14082,Health Disparities,Carmack,Chakema,15,0,1,0,0,0,0,3.834
+Spring 2024,MARK,4332,2,14083,Social Media Marketing,Zahn,William J,20,28,4,1,1,0,0,3.198
+Spring 2024,POLS,6381,1,14084,Quantitative Methods II,Basinger,Scott J,7,0,0,0,0,0,0,3.953
+Spring 2024,CHEE,4366,1,14087,Biomolecular Engr Fundamentals,Varadarajan,Navin,21,36,16,0,0,0,1,3.059
+Spring 2024,ENTR,3312,6,14091,Corporate Entrepreneurship,Karonika,John R,5,2,0,0,1,0,2,3.209
+Spring 2024,ELCS,6320,1,14092,Instructional Leadership I,Butcher,Keith,13,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2301,5,14093,Prin of Financial Accounting,Zhu,Limin,9,17,17,12,3,0,9,2.435
+Spring 2024,INDE,2333,3,14094,Engineering Statistics I,Diaz Martinez,Neil Orlando,12,26,9,0,0,0,9,3.071
+Spring 2024,GHL,1367,2,14095,Lodging Management,Kenyan,Erin Oeser,32,10,4,0,2,0,1,3.451
+Spring 2024,GHL,3358,2,14096,Hospitality Industry Law,Barth,Stephen C,22,6,5,1,2,0,3,3.186
+Spring 2024,GHL,3361,2,14097,Hospitality Marketing,Lee,Hyun Kyung,44,6,0,0,0,0,1,3.873
+Spring 2024,PHAR,5646,1,14098,Medication Safety,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6380,1,14102,Business Analytics,Lee,Minwoo,8,3,0,0,0,0,0,3.637
+Spring 2024,SOCW,7378,1,14103,Integrated Behav Healthcare,Eisenbaum,Stephanie,22,3,0,0,0,0,0,3.88
+Spring 2024,ENGL,1302,17,14104,First Year Writing II,Sicinski,Michael J,9,6,0,0,3,0,0,3.0
+Spring 2024,PSYC,2307,2,14112,Psychology of Adolescence,Anderson,Jill Annette,18,24,11,3,2,0,2,2.902
+Spring 2024,PSYC,2305,10,14119,Intro to Methods in Psychology,Saiyed,Amna Shabbir,62,24,5,2,4,0,2,3.372
+Spring 2024,SPAN,1507,1,14121,Intns Elem Span Heritage Learn,Ruiz,Eugenia Maria,8,5,4,0,1,0,1,2.909
+Spring 2024,ENGI,1331,4,14124,Computing for Engineers,Aksu,Gulin Tulunay,16,11,10,0,1,0,10,3.062
+Spring 2024,MATH,3330,4,14126,Abstract Algebra,Heier,Gordon,16,8,5,0,3,0,3,3.001
+Spring 2024,NURS,4322,1,14128,Policy &Ethics in Prof Nursing,Anderson,Viia,22,7,0,0,0,0,1,3.759
+Spring 2024,NURS,3230,1,14129,Nursing Professional Role I,Quintana,Danielle,41,6,0,0,0,0,3,3.872
+Spring 2024,NURS,3440,1,14130,Intro to Evid-Based Nurs Prac,Anderson,Viia,7,40,0,1,0,0,7,3.104
+Spring 2024,PHLS,8193,1,14132,Internship in Psychology,Smith,Bradley,0,0,0,0,0,9,0,
+Spring 2024,PHLS,8193,2,14133,Internship in Psychology,Arbona,Consuelo,0,0,0,0,0,8,0,
+Spring 2024,ENGI,2304,12,14134,Technical Communications,Contos,Ashlie Meghan,30,3,0,0,1,0,0,3.765
+Spring 2024,CHEM,8999,22,14136,Doctoral Dissertation,Do,Loi H,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6399,9,14138,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Spring 2024,PSYC,7399,10,14139,Masters Thesis,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6350,1,14140,Applied Music Pedagogy,Reed,Gavin Davis,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2300,3,14142,Applied Voice,Vasquez,Hector A,6,0,0,0,0,0,0,3.835
+Spring 2024,MUSA,2300,7,14143,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,1,14144,Doctoral Applied Music,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,2,14145,Doctoral Applied Music,Yon,Kirsten A,5,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,3,14146,Doctoral Applied Music,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,4,14147,Doctoral Applied Music,Witt,Woodrow W,1,0,0,0,0,0,0,3.67
+Spring 2024,RELS,3366,1,14148,Magic and Occult,Allen,Paul J,38,0,0,0,0,0,0,4.0
+Spring 2024,RELS,3370,1,14149,The Bible and Modern Science,Ott,Aaron Frederick,13,4,4,5,8,0,5,2.255
+Spring 2024,PHAR,4331,1,14151,Pharmaceutics II,Liu,Xinli,50,43,7,0,0,0,0,3.43
+Spring 2024,PHAR,4251,1,14152,Pharmacy Skills Program II,Shamsi,Aayna,66,32,6,0,0,0,0,3.577
+Spring 2024,MUSA,6340,1,14155,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6322,1,14156,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,5,14158,Doctoral Applied Music,Morgulis,Tali,3,0,0,0,0,0,0,3.89
+Spring 2024,MUSA,8320,6,14159,Doctoral Applied Music,Staupe,Andrew Paul,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,8,14160,Doctoral Applied Music,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,9,14161,Doctoral Applied Music,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,10,14162,Doctoral Applied Music,Bertman,David Garry,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6393,4,14163,Clinical Research Practicum,Zvolensky,Michael J,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8106,1,14165,Doctoral Large Ensemble,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Spring 2024,LACP,2111,1,14167,Liberal Arts Career Planning,Hayes,Olivia Kaye,0,0,0,0,0,17,2,
+Spring 2024,LACP,2111,2,14168,Liberal Arts Career Planning,Benavides,Bina,0,0,0,0,0,8,0,
+Spring 2024,MATH,1332,5,14169,Contemporary Mathematics,Hafeez,Shahinda,7,15,25,11,18,0,14,1.715
+Spring 2024,PHAR,5695,2,14170,Geriatrics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5686,2,14171,Psychiatry,Truong,Mabel,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7399,13,14173,Masters Thesis,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,8999,23,14175,Doctoral Dissertation,Brgoch,Jakoah,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8240,2,14177,Doctoral Recital I,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,KIN,4315,1,14178,Motor Learning and Control,Layne,Charles S,17,48,26,7,0,0,2,2.745
+Spring 2024,PHLA,6213,1,14181,Workforce Competency,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4436,1,14182,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6198,3,14183,Spec Prob-Physio Optics,Stevenson,Scott Bailli,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3426,1,14185,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,8999,1,14186,Dissertation,Cheung,Monit,0,0,0,0,0,1,0,
+Spring 2024,PETR,6399,11,14192,Masters Thesis,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Spring 2024,PETR,7399,11,14195,Masters Thesis,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Spring 2024,PETR,7399,12,14196,Masters Thesis,Dindoruk,Birol,0,0,0,0,0,2,0,
+Spring 2024,PETR,8298,11,14203,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,3,0,
+Spring 2024,PETR,8298,12,14204,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,6,0,
+Spring 2024,PETR,8398,12,14208,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Spring 2024,PETR,8598,11,14220,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,2,0,
+Spring 2024,PETR,8598,12,14221,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,3,0,
+Spring 2024,PETR,8699,11,14224,Doctoral Dissertation,Thakur,Ganesh Chandra,0,0,0,0,0,2,0,
+Spring 2024,PETR,8699,12,14225,Doctoral Dissertation,Dindoruk,Birol,0,0,0,0,0,2,0,
+Spring 2024,OPTO,6124,1,14231,Perception,Stevenson,Scott Bailli,75,18,0,0,0,0,0,3.806
+Spring 2024,MUSA,2310,3,14235,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8999,18,14237,Doctoral Dissertation,Bagashka,Tanya G,0,0,0,0,0,0,0,
+Spring 2024,ARTH,7399,1,14238,Master's Thesis,Tejada,Roberto Jose,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6667,8,14250,Research Practicum A,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6198,5,14255,Spec Prob-Physio Optics,Patel,Nimesh Bhikhu,3,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,7399,2,14259,Masters Thesis,Cheng,Han,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,7399,3,14260,Masters Thesis,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8698,18,14265,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Spring 2024,POLS,8999,19,14266,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,5,0,
+Spring 2024,ARCH,3501,15,14268,Architecture Design Studio VI,Davis,Curtis M,6,5,4,0,0,0,0,3.045
+Spring 2024,PHOP,6198,6,14272,Spec Prob-Physio Optics,Porter,Jason,2,0,0,0,0,0,0,4.0
+Spring 2024,MARK,8699,1,14273,Doctoral Dissertation,Ahearne,Michael,0,0,0,0,0,1,0,
+Spring 2024,PHOP,6198,8,14275,Spec Prob-Physio Optics,Ferreira,Tarsis Gesteira,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6257,10,14276,Research Practicum B,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6336,1,14281,Directed Rsch in Social Psyc,Derrick,Jaye L,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6336,2,14282,Directed Rsch in Social Psyc,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8999,21,14284,Doctoral Dissertation,Aleman,Eduardo,0,0,0,0,0,1,0,
+Spring 2024,PHOP,6198,9,14285,Spec Prob-Physio Optics,Rump,Rachel,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6398,14,14290,Independent Studies,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Spring 2024,MUSA,8240,7,14291,Doctoral Recital I,Krager,Franz A,1,0,0,0,0,0,0,4.0
+Spring 2024,EGRP,1151,1,14292,Engineering Applications VII,Luna Singh,Jennifer Austin,0,0,0,0,0,14,0,
+Spring 2024,ARTH,7399,2,14293,Master's Thesis,Harren,Natilee O,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8698,19,14295,Doctoral Research,Josic,Kresimir,0,0,0,0,0,1,0,
+Spring 2024,PEP,8699,7,14299,Doctoral Dissertation,Park,Yoonjung,1,0,0,0,0,0,0,4.0
+Spring 2024,COMD,7391,15,14301,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,3,0,0,0,0,0,0,3.67
+Spring 2024,CHEM,1111,38,14303,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,0,0,0,0,1,3.396
+Spring 2024,PHYS,1102,15,14305,College Physics II (lab),Wood,Lowell T,2,15,4,1,0,0,1,2.728
+Spring 2024,BIOE,8298,22,14306,Doctoral Research,Wu,Tianfu,0,0,0,0,0,2,0,
+Spring 2024,MATH,8698,20,14309,Doctoral Research,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6398,15,14310,Independent Studies,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Spring 2024,PSYC,6365,1,14311,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,2,0,
+Spring 2024,PEP,8699,1,14313,Doctoral Dissertation,Cottingham,Michael,0,0,0,0,0,1,0,
+Spring 2024,HON,4398,3,14316,Independent Study,Rhoden,Brenda,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6358,1,14319,Directed Rsch in Neuropsyc,Medina,Luis Daniel,0,0,0,0,0,2,0,
+Spring 2024,MATH,8698,22,14321,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Spring 2024,MUSA,3450,1,14324,Applied Percussion,Wilkins,Blake M,5,0,0,0,0,0,0,3.868
+Spring 2024,PSYC,6398,16,14328,Independent Studies,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8399,8,14330,Doctoral Dissertation,Woods,Steven Paul,1,0,0,0,0,4,0,4.0
+Spring 2024,MUSA,2326,1,14331,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,3.835
+Spring 2024,PSYC,8399,9,14332,Doctoral Dissertation,Walker,Rheeda L,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6336,3,14333,Directed Rsch in Social Psyc,Neighbors,Clayton T,2,0,0,0,0,0,0,4.0
+Spring 2024,ECON,3332,4,14339,Intermediate Microeconomics,Thorell,Troy E,10,19,9,4,1,0,5,2.752
+Spring 2024,ECON,3320,1,14340,Intro to Econ Data Analysis,Troncoso,Pablo A,45,39,21,13,6,0,16,2.825
+Spring 2024,ECON,7335,1,14341,Applied Econometrics,Chin,Aimee,8,7,0,0,1,0,0,3.374
+Spring 2024,ECON,2302,2,14342,Principles of Microeconomics,Zhang,Yujie,29,25,15,3,2,0,6,3.018
+Spring 2024,ECON,3347,1,14343,Capital Market Economics,Peru Durayalage,Dhanushka Arunasiri,29,27,7,2,4,0,2,3.077
+Spring 2024,MATH,4362,1,14344,Theory Diff Equ and Nonlnr Dyn,Jaramillo,Gabriela T,3,3,3,0,1,0,1,2.634
+Spring 2024,MATH,1324,2,14345,Finite Math with Applications,Constante,Beatrice,100,84,82,18,52,0,54,2.425
+Spring 2024,CHEM,1305,2,14346,Foundations of Chemistry,Zaitsev,Vladimir G,9,10,20,9,17,0,9,1.718
+Spring 2024,CHEM,2325,3,14347,Organic Chemistry II,Carrow,Bradley,5,7,2,4,1,0,3,2.631
+Spring 2024,INDE,8399,2,14355,Doctoral Dissertation,Lin,Ying,1,0,0,0,0,0,0,4.0
+Spring 2024,INDE,8399,3,14356,Doctoral Dissertation,Lim,Gino Jinho,1,0,0,0,0,1,0,4.0
+Spring 2024,LAW,6386,1,14358,Oil and Gas Tax,Wright,Denney L,1,3,0,0,0,0,0,3.415
+Spring 2024,LAW,6392,1,14359,Privacy and Data Protection,Guggenberger,Nikolas,8,15,1,0,0,0,0,3.319
+Spring 2024,LAW,6350,1,14360,Maritime Personal Injury Litig,Unger,John F,1,2,0,0,0,1,0,3.443
+Spring 2024,SOCW,7301,1,14362,Confronting Oppression & Injus,Bagneris,Jessica Rene',26,3,0,0,0,0,0,3.897
+Spring 2024,SOCW,7301,4,14363,Confronting Oppression & Injus,Guzman,Paola E,32,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7301,5,14364,Confronting Oppression & Injus,Guzman,Paola E,26,1,0,0,0,0,0,3.963
+Spring 2024,LAW,6205,1,14365,Patent Prosecution,Cotrone,Carlo M,3,4,0,0,0,0,0,3.381
+Spring 2024,MATH,2312,5,14366,Precalculus,Perepelitsa,Irina,90,58,54,28,36,0,38,2.494
+Spring 2024,SPAN,1501,5,14367,Elementary Spanish I,Carrera Quiroga,Emilio Vicente,6,5,8,2,2,0,2,2.478
+Spring 2024,SPAN,1502,1,14369,Elementary Spanish II,Reyes Ferrufino,Diana Eufemia,1,10,4,0,1,0,4,2.563
+Spring 2024,SPAN,2615,2,14371,Intsve Inter Span Heritg Lrnrs,Martinez,Raquel,12,7,4,0,0,0,0,3.305
+Spring 2024,GEOL,1303,1,14373,Physical Geology,Li,Aibing,31,51,9,6,2,0,1,3.02
+Spring 2024,GEOL,1370,1,14375,Natural Disasters,Hauptvogel,Daniel William,241,191,67,22,7,0,12,3.175
+Spring 2024,ENGI,1331,5,14376,Computing for Engineers,Aksu,Gulin Tulunay,28,18,7,0,1,0,6,3.352
+Spring 2024,ENGI,1100,1,14377,Introduction To Engineering,Kota,Venkata Krishna Tulasi,26,21,10,0,3,0,4,3.078
+Spring 2024,ENGI,1100,4,14378,Introduction To Engineering,Metrovich,Brian,21,20,11,0,4,0,4,2.953
+Spring 2024,CHEM,4330,1,14379,Polymer Chemistry,Harth,Eva M,12,6,5,9,1,0,4,2.496
+Spring 2024,PHAR,4200,1,14380,Immunology I,Zhang,Ruiwen,27,46,31,2,0,0,0,2.925
+Spring 2024,PHAR,4221,1,14381,Physiology II,Marwaha,Aditi,58,26,19,4,0,0,0,3.29
+Spring 2024,PHAR,4275,1,14382,FIMMRA,Cuny,Gregory D,32,42,28,2,0,0,0,3.0
+Spring 2024,PHAR,4160,1,14383,Fundamentals Comm Pharm Pract,Wallace,David A,84,19,1,0,0,0,0,3.798
+Spring 2024,PHAR,4265,1,14384,Patient Assessment,Surati,Dhara Divyang,37,49,17,1,0,0,0,3.173
+Spring 2024,PHAR,4340,1,14385,OTC & Self Care,Rosario,Natalie,50,45,10,0,0,0,0,3.381
+Spring 2024,INDI,3372,1,14386,Bollywood and Beyond,Tiwari,Bhavya,2,4,1,1,1,0,2,2.666
+Spring 2024,ELED,4314,1,14387,Mathematics in Elem School I,Cutler,Carrie Sybil,22,3,0,0,0,0,0,3.893
+Spring 2024,BIOL,2102,23,14389,Anatomy & Physiology II (lab),Gill,Tejendra,4,17,3,0,0,0,0,3.028
+Spring 2024,BIOL,2102,24,14390,Anatomy & Physiology II (lab),Gill,Tejendra,4,13,3,2,0,0,1,2.939
+Spring 2024,BIOL,2120,1,14391,Microbiology for Non-Science,Knapp,Richard D,12,3,7,1,0,0,0,3.188
+Spring 2024,BIOL,2120,2,14392,Microbiology for Non-Science,Knapp,Richard D,11,11,1,1,0,0,0,3.292
+Spring 2024,SPAN,3343,1,14393,Span for the Health Profession,Zubiate,Maria Laura,8,1,0,0,0,0,0,3.852
+Spring 2024,COMM,3317,1,14394,Multimedia Journalism,Baruch Blanco,Maria Felicitas,11,1,0,0,0,0,2,3.889
+Spring 2024,MIS,4477,3,14395,Network & Security Infrastruct,Khan,Hina F,35,5,0,0,0,0,0,3.793
+Spring 2024,COMM,3374,1,14397,Strategic Social Media,Uhrick,Jan,30,3,0,0,0,0,0,3.909
+Spring 2024,POLS,3313,2,14399,Intro Internatl Relatns,Karimov,Samad,11,18,6,1,0,0,4,3.028
+Spring 2024,POLS,3326,1,14401,Gov-Pol the Middle East,Contractor,Cyrus Ali,23,5,1,1,0,0,2,3.634
+Spring 2024,POLS,3348,1,14402,"Left, Right, and Center",Koganzon,Rita,12,18,5,3,0,0,2,3.035
+Spring 2024,ENRG,4320,1,14404,Case Studies-Enrgy & Sustainbl,Jacobsen,Nicolas Fisher,14,2,1,0,0,0,0,3.745
+Spring 2024,MANA,3335,6,14405,Intro Org Behavior and Mgmt,Carlin,Barbara A,39,67,17,1,1,0,2,3.165
+Spring 2024,MANA,4330,2,14406,Intro to Strategic HR Mgt,Reinoso,Gaston,11,7,0,0,0,0,1,3.574
+Spring 2024,MANA,4350,1,14407,International Management,Celly,Nikhil,28,0,0,0,0,0,0,3.988
+Spring 2024,COMM,4360,2,14408,Media Planning & Placement,Jin,Eunjoo,12,17,3,0,0,0,1,3.281
+Spring 2024,CUIN,3312,2,14409,Educational Technology,Hebert,Waneta Suzanne,18,3,0,1,0,0,0,3.742
+Spring 2024,COMM,4371,1,14410,American Cinema: The Directors,Jowett,Garth Samuel,17,3,0,0,0,0,2,3.817
+Spring 2024,COMM,4381,1,14411,Digital Cinematography,Houk,Keith R,19,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,2320,4,14413,Abnormal Psychology,Kim,Jinu,50,24,3,2,0,0,1,3.511
+Spring 2024,BIOL,2302,2,14414,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,111,84,76,27,9,0,34,2.846
+Spring 2024,COMM,2331,1,14416,Relational Communication,Uhrick,Jan,30,9,5,0,0,0,0,3.591
+Spring 2024,SOC,3313,3,14417,Criminology,Nelson,Steven M,28,20,7,2,1,0,2,3.167
+Spring 2024,SOC,3351,2,14418,Soc Class&Mobilty in Am,Lorence,Jon P,11,23,2,0,1,0,2,3.189
+Spring 2024,SOC,3390,1,14419,Sociology of Gender,Katz,Sheila,32,7,3,1,2,0,1,3.423
+Spring 2024,ELED,4311,3,14421,Science in Elementary School I,Domjan,Heather N,23,1,0,0,0,0,0,3.945
+Spring 2024,ELED,4311,4,14422,Science in Elementary School I,Domjan,Heather N,22,3,0,0,0,0,0,3.84
+Spring 2024,CUIN,7300,1,14423,Play-Early Chldhood Edu,Wilson,Jahnette,7,4,0,0,1,0,0,3.306
+Spring 2024,SOC,6306,2,14424,Sem in Quant Methods,Savage,Scott Vandenburgh,8,4,0,0,0,0,0,3.612
+Spring 2024,FINA,4320,4,14425,Investment Management,Pederzoli,Paola,39,14,1,0,0,0,0,3.624
+Spring 2024,FINA,4320,5,14426,Investment Management,Gargano,Antonio,15,9,1,0,0,0,2,3.52
+Spring 2024,PETR,6364,1,14428,Origin & Dev Oil & Gas Resvrs,Zargar,Zeinab,3,1,0,0,0,0,0,3.668
+Spring 2024,BIOL,6354,1,14431,Endocrinology,Warner,Margaret,18,0,0,0,0,0,0,4.0
+Spring 2024,COSC,4393,1,14438,Digital Image Processing,Mantini,Pranav,84,43,7,1,2,0,1,3.48
+Spring 2024,MARK,4363,1,14439,International Marketing,Beveridge,Ivana,35,4,0,0,0,0,0,3.771
+Spring 2024,MARK,3365,1,14440,Intro to Digital Marketing,Lee,Byung Cheol,60,65,19,1,3,0,1,3.151
+Spring 2024,MARK,3365,2,14441,Intro to Digital Marketing,Lee,Byung Cheol,52,67,27,2,2,0,0,3.089
+Spring 2024,SCM,4330,3,14443,Bus Modeling and Dec Analysis,Chin,Wynne W,6,5,2,0,2,0,2,2.867
+Spring 2024,SOC,3400,4,14444,Intro To Social Statistics,Baumle,Amanda K,14,14,2,2,4,0,2,2.843
+Spring 2024,ENGL,4382,1,14447,Poetry Writing,Belieu,Erin Colleen,7,2,0,0,0,0,1,3.814
+Spring 2024,BIOE,2100,1,14448,Intro To Biomedical Engr,Akay,Yasemin M,21,4,0,1,0,0,1,3.655
+Spring 2024,BIOE,6309,1,14449,Neural Interfaces,Abidian,Mohammad Reza,8,0,0,0,0,0,0,3.835
+Spring 2024,BIOE,6307,1,14450,Cell Biology for BME,Al-Ubaidi,Muayyad,2,3,0,0,0,0,0,3.334
+Spring 2024,COSC,6380,1,14452,Digital Image Processing,Mantini,Pranav,26,1,0,0,0,0,0,3.914
+Spring 2024,FINA,7A10,1,14453,Valuation,Povel,Paul,8,4,0,0,0,0,0,3.612
+Spring 2024,PHLS,6370,1,14454,Intro To Cross-Cultural Cslng,McCoy,Leah,13,2,0,0,0,0,0,3.911
+Spring 2024,ENGL,3365,1,14457,Postcolonial Literature,Chatterjee,Sreya,23,4,1,0,1,0,1,3.53
+Spring 2024,ENGL,4366,1,14458,Intro To Folklore,Lindahl,Carl R,12,4,0,1,0,0,9,3.491
+Spring 2024,PSYC,2320,5,14459,Abnormal Psychology,Farrell,Abigail,41,24,5,2,2,0,5,3.342
+Spring 2024,ELCS,8313,1,14462,Issues for Urban Education Adm,Shockley,Gerald,6,2,0,0,0,0,0,3.75
+Spring 2024,SPEC,4365,1,14464,Data-Based Indiv Instruct,Rigby-Wills,Hope,5,6,0,0,0,0,0,3.455
+Spring 2024,SPEC,6360,1,14465,Individuals with Disabilities,Dulas,Heather,6,1,0,0,0,0,0,3.857
+Spring 2024,SPEC,4362,1,14466,Behavior: EBD,Carp,Charlotte Lynn,11,9,0,1,0,0,0,3.303
+Spring 2024,SPEC,7392,1,14467,Assmt Intellectual Abilities,Cole,Jana Belinda,11,3,0,0,0,0,0,3.809
+Spring 2024,ELCS,8311,1,14468,Lab of Practice-Lit Revw Devel,Hawkins,Jacqueline McLean,4,0,0,0,0,0,0,3.918
+Spring 2024,ELCS,8311,2,14469,Lab of Practice-Lit Revw Devel,Santi,Kristi L,5,0,0,0,0,0,0,3.736
+Spring 2024,SPEC,4364,1,14472,Ed Students Giifts and Talents,Govan,Kordney J,27,7,1,0,0,0,0,3.743
+Spring 2024,SPEC,6362,1,14473,Behavior:Evidence-Based,Carp,Charlotte Lynn,18,3,0,0,0,0,1,3.747
+Spring 2024,SPEC,6365,1,14474,Data-Based Indiv Instruct,Rigby-Wills,Hope,13,3,1,0,0,0,1,3.628
+Spring 2024,SPEC,7343,1,14475,Psych Processes of Reading,Santi,Kristi L,20,2,1,0,0,0,0,3.826
+Spring 2024,PETR,6111,1,14476,Petroleum Graduate Seminar,Qin,Guan,0,0,0,0,0,30,0,
+Spring 2024,COMD,2339,1,14477,Language Development,Mills,Monique T,18,11,2,2,0,0,2,3.344
+Spring 2024,ENRG,3310,1,14478,Intro to Energy & Sustainblty,Jacobsen,Nicolas Fisher,19,6,0,0,0,0,0,3.773
+Spring 2024,MECE,3369,1,14480,Solid Mechanics,Kulkarni,Yashashree,8,16,22,5,6,0,6,2.252
+Spring 2024,ECE,6327,1,14481,Smart Grid Systems,Li,Xingpeng,9,3,0,0,0,0,0,3.695
+Spring 2024,ECE,6329,1,14482,Power System Protection,Yellajosula,Jaya Raghavendra Arun Kumar,6,0,0,0,0,0,0,4.0
+Spring 2024,HLT,4317,1,14483,Found of Epi in Public Health,Drenner,Kelli Linn,13,23,13,3,1,0,3,2.78
+Spring 2024,PHLS,7377,1,14484,Child & Adol Psychopathology,Smith,Bradley,6,0,0,0,0,0,0,3.945
+Spring 2024,ECE,3436,1,14485,Microprocessor Systems,De La Rosa-Pohl,Diana,39,7,0,0,0,0,0,3.747
+Spring 2024,ECE,3436,3,14486,Microprocessor Systems,Zheng,Jianfeng,11,3,0,1,0,0,0,3.556
+Spring 2024,ECE,5180,1,14487,Power Electonics Laboratory,Viswanath,Padmavati Aparna,8,0,0,0,0,0,0,3.918
+Spring 2024,HDFS,3300,1,14488,Educational Psychology,Conston,Toya,96,16,4,2,2,0,0,3.648
+Spring 2024,ECE,5380,1,14491,Pwr Electrncs & Electrc Drives,Huang,Hao,20,3,0,0,0,0,1,3.812
+Spring 2024,ECE,5436,1,14492,Adv Microprocessor Systems,Leigh,Kevin Benny,7,22,2,1,0,0,1,3.104
+Spring 2024,ECE,6336,1,14494,RTOS and IoT,Leigh,Kevin Benny,2,6,3,0,1,0,0,2.667
+Spring 2024,POLS,3311,2,14495,Intro Compar Politics,Pineda,Paula C,23,12,1,1,0,0,3,3.505
+Spring 2024,ECE,6357,1,14496,Introduction to Cybersecurity,Pan,Miao,73,5,0,0,0,0,0,3.911
+Spring 2024,ECE,3337,1,14497,Signals and Systems Analysis,Reddy,Rohith Krishna,7,13,10,3,3,0,2,2.454
+Spring 2024,HDFS,3320,1,14498,Careers in HDFS,Jordan,Erica F,21,3,0,0,1,0,0,3.654
+Spring 2024,BZAN,4397,1,14499,Sel Topics in Bus Analytics,Wang,Cheng,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8307,1,14500,Health Disparities,Carmack,Chakema,5,0,0,0,0,0,0,4.0
+Spring 2024,GHL,4353,2,14502,Leadership in Hospitality Ind,Barth,Stephen C,33,10,1,0,4,0,1,3.369
+Spring 2024,GHL,4361,1,14503,Marketing Strategies,Mohamed,Mohamed Elsayed AbdElaziz,17,9,5,0,0,0,1,3.281
+Spring 2024,COMD,3371,2,14504,Speech Devel & Dis in Children,Ermgodts,Katherine Natalie,15,16,1,0,0,0,1,3.386
+Spring 2024,BIOE,6306,1,14506,Adv Artificial Neural Networks,Francis,Joseph Thachil,2,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5300,1,14507,Criminal Defense Clinic,Locascio,Erik Matthew,0,2,0,0,0,0,0,3.33
+Spring 2024,ARCH,3501,17,14508,Architecture Design Studio VI,Clovis,Sam,6,8,0,0,0,0,0,3.523
+Spring 2024,IDNS,1101,2,14510,Physics 1301 Workshop,Pattison,Donna,14,3,2,0,0,0,3,3.527
+Spring 2024,FINA,4383,1,14511,R E Mkt Research & Valuation,Witte,Jerome,35,0,0,0,0,0,0,3.972
+Spring 2024,CUIN,6383,1,14512,Intro to Early Childhood Rsrch,Li,Xin,7,0,0,0,0,0,1,4.0
+Spring 2024,BZAN,6355,1,14514,Adv Programming-Big Data Anlyt,Ma,Xiao,35,0,0,0,0,0,0,4.0
+Spring 2024,WGSS,3321,1,14517,Gender in Transnational Persp,Al-Sowayel,Dina,14,6,7,0,3,0,0,2.944
+Spring 2024,LAW,5355,1,14518,Oil and Gas,Mason,Jasper,9,10,0,0,0,0,0,3.491
+Spring 2024,MUSI,1181,1,14519,Group Piano I,Van Kekerix,Todd Evan,4,3,1,0,3,0,0,2.365
+Spring 2024,MUSA,1300,6,14520,Applied Voice,Vasquez,Hector A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3400,4,14524,Applied Voice,Vasquez,Hector A,1,1,0,0,0,0,0,3.5
+Spring 2024,MUSA,3400,6,14525,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3422,1,14526,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3430,2,14527,Applied Flute,Russell,Peggy,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3440,2,14528,Applied Trumpet,Vassallo,Jim Cates,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4402,1,14530,Applied Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4420,1,14531,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4426,1,14533,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,3.67
+Spring 2024,MUSA,6141,3,14534,Graduate Recital II,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,4312,3,14536,Civil Engineering Capstone,Keyvani,Ali,18,20,6,0,0,0,0,3.295
+Spring 2024,MARK,4389,8,14538,Marketing Strategy & Planning,Randazzo,Gary W,26,5,0,0,0,0,0,3.743
+Spring 2024,CHEM,4370,1,14540,Physical Chemistry I,Xu,Shoujun,9,16,6,0,0,0,0,3.107
+Spring 2024,ELCS,8399,3,14543,Doctoral Dissertation,Horn,Catherine Lynn,4,0,0,0,0,2,0,4.0
+Spring 2024,NUTR,6305,1,14553,Research Methods,Ledoux,Tracey A,14,7,1,0,0,0,1,3.561
+Spring 2024,NUTR,6306,1,14554,Stats for Healthcare Prof,Haubrick,Kevin,13,9,0,0,0,0,1,3.471
+Spring 2024,SOCW,6294,1,14556,Social Work Practicum II,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Spring 2024,CIVE,5388,1,14557,Hazardous Waste Processes,Rixey,William G,3,0,0,0,0,0,0,3.89
+Spring 2024,ELED,4310,3,14560,Reading/Language in Elementary,Tyson,Eleanore S,22,1,1,0,0,0,0,3.903
+Spring 2024,MARK,3337,1,14561,Professional Selling,Boehm-Miller,Elizabeth A,116,70,19,9,3,0,7,3.301
+Spring 2024,MARK,3337,2,14562,Professional Selling,Vandaveer,Amy L,125,73,12,3,1,0,10,3.475
+Spring 2024,MARK,3337,3,14563,Professional Selling,Boehm-Miller,Elizabeth A,115,84,16,3,0,0,6,3.414
+Spring 2024,MARK,3337,4,14564,Professional Selling,Vandaveer,Amy L,115,66,22,2,6,0,14,3.308
+Spring 2024,EDUC,3101,1,14565,Practicum for Preservice Tchrs,Thompson,Amber M,121,0,0,0,0,0,1,3.997
+Spring 2024,CUIN,1103,1,14566,Educator Dispositions,Culpepper,Shea Mosley,74,9,1,1,0,0,1,3.758
+Spring 2024,CUIN,3321,1,14567,Intro to Teaching Middle Grade,McDonough,Michael Joseph,17,2,2,0,1,0,0,3.47
+Spring 2024,CUIN,3302,4,14568,Social Education,Campbell,Matthew,17,2,0,0,0,0,0,3.912
+Spring 2024,ELED,4320,1,14569,Social Studies Ele Sch,Ford,Haley Michelle Grimland,27,1,0,0,0,0,0,3.964
+Spring 2024,ELED,4320,2,14570,Social Studies Ele Sch,Ford,Haley Michelle Grimland,18,0,0,0,0,0,0,4.0
+Spring 2024,ELED,4310,4,14572,Reading/Language in Elementary,Tyson,Eleanore S,29,0,0,0,0,0,1,3.954
+Spring 2024,CHEM,8999,25,14573,Doctoral Dissertation,Teets,Thomas,1,0,0,0,0,2,0,4.0
+Spring 2024,MUSA,8320,11,14575,Doctoral Applied Music,Hester,Timothy E,6,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8240,9,14576,Doctoral Recital I,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6334,1,14579,Applied Clarinet,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6400,1,14580,Applied Voice,Sonnenberg,Melanie,3,0,0,0,0,0,0,4.0
+Spring 2024,COMD,4489,1,14582,Clinical Procedures,Ivey,Michelle L,20,5,0,0,0,0,1,3.747
+Spring 2024,CHEM,2123,9,14583,Organic Chemistry Lab I,Bean,Mary B,4,13,4,0,0,0,2,2.89
+Spring 2024,CHEM,2125,12,14584,Organic Chemistry Lab II,Bean,Mary B,5,7,8,2,0,0,1,2.727
+Spring 2024,ECE,3355,1,14586,Electronics,Ruchhoeft,Paul,7,10,11,3,0,0,1,2.656
+Spring 2024,FINA,4320,6,14593,Investment Management,Pederzoli,Paola,34,18,2,0,0,0,0,3.605
+Spring 2024,INDE,8298,5,14596,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Spring 2024,PHOP,8199,2,14601,Doctoral Dissertation,Patel,Nimesh Bhikhu,0,0,0,0,0,1,0,
+Spring 2024,PHOP,8299,2,14602,Doctoral Dissertation,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6767,1,14606,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Spring 2024,HDFS,1300,13,14623,Dev of Contemporary Families,Jordan,Erica F,37,8,1,0,0,0,0,3.725
+Spring 2024,MUSA,4424,2,14625,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6257,15,14629,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,2301,1,14633,Principles of Macroeconomics,Maden,Bitaran Jang,112,187,97,26,15,0,8,2.814
+Spring 2024,IEEM,6330,1,14634,Managing Engineering Functions,Kamrani,Ali K,16,10,2,0,0,0,0,3.382
+Spring 2024,CUIN,8398,12,14635,Independent Study,McNeil,Sara G,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6420,1,14640,Applied Violin,Yon,Kirsten A,4,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6198,10,14641,Spec Prob-Physio Optics,Matynia,Anna,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,3302,3,14642,Social Education,Thomas,Dustine J,10,0,0,0,0,0,0,4.0
+Spring 2024,ELED,4311,2,14645,Science in Elementary School I,Domjan,Heather N,20,0,0,0,0,0,0,3.951
+Spring 2024,ACCT,5330,2,14646,Advanced Accounting,Ramaswamy,Vinita,0,2,0,0,0,0,1,3.33
+Spring 2024,PSYC,6365,4,14647,Dir Rsch in Dev Cog Beh Neuro,Kosten,Therese A,2,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8399,7,14648,Doctoral Dissertation,Liu,Elaine Meichen,2,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8999,22,14671,Doctoral Dissertation,Morrison,Gregory C,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8999,26,14675,Doctoral Dissertation,Ren,Zhifeng,3,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8999,27,14676,Doctoral Dissertation,Renshaw,Andrew,2,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8999,32,14681,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6336,4,14684,Directed Rsch in Social Psyc,Knee,Clifford R,3,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,8393,3,14687,Adv Internship & Prac,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6498,8,14688,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6398,2,14691,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,2,0,
+Spring 2024,PCEU,8998,4,14692,Doctoral Research,Hu,Ming,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8242,1,14696,Doctoral Recital III,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,8699,11,14702,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8399,10,14704,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6393,5,14705,Clinical Research Practicum,Walker,Rheeda L,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,3331,2,14707,Beg Creative Writing-Poetry,Sutton,Anthony Villavelez,17,2,0,0,0,0,1,3.895
+Spring 2024,PSYC,6359,2,14713,Directed Rsch in Clinical Psyc,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Spring 2024,PHCA,6398,1,14714,SP- Outcomes Research,Varkey,Divya A,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,8398,14,14715,Independent Study,Gist,Conra D,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8399,11,14716,Doctoral Dissertation,Medina,Luis Daniel,0,0,0,0,0,2,0,
+Spring 2024,PSYC,8399,12,14719,Doctoral Dissertation,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Spring 2024,MUSI,4104,1,14720,New Music Ensemble,Smith,Robert Thomas,2,0,0,0,0,0,0,4.0
+Spring 2024,FINA,4330,1,14724,Corporate Finance,Suleymanov,Masim,16,15,3,1,0,0,0,3.333
+Spring 2024,CIVE,6361,1,14727,Engineering Hydrology,Rifai,Hanadi S,4,3,1,0,0,0,0,3.375
+Spring 2024,MUSA,8320,48,14728,Doctoral Applied Music,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,3.67
+Spring 2024,COMM,7399,1,14729,Masters Thesis,Camaj,Lindita,4,0,0,0,0,0,0,4.0
+Spring 2024,INDS,6329,1,14730,Comp Aided Industr Design I,Chow,George K,1,0,0,0,0,0,0,3.67
+Spring 2024,MATH,8398,27,14733,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8242,4,14735,Doctoral Recital III,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8399,13,14738,Doctoral Dissertation,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8298,23,14741,Doctoral Research,Nurminen,Lauri Oskari,0,0,0,0,0,1,0,
+Spring 2024,MIS,4374,4,14746,Info Technology Project Mgmt,Jagtap,Pankaj,16,27,1,0,0,0,1,3.266
+Spring 2024,CUIN,8398,10,14748,Independent Study,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Spring 2024,ARTH,7393,1,14749,Art History Internship,Harren,Natilee O,3,0,0,0,0,0,0,3.89
+Spring 2024,PSYC,6365,5,14751,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,3,0,0,0,0,0,0,4.0
+Spring 2024,NUTR,2332,4,14753,Intro To Human Nutrition,Hughes,Lindsay,53,29,7,4,0,0,3,3.352
+Spring 2024,NUTR,2332,5,14754,Intro To Human Nutrition,Hughes,Lindsay,52,26,12,1,0,0,5,3.338
+Spring 2024,ECON,4390,2,14757,Economics Internship,Troncoso,Pablo A,4,0,0,0,0,0,0,3.918
+Spring 2024,PSYC,6365,6,14758,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6365,7,14759,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Spring 2024,ECON,4390,3,14763,Economics Internship,Troncoso,Pablo A,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,6323,1,14769,Psychopathology,Lukingbeal,Patrick Livingston,20,0,0,0,0,0,0,3.984
+Spring 2024,CHEM,1312,5,14770,Fundamentals of Chemistry 2,Chen,Tai-Yen,47,67,77,21,28,0,48,2.289
+Spring 2024,MATH,6359,1,14771,Appl. Stat. & Mult. Analysis,Poliak,Cathy Dawn,20,1,0,0,0,0,0,3.89
+Spring 2024,MATH,6373,1,14772,Deep Learning and Neural Nets,Labate,Demetrio,18,6,0,0,0,0,1,3.723
+Spring 2024,MATH,6315,30,14773,Masters Tutorial,Poliak,Cathy Dawn,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7345,1,14774,Psych Methods,Gallagher,Matthew Ward,5,0,0,0,0,0,0,4.0
+Spring 2024,POLS,3312,1,14775,"Arguments, Data, Politics",Hanna,Tom Leard,34,5,1,0,1,0,0,3.724
+Spring 2024,POLS,3312,3,14776,"Arguments, Data, Politics",Karimov,Samad,10,15,9,2,0,0,2,2.926
+Spring 2024,ARCH,6357,1,14779,Contemporary Theory,Bassi Cendra,Giovanna Maria,16,5,0,0,0,0,1,3.73
+Spring 2024,POLS,3311,4,14780,Intro Compar Politics,Vardy,Ronald V,26,4,4,1,2,0,2,3.316
+Spring 2024,GERM,3350,1,14781,20Th C Thru German Culture,Kleinheider,Julia D,8,18,2,2,2,0,1,2.823
+Spring 2024,WCL,3366,2,14782,Latin American and Latino Film,Ramirez,Marie Theresa,19,6,3,2,2,0,0,3.177
+Spring 2024,POLC,6315,1,14784,Pol Res II: Mult Analysis,Buttorff,Gail J,16,3,2,0,0,0,1,3.667
+Spring 2024,POLC,6317,1,14785,Public Policy Capstone,Pinto,Pablo M,12,4,0,0,0,0,0,3.812
+Spring 2024,POLC,6320,1,14786,Pol Analysis II: Pol Analysis,Pinto,Pablo M,18,2,3,0,0,0,1,3.638
+Spring 2024,POLC,6330,1,14787,Philosophy and Public Policy I,Engster,Daniel A,17,7,0,0,1,0,1,3.507
+Spring 2024,POLC,6391,1,14788,Public Policy Internship,Bronk,Robert C,5,0,0,0,0,0,0,3.868
+Spring 2024,BIOL,6356,1,14789,Medical Ethics,Determeyer,Peggy Lee,4,0,0,0,0,0,0,4.0
+Spring 2024,INDE,4364,1,14791,Big Data and Analytics,Lin,Ying,11,20,12,2,0,0,1,2.904
+Spring 2024,PSYC,2317,5,14793,Intro to Psychology Statistics,Le,Giang Xuan,57,16,4,2,1,0,0,3.563
+Spring 2024,PSYC,2305,12,14794,Intro to Methods in Psychology,Saiyed,Amna Shabbir,61,32,3,0,2,0,2,3.51
+Spring 2024,BIOL,1307,51,14798,Biology for Science Majors II,Hanke,Marc H,5,18,6,1,1,0,1,2.881
+Spring 2024,POLS,3349,2,14799,American Political Thought,Fumurescu,Alin,6,14,10,4,1,0,4,2.543
+Spring 2024,HON,3301,3,14800,Readings in Medicine & Society,Liddell,Robert B,24,1,0,0,0,0,0,3.934
+Spring 2024,LAW,5345,1,14801,Real Estate Transactions,Crump,David L,13,19,0,0,0,0,0,3.365
+Spring 2024,HON,3302,1,14803,Readings in Public Health,Lunstroth,John,12,4,0,0,0,0,0,3.668
+Spring 2024,BIOE,4347,1,14804,Cell Biology for BME,Al-Ubaidi,Muayyad,0,5,3,0,0,0,1,2.543
+Spring 2024,BIOE,4309,1,14805,Neural Technology Interfaces,Abidian,Mohammad Reza,2,1,0,0,0,0,0,3.667
+Spring 2024,BIOE,4313,1,14806,Intro to Neural Computation,Francis,Joseph Thachil,4,0,0,0,0,0,0,3.918
+Spring 2024,LAW,5357,1,14807,Evidence,Brem,Katherine B,17,29,2,0,0,13,0,3.395
+Spring 2024,MANA,4310,2,14811,Behavioral Finance,Rude,Dale,3,4,0,0,0,0,1,3.287
+Spring 2024,MANA,3335,7,14812,Intro Org Behavior and Mgmt,Currie,Daniel David,190,54,8,1,0,0,3,3.662
+Spring 2024,MANA,6310,1,14815,Fundamentals of Business,Celly,Nikhil,14,1,0,0,0,0,0,3.911
+Spring 2024,MANA,7A49,1,14816,Managerial Decision Making,Carlin,Barbara A,14,12,0,0,0,0,0,3.551
+Spring 2024,MANA,7373,1,14818,Strat Mgt O & G Industry,Angelides,Christos O,7,0,0,0,0,0,0,3.859
+Spring 2024,MANA,7356,1,14819,Inclusive Leadership,Walker,William A,4,0,0,0,0,0,0,4.0
+Spring 2024,MANA,6A83,3,14820,Strategic Analysis,Sauerwald,Steve,9,2,0,0,0,0,0,3.818
+Spring 2024,AAMS,2300,1,14821,Intro Asian American Studies,Nguyen,An,10,6,1,1,1,0,2,3.106
+Spring 2024,COMM,1303,3,14822,Writing for Communicators,Lyn,Robyn,44,20,6,2,12,0,10,2.929
+Spring 2024,ARCH,1210,1,14823,Introduction to Design Media,Kudless,Andrew Justin,113,35,7,0,6,0,14,3.475
+Spring 2024,SPEC,7394,1,14824,Diagnostician Practicum I,Hassett,Kristen Spring,0,0,0,0,0,3,0,
+Spring 2024,SPEC,7395,1,14825,Diagnostician Practicum II,Hassett,Kristen Spring,0,0,0,0,0,11,0,
+Spring 2024,ARCH,1501,20,14826,Arc/Int Arc Design Studio II,Murray,Cara,5,6,2,0,0,0,0,3.18
+Spring 2024,PHYS,6363,1,14829,Graduate Laboratory,Ren,Zhifeng,10,0,0,0,0,0,0,3.769
+Spring 2024,INDS,3397,1,14830,Selected Topics,Kang,Chul Min,5,0,0,0,0,0,0,3.802
+Spring 2024,ELED,4315,4,14831,Mathematics in Elem School II,Cutler,Carrie Sybil,32,1,0,0,0,0,0,3.9
+Spring 2024,ACCT,7378,1,14832,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,19,0,0,0,0,0,0,3.983
+Spring 2024,ACCT,2302,8,14833,Prin of Managerial Accounting,Seltz,Joe D,15,17,16,6,6,0,3,2.533
+Spring 2024,PSYC,3339,3,14834,Intro To Clinical Psychology,Cifre,Anthony Ballachie,17,35,19,3,5,0,1,2.717
+Spring 2024,SEDE,4311,1,14835,Teaching Social Studie Sec Sch,Ford,Haley Michelle Grimland,9,0,0,0,0,0,0,4.0
+Spring 2024,KIN,3304,2,14836,Human Structure & Phys Perform,Breslin,Whitney L,23,43,56,13,2,0,2,2.523
+Spring 2024,KIN,3306,1,14837,Physiology-Human Performance,Hamilton,Marc,17,14,12,3,8,0,10,2.519
+Spring 2024,KIN,3309,1,14838,Biomechanics,Gorniak,Stacey,14,27,30,7,13,0,4,2.202
+Spring 2024,KIN,4310,2,14839,Measurement Tech Human Perf,Parikh,Pranav J,78,15,4,0,2,0,1,3.647
+Spring 2024,KIN,4370,1,14840,Exercise Testing,Markofski,Melissa,44,68,17,6,4,0,5,3.017
+Spring 2024,SPAN,4337,1,14847,Contempry Span-Amer Lit,Rivera Garza,Cristina,9,3,0,0,0,0,0,3.723
+Spring 2024,COMM,2326,1,14849,Intro to Sports Broadcasting,Trupiano,Jerome,22,3,0,0,0,0,0,3.92
+Spring 2024,COMM,2327,1,14850,Introduction to Screen Writing,Vaughan,Thomas Michael,22,1,0,0,0,0,0,3.942
+Spring 2024,HIST,1302,51,14852,The U.S. Since 1877,Modaff,Abigail,24,1,0,0,0,0,0,3.907
+Spring 2024,COMM,2356,1,14853,Business & Professional Comm,Uhrick,Jan,240,28,16,6,6,0,5,3.633
+Spring 2024,NUTR,4353,1,14854,Cultural Comp for Nutr Prof,Vollrath,Kirstin,57,10,1,1,0,0,0,3.73
+Spring 2024,NUTR,4351,1,14855,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,103,54,6,3,2,0,5,3.461
+Spring 2024,EDUC,1301,1,14860,Intro to Teaching Profession,Larry,Frederick,21,2,1,0,0,0,1,3.847
+Spring 2024,NUTR,4201,1,14861,Dietetics as a Profession II,Honig,Caryn A,16,9,1,1,0,0,1,3.371
+Spring 2024,ECE,4113,1,14862,Energy Conversion Laboratory,Viswanath,Padmavati Aparna,20,0,0,0,0,0,0,3.967
+Spring 2024,ECE,4363,1,14863,Electromech Energy Conv,Viswanath,Padmavati Aparna,23,4,0,0,0,0,0,3.632
+Spring 2024,PHYS,1303,1,14864,Stars and Galaxies,Bellwied,Rene,17,38,22,1,4,0,13,2.752
+Spring 2024,CUIN,4375,1,14865,Classroom Management,Thompson,Alan M,16,8,0,0,0,0,0,3.694
+Spring 2024,CUIN,4375,3,14866,Classroom Management,Castillo,Bernadette Marie,12,1,0,0,1,0,0,3.619
+Spring 2024,ECE,6353,1,14868,Rf & Microwave Electronics,Chen,Jinghong,4,1,0,0,0,0,0,3.668
+Spring 2024,ENGL,3304,1,14871,Chaucer,Stock,Lorraine K,7,7,1,0,0,0,5,3.356
+Spring 2024,ENGL,3317,1,14872,The British Novel Before 1832,Mazella,David S,16,0,0,0,2,0,5,3.482
+Spring 2024,ENGL,3322,1,14873,Contemporary Novel,Zamora,Lois,3,8,3,5,0,0,9,2.526
+Spring 2024,ENGL,4300,1,14875,Intro-Study of Language,Zentz,Lauren R,22,4,1,0,1,0,2,3.584
+Spring 2024,ACCT,3368,2,14876,Intermediate Accounting II,Kraten,Michael,35,29,15,0,1,0,1,3.184
+Spring 2024,COSC,1336,4,14878,Computer Science & Program,Alipour,Mohammad Amin,58,46,42,12,17,0,34,2.667
+Spring 2024,BIOL,4374,2,14879,Cell Biology,Gifford,Jenifer,42,26,7,2,1,0,3,3.346
+Spring 2024,BCHS,4313,3,14880,Cell Biochemistry,Rea,Michael A,6,2,1,0,0,0,0,3.556
+Spring 2024,KIN,4300,1,14882,Phys Activity Older Adults,Alastuey,Lisa L,43,32,32,5,6,0,7,2.761
+Spring 2024,LAW,6321,2,14884,Professional Responsibility,Duncan,Meredith J,27,41,1,0,0,0,0,3.386
+Spring 2024,BIOL,6350,1,14885,Biomedical Sciences Practicum,Gifford,Jenifer,23,0,0,0,1,0,0,3.833
+Spring 2024,ELCS,6304,1,14886,Law & Policy for School Leader,Klussmann,Duncan Foster,9,0,0,0,0,0,0,3.963
+Spring 2024,ELCS,6310,1,14887,Strategic Engagement,Davis,Bradley,8,2,0,0,0,0,0,3.734
+Spring 2024,EDRS,8380,1,14890,Rsch Mthds in Educ,Hawkins,Jacqueline McLean,10,0,0,0,0,0,0,3.967
+Spring 2024,COSC,2306,1,14891,Data Programming,Yan,Feng,26,12,3,0,0,0,15,3.529
+Spring 2024,COSC,2436,1,14892,Programming and Data Structure,Biediger,Daniel Edward,28,29,24,3,11,0,31,2.604
+Spring 2024,COSC,2436,3,14894,Programming and Data Structure,Rizk,Nouhad J,9,17,22,10,17,0,19,1.911
+Spring 2024,COSC,3320,2,14895,Algorithms and Data Structures,Pandurangan,Gopal,19,63,33,8,6,0,18,2.623
+Spring 2024,COSC,4337,1,14896,Data Science II,Vilalta,Ricardo,55,15,0,0,0,0,0,3.649
+Spring 2024,BIOL,4206,3,14899,Ecology & Evolution Laboratory,Cheek,Ann Oliver,22,1,0,0,0,0,1,3.957
+Spring 2024,GHL,1320,1,14900,Foodservice Management,Legendre,Jungyoung Shin,30,7,0,0,0,0,3,3.766
+Spring 2024,WGSS,4350,2,14901,Issues in Feminist Research,Villarroel,Carolina A,4,1,0,1,0,0,0,3.333
+Spring 2024,GHL,2356,1,14903,Comm Strategies for Hospitalty,Haskell,Rebecca Erin,25,4,1,1,2,0,1,3.445
+Spring 2024,GHL,3335,1,14904,Alcoholic Beverage Production,Corsi,Aaron James,21,2,0,0,0,0,0,3.87
+Spring 2024,GHL,3349,1,14905,Hosp Procurement & Purchasing,Corsi,Aaron James,37,3,0,0,0,0,0,3.777
+Spring 2024,GHL,3420,1,14906,Foodservice Operations,Ginapp,Kathrine,16,9,1,0,0,0,0,3.552
+Spring 2024,GHL,4350,1,14908,Strategy&Innovation Hosp Ind,Morosan,Cristian,10,8,2,3,1,0,0,2.917
+Spring 2024,GHL,4352,1,14909,Hosp Organizational Behavior,Maneethai,Dustin,10,8,6,0,1,0,0,3.08
+Spring 2024,GHL,2356,2,14910,Comm Strategies for Hospitalty,Barth,Stephen C,13,2,3,3,2,0,5,2.913
+Spring 2024,MATH,3349,1,14912,Inferential Statistics,Poliak,Cathy Dawn,17,7,5,1,1,0,3,3.236
+Spring 2024,GHL,6342,1,14913,Alcoholic Beverage Production,Corsi,Aaron James,4,0,0,0,0,0,0,3.67
+Spring 2024,CUIN,7390,2,14915,Instructional Design,Dogan,Bulent,17,0,0,0,0,0,0,3.981
+Spring 2024,PHAR,5270,1,14916,Pcon & Hospital Pharmacy Mgmt,Sansgiry,Sujit Sharad,78,29,1,0,0,0,0,3.713
+Spring 2024,PHAR,5259,1,14917,Module Related Skills Lab II,Davis,Shantera Rayford,104,4,0,0,0,0,0,3.963
+Spring 2024,PHAR,5327,1,14918,Integrated Endocrine Module,Asias-Dinh,Bernadette De Leon,42,47,20,0,0,0,0,3.202
+Spring 2024,PHAR,5228,1,14919,Integrated Men & Women Health,Das,Joydip,48,42,18,0,0,0,0,3.278
+Spring 2024,PHAR,5329,1,14920,Integrated CV I Module,McConnell,Bradley K,62,35,11,0,0,0,0,3.472
+Spring 2024,PHAR,5330,1,14921,Integrated CV II Module,Boini,Krishna M,69,35,4,0,0,0,0,3.602
+Spring 2024,RELS,1301,3,14923,Intro To Religious Studies,Borkataky-Varma,Sravana,18,15,3,2,4,0,2,2.913
+Spring 2024,ECE,3317,1,14924,Applied Electromagnetic Waves,Chen,Ji,23,12,15,1,0,0,4,3.066
+Spring 2024,LAW,5323,1,14925,Conflict of Laws,Ungureanu,Razvan C,5,5,0,0,0,0,0,3.434
+Spring 2024,PSYC,2307,3,14926,Psychology of Adolescence,Martin,Rebecca B,69,23,11,2,8,0,3,3.254
+Spring 2024,MATH,4323,1,14927,Data Science and Stats Learn,Wang,Wenshuang,72,20,5,1,1,0,0,3.53
+Spring 2024,INTB,3355,4,14928,Global Environment of Business,Miljanic,Andra Olivia,112,11,0,0,0,0,2,3.878
+Spring 2024,ACCT,2302,9,14929,Prin of Managerial Accounting,Weber,Catherine K,27,33,27,7,4,0,6,2.795
+Spring 2024,BZAN,6354,1,14930,DB Mgt Tools Bus Analytics,Grimes,George M,21,7,2,0,0,0,0,3.633
+Spring 2024,FINA,7323,1,14931,Applied Equity Fund Management,George,Thomas J,16,0,0,0,0,0,0,3.979
+Spring 2024,COMM,1303,1,14932,Writing for Communicators,Lyn,Robyn,61,13,3,2,6,0,7,3.389
+Spring 2024,IEEM,6335,1,14933,Engr Mgmt of Organizations,Hu,Minxiang,61,6,0,1,1,0,0,3.773
+Spring 2024,MIS,3376,3,14934,Busn Appls Database Mgmt I,Dimoka,Angelika,10,16,5,2,0,0,1,2.92
+Spring 2024,MIS,3376,4,14935,Busn Appls Database Mgmt I,Dimoka,Angelika,21,9,3,1,0,0,0,3.393
+Spring 2024,SPEC,8341,1,14936,Seminar in Learning Science,McCormick,Marina,4,3,0,0,0,0,1,3.571
+Spring 2024,ACCT,4335,1,14937,Financial Statement Auditing,Rousseau,Linette Marie,7,9,4,1,2,0,2,2.797
+Spring 2024,ACCT,4331,5,14938,Federal Income Tax,Small,Randolph Christopher,19,9,1,0,1,0,1,3.5
+Spring 2024,ARLD,6340,1,14939,Law and the Arts,Payne,Brendettae,5,0,0,0,0,0,0,4.0
+Spring 2024,MUED,2320,1,14940,Computers for Musicians,Zajicek,Daniel James,4,5,2,0,0,0,1,3.032
+Spring 2024,MUED,2320,2,14941,Computers for Musicians,Zajicek,Daniel James,12,1,2,0,0,0,0,3.535
+Spring 2024,MUED,2342,2,14943,Music for Children,Schlosser,Emily Elizabeth,19,1,1,0,0,0,1,3.81
+Spring 2024,MUED,3100,1,14946,Woodwinds,Bell,Priscilla Garrett,12,2,0,0,0,0,0,3.857
+Spring 2024,MUED,3101,1,14947,Woodwinds,Bell,Priscilla Garrett,14,2,0,0,0,0,0,3.834
+Spring 2024,MUED,3103,1,14948,Brasses,Bell,Priscilla Garrett,11,5,1,1,0,0,0,3.408
+Spring 2024,MUED,4221,1,14949,Choral Conducting II,Koppel,Alexander,8,0,0,0,0,0,0,4.0
+Spring 2024,MUED,4231,1,14950,Instrumental Conducting II,Bertman,David Garry,15,3,0,0,0,0,0,3.852
+Spring 2024,MUED,4340,1,14951,Elem/Middle Schl Inst. Admin.,Meals,Cory Dewitt,18,3,2,0,0,0,1,3.696
+Spring 2024,FINA,4310,1,14952,Behavioral Finance,Rude,Dale,19,13,0,0,0,0,0,3.573
+Spring 2024,MUED,3108,1,14953,Piano for Choral Directors,Van Kekerix,Todd Evan,4,0,1,0,1,0,0,3.0
+Spring 2024,IRW,1300,2,14958,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,13,0,
+Spring 2024,THEA,4367,1,14959,Costume Cutting & Draping,Niederer,Barbara,3,2,0,0,0,0,0,3.6
+Spring 2024,ARCH,5500,19,14961,Architecture Design Studio IX,Race,Bruce Alan,8,8,0,0,0,0,0,3.459
+Spring 2024,MUSA,1324,1,14963,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2024,MUED,3107,1,14964,Basic Vocal Techniques,Gianni,Alicia Marie,15,5,0,0,0,0,0,3.767
+Spring 2024,MUSI,6200,1,14966,Accompanying Seminar,Hester,Timothy E,4,0,0,0,0,0,0,4.0
+Spring 2024,THEA,6185,1,14968,Scenic Methods & Materials,Vlahos,Kalliope,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1340,1,14969,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6381,1,14970,Information Visualization,Shastri,Dvijesh J,10,7,0,0,0,0,0,3.414
+Spring 2024,MUSA,2342,2,14971,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Spring 2024,NURS,4312,1,14972,Ldership and Mgmt in Prof Nur,Edwards-Maddox,Shermel Vinese,14,24,0,3,0,0,0,3.195
+Spring 2024,MUSA,4400,5,14973,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4400,4,14974,Applied Voice,Vasquez,Hector A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6341,1,14975,Graduate Music Theory Review,Garza,Paul Victor,6,4,0,0,0,0,0,3.534
+Spring 2024,ARCH,1360,1,14979,Architectural Sketching I,Williams,Celeste,17,4,2,0,0,0,0,3.58
+Spring 2024,NURS,6332,1,14981,Biostatistics,Connelly,Linda K,4,1,0,0,0,0,0,3.8
+Spring 2024,NURS,3312,1,14982,Fundamental Concepts of Care,Schrader,Patricia K,13,16,0,0,0,0,1,3.448
+Spring 2024,NURS,3313,1,14983,Fundamental Clinical,Kantala,Nadine,17,12,0,0,0,0,1,3.586
+Spring 2024,NURS,4211,1,14984,Mental Health Concepts of Care,Schrader,Patricia K,2,19,0,0,0,0,1,3.095
+Spring 2024,NURS,4213,1,14985,Mental Health Clinical,Smith,Deborah Ann,20,1,0,0,0,0,1,3.952
+Spring 2024,NURS,3314,1,14986,Pharmacology,Kleinhans,Alicia Diane,4,24,0,1,0,0,1,3.069
+Spring 2024,ENTR,3312,7,14987,Corporate Entrepreneurship,Lish,Alan D,19,44,17,5,4,0,5,2.72
+Spring 2024,LAW,7308,1,14989,WRS: Scientific Evidence Law,Sanders,Joseph,4,6,0,0,0,0,0,3.4
+Spring 2024,CHEM,1111,36,14990,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,11,0,0,1,0,4,2.858
+Spring 2024,EDUC,4512,1,14992,Student Teaching - Elementary,Culpepper,Shea Mosley,95,3,0,0,0,0,0,3.919
+Spring 2024,EDUC,4511,1,14993,Student Teaching - Elementary,Thompson,Amber M,63,3,2,0,0,0,1,3.883
+Spring 2024,COSC,8398,101,14995,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,102,14996,Doctoral Research,Chen,Guoning,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,103,14997,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Spring 2024,COSC,8398,106,15000,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,
+Spring 2024,COSC,8398,107,15001,Doctoral Research,Eick,Christoph F,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,109,15003,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,2,0,
+Spring 2024,COSC,8398,113,15007,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,115,15009,Doctoral Research,Leiss,Ernst L,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,118,15012,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,122,15016,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,124,15018,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,127,15021,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,2,0,
+Spring 2024,COSC,8398,128,15022,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Spring 2024,COSC,8398,129,15023,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Spring 2024,COSC,8398,130,15024,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Spring 2024,COSC,8698,101,15026,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,102,15027,Doctoral Research,Chen,Guoning,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,103,15028,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Spring 2024,COSC,8698,112,15037,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,117,15042,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,
+Spring 2024,COSC,8698,119,15044,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,120,15045,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,122,15047,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,124,15049,Doctoral Research,Shah,Shishir,0,0,0,0,0,2,0,
+Spring 2024,COSC,8698,126,15051,Doctoral Research,Solorio Martinez,Thamar Ivette,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,127,15052,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,128,15053,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,129,15054,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Spring 2024,COSC,8698,130,15055,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,102,15058,Doctoral Research,Chen,Guoning,0,0,0,0,0,2,0,
+Spring 2024,COSC,8998,103,15059,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,106,15062,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,107,15063,Doctoral Research,Eick,Christoph F,0,0,0,0,0,2,0,
+Spring 2024,COSC,8998,112,15068,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,114,15070,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,117,15073,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,118,15074,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,120,15076,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,0,0,
+Spring 2024,COSC,8998,122,15078,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,2,0,
+Spring 2024,COSC,8998,125,15081,Doctoral Research,Shi,Weidong,0,0,0,0,0,3,0,
+Spring 2024,COSC,8998,128,15084,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,3,0,
+Spring 2024,COSC,8998,129,15085,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Spring 2024,COSC,8998,130,15086,Doctoral Research,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Spring 2024,COSC,8998,131,15087,Doctoral Research,Wu,Panruo,0,0,0,0,0,1,0,
+Spring 2024,COSC,8399,109,15096,Doctoral Dissertation,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Spring 2024,COSC,8399,117,15104,Doctoral Dissertation,Merchant,Fatima Aziz,1,0,0,0,0,1,0,3.67
+Spring 2024,COSC,8399,119,15106,Doctoral Dissertation,Ordonez,Carlos,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,8399,122,15109,Doctoral Dissertation,Pavlidis,Ioannis T,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,8399,125,15112,Doctoral Dissertation,Shi,Weidong,0,0,0,0,0,1,0,
+Spring 2024,COSC,8399,126,15113,Doctoral Dissertation,Solorio Martinez,Thamar Ivette,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,8399,130,15117,Doctoral Dissertation,Vilalta,Ricardo,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,8699,109,15127,Doctoral Dissertation,Gnawali,Omprakash D,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,6398,107,15156,Special Problems,Eick,Christoph F,0,0,0,0,0,1,0,
+Spring 2024,COSC,6398,109,15158,Special Problems,Gnawali,Omprakash D,0,0,0,0,0,2,0,
+Spring 2024,COSC,6398,113,15162,Special Problems,Johnsson,Lennart,0,0,0,0,0,1,0,
+Spring 2024,COSC,6398,118,15167,Special Problems,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Spring 2024,COSC,6398,125,15174,Special Problems,Shi,Weidong,0,0,0,0,0,1,0,
+Spring 2024,COSC,6398,127,15176,Special Problems,Subhlok,Jaspal,0,0,0,0,0,1,0,
+Spring 2024,COSC,6398,128,15177,Special Problems,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Spring 2024,COSC,6398,130,15179,Special Problems,Vilalta,Ricardo,0,0,0,0,0,2,0,
+Spring 2024,MUSA,6204,2,15184,Conducting,Weber,Mary E,4,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,1102,4,15185,Intro to Climate Change Lab,Wang,Yuxuan,13,7,1,2,1,0,0,3.153
+Spring 2024,ARLD,3300,1,15186,Intro to Arts Administration,Wilson,Paula Michelle,8,9,8,0,0,0,0,3.053
+Spring 2024,MUSA,1334,2,15187,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,1,4.0
+Spring 2024,COMD,7392,1,15190,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,3,1,0,0,0,0,0,3.668
+Spring 2024,CHEE,3462,1,15195,Unit Operations,Zerze,Hasan,35,3,0,0,0,0,2,3.739
+Spring 2024,PHOP,6667,11,15210,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6667,12,15212,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2024,HDFS,4315,3,15216,Culture and Diversity,Hall,Juanita J,26,6,3,0,0,0,0,3.553
+Spring 2024,ENGL,8699,1,15218,Doctoral Dissertation,Davies,Daniel,0,0,0,0,0,1,0,
+Spring 2024,COMM,1303,2,15220,Writing for Communicators,Lyn,Robyn,51,13,7,1,11,0,9,3.112
+Spring 2024,ARTH,7399,3,15222,Master's Thesis,Koontz,Rex A,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2340,1,15224,Applied Trumpet,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,4363,1,15226,Concrete Design,Belarbi,Abdeldjelil,11,24,14,4,2,0,0,2.655
+Spring 2024,PHAR,5681,4,15228,Infectious Diseases,Sofjan,Amelia Kartikasari,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4442,2,15229,Applied French Horn,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,6111,4,15230,Graduate Research Seminar,Li,Xingpeng,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,1,15235,Graduate Research,Chatterjee,Sreya,0,0,0,0,0,1,0,
+Spring 2024,CUIN,4361,4,15238,Second Language Methodology,Burgess,Miguel,26,1,0,0,0,0,0,3.963
+Spring 2024,NUTR,6312,1,15239,Capstone II,Haubrick,Kevin,5,6,0,0,0,0,0,3.515
+Spring 2024,NUTR,6311,1,15240,Capstone I,Haubrick,Kevin,1,0,0,0,0,0,0,3.67
+Spring 2024,HDFS,2314,8,15241,Human Dev and Interventions,Dunsmore,Julie C,17,12,9,3,0,0,3,3.033
+Spring 2024,SOCW,8399,4,15243,Dissertation,Leung,Yuk-Hi Patrick,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8398,1,15246,Doctoral Dissertation Research,Aparasu,Rajender R,2,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8298,3,15247,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2334,2,15248,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6309,1,15251,Mathematical Biology,Azevedo,Ricardo,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,3330,2,15252,Beg Creative Writing-Fiction,Repass,Scott,10,6,1,0,2,0,0,3.141
+Spring 2024,PHCA,8298,5,15254,Doctoral Dissertation Research,Thornton,James D,2,0,0,0,0,0,0,4.0
+Spring 2024,EGRP,1150,2,15256,Engineering Applications VI,Luna Singh,Jennifer Austin,0,0,0,0,0,9,0,
+Spring 2024,ENGL,2330,2,15258,Writing Discipline English,Gonzalez,Maria C,8,8,0,0,2,0,1,2.983
+Spring 2024,MUSA,8243,2,15259,Doctoral Lecture Recital,Koozin,Timothy,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8999,2,15260,Doctoral Dissertation,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,6390,1,15261,Applied Project,Ni,Lan,0,0,0,0,0,3,0,
+Spring 2024,ENGI,1331,7,15263,Computing for Engineers,Luna Singh,Jennifer Austin,29,11,11,1,2,0,7,3.179
+Spring 2024,CUIN,8398,3,15264,Independent Study,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,7,15266,Doctoral Applied Music,Robinson,Daryl Allen,2,0,0,0,0,0,0,4.0
+Spring 2024,EGRP,1142,1,15270,Engineering Applications V,Luna Singh,Jennifer Austin,0,0,0,0,0,10,0,
+Spring 2024,SPAN,8699,12,15275,Dissertation,Kanellos,Nicolas,0,0,0,0,0,2,0,
+Spring 2024,CHEM,6498,10,15276,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8298,27,15277,Doctoral Research,Li,Zhengwei,0,0,0,0,0,2,0,
+Spring 2024,MUSA,8243,4,15279,Doctoral Lecture Recital,Bertagnolli,Paul A,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,3317,2,15281,Multimedia Journalism,Roth,Geoffrey,14,1,1,0,0,0,0,3.792
+Spring 2024,HIST,6380,1,15283,Public History Internship,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4440,2,15284,Applied Trumpet,Vassallo,Jim Cates,2,0,0,0,1,0,0,2.557
+Spring 2024,PCOL,6498,2,15293,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Spring 2024,PHLA,6100,1,15295,Leadership Seminar,Garey,Kevin W,14,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8999,3,15296,Doctoral Dissertation,O'Connor,Daniel Patrick,0,0,0,0,0,1,0,
+Spring 2024,PHAR,5675,3,15297,Disease State Management,Gee,Jodie Sue,3,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6398,12,15299,Special Problems,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Spring 2024,MUSA,4434,3,15300,Applied Clarinet,Griffin,Randall S,3,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,1112,66,15302,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,2,0,0,0,1,3.056
+Spring 2024,COSC,4370,1,15305,Interactive Computer Graphics,Deng,Zhigang,40,24,4,0,1,0,2,3.469
+Spring 2024,BIOE,8598,24,15306,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Spring 2024,COSC,4331,1,15307,Real-Time Syst & Embedded Prog,Cheng,Albert M K,8,15,7,1,0,0,16,2.957
+Spring 2024,COMM,6390,3,15308,Applied Project,Vardeman,Jennifer E,0,0,0,0,0,1,0,
+Spring 2024,WGSS,2350,10,15311,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,3,1,0,0,0,0,3.844
+Spring 2024,CUIN,8699,9,15313,Doctoral Dissertation,McNeil,Sara G,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8243,5,15314,Doctoral Lecture Recital,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,8399,3,15316,Doctoral Dissertation,Alarcon,Jeannette Driscoll,0,0,0,0,0,1,0,
+Spring 2024,CUIN,8699,4,15317,Doctoral Dissertation,Lee,Mimi Miyoung,0,0,0,0,0,2,0,
+Spring 2024,WGSS,2350,2,15318,Intro To Women's Studies,Pegoda,Andrew Joseph,5,5,10,1,4,0,4,2.174
+Spring 2024,MUSA,3402,1,15320,Applied Composition,Smith,Robert Thomas,0,1,0,0,0,0,0,2.67
+Spring 2024,COMM,6390,4,15321,Applied Project,Olson,Beth M,0,0,0,0,0,1,0,
+Spring 2024,PHCA,8198,1,15322,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8398,3,15326,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,1502,7,15327,Elementary Spanish II,Mejia Lara,Airy Sindik,10,9,4,0,2,0,1,2.987
+Spring 2024,SPAN,2311,2,15329,Intermediate Spanish I,Gellon,Sofia,3,8,4,0,1,0,4,2.771
+Spring 2024,BZAN,6310,3,15330,Quant Analysis for Busn Dec,Hou,Jinghui,72,7,1,0,0,0,0,3.863
+Spring 2024,MATH,8698,25,15332,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,3,0,
+Spring 2024,ARTH,4399,1,15333,Senior Honors Thesis,Harren,Natilee O,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,8398,5,15334,Independent Study,Lee,Mimi Miyoung,1,0,0,0,0,0,1,4.0
+Spring 2024,MUSA,2332,1,15335,Applied Oboe,Dinitz,Adam L,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6359,7,15336,Directed Rsch in Clinical Psyc,Walker,Rheeda L,0,0,0,0,0,1,0,
+Spring 2024,BIOL,7124,2,15339,Cell Biology Seminar,Dauwalder,Brigitte,0,0,0,0,0,6,0,
+Spring 2024,EGRP,1170,2,15344,Engineering Applications IX,Luna Singh,Jennifer Austin,0,0,0,0,0,7,0,
+Spring 2024,CUIN,8398,6,15346,Independent Study,Cole,Mikel Walker,1,0,0,0,0,0,0,4.0
+Spring 2024,MUED,4340,2,15350,Elem/Middle Schl Inst. Admin.,Hansen,Erin Melissa,1,1,0,0,0,0,0,3.5
+Spring 2024,MUSI,8106,4,15351,Doctoral Large Ensemble,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,4399,1,15356,Senior Honors Thesis,Hernandez,Jose A,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,8699,5,15357,Doctoral Dissertation,Alarcon,Jeannette Driscoll,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6298,2,15358,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Spring 2024,CUIN,8699,3,15363,Doctoral Dissertation,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8243,8,15364,Doctoral Lecture Recital,Dirst,Matthew C,1,0,0,0,0,0,0,4.0
+Spring 2024,NSS,4345,1,15367,Capstone - Nat. Sec. Studies,Vardy,Ronald V,4,5,2,2,0,0,4,2.77
+Spring 2024,POLS,3310,1,15369,Intro to Political Theory,Church,Jeffrey,107,30,11,0,3,0,3,3.55
+Spring 2024,POLS,3318,1,15370,Intro To Public Policy,Cortina,Jeronimo,19,10,6,3,1,0,1,3.06
+Spring 2024,SOCW,7329,1,15373,SW Practice for Policy Change,Ortiz,Lillian Aguirre,10,1,0,0,0,0,0,3.909
+Spring 2024,SOCW,6305,1,15374,Social Work Research,Boyd,Reiko K,22,2,1,0,0,0,0,3.84
+Spring 2024,SOCW,6305,2,15375,Social Work Research,Boyd,Reiko K,21,3,1,1,0,0,0,3.692
+Spring 2024,SOCW,6305,3,15376,Social Work Research,Leung,Yuk-Hi Patrick,19,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7310,1,15377,Program Planning & Evaluation,Foster,Charday D,17,0,0,0,0,0,1,4.0
+Spring 2024,SOCW,6307,1,15378,Policy in the Soc Environment,Parker,Jamie Lynne,19,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,6307,2,15379,Policy in the Soc Environment,Powell,Torey Ian,23,3,0,0,0,0,0,3.885
+Spring 2024,SOCW,6307,3,15380,Policy in the Soc Environment,Aquino-Adriatico,Gabrielle Alanna,25,0,0,0,0,0,0,4.0
+Spring 2024,ENGI,1331,8,15381,Computing for Engineers,Kowal,Marsha Christine,28,12,4,1,0,0,3,3.438
+Spring 2024,SOCW,7301,2,15382,Confronting Oppression & Injus,Barthelemy,Juan,24,1,0,0,0,0,0,3.96
+Spring 2024,PHAR,5169,1,15384,Module Related Skills Lab IV,Surati,Dhara Divyang,63,39,6,0,0,0,0,3.528
+Spring 2024,PHAR,5367,1,15385,Integrated Heme/Onc Module,Trivedi,Meghana,26,62,20,0,0,0,0,3.056
+Spring 2024,PHAR,5368,1,15386,Integrated Psychiatric Module,Tejada-Simon,Maria Victoria,23,62,23,0,0,0,0,3.0
+Spring 2024,PHAR,5269,1,15387,Complex Problems,Fernandez,Julianna M,37,57,14,0,0,0,0,3.213
+Spring 2024,PHAR,5266,1,15388,Pharmacy Law,Tolleson,Shane Russell,41,54,13,0,0,0,0,3.259
+Spring 2024,GHL,3440,1,15391,Hotel Operations,Cheatham,Cathy A,24,12,6,2,0,0,0,3.318
+Spring 2024,ECON,3385,1,15393,Economics of Energy,Hirs,Edward A,27,10,0,0,0,0,9,3.676
+Spring 2024,ECON,3362,1,15394,Mathematics for Economics,Saboury,Piruz,10,6,0,0,0,0,4,3.584
+Spring 2024,ECON,7331,1,15396,Econometrics I,Sorensen,Bent E,6,3,1,0,0,0,0,3.533
+Spring 2024,HON,4330,1,15397,Narratives in the Professions,Reynolds,Aaron E,25,1,0,0,0,0,0,3.962
+Spring 2024,HON,3350,1,15399,Principles of Data and Society,Kapral,Andrew J,10,1,0,0,0,0,0,3.849
+Spring 2024,HON,4350,1,15400,Data and Society in Practice,Konstantinidis,Ioannis,5,1,0,0,0,0,1,3.778
+Spring 2024,COMD,1333,1,15401,Intro to Comm Sci & Disorders,Ross,Byron L,7,8,11,1,1,0,2,2.631
+Spring 2024,POLC,6342,1,15402,Pol Econ & Ethics of Market Pr,Granato,James S,5,3,0,0,0,0,0,3.625
+Spring 2024,ILAS,4350,1,15403,Interdisciplinary Problem Solv,Oliva,Luca,18,2,5,0,2,0,1,3.271
+Spring 2024,ARCH,1501,22,15404,Arc/Int Arc Design Studio II,Lee,Seo Hee,3,4,2,0,0,0,4,3.148
+Spring 2024,POLC,4342,2,15406,Pol Econ and Ethics of Market,Granato,James S,3,12,7,1,0,0,1,2.753
+Spring 2024,BIOL,4315,2,15407,Neuroscience,Ziburkus,Jokubas,88,38,23,1,0,0,3,3.387
+Spring 2024,BIOL,6315,1,15408,Neuroscience,Ziburkus,Jokubas,5,2,1,0,0,0,0,3.459
+Spring 2024,HON,3332,1,15409,Mapping Success,Rayder,Benjamin Taylor,9,2,0,0,1,0,0,3.5
+Spring 2024,HON,3132,1,15410,Mapping Success,Rayder,Benjamin Taylor,10,0,0,0,0,0,0,3.967
+Spring 2024,ARCH,5500,23,15413,Architecture Design Studio IX,Rogers,Susan,9,5,0,0,0,0,0,3.525
+Spring 2024,ARCH,5500,25,15415,Architecture Design Studio IX,Brune,Geoffrey,8,5,2,0,0,0,0,3.356
+Spring 2024,SPAN,2311,4,15417,Intermediate Spanish I,Miranda Moreno,Sujaila Abigail,6,9,6,1,2,0,2,2.68
+Spring 2024,SPAN,2311,5,15418,Intermediate Spanish I,Miranda Moreno,Sujaila Abigail,8,10,5,0,0,0,4,3.159
+Spring 2024,SPAN,1501,7,15419,Elementary Spanish I,Gellon,Sofia,9,9,5,0,2,0,0,2.973
+Spring 2024,SPAN,1501,9,15421,Elementary Spanish I,Borroto Lopez,Cecilia De La Caridad,5,16,3,0,1,0,0,2.947
+Spring 2024,SPAN,1501,15,15423,Elementary Spanish I,Torres-Calle,Maria Jose,7,4,4,0,2,0,1,2.785
+Spring 2024,SPAN,1501,19,15425,Elementary Spanish I,Serrano,Paloma A,5,8,2,0,2,0,2,2.785
+Spring 2024,MANA,6383,1,15427,Strategic Managment,Carlin,Barbara A,4,4,0,0,0,0,0,3.5
+Spring 2024,INDE,6378,1,15429,Case Study in Applied Inde Erg,Irani,Shahrukh A,15,2,0,0,0,0,0,3.824
+Spring 2024,CHEM,7325,1,15431,Surface Science,Baldelli,Steve,10,2,0,0,0,0,0,3.668
+Spring 2024,WCL,2370,2,15435,Cultures of India,Tiwari,Bhavya,2,7,0,0,1,0,0,2.768
+Spring 2024,WCL,3366,3,15436,Latin American and Latino Film,Ramirez,Marie Theresa,17,8,6,3,0,0,0,3.128
+Spring 2024,INDS,1501,3,15437,Industrial Design Studio II,Jackson,Megan H,1,4,1,0,1,0,1,2.619
+Spring 2024,PETR,6326,1,15440,Applied Reservoir Simulation,Rietz,Dean C,3,2,6,0,0,0,0,2.607
+Spring 2024,HON,2341,1,15441,Classics of Modernity,Barnes,Michael,10,0,0,0,0,0,0,3.934
+Spring 2024,HON,2341,2,15442,Classics of Modernity,Barnes,Michael,11,1,0,0,0,0,1,3.944
+Spring 2024,MATH,4322,1,15443,Data Science and Machine Learn,Poliak,Cathy Dawn,83,13,3,0,1,0,0,3.754
+Spring 2024,MATH,1100,1,15446,Developmental Math,Leger,Nicholas M,0,0,0,0,0,69,11,
+Spring 2024,GEOL,7301,2,15448,Capstone Project,Van Nieuwenhuise,Donald S,4,1,0,0,0,0,0,3.734
+Spring 2024,BCHS,4355,1,15449,Eukaryotic Gene Regulation,Schwartz,Robert J,10,2,0,0,0,0,0,3.833
+Spring 2024,PHYS,4360,1,15451,Space and Atmospheric Physics,Bering,Edgar A,10,2,0,0,0,0,0,3.778
+Spring 2024,ELCS,8399,4,15457,Doctoral Dissertation,Butcher,Keith,0,0,0,0,0,0,0,
+Spring 2024,ELCS,8699,4,15459,Doctoral Dissertation,McKinney,Lonnie Lyle,1,0,0,0,0,1,0,4.0
+Spring 2024,ELCS,8331,1,15460,Finance in Higher Education,Louis,Dave A,4,1,0,0,0,0,0,3.8
+Spring 2024,MATH,3338,2,15461,Probability,Fu,Wenjiang,11,16,3,2,1,0,8,3.05
+Spring 2024,MATH,6359,2,15462,Appl. Stat. & Mult. Analysis,Poliak,Cathy Dawn,6,0,0,0,0,0,0,3.945
+Spring 2024,PHLS,7393,3,15463,Internship and Practicum,Hassett,Kristen Spring,5,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4311,1,15467,Close Relationships,Derrick,Jaye L,38,10,1,0,0,0,0,3.62
+Spring 2024,ENGI,1331,9,15468,Computing for Engineers,Burleson,Daniel W,22,19,6,0,2,0,5,3.218
+Spring 2024,ENGI,1331,10,15469,Computing for Engineers,Luna Singh,Jennifer Austin,7,3,3,0,0,0,2,3.409
+Spring 2024,ARLD,6315,1,15470,PR & Marketing for Arts,Luks Jacobs,Joel,9,0,0,0,0,0,0,4.0
+Spring 2024,HIST,1302,3,15472,The U.S. Since 1877,Amaral,Lindsay Nicole,165,74,26,9,25,0,25,3.115
+Spring 2024,PHAR,5662,2,15473,Academic Scholarship,Surati,Dhara Divyang,2,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5662,5,15474,Academic Scholarship,Trivedi,Meghana,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,3318,1,15476,The British Novel Since 1832,Chatterjee,Sreya,11,4,0,0,0,0,1,3.623
+Spring 2024,ENGL,4319,1,15478,English in Secondary Schools,Wingard,Jennifer L,25,3,0,0,1,0,0,3.724
+Spring 2024,ENGL,4394,1,15480,The Historical Novel,Zamora,Lois,7,6,6,1,2,0,1,2.562
+Spring 2024,CUIN,4304,1,15481,La/Read Meth in Span,Burgess,Miguel,10,0,0,0,0,0,0,4.0
+Spring 2024,MARK,4379,2,15482,Personal Branding,Muschalik,Monica Harper,22,4,0,0,0,0,0,3.846
+Spring 2024,MANA,6A32,4,15483,Organizational Behavior & Mgt,Krylova,Ksenia O,17,5,0,0,1,0,0,3.594
+Spring 2024,COSC,6384,1,15484,Real-Time Systems,Cheng,Albert M K,3,2,0,0,0,0,4,3.534
+Spring 2024,COSC,6372,1,15485,Computer Graphics,Deng,Zhigang,4,0,0,0,0,0,1,4.0
+Spring 2024,MATH,1342,2,15488,Elementary Statistical Methods,Chern,Haley Nicole,62,132,112,28,26,0,58,2.456
+Spring 2024,ELED,3322,5,15489,Elem Reading Phonics Instructn,Alba,Celeste,26,1,0,0,0,0,0,3.926
+Spring 2024,MANA,7356,2,15490,Inclusive Leadership,Fernandez,Alejandro,12,0,0,0,0,0,0,4.0
+Spring 2024,MANA,7334,1,15491,Learning Sys &Mgmt Development,Bozeman,Dennis,3,5,3,1,0,0,1,2.916
+Spring 2024,BUSI,2305,1,15492,Business Statistics,Patterson,Staci A,132,144,100,88,26,0,82,2.485
+Spring 2024,BUSI,2305,2,15493,Business Statistics,Patterson,Staci A,142,104,114,82,20,0,110,2.554
+Spring 2024,GHL,3353,1,15496,Hosp Metrics & Data Analytics,Li,Ningqiao,9,4,0,0,0,0,0,3.718
+Spring 2024,GHL,4360,1,15497,Professional Development,Kenyan,Erin Oeser,61,13,1,0,3,0,0,3.603
+Spring 2024,GHL,6324,1,15498,Hosp. Busn Strategies in Amer,Kim,Jaewook,8,0,0,0,0,0,0,4.0
+Spring 2024,GHL,7334,1,15499,Pricing & Revenue Mgmt in Hosp,Kazemi Zarkouei,Mohammad Sadegh,7,0,2,0,0,0,0,3.519
+Spring 2024,GHL,6340,1,15500,Behavior and Hosp. Lead. Strat,Guchait,Priyanko,8,0,0,0,0,0,0,4.0
+Spring 2024,MATH,3339,4,15501,Statistics for the Sciences,Cao,Jian,11,8,11,5,10,0,6,2.104
+Spring 2024,ATP,6324,1,15502,Healthcare Administration,Knoblauch,Mark Alan,9,6,0,0,0,0,0,3.6
+Spring 2024,GHL,6317,1,15504,Innovative Hosp. Technologies,Lee,Minwoo,8,0,0,0,0,0,0,3.918
+Spring 2024,MANA,4346,2,15505,Leadership Development,Evans,Klavdia Markelova,50,6,3,1,0,0,0,3.673
+Spring 2024,MANA,4350,2,15506,International Management,Celly,Nikhil,56,3,1,0,0,0,0,3.917
+Spring 2024,MANA,4341,1,15507,Leading Organizational Change,Evans,Klavdia Markelova,46,7,4,2,0,0,0,3.616
+Spring 2024,MANA,4331,2,15508,Current Issues Human Res Mgmt,Walker,William A,9,1,3,0,0,0,1,3.385
+Spring 2024,MANA,4330,3,15509,Intro to Strategic HR Mgt,Sebastijanovic,Marina,26,24,7,1,0,0,2,3.333
+Spring 2024,MANA,4358,1,15510,Compensation and Benefits,Zamanipour,Tina,40,16,2,0,0,0,1,3.655
+Spring 2024,BUSI,2305,4,15511,Business Statistics,Wiley,Briceon C,36,6,6,0,0,0,4,3.529
+Spring 2024,BZAN,6350,1,15512,Quant Found for Busi Analytics,Wang,Cheng,8,0,0,0,0,0,0,4.0
+Spring 2024,BZAN,6353,1,15513,Res Design-Probs Busi Anlytcs,Aron,Ravi,6,23,0,0,0,0,0,3.207
+Spring 2024,BUSI,3300,1,15514,Intro to Personal Finance,Munchbach,Jim,44,6,0,0,1,0,4,3.791
+Spring 2024,BUSI,3300,2,15515,Intro to Personal Finance,Munchbach,Jim,41,5,1,0,1,0,2,3.688
+Spring 2024,BUSI,3300,3,15516,Intro to Personal Finance,Harvey,Danny,52,2,1,0,0,0,0,3.927
+Spring 2024,MIS,4378,3,15517,Admin of Computer-Based MIS,Kniffen,Richard Chad,12,35,6,0,0,0,0,3.113
+Spring 2024,BCIS,1305,1,15518,Business Computer Applications,Felvegi,Emese,182,40,18,2,2,0,3,3.623
+Spring 2024,BCIS,1305,2,15519,Business Computer Applications,Felvegi,Emese,145,54,28,5,7,0,10,3.343
+Spring 2024,BCIS,1305,3,15520,Business Computer Applications,Felvegi,Emese,25,0,0,0,0,0,1,4.0
+Spring 2024,PHOP,6160,2,15521,Gen Sem Visual Sciences,Sapoznik,Kaitlyn Anne,0,0,0,0,0,26,0,
+Spring 2024,PHOP,7241,2,15522,Pathophysiology of the Eye,Harrison,Wendy W,6,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,7242,2,15523,Visual Neuroscience,Das,Vallabh E,5,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,7243,2,15524,Optics and the Eye,Porter,Jason,4,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6371,3,15525,Experimental Design in VS,Burns,Alan R,17,0,0,0,0,0,0,3.806
+Spring 2024,FINA,4353,2,15527,Practicum Pers Finan Planning,Lopez,John C,7,9,1,0,0,0,0,3.469
+Spring 2024,FINA,4382,1,15528,Developing R E Project,Williams,Junious E,27,7,3,0,2,0,1,3.478
+Spring 2024,SCM,7335,1,15529,Logistics Management,Robinson Jr,Powell Ersell,11,18,0,0,0,0,0,3.3
+Spring 2024,SCM,7385,1,15530,Supply Chain Corp Projects,Smith,Gordon D,8,0,0,0,0,0,0,4.0
+Spring 2024,FINA,7383,1,15531,R E MKT Analysis & Valuation,Witte,Jerome,8,0,0,0,0,0,0,3.959
+Spring 2024,FINA,4323,1,15532,Investment & Mutual Fund Mgt,Blanchfield,Craig,34,17,3,0,0,0,0,3.635
+Spring 2024,BUSI,3302,1,15533,Connecting Bauer to Business,Belinne,Jamie King,363,32,11,2,1,0,5,3.844
+Spring 2024,BUSI,3302,2,15534,Connecting Bauer to Business,Belinne,Jamie King,246,53,19,3,3,0,5,3.654
+Spring 2024,BUSI,4350,1,15535,Business Law and Ethics,Currie,Daniel David,231,37,4,2,0,0,0,3.751
+Spring 2024,BUSI,4350,2,15536,Business Law and Ethics,Williams,John M,211,47,12,2,0,0,2,3.688
+Spring 2024,BUSI,4350,3,15537,Business Law and Ethics,Williams,John M,116,48,7,3,6,0,7,3.428
+Spring 2024,BUSI,4350,4,15538,Business Law and Ethics,Williams,John M,81,22,3,1,0,0,0,3.649
+Spring 2024,BUSI,4350,5,15539,Business Law and Ethics,Williams,John M,29,13,2,1,1,0,0,3.464
+Spring 2024,PHYS,1301,3,15540,College Physics I (lecture),Portillo Vazquez,Israel,7,7,6,5,2,0,8,2.42
+Spring 2024,PHYS,1301,6,15541,College Physics I (lecture),McElhenny,Brian Patrick,40,59,58,13,10,0,33,2.53
+Spring 2024,MANA,4353,2,15542,Mgmt Training and Career Devel,Shumate,Lisa T,22,3,0,0,0,0,0,3.774
+Spring 2024,KIN,1304,2,15545,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,263,22,1,0,0,0,1,3.929
+Spring 2024,KIN,1304,3,15546,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,238,18,1,3,5,0,3,3.83
+Spring 2024,KIN,1304,4,15547,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,52,5,1,0,2,0,0,3.767
+Spring 2024,MANA,3335,9,15551,Intro Org Behavior and Mgmt,Currie,Daniel David,127,26,3,1,0,0,2,3.727
+Spring 2024,BUSI,1301,1,15552,Business Principles,Thompson,Joseph Lee,116,1,1,0,1,0,2,3.938
+Spring 2024,BUSI,1301,2,15553,Business Principles,Thompson,Joseph Lee,193,18,1,3,7,0,2,3.733
+Spring 2024,COMM,2311,5,15554,Writing for Print and Digital,Crixell,Charles A,35,15,1,0,1,0,0,3.596
+Spring 2024,COMM,2311,9,15555,Writing for Print and Digital,Butler,Bryan C,11,10,2,0,0,0,1,3.248
+Spring 2024,BUSI,1301,3,15557,Business Principles,Thompson,Joseph Lee,24,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7338,1,15558,CDLNeuropsych: Assess/App II,Cirino,Paul,4,1,0,0,0,0,0,3.8
+Spring 2024,KIN,4315,2,15559,Motor Learning and Control,Park,Seoung Hoon,35,7,1,0,0,0,2,3.775
+Spring 2024,COMM,2311,11,15560,Writing for Print and Digital,Roth,Geoffrey,15,5,1,0,2,0,2,3.333
+Spring 2024,COMM,2311,13,15562,Writing for Print and Digital,Radcliffe Andre,Jennifer,15,5,3,0,0,0,2,3.436
+Spring 2024,MARK,4380,1,15564,Digital Selling,Habel,Johannes,14,12,0,0,0,0,0,3.386
+Spring 2024,MANA,4355,3,15567,Selection and Staffing,Belinne,Jamie King,16,1,0,0,0,0,0,3.902
+Spring 2024,COMM,3301,1,15568,Doctor-Patient Interaction,Yamasaki,Jill S,40,10,6,2,0,0,0,3.477
+Spring 2024,COMM,3311,2,15569,Editing Print & Digital Media,Crixell,Charles A,10,8,2,0,0,0,0,3.433
+Spring 2024,COMM,3311,3,15570,Editing Print & Digital Media,Crixell,Charles A,9,12,4,0,0,0,0,3.187
+Spring 2024,CHEM,1305,3,15575,Foundations of Chemistry,St Hill,Lydia Ruth,7,2,15,8,8,0,24,1.726
+Spring 2024,BIOE,4150,3,15576,Genomic & Proteomic Lab,Akay,Yasemin M,12,1,0,0,0,0,0,3.923
+Spring 2024,BIOE,4150,4,15577,Genomic & Proteomic Lab,Akay,Yasemin M,6,4,0,0,0,0,0,3.732
+Spring 2024,BIOE,3340,2,15578,Quantitative Physiology,Roh,Jinsook,0,1,1,0,0,0,0,2.335
+Spring 2024,CUIN,4375,10,15579,Classroom Management,Mateer,Ramona Caravella,10,4,1,0,0,0,0,3.534
+Spring 2024,EDUC,4315,2,15580,Student Teaching Sec,Evans,Paige K,26,3,0,0,0,0,0,3.908
+Spring 2024,PHYS,3112,1,15581,Modern Optics Laboratory,Forrest,Rebecca L,9,1,2,0,0,0,0,3.556
+Spring 2024,PHYS,3313,1,15582,Advanced Laboratory I,Timmins,Anthony Robert,9,2,0,0,0,0,2,3.758
+Spring 2024,ECON,6395,1,15584,Wkshp Res Method II,Prokopovych,Pavlo,2,2,0,0,0,0,0,3.5
+Spring 2024,SOC,3301,1,15585,Intro to Sociological Research,Savage,Scott Vandenburgh,7,10,0,0,0,0,1,3.354
+Spring 2024,COMM,3328,1,15586,Intro to Sports Production,Crowe,Craig Warren,26,3,1,0,0,0,0,3.811
+Spring 2024,BUSI,4335,1,15587,Brainstorming to Bankrolling,Khumawala,Saleha B,9,3,1,0,0,0,0,3.514
+Spring 2024,THEA,2373,1,15588,Costume Technology,Niederer,Barbara,7,4,3,0,0,0,0,3.144
+Spring 2024,BUSI,1301,5,15590,Business Principles,Carvalho,Diogo,158,47,24,8,7,0,4,3.365
+Spring 2024,BUSI,1301,6,15591,Business Principles,Carvalho,Diogo,108,52,26,12,8,0,10,3.09
+Spring 2024,PHLS,6312,2,15593,Crisis Counseling,Lee,Jungeun,16,2,0,0,0,0,0,3.871
+Spring 2024,INTB,3355,5,15594,Global Environment of Business,Miljanic,Andra Olivia,146,75,20,5,1,0,3,3.428
+Spring 2024,INTB,3355,7,15595,Global Environment of Business,Farah,Elena,83,32,5,4,0,0,0,3.551
+Spring 2024,COMM,3368,4,15596,Principles of Public Relations,Ni,Lan,26,15,1,0,0,0,0,3.517
+Spring 2024,BIOE,4348,1,15597,Tissue Engineering,Horton,Renita Elillian,0,3,1,0,0,0,0,2.75
+Spring 2024,COMM,3369,4,15598,Strategic Comm. Writing,Rougeau,Rose,8,7,0,0,1,0,1,3.23
+Spring 2024,COMM,3376,1,15599,Media Effects,Archer,Allison Michelle Nam,24,7,1,0,0,0,0,3.564
+Spring 2024,ENGL,2306,3,15601,Intro To Poetry,Griffin,Emelie Marie,21,4,0,0,0,0,0,3.761
+Spring 2024,ENGL,1301,14,15604,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,6,4,2,2,5,0,5,2.158
+Spring 2024,ENGL,1301,21,15605,First Year Writing I,Bose,Godhuly,17,3,0,1,3,0,0,3.223
+Spring 2024,ENGL,1301,28,15606,First Year Writing I,Murray,Christopher Brean,6,3,3,0,2,0,4,2.762
+Spring 2024,ENGL,1301,30,15608,First Year Writing I,Murray,Christopher Brean,9,5,0,1,2,0,2,3.02
+Spring 2024,ENGL,1301,32,15609,First Year Writing I,Murray,Christopher Brean,12,3,0,0,2,0,2,3.314
+Spring 2024,ENGL,1301,36,15611,First Year Writing I,Niu,Catherine,5,4,4,2,0,0,4,2.69
+Spring 2024,ENGL,1301,38,15612,First Year Writing I,Seelen,William,16,0,1,0,0,0,1,3.882
+Spring 2024,ENGL,1301,39,15613,First Year Writing I,Cunningham,Sara Kaplan,6,5,3,1,2,0,2,2.628
+Spring 2024,ENGL,1301,40,15614,First Year Writing I,Hiers,Maria,11,2,2,0,3,0,0,3.018
+Spring 2024,ENGL,1301,44,15615,First Year Writing I,Zachow,Alix V,5,9,2,0,1,0,2,2.961
+Spring 2024,ENGL,1301,46,15616,First Year Writing I,Zachow,Alix V,7,4,2,0,3,0,2,2.585
+Spring 2024,ENGL,1302,19,15617,First Year Writing II,Rolater,Sara C,6,2,6,0,1,0,2,2.734
+Spring 2024,ENGL,1302,20,15618,First Year Writing II,Lopez,Reese D,10,4,3,1,0,0,1,3.131
+Spring 2024,ENGL,1302,21,15619,First Year Writing II,Rolater,Sara C,7,8,1,0,1,0,2,3.157
+Spring 2024,ENGL,1302,22,15620,First Year Writing II,Bellomy,Charlotte Seychelles,16,0,1,1,0,0,1,3.704
+Spring 2024,ENGL,1302,34,15621,First Year Writing II,Kozma,Andrew,15,3,2,0,0,0,5,3.601
+Spring 2024,ENGL,1302,38,15622,First Year Writing II,Yates,Kaitlyn,15,6,2,1,1,0,0,3.294
+Spring 2024,ENGL,1302,39,15623,First Year Writing II,Yates,Kaitlyn,11,11,0,0,0,0,3,3.485
+Spring 2024,ENGL,1302,40,15624,First Year Writing II,Rolater,Sara C,4,10,4,2,1,0,4,2.588
+Spring 2024,ENGL,1302,41,15625,First Year Writing II,Rolater,Sara C,6,8,4,2,1,0,4,2.762
+Spring 2024,ENGL,1302,43,15626,First Year Writing II,Downey,Carlton M,19,4,0,0,0,0,2,3.84
+Spring 2024,ENGL,1302,44,15627,First Year Writing II,Anderson,Claire F,15,6,0,0,2,0,1,3.391
+Spring 2024,ENGL,1302,45,15628,First Year Writing II,O'Bryan,Ann Patricia,16,6,0,1,1,0,1,3.458
+Spring 2024,ENGL,1302,47,15629,First Year Writing II,O'Bryan,Ann Patricia,19,1,3,0,0,0,1,3.696
+Spring 2024,ENGL,1302,49,15630,First Year Writing II,Anderson,Claire F,17,5,1,0,0,0,2,3.71
+Spring 2024,ENGL,1302,50,15631,First Year Writing II,Sahi,Aishwarya,16,5,0,0,1,0,1,3.531
+Spring 2024,ENGL,1302,51,15632,First Year Writing II,Barr,Anna Kate,14,4,1,0,0,0,0,3.597
+Spring 2024,ENGL,1302,52,15633,First Year Writing II,Al-Bedawi,Layla,12,3,2,0,1,0,1,3.316
+Spring 2024,ENGL,1302,53,15634,First Year Writing II,Barr,Anna Kate,12,5,2,0,0,0,0,3.596
+Spring 2024,ENGL,1302,54,15635,First Year Writing II,Cervantes,Kimberly Ann,18,0,0,1,0,0,0,3.651
+Spring 2024,ENGL,1302,56,15636,First Year Writing II,Rajkumar,Nidhi,16,5,1,0,0,0,3,3.637
+Spring 2024,ENGL,1302,61,15637,First Year Writing II,Jones,Baylea,9,9,3,0,2,0,2,3.014
+Spring 2024,CHEM,1112,5,15638,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,0,0,0,0,1,3.245
+Spring 2024,COMM,2328,3,15639,Broadcast Writing Basics,Baruch Blanco,Maria Felicitas,23,5,1,0,0,0,0,3.679
+Spring 2024,IDNS,1141,1,15641,Chemistry I SEP Workshop,Pattison,Donna,9,17,2,1,0,0,1,3.207
+Spring 2024,IDNS,2112,1,15642,Precalculus SEP Workshop,Pattison,Donna,17,4,2,1,0,0,2,3.569
+Spring 2024,IDNS,1141,2,15643,Chemistry I SEP Workshop,Pattison,Donna,13,6,4,4,0,0,2,3.061
+Spring 2024,IDNS,1141,3,15644,Chemistry I SEP Workshop,Pattison,Donna,13,9,0,1,0,0,7,3.464
+Spring 2024,IDNS,2113,1,15645,Calculus I SEP Workshop,Pattison,Donna,20,4,0,0,0,0,4,3.778
+Spring 2024,IDNS,2113,2,15646,Calculus I SEP Workshop,Pattison,Donna,5,2,4,0,0,0,1,3.061
+Spring 2024,IDNS,1142,1,15647,Chemistry II SEP Workshop,Pattison,Donna,16,10,2,1,1,0,4,3.267
+Spring 2024,IDNS,2114,1,15648,Calculus II SEP Workshop,Pattison,Donna,13,4,1,1,1,0,2,3.35
+Spring 2024,IDNS,1142,2,15649,Chemistry II SEP Workshop,Pattison,Donna,23,9,2,1,0,0,1,3.515
+Spring 2024,IDNS,2114,2,15650,Calculus II SEP Workshop,Pattison,Donna,16,5,2,3,0,0,0,3.32
+Spring 2024,IDNS,1142,3,15651,Chemistry II SEP Workshop,Pattison,Donna,10,7,5,3,1,0,5,2.833
+Spring 2024,IDNS,2114,3,15652,Calculus II SEP Workshop,Pattison,Donna,11,3,1,0,0,0,2,3.645
+Spring 2024,COMM,1307,5,15653,Media and Society,Ashley,Laura B,52,32,12,3,1,0,0,3.307
+Spring 2024,IDNS,1142,4,15654,Chemistry II SEP Workshop,Pattison,Donna,15,10,2,2,0,0,4,3.333
+Spring 2024,IDNS,1142,5,15655,Chemistry II SEP Workshop,Pattison,Donna,21,4,1,1,0,0,3,3.654
+Spring 2024,IDNS,2133,1,15656,Calculus III SEP Workshop,Pattison,Donna,13,1,5,4,1,0,3,2.903
+Spring 2024,COMM,3353,3,15657,Information & Comm Tech I,Liu,Youmei,27,3,2,0,0,0,7,3.781
+Spring 2024,IDNS,1142,6,15658,Chemistry II SEP Workshop,Pattison,Donna,15,7,3,0,0,0,3,3.454
+Spring 2024,IDNS,3121,1,15660,Engineering Math SEP Workshop,Pattison,Donna,9,5,0,2,2,0,2,2.963
+Spring 2024,COMM,4365,2,15661,Digital PR and Advertising,Choi,Ho Joon,33,1,0,0,0,0,0,3.971
+Spring 2024,IDNS,2123,1,15662,Organic Chem I SEP Workshop,Pattison,Donna,12,10,9,4,0,0,3,2.848
+Spring 2024,IDNS,2123,2,15663,Organic Chem I SEP Workshop,Pattison,Donna,15,8,8,1,0,0,5,3.156
+Spring 2024,IDNS,2123,3,15664,Organic Chem I SEP Workshop,Pattison,Donna,21,8,6,1,0,0,2,3.334
+Spring 2024,IDNS,2123,4,15665,Organic Chem I SEP Workshop,Pattison,Donna,13,6,5,2,0,0,4,3.128
+Spring 2024,IDNS,2125,1,15666,Organic Chem II SEP Workshop,Pattison,Donna,8,14,4,2,1,0,0,2.862
+Spring 2024,IDNS,2125,2,15667,Organic Chem II SEP Workshop,Pattison,Donna,13,9,3,1,0,0,2,3.308
+Spring 2024,IDNS,2125,3,15668,Organic Chem II SEP Workshop,Pattison,Donna,15,7,7,1,0,0,4,3.134
+Spring 2024,IDNS,2125,4,15669,Organic Chem II SEP Workshop,Pattison,Donna,17,13,3,1,1,0,0,3.229
+Spring 2024,IDNS,2125,5,15670,Organic Chem II SEP Workshop,Pattison,Donna,17,12,4,1,0,0,4,3.304
+Spring 2024,IDNS,2125,6,15671,Organic Chem II SEP Workshop,Pattison,Donna,16,12,3,0,0,0,4,3.377
+Spring 2024,IDNS,2125,7,15672,Organic Chem II SEP Workshop,Pattison,Donna,21,14,1,0,0,0,0,3.601
+Spring 2024,IDNS,2113,3,15673,Calculus I SEP Workshop,Pattison,Donna,10,6,4,3,1,0,2,2.903
+Spring 2024,IDNS,2114,4,15674,Calculus II SEP Workshop,Pattison,Donna,15,4,1,2,1,0,3,3.319
+Spring 2024,GENB,6A50,1,15676,Business Communications,Pineda,Dalia Rivera,15,2,1,0,0,0,0,3.759
+Spring 2024,ENTR,3342,1,15677,Women in Entrepreneurship,McCormick,Kelly,18,8,6,2,0,0,0,3.206
+Spring 2024,ENTR,7342,1,15678,Women in Entrepreneurship,McCormick,Kelly,3,1,0,0,0,0,1,3.75
+Spring 2024,CHEM,1112,51,15679,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,0,0,0,0,0,3.257
+Spring 2024,CHEE,5323,1,15680,Fundamental of Tissue Engineer,Horton,Renita Elillian,1,1,0,0,0,0,0,3.5
+Spring 2024,HLT,4303,1,15685,The Obesity Epidemic,Olvera,Norma E,21,34,3,1,1,0,0,3.129
+Spring 2024,BUSI,4350,11,15686,Business Law and Ethics,Krylova,Ksenia O,13,7,0,0,0,0,0,3.518
+Spring 2024,MARK,4380,2,15687,Digital Selling,Habel,Johannes,25,4,0,0,0,0,0,3.839
+Spring 2024,ECE,7373,1,15688,Adv Topics in Comp Arch,Fu,Xin,21,35,2,0,0,0,0,3.339
+Spring 2024,NURS,4318,1,15689,High Acuity Concepts of Care,Kleinhans,Alicia Diane,5,33,0,0,0,0,6,3.132
+Spring 2024,NURS,4419,1,15690,High Acuity Clinical,Kleinhans,Alicia Diane,35,3,0,0,0,0,6,3.921
+Spring 2024,NURS,4219,1,15691,Pediatric Concepts of Care,Anderson,Viia,7,31,0,0,0,0,2,3.184
+Spring 2024,NURS,4221,1,15692,Pediatric Clinical,Anderson,Viia,35,3,0,0,0,0,2,3.921
+Spring 2024,BUSI,3300,4,15693,Intro to Personal Finance,Harvey,Danny,53,2,0,0,0,0,0,3.964
+Spring 2024,FINA,4328,2,15694,Principles of Personal Finance,Coleman,Alfred G,30,3,0,0,2,0,0,3.573
+Spring 2024,ACCT,2302,10,15700,Prin of Managerial Accounting,Weber,Catherine K,26,37,30,7,3,0,5,2.783
+Spring 2024,HIST,4366,1,15701,Latin Amer Hist Thru the Novel,Zamora,Lois,1,0,1,0,0,0,2,2.835
+Spring 2024,ACCT,6331,4,15702,Financial Accounting,Li,Bin,6,0,0,0,0,0,0,3.945
+Spring 2024,MARK,6361,2,15703,Marketing Administration,Koch,Steven F,6,0,0,0,0,0,0,4.0
+Spring 2024,HIST,1302,5,15706,The U.S. Since 1877,Amaral,Lindsay Nicole,162,80,32,9,21,0,20,3.141
+Spring 2024,LAW,5222,1,15708,Intro to the Law of Mexico,Pinto-Leon,Ignacio,1,3,0,0,0,3,0,3.415
+Spring 2024,FINA,4330,4,15709,Corporate Finance,Allena,Rohit,11,4,2,0,0,0,0,3.51
+Spring 2024,MUED,3104,1,15712,Strings,Hansen,Erin Melissa,8,6,2,1,0,0,1,3.119
+Spring 2024,LAW,5402,1,15713,Entrpr Community Dev Clinic I,Heard,Christopher D,2,5,0,0,0,0,0,3.38
+Spring 2024,MUED,4231,2,15714,Instrumental Conducting II,Bertman,David Garry,14,3,0,0,0,0,0,3.824
+Spring 2024,PHCA,7320,1,15715,Health Care Systems & Policy,Thornton,James D,0,4,1,0,0,0,0,2.8
+Spring 2024,PHCA,7307,1,15716,Methods & Research Design,Essien,Ekere James,0,2,1,0,0,0,0,2.667
+Spring 2024,SCM,7A01,1,15717,Project Management,Tibodeau,Dale,5,3,0,0,0,0,0,3.543
+Spring 2024,MUSI,1122,1,15718,Concert Chorale,Weber,Mary E,48,2,0,0,0,0,0,3.953
+Spring 2024,PHYS,8398,42,15722,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,1,0,
+Spring 2024,MUSI,1121,2,15726,Concert Chorus,Koppel,Alexander,20,1,0,0,0,0,0,3.937
+Spring 2024,MUSI,6350,2,15727,Applied Music Pedagogy,Van Kekerix,Todd Evan,6,0,0,0,0,0,0,4.0
+Spring 2024,LAW,6240,1,15728,Death Penalty & Crim Appeals,Dow,David R,0,1,0,0,0,1,0,3.33
+Spring 2024,LAW,6213,1,15729,Innocence Investigations,Dow,David R,2,3,0,0,0,0,0,3.4
+Spring 2024,HIST,2368,1,15730,Intro to African Studies,Chery,Tshepo Morongwa,11,14,2,0,2,0,2,3.115
+Spring 2024,LAW,5382,1,15732,Administrative Law,Duke,Brandon W,2,6,0,0,0,1,0,3.374
+Spring 2024,MUSA,1310,2,15733,Applied Piano,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1310,3,15734,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1324,2,15735,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2320,2,15736,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2324,2,15737,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2340,2,15739,Applied Trumpet,Vassallo,Jim Cates,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2346,1,15740,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2350,2,15741,Applied Percussion,Wilkins,Blake M,2,0,0,0,0,0,0,3.835
+Spring 2024,MUSA,3402,2,15742,Applied Composition,Maroney,Marcus K,1,1,0,0,0,0,0,3.5
+Spring 2024,MUSA,3410,3,15743,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3424,2,15744,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,3442,2,15745,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Spring 2024,ARTH,4388,1,15748,Methods of Art History,Nevitt Jr,Hugh R,2,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5218,1,15749,Critical Care Therapeutics,Wanat,Matthew A,68,20,1,0,0,0,0,3.753
+Spring 2024,PHAR,5208,1,15750,Infect Disease Pharmacotherapy,Sofjan,Amelia Kartikasari,18,6,0,0,0,0,0,3.75
+Spring 2024,AAMS,2300,2,15752,Intro Asian American Studies,Nguyen,An,4,4,4,1,1,0,2,2.666
+Spring 2024,MUSA,8320,14,15753,Doctoral Applied Music,Dorough,Aralee,3,0,0,0,0,0,0,3.89
+Spring 2024,LAW,6369,1,15755,Legal Analysis and Writing,Stein,Katherine Ann,0,0,0,0,0,9,0,
+Spring 2024,FINA,4352,2,15756,Fin Planning for Professionals,Lopez,John C,5,8,5,1,0,0,1,2.929
+Spring 2024,FINA,4325,2,15757,Retirement and Estate Planning,Lopez,John C,4,9,5,0,2,0,1,2.634
+Spring 2024,ARCH,3501,19,15758,Architecture Design Studio VI,Story,Jon Kevin,4,10,1,0,0,0,0,3.156
+Spring 2024,FINA,7A33,1,15760,Mergers & Acquisitions I,Yerramilli,Vijay,34,3,1,0,1,0,1,3.752
+Spring 2024,FINA,7A34,1,15761,Mergers & Acquisitions II,Yerramilli,Vijay,17,8,0,0,0,0,0,3.733
+Spring 2024,ARCH,5500,27,15762,Architecture Design Studio IX,Race,Bruce Alan,2,12,0,0,0,0,0,3.284
+Spring 2024,ARCH,5500,29,15764,Architecture Design Studio IX,Beneytez-Duran,Rafael,9,13,3,0,0,0,0,3.253
+Spring 2024,COMM,4355,1,15767,Organizational Comm,Liu,Wenlin,20,6,1,0,0,0,1,3.667
+Spring 2024,COMD,3383,1,15768,Language Disorders in Children,Ivey,Michelle L,16,13,0,0,0,0,1,3.529
+Spring 2024,CUIN,3111,4,15770,Educational Tech Elem Teachers,Davis,Kelly M,16,0,0,0,1,0,0,3.726
+Spring 2024,FINA,7A50,1,15772,Derivatives I,Rabinovitch,Ramon,6,6,0,0,1,0,0,3.282
+Spring 2024,FINA,7A51,1,15773,Derivatives II,Rabinovitch,Ramon,6,2,0,0,0,0,0,3.791
+Spring 2024,MANA,7354,1,15774,Cultrl Issues in Global Mgt,Sebastijanovic,Marina,13,0,0,0,0,0,0,3.873
+Spring 2024,MUSI,6106,4,15775,Grad Large Ensemble,Weber,Mary E,5,0,0,0,0,0,0,4.0
+Spring 2024,MANA,4333,1,15776,Current Issues in Mgmt,Currie,Daniel David,57,1,1,0,0,0,0,3.899
+Spring 2024,MATH,2312,2,15778,Precalculus,Ansari,Haseeb E,124,70,90,30,28,0,50,2.644
+Spring 2024,LAW,6364,1,15783,Contract Drafting,Toedt III,Dell Charles,6,11,0,0,0,4,0,3.392
+Spring 2024,LAW,6364,2,15784,Contract Drafting,Toedt III,Dell Charles,8,12,0,0,0,0,0,3.417
+Spring 2024,LAW,6369,5,15791,Legal Analysis and Writing,Nieuwveld,Lisa Bench,0,0,0,0,0,8,0,
+Spring 2024,LAW,6369,7,15793,Legal Analysis and Writing,Simmons,Laurel Ellis Parker,0,0,0,0,0,8,0,
+Spring 2024,MSCI,4320,1,15794,Company Grade Leadership,Comiskey,Melissa C,2,0,0,0,0,0,0,4.0
+Spring 2024,FINA,6A31,2,15795,Analyzing Financial Statements,Woods,James D,10,3,2,0,0,0,0,3.533
+Spring 2024,ENGL,1301,4,15797,First Year Writing I,Presswood,Phillip Hilliard,23,1,1,0,0,0,0,3.893
+Spring 2024,ENGL,1301,48,15798,First Year Writing I,Weitman,Mathew,15,2,1,0,0,0,1,3.778
+Spring 2024,WGSS,2350,11,15800,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,23,5,0,0,0,0,0,3.833
+Spring 2024,WGSS,2350,12,15801,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,22,5,0,1,1,0,0,3.586
+Spring 2024,WGSS,2350,13,15802,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,29,3,1,0,0,0,1,3.888
+Spring 2024,ENGL,1302,62,15803,First Year Writing II,Cowan,Joshua Jared,14,2,4,0,1,0,4,3.223
+Spring 2024,ENGL,1302,63,15804,First Year Writing II,Dykes,Justin,2,8,7,4,1,0,2,2.303
+Spring 2024,ENGL,1302,64,15805,First Year Writing II,Dykes,Justin,7,6,5,0,3,0,4,2.651
+Spring 2024,ENGL,1302,65,15806,First Year Writing II,Dykes,Justin,8,6,8,0,3,0,0,2.666
+Spring 2024,ENGL,1302,66,15807,First Year Writing II,Dykes,Justin,4,2,7,3,4,0,4,1.967
+Spring 2024,ENGL,1302,68,15808,First Year Writing II,Ornell,Colby,7,9,3,2,2,0,2,2.725
+Spring 2024,ENGL,1302,69,15809,First Year Writing II,Sicinski,Michael J,13,6,0,0,2,0,4,3.318
+Spring 2024,ENGL,1302,74,15810,First Year Writing II,Presswood,Phillip Hilliard,21,0,1,0,2,0,1,3.583
+Spring 2024,ENGL,2305,3,15811,Intro To Fiction,Kanwal,Tayyba,10,3,3,1,2,0,1,2.895
+Spring 2024,CIVE,4381,2,15813,Satellite-based Geomatics,Lee,Hyongki,8,7,0,0,0,0,0,3.489
+Spring 2024,NUTR,3330,1,15814,Mgmt in Food & Nutr Systems,Haubrick,Kevin,7,7,4,0,0,0,0,3.02
+Spring 2024,ELCS,8399,5,15815,Doctoral Dissertation,Zou,Yali,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,3441,3,15816,Digital Logic Design,Sheth,Bhavin R,41,21,12,2,1,0,6,3.243
+Spring 2024,HLT,4310,3,15821,Program Planning for Hlt Prof,Bennett,Kristin C,21,2,2,0,1,0,3,3.603
+Spring 2024,WGSS,2350,14,15822,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,28,6,1,0,0,0,1,3.762
+Spring 2024,WGSS,2350,15,15823,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,25,3,1,0,0,0,1,3.85
+Spring 2024,SOCW,7301,3,15825,Confronting Oppression & Injus,Barthelemy,Juan,33,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,3224,4,15826,Human Physiology Laboratory,Gill,Tejendra,25,16,3,0,0,0,1,3.403
+Spring 2024,MUSA,6324,1,15827,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6324,2,15828,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6342,1,15829,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4432,2,15836,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,7181,1,15840,Pharmaceutics Seminar,McConnell,Bradley K,0,0,0,0,0,5,0,
+Spring 2024,PCOL,7181,1,15841,Pharmacology Seminar,McConnell,Bradley K,0,0,0,0,0,17,0,
+Spring 2024,GHL,3445,1,15843,Global Wine Immersion,Taylor,David C,9,1,0,0,1,0,0,3.575
+Spring 2024,BUSI,4396,1,15846,Business Internship,Wortzel,Zachary,0,0,0,0,0,44,1,
+Spring 2024,BUSI,4396,2,15847,Business Internship,Wortzel,Zachary,0,0,0,0,0,4,0,
+Spring 2024,MECE,8298,33,15848,Doctoral Research,Chen,Zheng,0,0,0,0,0,2,0,
+Spring 2024,MECE,8398,30,15849,Doctoral Research,Chen,Zheng,0,0,0,0,0,2,0,
+Spring 2024,MECE,8399,27,15851,Doctoral Dissertation,Chen,Zheng,0,0,0,0,0,2,0,
+Spring 2024,COSC,4353,3,15854,Software Design,Subramaniam,Venkat,16,9,0,0,0,0,1,3.614
+Spring 2024,COSC,6353,3,15855,Software Design,Subramaniam,Venkat,2,1,0,0,0,0,0,3.557
+Spring 2024,CHEM,8999,27,15857,Doctoral Dissertation,Harth,Eva M,2,0,0,0,0,0,0,4.0
+Spring 2024,MANA,4356,2,15859,Managing Diversity,Fernandez,Alejandro,55,4,0,0,1,0,0,3.856
+Spring 2024,MUSI,8399,1,15860,Doctoral Document,Maroney,Marcus K,0,0,0,0,0,1,0,
+Spring 2024,COMM,2327,2,15865,Introduction to Screen Writing,Vaughan,Thomas Michael,23,1,0,0,0,0,0,3.931
+Spring 2024,ARCH,1198,1,15866,Special Problems,Phan,Trang Anh Thuc,10,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,15,15867,Research,Brooks,Wayne A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4298,1,15868,Special Problems in Pedagogy,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,8698,5,15879,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8698,6,15880,Doctoral Research,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8698,7,15881,Doctoral Research,Yi,Ping,0,0,0,0,0,1,0,
+Spring 2024,MUSI,8296,2,15883,Doctoral Essay,Bertagnolli,Paul A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,16,15884,Research,Kitai,Anthony T,3,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8199,2,15885,Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Spring 2024,BIOL,8399,2,15894,Doctoral Dissertation,Sater,Amy,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,8399,3,15895,Doctoral Dissertation,Lekven,Arne,2,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8699,4,15901,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Spring 2024,MECE,8298,35,15902,Doctoral Research,Cescon,Marzia,0,0,0,0,0,3,0,
+Spring 2024,PHLS,8699,5,15903,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Spring 2024,KIN,3305,2,15904,Sport Sociology,Ogunrinde,Joyce,9,23,10,0,3,0,3,2.748
+Spring 2024,MECE,7399,2,15912,Masters Thesis,Ryou,Jae-Hyun,1,0,0,0,0,0,0,4.0
+Spring 2024,BUSI,1301,7,15913,Business Principles,Carvalho,Diogo,35,15,7,0,2,0,0,3.311
+Spring 2024,MUSI,6198,18,15920,Research,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,6,15922,Special Problems in Repertoire,Larson,Eric Amery,5,0,0,0,0,0,0,3.934
+Spring 2024,MUSI,4198,7,15923,Special Problems in Repertoire,Lo,Mann-Wen,2,0,0,0,0,0,0,3.835
+Spring 2024,MUSI,4198,2,15924,Special Problems in Repertoire,Brooks,Wayne A,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,3,15925,Special Problems in Repertoire,Kitai,Anthony T,2,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8398,28,15926,Doctoral Research,Ott,William R,0,0,0,0,0,1,0,
+Spring 2024,POLS,4398,3,15928,Independent Study,Clark,Jennifer H,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,8399,6,15931,Doctoral Dissertation,Schwartz,Robert J,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,6498,6,15937,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Spring 2024,BCHS,6498,8,15939,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2024,BCHS,6498,4,15947,Special Problems,Widger,William R,0,0,0,0,0,5,0,
+Spring 2024,ENGL,8698,2,15950,Graduate Research,Wingard,Jennifer L,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8999,8,15954,Doctoral Dissertation,Rodrigues,Debora Frigi,1,0,0,0,0,1,0,4.0
+Spring 2024,BIOL,8999,9,15955,Doctoral Dissertation,Feng,Qin,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8999,2,15959,Doctoral Dissertation,Dauwalder,Brigitte,1,0,0,0,0,0,0,4.0
+Spring 2024,MARK,8999,4,15962,Doctoral Dissertation,Ahearne,Michael,0,0,0,0,0,1,0,
+Spring 2024,ENGL,2330,3,15964,Writing Discipline English,Yang,Sunny Chen,8,7,1,1,0,0,2,3.216
+Spring 2024,MECE,8198,3,15965,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Spring 2024,MECE,8398,35,15966,Doctoral Research,Liu,Dong,0,0,0,0,0,2,0,
+Spring 2024,MECE,8498,24,15967,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Spring 2024,MECE,7399,3,15970,Masters Thesis,Ghasemi,Hadi,1,0,0,0,0,0,0,3.67
+Spring 2024,PHOP,6167,4,15983,Research Practicum A,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1312,1,15986,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8240,3,15990,Doctoral Recital I,Dorough,Aralee,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8240,6,15993,Doctoral Recital I,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8298,37,15995,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Spring 2024,MECE,8399,30,15997,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Spring 2024,MECE,8298,38,16000,Doctoral Research,Yang,Di,0,0,0,0,0,3,0,
+Spring 2024,BUSI,2305,5,16003,Business Statistics,Patterson,Staci A,8,22,14,20,0,0,34,2.292
+Spring 2024,COMM,1303,4,16004,Writing for Communicators,Lyn,Robyn,32,2,2,0,2,0,1,3.632
+Spring 2024,BIOL,6398,3,16014,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Spring 2024,PSYC,7398,1,16020,Statistics in PSYC Practicum,Francis,David J,0,0,0,0,0,3,0,
+Spring 2024,BUSI,4396,3,16022,Business Internship,Newman,Michael Ray,0,0,0,0,0,42,0,
+Spring 2024,INDE,4337,1,16027,Human Factors & Ergonomics,Schulze,Lawrence John Henry,4,26,5,0,0,0,0,2.868
+Spring 2024,MUSI,7399,1,16030,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,0,0,
+Spring 2024,CUIN,3347,3,16035,Reading in the Content Area,Stubbs,Susan,22,3,1,0,0,0,0,3.833
+Spring 2024,MUSI,6198,5,16037,Research in Chamber Music,Yon,Kirsten A,4,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8598,40,16038,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Spring 2024,MECE,8298,40,16039,Doctoral Research,Song,Gangbing,0,0,0,0,0,3,0,
+Spring 2024,BIOL,6298,2,16045,Special Problems,Chung,Sanghyuk,0,0,0,0,0,2,0,
+Spring 2024,CIVE,6111,1,16064,Graduate Seminar,Momen,Mostafa,0,0,0,0,0,31,0,
+Spring 2024,PCOL,6498,1,16066,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,2,0,
+Spring 2024,PCOL,6398,3,16067,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2024,SOC,7399,3,16070,Masters Thesis,Lee,Shayne,1,0,0,0,0,1,0,4.0
+Spring 2024,PSYC,6365,8,16071,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,0,0,0,0,0,2,0,
+Spring 2024,BIOL,6198,4,16075,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6198,5,16076,Special Problems,O'Brien,John,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6198,2,16082,Special Problems,Yi,Ping,0,0,0,0,0,2,0,
+Spring 2024,MUSI,4198,50,16090,SP-Opera Production,Belcher,Kathleen,2,0,0,0,0,0,0,4.0
+Spring 2024,MIS,3370,4,16091,Info Systems Development Tools,Hosseini,Leila,11,19,14,3,2,0,8,2.694
+Spring 2024,BIOL,6498,5,16092,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Spring 2024,MECE,8298,41,16095,Doctoral Research,Sun,Li,0,0,0,0,0,2,0,
+Spring 2024,MECE,8298,42,16096,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,3,0,
+Spring 2024,MECE,8398,39,16098,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,2,0,
+Spring 2024,MECE,8598,41,16099,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,
+Spring 2024,MECE,8598,42,16100,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Spring 2024,MECE,8399,32,16102,Doctoral Dissertation,Sun,Li,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8399,33,16103,Doctoral Dissertation,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Spring 2024,POLC,6311,1,16104,Leader and Prof Development,Witt,Lawrence A,19,0,0,0,0,0,1,4.0
+Spring 2024,MECE,8598,43,16106,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,2,0,
+Spring 2024,MECE,8398,41,16108,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Spring 2024,MECE,8598,44,16109,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,2,0,
+Spring 2024,SPAN,2312,2,16111,Intermediate Spanish II,Ruffino,Maythe,7,13,2,0,0,0,2,3.122
+Spring 2024,ENGI,8111,1,16114,FFP,Sharma,Pradeep,0,0,0,0,0,14,0,
+Spring 2024,MUSI,8296,6,16118,Doctoral Essay,Snyder,John L,0,0,0,0,0,1,0,
+Spring 2024,CHEM,2125,18,16123,Organic Chemistry Lab II,Bean,Mary B,5,6,8,2,0,0,2,2.651
+Spring 2024,MECE,8598,45,16125,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Spring 2024,MECE,8598,46,16126,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6422,1,16139,Applied Viola,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,6,16140,Research in Chamber Music,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6398,4,16141,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Spring 2024,MECE,7399,5,16145,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Spring 2024,MECE,8598,49,16147,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,
+Spring 2024,MECE,8398,42,16148,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,4,0,
+Spring 2024,MECE,8399,37,16149,Doctoral Dissertation,Selvamanickam,Venkat,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8398,43,16150,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,
+Spring 2024,BIOL,6598,2,16154,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6598,3,16155,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2024,ACCT,8999,2,16158,Doctoral Dissertation,Lu,Tong,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8199,5,16162,Dissertation,Arbona,Consuelo,0,0,0,0,0,2,0,
+Spring 2024,CUIN,8399,6,16173,Doctoral Dissertation,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Spring 2024,WGSS,2360,6,16174,Introduction to LGBT Studies,Stone,Lauren Michelle,13,11,3,1,2,0,0,3.067
+Spring 2024,MECE,8298,44,16175,Doctoral Research,Franchek,Matthew,0,0,0,0,0,4,0,
+Spring 2024,MECE,8699,10,16176,Doctoral Dissertation,Franchek,Matthew,0,0,0,0,0,1,0,
+Spring 2024,MECE,8298,45,16178,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,5,0,
+Spring 2024,MECE,8298,46,16183,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,1,0,
+Spring 2024,MUSI,4330,1,16184,Adv Instrumental Conducting,Krager,Franz A,2,0,0,0,0,0,0,4.0
+Spring 2024,WGSS,2350,16,16189,Intro To Women's Studies,Bustillo,Anneliese,16,7,2,0,2,0,2,3.26
+Spring 2024,MUSA,6304,3,16195,Conducting,Bertman,David Garry,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6304,2,16196,Conducting,Krager,Franz A,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8298,7,16200,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6336,5,16205,Directed Rsch in Social Psyc,Damian,Rodica Ioana,0,0,0,0,0,3,0,
+Spring 2024,MUSI,8296,5,16209,Doctoral Essay,Koozin,Timothy,2,0,0,0,0,1,0,4.0
+Spring 2024,CHEE,8598,19,16212,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,2,0,
+Spring 2024,MECE,8398,45,16214,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,
+Spring 2024,MECE,8398,46,16218,Doctoral Research,Yang,Di,0,0,0,0,0,2,0,
+Spring 2024,MUSA,8242,5,16220,Doctoral Recital III,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,7399,22,16222,Masters Thesis,May,Jeremy A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8420,1,16223,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,6399,4,16228,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6359,8,16229,Directed Rsch in Clinical Psyc,Bick,Johanna R,0,0,0,0,0,1,0,
+Spring 2024,CUIN,8699,2,16237,Doctoral Dissertation,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Spring 2024,PETR,6312,2,16239,Well Log Eval of Petr Formatn,Hathon,Lori A,1,3,1,0,0,0,0,3.0
+Spring 2024,MUSI,6198,7,16247,Research in Chamber Music,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,8,16248,Research in Chamber Music,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,9,16249,Research in Chamber Music,Suits,Brian J,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,10,16250,Research in Chamber Music,Lo,Mann-Wen,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,2301,5,16251,Introduction to Psychology,Gehm,Kevan H,27,9,2,1,0,0,1,3.564
+Spring 2024,PSYC,2319,5,16252,Intro to Social Psychology,Weinstein,Andrew Philip,39,27,8,3,2,0,0,3.236
+Spring 2024,PSYC,2305,24,16253,Intro to Methods in Psychology,Anderson,Jill Annette,33,14,1,0,0,0,0,3.598
+Spring 2024,FINA,6A98,3,16255,Research,Richards,Keith Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,3304,5,16257,General Biochemistry I,Scott,Sean-Patrick,44,56,23,4,1,0,8,3.112
+Spring 2024,MECE,8399,41,16259,Doctoral Dissertation,Joshi,Shailendra Pramod,1,0,0,0,0,0,0,4.0
+Spring 2024,SOC,3380,2,16268,Intro/Soc Health Care,Monserud,Maria Aleksandrovna,37,3,4,0,0,0,4,3.743
+Spring 2024,HISP,2374,2,16269,Spanish American Culture & Civ,De Los Reyes Heredia,Jose Guillermo,29,5,5,0,5,0,0,3.212
+Spring 2024,SPAN,3373,1,16272,Spanish Culture & Civilization,Ruisanchez Serra,Jose Ramon,11,8,2,1,0,0,0,3.303
+Spring 2024,SPAN,2307,2,16273,Span for Heritage Learners I,Hernandez,Yanina,10,6,0,1,0,0,0,3.432
+Spring 2024,WCL,2352,3,16276,World Cinema,Choi,Jin Aeng,13,7,0,0,1,0,4,3.335
+Spring 2024,WCL,4352,1,16277,Frames of Modernity II,Carrera,Alessandro,11,3,0,0,0,0,0,3.762
+Spring 2024,ARED,2310,1,16281,Intro Critical Visual Culture,Chung,Sheng Kuan,20,1,1,0,0,0,1,3.789
+Spring 2024,PHLS,8328,1,16282,HLM in Psyc & Educ Research,Fan,Weihua,10,1,0,0,0,0,0,3.909
+Spring 2024,HDFS,4397,1,16283,Selected Topics in Hdfs,Master,Allison,6,3,0,0,0,0,0,3.74
+Spring 2024,ELCS,6310,2,16287,Strategic Engagement,Johnson,Detra DeVerne,10,1,0,0,0,0,0,3.939
+Spring 2024,ELCS,6304,2,16288,Law & Policy for School Leader,Klussmann,Duncan Foster,13,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,1309,1,16290,Biol for Non-Science Majors II,Ibrahim,Abdalla Zanouny,11,48,31,8,7,0,6,2.507
+Spring 2024,BIOL,1309,2,16291,Biol for Non-Science Majors II,Gifford,Jenifer,31,50,45,13,6,0,7,2.591
+Spring 2024,ELCS,6342,1,16292,Critical Issues in Higher Educ,Hernandez,Belkis Pamela,5,0,0,0,0,0,0,4.0
+Spring 2024,EDUC,2301,2,16294,Intro to Special Populations,Christensen,Caroline,88,46,19,2,4,0,3,3.257
+Spring 2024,SPEC,2350,1,16297,RBT Training,Richardson,Amy Renee,8,4,1,0,0,0,0,3.437
+Spring 2024,SPEC,6367,1,16298,Special Education for Leaders,McCormick,Marina,5,0,0,0,1,0,0,3.168
+Spring 2024,ECON,7344,1,16299,Macroeconomic Theory II,Cubas Norando,German,6,3,0,0,0,0,0,3.63
+Spring 2024,ENGR,2301,1,16300,Mechanics I (Statics),Krakowiak,Konrad,5,9,15,8,8,0,11,1.889
+Spring 2024,ENGR,2301,2,16301,Mechanics I (Statics),Hoskere,Vedhus,23,14,10,3,4,0,5,2.797
+Spring 2024,PHIL,1334,1,16305,Minds and Machines,Weisberg,Joshua,7,38,23,6,11,0,5,2.251
+Spring 2024,CHIN,1502,1,16306,Elementary Chinese II,Zhang,Jing,16,2,1,1,0,0,0,3.584
+Spring 2024,CHIN,2312,1,16310,Intermediate Chinese II,Zhang,Jing,17,5,5,0,0,0,0,3.383
+Spring 2024,CHIN,3302,1,16311,Advanced Mandarin Chinese II,Li,Melody Yunzi,9,6,0,0,0,0,1,3.622
+Spring 2024,SPCH,1318,1,16312,Interpersonal Communication,Uhrick,Jan,25,6,2,0,0,0,0,3.667
+Spring 2024,ECE,8699,8,16313,Doctoral Dissertation,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2024,LATI,1302,2,16314,Elementary Latin II,Behr,Francesca D,2,6,3,1,1,0,4,2.513
+Spring 2024,LATI,2312,1,16315,Intermediate Latin II,Armstrong,Richard H,5,6,0,0,0,0,0,3.425
+Spring 2024,SOCI,1301,2,16318,Introduction To Sociology,Dorsey,Patricia Lynne,9,17,6,2,4,0,2,2.667
+Spring 2024,CHIN,1502,5,16319,Elementary Chinese II,Zhang,Jing,9,4,0,0,1,0,0,3.405
+Spring 2024,CHIN,4302,1,16321,Integrated Chinese,Wen,Xiaohong Sharon,3,1,0,0,0,0,0,3.833
+Spring 2024,GOVT,2306,6,16323,US and Texas Const/Politics,Cooper,Carol B,56,53,35,13,14,0,9,2.702
+Spring 2024,CUIN,8398,13,16326,Independent Study,Hausmann,Robert Carl,2,0,0,0,0,0,0,4.0
+Spring 2024,SGNL,2302,1,16327,Intermediate Sign Language II,Gietz,Merrilee Ruth,4,5,4,3,0,0,0,2.522
+Spring 2024,SGNL,2302,2,16328,Intermediate Sign Language II,Gietz,Merrilee Ruth,7,8,3,0,0,0,0,3.076
+Spring 2024,SOCI,1301,14,16329,Introduction To Sociology,Adams,Jennifer Lauren,35,1,1,0,1,0,0,3.79
+Spring 2024,GOVT,2306,1,16330,US and Texas Const/Politics,McDonald,John Terrence George,37,70,66,30,30,0,14,2.212
+Spring 2024,SGNL,1301,1,16331,Elementary Sign Language I,Brittain,Terrell,3,8,3,0,0,0,6,2.859
+Spring 2024,SOCI,1301,11,16333,Introduction To Sociology,Dorsey,Patricia Lynne,7,21,5,2,4,0,2,2.633
+Spring 2024,SOCI,1301,12,16334,Introduction To Sociology,Dorsey,Patricia Lynne,7,7,6,1,1,0,1,2.758
+Spring 2024,GOVT,2306,7,16336,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,99,73,34,11,7,0,8,3.076
+Spring 2024,SGNL,1302,5,16338,Elementary Sign Language II,Warmack,Chris Kiskinis,11,6,2,0,0,0,1,3.352
+Spring 2024,GOVT,2306,50,16339,US and Texas Const/Politics,Belco,Michelle Helene,23,2,0,0,0,0,0,3.946
+Spring 2024,SGNL,2302,3,16340,Intermediate Sign Language II,Brittain,Terrell,5,5,0,0,0,0,1,3.335
+Spring 2024,CHIN,3360,2,16342,A Look Into Modern China,McArthur,Charles M,10,11,7,1,0,0,2,3.091
+Spring 2024,SOCI,1301,8,16343,Introduction To Sociology,Nelson,Steven M,19,11,4,7,3,0,4,2.758
+Spring 2024,SOCI,1301,13,16344,Introduction To Sociology,Adams,Jennifer Lauren,33,3,1,0,2,0,1,3.667
+Spring 2024,DANC,1301,1,16346,Dance Improvisation,Scates,Leslie Ann,24,0,0,0,0,0,0,4.0
+Spring 2024,DANC,2303,1,16347,Introduction to Dance,Bobet,Jacqueline A,44,28,10,4,0,0,4,3.287
+Spring 2024,DANC,3302,1,16348,Int. Technique and Theory,Estrada,Maria Gabriela,14,0,0,1,0,0,0,3.778
+Spring 2024,DANC,3311,1,16349,Dance History II,Estrada,Maria Gabriela,10,5,4,0,0,0,1,3.212
+Spring 2024,DANC,4110,1,16350,Dance Ensemble,Lockett,KeyAira,13,0,0,0,0,0,0,3.975
+Spring 2024,DANC,4302,1,16351,Advanced Technique and Theory,Prokop,Travis Cooper,13,0,0,0,0,0,0,3.975
+Spring 2024,DANC,4308,1,16352,Teaching Dance Skills,Woodson,Elizabeth Ann,5,4,0,0,0,0,0,3.702
+Spring 2024,DRAM,1310,1,16353,Introduction to Theatre,Egging,Jon Leo,28,10,3,1,3,0,4,3.223
+Spring 2024,DRAM,1310,12,16354,Introduction to Theatre,Egging,Jon Leo,34,10,3,0,1,0,2,3.57
+Spring 2024,DRAM,1310,3,16355,Introduction to Theatre,Ostrow,Stuart,24,0,0,0,0,0,1,4.0
+Spring 2024,DRAM,1310,4,16356,Introduction to Theatre,Hinkel,Heidi Anne,43,5,3,0,1,0,1,3.661
+Spring 2024,DRAM,1310,7,16357,Introduction to Theatre,Hinkel,Heidi Anne,48,1,1,0,0,0,0,3.907
+Spring 2024,DRAM,1352,1,16358,Acting II,Ferrarone,Jessica,11,1,0,0,0,0,0,3.944
+Spring 2024,DRAM,1341,1,16359,Make up for Actors,Gardecki,Samantha Lauren,7,3,1,0,0,0,0,3.545
+Spring 2024,DRAM,1330,1,16361,Scenic Technology,Ramos,Emili,9,0,0,0,0,0,1,4.0
+Spring 2024,DRAM,2331,1,16363,Lighting and Sound Technology,Webb,Matthew Clark,9,2,0,0,0,0,0,3.818
+Spring 2024,DANC,2306,1,16365,Dance Composition II,Lockett,KeyAira,14,1,0,0,0,0,1,3.933
+Spring 2024,ARTS,1303,1,16366,Art Hist I(Prehistoric 14th C),Koontz,Rex A,102,26,16,3,8,0,7,3.287
+Spring 2024,ARTS,1316,3,16367,Fundamentals of Drawing,Coulter,Crystal Lennette,13,2,3,0,0,0,0,3.537
+Spring 2024,ARTS,1316,2,16368,Fundamentals of Drawing,Coulter,Crystal Lennette,12,4,0,0,0,0,1,3.771
+Spring 2024,ARTS,1316,4,16371,Fundamentals of Drawing,Siddiq,Sajeela,11,4,0,0,0,0,2,3.645
+Spring 2024,ARTS,2316,4,16372,Fundamentals of Painting,Kidd,Julia A,15,1,0,0,0,0,1,3.876
+Spring 2024,ARTS,2316,1,16373,Fundamentals of Painting,Bender,Hannah,12,3,1,1,0,0,0,3.452
+Spring 2024,ARTS,2333,1,16374,Fundamentals of Printmaking,Alderson,Saran,13,1,0,0,0,0,1,3.929
+Spring 2024,ARTS,1311,1,16375,Fundamentals of Graphic Design,Williams,Celeste,11,8,1,0,0,0,4,3.517
+Spring 2024,ARTS,1311,2,16376,Fundamentals of Graphic Design,Williams,Celeste,17,6,0,0,0,0,1,3.653
+Spring 2024,ARTS,2326,1,16377,Fundamentals of Sculpture,Jensen,Margaret,4,2,3,1,1,0,1,2.606
+Spring 2024,ARTS,2326,2,16378,Fundamentals of Sculpture,Jensen,Margaret,5,4,2,0,1,0,0,2.918
+Spring 2024,ARTS,2356,2,16379,Fundamentals of Photo/DM,Ranjbarcheshmehsorkhi,Mandana,9,2,0,0,2,0,1,3.155
+Spring 2024,ARTS,1372,1,16380,Fundamentals of Video Art,Hillerbrand,Stephan C,11,2,2,0,0,0,0,3.49
+Spring 2024,ARTS,1383,1,16382,Introduction to New Media,Reed,John G,11,3,0,1,3,0,3,2.963
+Spring 2024,ARTS,2311,1,16383,"Color, Materials and Methods",Bootwala,Jennifer Elizabeth,12,6,3,1,0,0,1,3.228
+Spring 2024,ARTS,2311,2,16384,"Color, Materials and Methods",Williams,Celeste,21,3,0,0,0,0,0,3.82
+Spring 2024,ARTS,3304,1,16385,Intermediate Painting,Meza,Edgar,20,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3309,1,16386,Jr Painting Major,Suber,Anthony,12,2,0,0,0,0,0,3.904
+Spring 2024,ARTS,3310,1,16387,Jr Painting Major,Parazette,Aaron,12,2,0,0,0,0,0,3.904
+Spring 2024,ARTS,3311,1,16388,Jr Painting Major,Parazette,Aaron,12,2,0,0,0,0,0,3.904
+Spring 2024,ARTS,3313,1,16389,Silkscreen,Masterson,Patrick D,13,0,0,0,0,0,0,3.898
+Spring 2024,ARTS,3313,2,16390,Silkscreen,Masterson,Patrick D,12,0,0,0,0,0,0,3.945
+Spring 2024,ARTS,3330,1,16392,Intermediate Graphic Design,Jamaluddin,Mohd Ikhram,7,1,4,0,4,0,2,2.376
+Spring 2024,ARTS,3331,1,16393,Graphic Design Software,So,Tom Wen-Meng,9,6,2,1,1,0,1,3.071
+Spring 2024,ARTS,3334,2,16394,Introduction to Typography,Gamble,Travis Hunter,15,5,1,2,0,0,1,3.32
+Spring 2024,ARTS,3335,1,16395,Junior Graphic Design Major,Hagmann,Sibylle,19,4,1,0,0,0,0,3.613
+Spring 2024,ARTS,3336,1,16396,Junior Graphic Design Major,Beckett,Cheryl A,12,10,2,0,0,0,0,3.472
+Spring 2024,ARTS,3337,1,16397,Junior Graphic Design Major,Unikel,Joshua,19,4,0,1,0,0,0,3.736
+Spring 2024,ARTS,3361,1,16398,Wood and Metal Fabrication,Giampietro,Francis A,15,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3365,1,16399,Jr Sculpture Major,Kittelson,Paul A,2,2,0,0,0,0,0,3.418
+Spring 2024,ARTS,3366,1,16400,Jr Sculpture Major,Conrad,Jillian,0,3,1,0,0,0,0,2.998
+Spring 2024,ARTS,3367,1,16401,Jr Sculpture Major,Conrad,Jillian,2,2,0,0,0,0,0,3.418
+Spring 2024,ARTS,3372,1,16402,Intermediate Video Art,Kokoladze,Salome,5,1,0,1,1,0,0,3.041
+Spring 2024,ARTS,3374,1,16403,Computer Imaging,Ranjbarcheshmehsorkhi,Mandana,6,10,0,1,0,0,0,3.216
+Spring 2024,ARTS,3375,1,16404,Jr Photo/Digital Media Major,Ho,Jamie C,10,3,0,0,0,0,0,3.769
+Spring 2024,ARTS,3376,1,16405,Jr Photo/Digital Media Major,Kirages,Anastasia Francisca,13,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3377,1,16406,Jr Photo/Digital Media Major,Molina,Lorena Guadalupe,12,1,0,0,0,0,0,3.822
+Spring 2024,ARTS,4300,1,16407,Senior Painting Major I,Hecker,Rachel G,13,2,1,0,0,0,0,3.771
+Spring 2024,ARTS,4301,1,16408,Senior Painting Major I,Hecker,Rachel G,13,2,1,0,0,0,0,3.771
+Spring 2024,ARTS,4302,1,16409,Senior Painting Major I,Frankfort,Dana M,13,2,1,0,0,0,0,3.771
+Spring 2024,ARTS,4303,1,16410,Senior Painting Major II,Hecker,Rachel G,9,5,0,0,0,0,0,3.572
+Spring 2024,ARTS,4304,1,16411,Senior Painting Major II,Hecker,Rachel G,9,5,0,0,0,0,0,3.572
+Spring 2024,ARTS,4305,1,16412,Senior Painting Major II,Frankfort,Dana M,9,5,0,0,0,0,0,3.572
+Spring 2024,ARTS,4334,1,16413,Senior Graphic Design Major II,Kim,Yoonkyung,14,6,2,0,0,0,0,3.62
+Spring 2024,ARTS,4335,1,16414,Senior Graphic Design Major II,Beckett,Cheryl A,19,2,1,0,0,0,0,3.788
+Spring 2024,ARTS,4360,1,16415,Senior Sculpture Major I,Kittelson,Paul A,3,0,1,0,0,0,0,3.418
+Spring 2024,ARTS,4361,1,16416,Senior Sculpture Major I,Conrad,Jillian,4,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4362,1,16417,Senior Sculpture Major I,Conrad,Jillian,3,0,1,0,0,0,0,3.418
+Spring 2024,ARTS,4363,1,16418,Senior Sculpture Major II,Kittelson,Paul A,5,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4364,1,16419,Senior Sculpture Major II,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4365,1,16420,Senior Sculpture Major II,Conrad,Jillian,5,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4373,1,16421,Sr Photo/Digital Media Maj II,Ho,Jamie C,11,5,2,0,0,0,0,3.482
+Spring 2024,ARTS,4374,1,16422,Sr Photo/Digital Media Maj II,Molina,Lorena Guadalupe,14,2,1,1,0,0,0,3.519
+Spring 2024,ARTS,4375,1,16423,Sr Photo/Digital Media Maj II,Anderson-Staley,Keliy,10,6,2,0,0,0,0,3.426
+Spring 2024,ARTS,6300,1,16424,Drawing Studio,Hecker,Rachel G,14,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,6330,1,16425,Graphic Design Studio,Unikel,Joshua,3,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,6360,1,16426,Sculpture Studio,Conrad,Jillian,6,1,0,0,0,0,0,3.857
+Spring 2024,ARTS,6370,1,16427,Photography Studio,Anderson-Staley,Keliy,6,1,0,0,0,0,0,3.857
+Spring 2024,ARTS,6385,1,16428,IPEF Studio,Reed,John G,6,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,7310,1,16429,Printmaking Studio,Masterson,Patrick D,4,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,7310,2,16430,Printmaking Studio,Masterson,Patrick D,4,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,1316,1,16431,Fundamentals of Drawing,Griffin,Alvin Garrett,7,3,4,0,1,0,2,2.89
+Spring 2024,GOVT,2305,50,16432,"US Govt: Congress,Pres & Crts",Belco,Michelle Helene,22,0,0,0,1,0,1,3.812
+Spring 2024,GOVT,2306,16,16433,US and Texas Const/Politics,McDonald,John Terrence George,43,17,6,2,1,0,0,3.373
+Spring 2024,GOVT,2306,53,16434,US and Texas Const/Politics,Leland,Alison W,7,17,1,0,0,0,0,3.24
+Spring 2024,ARTS,6308,1,16435,Graduate Critique,Rubinstein,Raphael,6,0,0,0,0,0,0,4.0
+Spring 2024,DANC,2303,2,16436,Introduction to Dance,Bobet,Jacqueline A,52,20,8,0,4,0,4,3.334
+Spring 2024,CHIN,3360,3,16437,A Look Into Modern China,McArthur,Charles M,8,10,2,0,1,0,0,3.19
+Spring 2024,SGNL,1302,3,16440,Elementary Sign Language II,Warmack,Chris Kiskinis,11,5,3,0,0,0,0,3.317
+Spring 2024,SGNL,2301,2,16441,Intermediate Sign Language I,Warmack,Chris Kiskinis,9,10,3,0,0,0,0,3.198
+Spring 2024,SGNL,1301,2,16442,Elementary Sign Language I,Brittain,Terrell,4,9,4,2,0,0,0,2.703
+Spring 2024,GOVT,2305,17,16443,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,28,21,9,2,1,0,4,3.164
+Spring 2024,DRAM,1310,2,16444,Introduction to Theatre,Ostrow,Stuart,24,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4333,1,16446,Senior Graphic Design Major II,Hagmann,Sibylle,18,4,0,0,0,0,0,3.773
+Spring 2024,DRAM,1310,6,16447,Introduction to Theatre,Hinkel,Heidi Anne,505,98,21,7,9,0,4,3.649
+Spring 2024,DRAM,1310,8,16448,Introduction to Theatre,Hinkel,Heidi Anne,43,3,2,2,0,0,0,3.727
+Spring 2024,DRAM,1310,9,16449,Introduction to Theatre,Young,Courtney Leigh,43,4,1,0,2,0,1,3.667
+Spring 2024,ARTS,3374,2,16453,Computer Imaging,Chen,Shang-Yee Mark,13,3,1,0,1,0,0,3.39
+Spring 2024,ARTS,2316,2,16454,Fundamentals of Painting,Foutz,Madelyn Mairie,10,1,1,0,0,0,4,3.695
+Spring 2024,ARTS,3301,1,16455,Life Drawing,Barrera,Debra,20,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4398,2,16456,Independent Study,Kittelson,Paul A,1,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,2326,3,16457,Fundamentals of Sculpture,Conrad,Jillian,8,1,0,1,1,0,0,3.273
+Spring 2024,ARTS,2333,2,16458,Fundamentals of Printmaking,Sawhney,Ashita,12,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,2356,3,16459,Fundamentals of Photo/DM,Marion,Jennifer L,14,1,0,0,1,0,2,3.708
+Spring 2024,ARTS,3304,3,16460,Intermediate Painting,Willis,William H,20,0,0,0,0,0,0,4.0
+Spring 2024,CHIN,3354,1,16463,Chinese Culture and Language,Wang,Wei,3,7,8,0,0,0,1,2.667
+Spring 2024,SOCI,1301,5,16465,Introduction To Sociology,Nelson,Steven M,18,17,8,3,3,0,4,2.891
+Spring 2024,ARTS,3330,2,16467,Intermediate Graphic Design,Kim,Yoonkyung,3,16,1,0,1,0,3,2.968
+Spring 2024,ARTS,3334,1,16468,Introduction to Typography,Hagmann,Sibylle,4,14,1,0,2,0,1,2.999
+Spring 2024,DANC,3314,1,16469,Technology in Dance,Valle,Toni Leago,5,2,0,0,0,0,0,3.761
+Spring 2024,ARTS,3371,1,16470,Photo-Dig Media Portfolio Dev,Ho,Jamie C,6,0,1,0,1,0,0,3.291
+Spring 2024,SGNL,1301,3,16472,Elementary Sign Language I,Brittain,Robyn Michelle,2,4,4,1,1,0,7,2.334
+Spring 2024,DRAM,1310,10,16473,Introduction to Theatre,Young,Courtney Leigh,41,5,2,0,0,0,2,3.806
+Spring 2024,DRAM,1310,11,16474,Introduction to Theatre,Young,Courtney Leigh,40,6,3,0,1,0,0,3.64
+Spring 2024,ARTS,4398,1,16475,Independent Study,Parazette,Aaron,4,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3304,2,16477,Intermediate Painting,Suber,Anthony,20,0,0,0,0,0,0,3.918
+Spring 2024,CUIN,8398,2,16479,Independent Study,Alarcon,Jeannette Driscoll,3,0,0,0,0,0,0,4.0
+Spring 2024,DRAM,1310,13,16480,Introduction to Theatre,Egging,Jon Leo,34,4,4,0,5,0,0,3.298
+Spring 2024,GOVT,2306,3,16482,US and Texas Const/Politics,McDonald,John Terrence George,53,53,44,15,9,0,14,2.724
+Spring 2024,CHIN,3350,1,16483,Chinese Culture Through Films,McArthur,Charles M,12,8,0,0,2,0,0,3.288
+Spring 2024,CHIN,3304,1,16484,Business Chinese,Wen,Xiaohong Sharon,7,1,0,0,0,0,0,3.834
+Spring 2024,GOVT,2306,55,16485,US and Texas Const/Politics,Leland,Alison W,14,5,4,0,0,0,2,3.377
+Spring 2024,BIOL,4374,50,16486,Cell Biology,Sharp,Rita Evelyn,18,5,1,0,0,0,2,3.64
+Spring 2024,BCHS,4313,50,16487,Cell Biochemistry,Sharp,Rita Evelyn,2,0,0,1,0,0,1,3.0
+Spring 2024,DRAM,1352,2,16488,Acting II,Ferrarone,Jessica,7,1,0,0,0,0,0,3.875
+Spring 2024,ARTS,6305,1,16489,Painting Studio,Frankfort,Dana M,12,0,0,0,0,0,0,4.0
+Spring 2024,DANC,4331,1,16490,PR and Marketing - Arts,Valle,Toni Leago,8,5,3,1,0,0,0,3.196
+Spring 2024,ARTS,1304,1,16491,Art Hist II(15th C to Present),Zalman,Sandra,46,78,26,10,10,0,9,2.781
+Spring 2024,ARTS,2326,5,16492,Fundamentals of Sculpture,Kittelson,Paul A,6,4,1,0,1,0,0,3.112
+Spring 2024,ARTS,3374,3,16493,Computer Imaging,Sudhoff,Sarah Antonia,7,10,1,0,0,0,0,3.352
+Spring 2024,COMM,6399,7,16495,Masters Thesis,Camaj,Lindita,1,0,0,0,0,0,0,4.0
+Spring 2024,GOVT,2306,2,16496,US and Texas Const/Politics,Cole,Jeffrey Bryan,87,89,19,8,16,0,8,3.023
+Spring 2024,GOVT,2306,56,16500,US and Texas Const/Politics,LeVeaux,Christine,18,9,0,0,0,0,0,3.52
+Spring 2024,BIOL,1307,52,16501,Biology for Science Majors II,Sharp,Rita Evelyn,20,11,1,0,0,0,0,3.594
+Spring 2024,ARTS,7330,1,16502,Graphic Design Studio,Beckett,Cheryl A,2,0,0,0,0,0,0,3.67
+Spring 2024,ARTS,3360,1,16503,Intermediate Sculpture,Kittelson,Paul A,10,5,2,0,0,0,0,3.471
+Spring 2024,DANC,2309,1,16504,Dance Production II,Valle,Toni Leago,13,1,0,0,0,0,1,3.858
+Spring 2024,PHLA,7299,1,16505,Masters Thesis,Wanat,Matthew A,0,0,0,0,0,1,0,
+Spring 2024,PHLA,7299,2,16506,Masters Thesis,Tolleson,Shane Russell,0,0,0,0,0,1,0,
+Spring 2024,PHLA,7299,3,16507,Masters Thesis,Wallace,David A,0,0,0,0,0,1,0,
+Spring 2024,PHLA,7299,4,16508,Masters Thesis,Varkey,Divya A,0,0,0,0,0,2,0,
+Spring 2024,PHLA,7299,7,16509,Masters Thesis,Garey,Kevin W,0,0,0,0,0,1,0,
+Spring 2024,ARTS,2326,4,16510,Fundamentals of Sculpture,De Leon,Laura,11,0,0,0,1,0,0,3.639
+Spring 2024,BIOL,6598,13,16514,Special Problems,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Spring 2024,LATI,1302,1,16517,Elementary Latin II,Armstrong,Richard H,6,2,0,0,1,0,3,3.333
+Spring 2024,BIOE,6306,2,16518,Adv Artificial Neural Networks,Francis,Joseph Thachil,4,2,1,0,0,0,0,3.381
+Spring 2024,BIOE,4313,2,16519,Intro to Neural Computation,Francis,Joseph Thachil,7,0,0,0,0,0,1,3.811
+Spring 2024,GEOL,1102,5,16520,Intro to Climate Change Lab,Wang,Yuxuan,10,2,3,0,0,0,0,3.533
+Spring 2024,GEOL,1102,6,16521,Intro to Climate Change Lab,Wang,Yuxuan,16,2,0,0,0,0,0,3.907
+Spring 2024,POLS,3311,5,16523,Intro Compar Politics,Vardy,Ronald V,31,2,1,1,1,0,3,3.713
+Spring 2024,CUIN,8352,1,16524,Tech Apps for Ed Leaders,McNeil,Sara G,15,0,0,0,1,0,0,3.709
+Spring 2024,MATH,2318,4,16525,Linear Algebra,Mang,Andreas,17,29,6,0,1,0,7,3.107
+Spring 2024,MATH,2318,5,16526,Linear Algebra,Yoon,Ryeongkyung,20,10,15,7,1,0,2,2.792
+Spring 2024,MATH,3321,5,16529,Engineering Mathematics,Ryan,John M,36,57,51,18,18,0,12,2.42
+Spring 2024,MATH,3333,2,16531,Intermediate Analysis,Leger,Nicholas M,6,12,10,5,6,0,4,2.171
+Spring 2024,PHYS,3214,1,16532,Advanced Laboratory II,Das,Mini,3,4,1,1,0,0,0,3.073
+Spring 2024,MATH,3363,3,16533,Introduction To PDE,Fitzgibbon,William E,5,14,4,1,2,0,2,2.705
+Spring 2024,MATH,3363,5,16534,Introduction To PDE,He,Yunhui,1,5,3,2,5,0,9,1.626
+Spring 2024,CUIN,2300,1,16535,Introduction to STEM Teaching,Ekeoba,Jacqueline Njideka,16,0,0,0,0,0,1,3.959
+Spring 2024,INDE,2331,1,16536,Computer Applications for IE,Wiggins,Nathanial David,3,2,0,0,0,0,0,3.402
+Spring 2024,CHEE,6383,1,16538,Adv Unit Operations,Kaushik,Krishna R,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,1314,4,16539,College Algebra,Hafeez,Shahinda,10,10,23,6,25,0,12,1.609
+Spring 2024,GEOL,1147,3,16541,Introductory Meteorology Lab,Rappenglueck,Bernhard,5,6,1,1,0,0,1,3.154
+Spring 2024,GEOL,1303,2,16542,Physical Geology,Antonelli,Michael Ariel,63,97,42,4,4,0,12,2.989
+Spring 2024,FINA,4330,5,16543,Corporate Finance,Allena,Rohit,34,13,4,0,1,0,3,3.481
+Spring 2024,ARCH,7601,5,16545,Architecture Design Studio VI,Froehlich,Dietmar,6,3,0,0,0,0,0,3.63
+Spring 2024,MATH,2131,2,16548,Linear Alg Labs w/MATLAB,Goligerdian,Arash,14,3,2,2,2,0,3,3.044
+Spring 2024,CUIN,4303,2,16550,Sec Language Acq,Burgess,Miguel,15,3,3,0,0,0,1,3.571
+Spring 2024,CUIN,4361,3,16551,Second Language Methodology,Burgess,Miguel,26,2,0,0,1,0,0,3.793
+Spring 2024,LAW,6239,1,16552,Admiralty Envirmnt'l Insurance,Engerrand,Kenneth G,1,8,0,0,0,10,0,3.331
+Spring 2024,CUIN,3111,1,16553,Educational Tech Elem Teachers,Davis,Kelly M,24,0,0,0,0,0,0,3.959
+Spring 2024,GHL,4350,2,16554,Strategy&Innovation Hosp Ind,Johnson,Tucker A,27,14,4,2,4,0,0,3.105
+Spring 2024,GHL,4352,2,16555,Hosp Organizational Behavior,Doudna,Simone P,25,16,5,2,0,0,2,3.313
+Spring 2024,GHL,3372,1,16556,Convention and Meeting Mgmt,Kenyan,Erin Oeser,40,6,0,2,0,0,0,3.723
+Spring 2024,GHL,3384,1,16557,Gourmet Night Managment,Haskell,Rebecca Erin,10,0,0,0,0,0,0,4.0
+Spring 2024,GHL,4326,1,16558,Catering Management,Ginapp,Kathrine,4,3,0,0,0,0,0,3.524
+Spring 2024,GHL,4384,1,16560,Gourmet Night Management II,Haskell,Rebecca Erin,4,0,0,0,0,0,0,4.0
+Spring 2024,GHL,4462,1,16561,Practical Project Mgmt in Hosp,Abbott,Jeanna L,14,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6364,2,16563,Hosp. Managerial Accounting,Johnson,Tucker A,3,1,0,0,0,0,0,3.833
+Spring 2024,GHL,6351,1,16565,Lodging Operations Mgmt,Johnson,Tucker A,13,0,0,0,1,0,0,3.691
+Spring 2024,GHL,6352,1,16566,Hospitality Market Analysis,McCaslin,Glynn Randle,8,0,0,0,0,0,0,4.0
+Spring 2024,GHL,7353,1,16567,Services Management in Hosp.,Boger Jr,Carl A,11,0,0,0,0,0,0,4.0
+Spring 2024,GHL,7369,1,16568,Hospitality Financial Assets,Koh,Yoon,7,1,0,0,0,0,0,3.669
+Spring 2024,GHL,7366,1,16569,Hosp. Management Strategies,Kim,Jaewook,12,1,0,0,1,0,0,3.596
+Spring 2024,GHL,7353,2,16571,Services Management in Hosp.,Boger Jr,Carl A,5,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,1507,3,16572,Intns Elem Span Heritage Learn,Hernandez,Estela,13,1,4,0,1,0,1,3.246
+Spring 2024,SEDE,7340,1,16579,Reading in Middle and Secondar,Russell IV,Glen Curtis,3,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,7361,1,16580,Seminar: Literacy Leadership,Hale,Margaret Ann,5,0,0,0,0,0,0,3.934
+Spring 2024,CUIN,7325,1,16581,Dev & Publ Literacy Material,Walker,Shontoria,7,0,0,0,0,0,1,3.953
+Spring 2024,LAW,5339,2,16583,Trusts and Wills,Reed,Hilary S,10,14,0,0,0,25,0,3.403
+Spring 2024,LAW,5342,1,16584,Prof Writing Strategies,Mathew,Juli Anna,4,7,0,0,0,0,0,3.394
+Spring 2024,LAW,5312,1,16585,First Amendment,Salib,Peter,12,19,0,0,0,19,0,3.419
+Spring 2024,LAW,6316,1,16586,Energy Law & Policy,Warren,Gina S,7,11,0,0,0,1,0,3.371
+Spring 2024,LAW,5326,1,16587,Criminal Procedure,Braley,Timothy Shawn,10,30,0,0,0,5,0,3.201
+Spring 2024,LAW,5326,2,16588,Criminal Procedure,Kwok,David Y,12,18,0,0,0,4,0,3.356
+Spring 2024,LAW,5333,1,16590,Health Transactions,Mantel,Jessica,2,8,0,0,0,0,0,3.398
+Spring 2024,LAW,5209,1,16591,Legal Spanish-Spanish Speakers,Romero Jr,Reynaldo,3,4,0,0,0,3,0,3.334
+Spring 2024,BIOE,4309,2,16595,Neural Technology Interfaces,Abidian,Mohammad Reza,15,3,0,0,0,0,0,3.742
+Spring 2024,BIOE,6309,2,16596,Neural Interfaces,Abidian,Mohammad Reza,12,1,0,0,1,0,0,3.525
+Spring 2024,CUIN,4326,1,16597,Teach Science in Grades 4-8 II,Varnado,Jakarda Wiltz,4,2,0,0,0,0,0,3.667
+Spring 2024,CUIN,3312,1,16599,Educational Technology,Hebert,Waneta Suzanne,18,3,2,2,1,0,0,3.283
+Spring 2024,BIOE,6320,1,16600,Tissue Engineering,Horton,Renita Elillian,1,5,1,0,0,0,0,3.0
+Spring 2024,CHEM,6330,1,16601,Advanced Polymer Chemistry,Harth,Eva M,20,4,2,1,1,0,0,3.464
+Spring 2024,MANA,4336,2,16603,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,1,2,4,0,1,0,0,2.374
+Spring 2024,MANA,4337,1,16604,Stress and Work,Sebastijanovic,Marina,52,7,1,0,0,0,0,3.828
+Spring 2024,MANA,4347,2,16605,Ethics and Corp Soc Respon.,Salaiz,Ashley,31,1,1,0,0,0,1,3.909
+Spring 2024,MANA,4353,3,16606,Mgmt Training and Career Devel,Bozeman,Dennis,28,20,9,0,1,0,2,3.361
+Spring 2024,MANA,4385,2,16607,Intro to Strategic Management,Chiu,Shih-chi,15,9,1,0,1,0,1,3.372
+Spring 2024,MANA,7351,1,16609,Mgt of  Global Organizations,Keller,Robert T,6,0,0,0,0,0,0,3.945
+Spring 2024,MANA,7355,1,16610,Staffing & Talent Management,Bozeman,Dennis,6,5,1,0,1,0,1,3.23
+Spring 2024,MANA,7358,1,16611,Compensation & Benefits,Zamanipour,Tina,11,1,0,0,0,0,0,3.917
+Spring 2024,MANA,7380,1,16612,People Analytics,Abbott,Jeanna L,18,0,0,0,0,0,0,4.0
+Spring 2024,MANA,7382,1,16613,Strateg Leadership-Healthcare,Kroger,Edward John,5,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2301,6,16616,Prin of Financial Accounting,Zhu,Limin,10,15,15,5,6,0,5,2.469
+Spring 2024,MIS,6341,1,16617,Information Systems,Silva,Leiser O,6,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2302,11,16618,Prin of Managerial Accounting,Parthasarathy,Kiran M,62,56,25,2,0,0,5,3.28
+Spring 2024,ACCT,3367,1,16619,Intermediate Accounting I,Cheng,Yuqi,5,4,2,0,0,0,2,3.333
+Spring 2024,ACCT,3367,2,16620,Intermediate Accounting I,Kraten,Michael,36,38,10,2,1,0,3,3.211
+Spring 2024,ACCT,3367,3,16621,Intermediate Accounting I,Zhang,Jianyu,9,1,1,0,0,0,0,3.697
+Spring 2024,FINA,7A34,2,16622,Mergers & Acquisitions II,Yerramilli,Vijay,2,0,0,0,0,0,0,3.835
+Spring 2024,MATH,1100,2,16623,Developmental Math,Leger,Nicholas M,0,0,0,0,0,27,6,
+Spring 2024,MATH,1100,3,16624,Developmental Math,Leger,Nicholas M,0,0,0,0,0,11,10,
+Spring 2024,MATH,1100,4,16625,Developmental Math,Leger,Nicholas M,0,0,0,0,0,5,2,
+Spring 2024,BZAN,6351,2,16627,Basic Prog for Busi Analytics,Wang,Cheng,42,1,0,0,0,0,1,3.984
+Spring 2024,LAW,5201,1,16628,Intellectual Property Survey,Andrews,Jeffrey A,2,8,0,0,0,0,0,3.266
+Spring 2024,ACCT,3371,1,16629,Accounting Information Systems,Miles,Carolyn A,14,36,9,2,0,0,5,3.07
+Spring 2024,ACCT,3371,2,16630,Accounting Information Systems,Seijas,Nuria S,35,25,6,0,1,0,2,3.393
+Spring 2024,ACCT,3371,3,16631,Accounting Information Systems,Seijas,Nuria S,10,11,4,0,0,0,0,3.214
+Spring 2024,ACCT,3377,1,16632,Cost Accounting,Serrato,Darlene Marie  Bohac,24,18,12,3,2,0,9,3.017
+Spring 2024,SOCW,7339,1,16633,Prof. Grant Writing for SW,Stagg,Helen Ruth,18,1,0,0,0,0,0,3.947
+Spring 2024,SOCW,7367,3,16634,Social Policy Analysis,Bromfield,Nicole,23,1,0,0,2,0,2,3.667
+Spring 2024,SOCW,7367,4,16635,Social Policy Analysis,Borja,Sharon G,24,2,1,0,0,0,0,3.754
+Spring 2024,ACCT,3377,2,16636,Cost Accounting,Serrato,Darlene Marie  Bohac,28,27,3,3,0,0,8,3.29
+Spring 2024,SOCW,7367,5,16637,Social Policy Analysis,Pang,Melanie Espinosa,30,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,6313,1,16638,Prof Orientation & Adv Ethics,Hurt,Kara Marie,34,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,4332,1,16640,Corporate Taxation,Fernandez,Ramon,2,3,0,0,0,0,0,3.466
+Spring 2024,ACCT,4332,2,16641,Corporate Taxation,Chen,Xi,3,2,0,0,0,0,0,3.534
+Spring 2024,ACCT,4332,3,16642,Corporate Taxation,Chen,Xi,2,2,0,0,0,0,0,3.583
+Spring 2024,ACCT,4335,2,16643,Financial Statement Auditing,Rousseau,Linette Marie,14,13,13,5,0,0,1,2.8
+Spring 2024,ACCT,4375,1,16646,Internal Audit Entity Environ,Brant Jr,Robert Edward,3,4,0,1,0,0,1,3.249
+Spring 2024,ACCT,5332,1,16647,Taxation of Business Entities,Fernandez,Ramon,0,1,0,0,0,0,0,3.33
+Spring 2024,ACCT,7375,3,16648,Taxation of Business Entities,Fernandez,Ramon,1,7,0,0,0,0,0,3.208
+Spring 2024,ACCT,5332,2,16649,Taxation of Business Entities,Chen,Xi,3,2,1,0,0,0,0,3.278
+Spring 2024,ACCT,7375,4,16650,Taxation of Business Entities,Chen,Xi,6,6,2,0,0,0,0,3.239
+Spring 2024,ACCT,7375,1,16651,Taxation of Business Entities,Chen,Xi,1,1,0,0,0,0,0,3.5
+Spring 2024,ACCT,5335,1,16652,Financial Statement Auditing,Rousseau,Linette Marie,4,5,3,1,0,0,2,2.847
+Spring 2024,ACCT,5371,1,16656,Accounting Information Systems,Seijas,Nuria S,7,5,1,0,1,0,0,3.073
+Spring 2024,ACCT,5376,1,16659,Adv Fin Statement Auditing,Seltz,Joe D,1,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,7370,1,16660,Adv Fin Statement Auditing,Seltz,Joe D,11,6,0,0,0,0,2,3.666
+Spring 2024,ACCT,5377,2,16661,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,8,1,0,0,0,0,1,3.816
+Spring 2024,SOCW,7312,1,16663,Suicide Assessment & Treatment,Gearing,Robin Edward,26,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,7373,1,16664,Data Analytics Tools Acct,Miles,Carolyn A,6,3,1,0,0,0,0,3.401
+Spring 2024,ENGL,2361,3,16665,Western World Lit II--Honors,Charara,Hayan S,2,0,0,0,0,0,0,3.835
+Spring 2024,ENGL,2361,4,16666,Western World Lit II--Honors,Charara,Hayan S,1,2,0,0,0,0,0,3.333
+Spring 2024,ENGL,2361,5,16667,Western World Lit II--Honors,Cooper,Carol B,3,0,0,0,1,0,1,2.918
+Spring 2024,ENGL,2361,6,16668,Western World Lit II--Honors,Cooper,Carol B,3,3,1,0,0,0,0,3.286
+Spring 2024,ENGL,2361,7,16669,Western World Lit II--Honors,Cremins,Robert Paul,1,1,0,0,1,0,0,2.333
+Spring 2024,ENGL,2361,8,16670,Western World Lit II--Honors,Cremins,Robert Paul,3,1,1,0,0,0,0,3.268
+Spring 2024,ENGL,2361,9,16671,Western World Lit II--Honors,Ferguson,Jamie H,2,0,0,0,0,0,0,3.67
+Spring 2024,ENGL,2361,10,16672,Western World Lit II--Honors,Lyke,Larry,1,2,0,0,0,0,0,3.443
+Spring 2024,ENGL,2361,11,16673,Western World Lit II--Honors,Morrison,Iain P D,0,3,0,0,0,0,0,3.0
+Spring 2024,ENGL,2361,12,16674,Western World Lit II--Honors,Morrison,Iain P D,1,3,0,0,0,0,0,3.415
+Spring 2024,ENGL,2361,13,16675,Western World Lit II--Honors,Rayneard,Max James Anthony,3,1,0,0,0,0,0,3.75
+Spring 2024,ENGL,2361,14,16676,Western World Lit II--Honors,Rayneard,Max James Anthony,4,2,0,0,0,0,0,3.392
+Spring 2024,ENGL,2361,21,16677,Western World Lit II--Honors,Bland,Laura Elizabeth,4,0,2,0,0,0,0,3.333
+Spring 2024,ENGL,2361,22,16678,Western World Lit II--Honors,Bland,Laura Elizabeth,1,2,1,0,0,0,0,3.165
+Spring 2024,ENGL,2361,23,16679,Western World Lit II--Honors,Garner,Richard A,2,0,1,0,0,0,0,3.333
+Spring 2024,ENGL,2361,24,16680,Western World Lit II--Honors,Garner,Richard A,1,3,2,0,1,0,0,2.476
+Spring 2024,ENGL,2361,25,16681,Western World Lit II--Honors,Gish,Dustin,0,4,0,0,1,0,0,2.466
+Spring 2024,ENGL,2361,26,16682,Western World Lit II--Honors,Gish,Dustin,1,1,1,0,0,0,1,2.89
+Spring 2024,ENGL,2361,28,16683,Western World Lit II--Honors,Mikics,David,1,1,0,0,0,0,0,3.335
+Spring 2024,ENGL,2361,29,16684,Western World Lit II--Honors,Rainbow,David,3,1,1,0,0,0,0,3.268
+Spring 2024,ENGL,2361,30,16685,Western World Lit II--Honors,Rainbow,David,0,3,0,0,0,0,0,3.22
+Spring 2024,ENGL,2361,31,16686,Western World Lit II--Honors,Hallmark,Terrell L,2,2,0,0,0,0,1,3.335
+Spring 2024,ENGL,2361,33,16688,Western World Lit II--Honors,Sisman,Cengiz,1,3,0,0,0,0,0,3.415
+Spring 2024,ENGL,2361,34,16689,Western World Lit II--Honors,Sisman,Cengiz,2,0,0,0,0,0,0,3.835
+Spring 2024,ENGL,2361,35,16690,Western World Lit II--Honors,Vollrath,Lesli A,2,1,0,0,0,0,0,3.557
+Spring 2024,ENGL,2361,36,16691,Western World Lit II--Honors,Vollrath,Lesli A,4,1,0,0,0,0,0,3.602
+Spring 2024,ACCT,7362,2,16693,Tax Research,Meade,Janet,5,5,0,0,0,0,0,3.467
+Spring 2024,INTB,3361,1,16694,Global Engagement and Research,Miljanic,Andra Olivia,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,4349,2,16695,Biomedical Microdevices,Majd,Sheereen,13,3,0,0,0,0,0,3.73
+Spring 2024,BIOE,6349,2,16696,Biomedical Microdevices,Majd,Sheereen,14,2,0,0,0,0,0,3.813
+Spring 2024,FINA,4336,1,16697,Consulting-Small Business Need,Becker,Charles D,12,6,0,0,1,0,0,3.474
+Spring 2024,HON,2341,3,16699,Classics of Modernity,Charara,Hayan S,7,8,0,0,0,0,0,3.511
+Spring 2024,HON,2341,4,16700,Classics of Modernity,Charara,Hayan S,4,9,0,0,1,0,0,3.236
+Spring 2024,HON,2341,5,16701,Classics of Modernity,Cooper,Carol B,9,2,0,0,1,0,0,3.418
+Spring 2024,HON,2341,6,16702,Classics of Modernity,Cooper,Carol B,8,2,0,0,0,0,0,3.767
+Spring 2024,HON,2341,7,16703,Classics of Modernity,Cremins,Robert Paul,11,3,0,0,0,0,0,3.715
+Spring 2024,HON,2341,8,16704,Classics of Modernity,Cremins,Robert Paul,7,4,0,0,0,0,1,3.636
+Spring 2024,HON,2341,9,16705,Classics of Modernity,Ferguson,Jamie H,8,8,0,0,0,0,0,3.541
+Spring 2024,HON,2341,10,16706,Classics of Modernity,Lyke,Larry,8,6,0,0,0,0,0,3.383
+Spring 2024,HON,2341,11,16707,Classics of Modernity,Morrison,Iain P D,8,4,0,0,0,0,0,3.612
+Spring 2024,HON,2341,12,16708,Classics of Modernity,Morrison,Iain P D,7,5,0,0,0,0,0,3.638
+Spring 2024,HON,2341,13,16709,Classics of Modernity,Rayneard,Max James Anthony,6,7,0,0,0,0,0,3.462
+Spring 2024,HON,2341,14,16710,Classics of Modernity,Rayneard,Max James Anthony,8,2,0,0,0,0,0,3.668
+Spring 2024,HON,2341,21,16711,Classics of Modernity,Bland,Laura Elizabeth,7,5,0,0,0,0,0,3.666
+Spring 2024,HON,2341,22,16712,Classics of Modernity,Bland,Laura Elizabeth,7,3,2,0,0,0,1,3.499
+Spring 2024,HON,2341,23,16713,Classics of Modernity,Garner,Richard A,8,4,0,0,1,0,1,3.385
+Spring 2024,HON,2341,24,16714,Classics of Modernity,Garner,Richard A,6,2,2,0,0,0,1,3.367
+Spring 2024,HON,2341,25,16715,Classics of Modernity,Gish,Dustin,6,5,0,0,0,0,0,3.515
+Spring 2024,HON,2341,26,16716,Classics of Modernity,Gish,Dustin,3,0,0,0,0,0,1,3.78
+Spring 2024,HON,2341,28,16718,Classics of Modernity,Mikics,David,4,6,0,0,0,0,0,3.334
+Spring 2024,HON,2341,29,16719,Classics of Modernity,Rainbow,David,11,1,0,0,0,0,0,3.807
+Spring 2024,HON,2341,30,16720,Classics of Modernity,Rainbow,David,12,2,0,0,0,0,0,3.834
+Spring 2024,HON,2341,31,16721,Classics of Modernity,Hallmark,Terrell L,3,5,1,0,2,0,1,2.666
+Spring 2024,HON,2341,33,16723,Classics of Modernity,Sisman,Cengiz,9,4,0,0,0,0,0,3.692
+Spring 2024,HON,2341,34,16724,Classics of Modernity,Sisman,Cengiz,12,2,0,0,0,0,0,3.692
+Spring 2024,HON,2341,35,16725,Classics of Modernity,Vollrath,Lesli A,8,4,0,0,0,0,1,3.612
+Spring 2024,HON,2341,36,16726,Classics of Modernity,Vollrath,Lesli A,7,4,1,0,0,0,0,3.473
+Spring 2024,GENB,7304,2,16728,Bus Ethics for Accountants,Brant Jr,Robert Edward,9,3,2,0,0,0,0,3.594
+Spring 2024,FINA,4335,1,16729,Brainstorming to Bankrolling,Khumawala,Saleha B,15,3,1,0,2,0,1,3.35
+Spring 2024,GENB,5335,1,16730,Brainstorming to Bankrolling,Khumawala,Saleha B,1,0,0,0,0,0,0,4.0
+Spring 2024,GENB,5303,2,16731,Prof Acct Communication,Newman,Michael Ray,1,0,0,0,0,0,0,4.0
+Spring 2024,GENB,7303,2,16732,Prof Accounting Communication,Newman,Michael Ray,4,2,0,0,0,0,0,3.777
+Spring 2024,BIOE,7399,4,16735,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,7399,5,16736,Masters Thesis,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Spring 2024,PHLA,7A20,1,16738,Leadership Transitions,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Spring 2024,PHLA,6240,1,16739,Regulatory Compliance,Varkey,Divya A,7,0,0,0,0,0,0,4.0
+Spring 2024,PHLA,6250,1,16740,Research Methodology,Ononogbu,Onyebuchi J,7,0,0,0,0,0,0,4.0
+Spring 2024,MARK,7A75,1,16741,Marketing Strategy,Lish,Alan D,4,7,2,0,1,0,1,2.905
+Spring 2024,COMM,1307,6,16743,Media and Society,Olson,Beth M,21,97,58,28,24,0,20,2.268
+Spring 2024,MARK,6A61,3,16744,Marketing Administration,Lish,Alan D,2,12,2,1,1,0,0,2.722
+Spring 2024,MARK,4389,7,16746,Marketing Strategy & Planning,Herman,Carl,19,11,2,0,0,0,0,3.428
+Spring 2024,POLC,3314,1,16749,Leadership and Public Policy,Witt,Lawrence A,22,4,1,0,1,0,1,3.631
+Spring 2024,COMD,3383,2,16750,Language Disorders in Children,Ivey,Michelle L,14,9,1,0,0,0,0,3.473
+Spring 2024,ARCH,5593,15,16752,Thesis Project,Johnson,Matthew W,4,3,0,0,0,0,0,3.524
+Spring 2024,ENGL,3327,1,16754,Masterpieces of British Lit I,Lindahl,Carl R,8,5,3,0,0,0,9,3.209
+Spring 2024,ENGL,4341,1,16756,Queer Theory,Harrell,Haylee C,8,5,0,0,0,0,0,3.59
+Spring 2024,SCM,7350,1,16757,Strategic Supply Management,Wayhan,Victor Brian,13,3,0,0,0,0,1,3.854
+Spring 2024,SCM,7320,1,16759,Supply Chain Analytics,Murray,Michael J,11,4,10,0,0,0,0,2.882
+Spring 2024,SCM,6A01,2,16760,SCM Concepts,Hossain,Md Mahbub,33,3,0,0,0,0,0,3.908
+Spring 2024,SCM,7A01,2,16761,Project Management,Tibodeau,Dale,5,1,0,0,0,0,0,3.613
+Spring 2024,ENGL,4383,1,16762,Poetic Forms,Williams,Adele E,14,3,0,0,0,0,1,3.804
+Spring 2024,CHEE,8298,20,16764,Doctoral Research,Zerze,Gul,0,0,0,0,0,3,0,
+Spring 2024,ENGL,4392,1,16765,Practicum: TEAL,Nelms,Jodi Lynn,8,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8398,20,16767,Doctoral Research,Zerze,Gul,0,0,0,0,0,1,0,
+Spring 2024,ARTS,2346,1,16769,Fundamentals of Ceramics,Oloshove,Angel,8,2,0,0,0,0,6,3.767
+Spring 2024,ARTS,2346,2,16770,Fundamentals of Ceramics,Oloshove,Angel,13,2,0,0,0,0,0,3.801
+Spring 2024,CHEE,8598,20,16772,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Spring 2024,CHEE,8399,19,16773,Doctoral Dissertation,Mountziaris,Triantafillos John,2,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8399,20,16774,Doctoral Dissertation,Zerze,Gul,3,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,6399,1,16775,Masters Thesis,Karim,Alamgir,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,6383,2,16777,Adv Unit Operations,Kaushik,Krishna R,1,2,0,0,0,0,0,3.443
+Spring 2024,COMD,4333,2,16783,Neuroscience for COMD,Blake,Margaret T,14,17,7,0,0,0,1,3.158
+Spring 2024,COMD,6230,3,16784,Autism Spectrum Disorder,Ross,Byron L,35,9,0,0,0,0,0,3.765
+Spring 2024,COMM,4370,2,16785,Social Aspects of Film,Jowett,Garth Samuel,10,1,0,0,0,0,0,3.909
+Spring 2024,ENGI,2304,9,16786,Technical Communications,Wilson,Chad A,17,8,0,0,0,0,0,3.588
+Spring 2024,COMM,4378,3,16787,Social Impact of Info Tech,Ashley,Laura B,36,3,1,0,1,0,0,3.789
+Spring 2024,ACCT,3367,4,16788,Intermediate Accounting I,Kilic,Emre,21,22,17,9,1,0,10,2.809
+Spring 2024,ACCT,3367,5,16789,Intermediate Accounting I,Kilic,Emre,21,9,13,9,1,0,5,2.792
+Spring 2024,COMD,2339,2,16791,Language Development,Ross,Byron L,5,20,4,3,2,0,1,2.609
+Spring 2024,PHCA,7330,1,16794,Advanced Pharmacoeconomics,Tatar,Moosa,4,1,0,0,0,0,0,3.8
+Spring 2024,KIN,3301,2,16795,Design/Eval Phys Activity Prog,Graham,Marilynn Hadassah,50,8,1,1,2,0,3,3.635
+Spring 2024,POLS,3314,1,16796,Intro To Public Admin,Koelling,Peter,12,9,2,0,0,0,0,3.349
+Spring 2024,SOCI,1301,1,16797,Introduction To Sociology,Cooper,Chelsey Wells,42,11,1,2,3,0,0,3.48
+Spring 2024,SOCI,1301,4,16798,Introduction To Sociology,Davis,Mary A,34,5,0,0,1,0,0,3.742
+Spring 2024,SOC,3349,1,16799,Sociology of Culture,Adams,Jennifer Lauren,43,6,2,1,0,0,0,3.731
+Spring 2024,BUSI,3302,3,16801,Connecting Bauer to Business,Belinne,Jamie King,362,35,11,2,0,0,3,3.846
+Spring 2024,GOVT,2305,1,16804,"US Govt: Congress,Pres & Crts",Cole,Jeffrey Bryan,59,94,47,19,22,0,8,2.625
+Spring 2024,GOVT,2305,11,16805,"US Govt: Congress,Pres & Crts",Clark,Jennifer H,136,71,30,3,2,0,7,3.361
+Spring 2024,GOVT,2305,12,16806,"US Govt: Congress,Pres & Crts",Shor,Boris,23,52,38,11,17,0,13,2.336
+Spring 2024,GOVT,2305,13,16807,"US Govt: Congress,Pres & Crts",Colby,Cory G,24,81,69,10,17,0,36,2.364
+Spring 2024,GOVT,2306,13,16809,US and Texas Const/Politics,Littlepage,Kelley G,85,74,27,8,14,0,12,2.962
+Spring 2024,GOVT,2306,14,16810,US and Texas Const/Politics,McDonald,John Terrence George,49,64,60,30,15,0,25,2.459
+Spring 2024,MATH,2413,21,16811,Calculus I,Almus,Melahat,190,120,100,36,38,0,32,2.765
+Spring 2024,CHEE,8398,21,16816,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Spring 2024,KIN,4330,1,16828,Child and Adolescent Obesity,Breslin,Whitney L,13,22,9,3,2,0,0,2.769
+Spring 2024,ENGI,1100,5,16829,Introduction To Engineering,Kota,Venkata Krishna Tulasi,7,5,0,0,0,0,0,3.583
+Spring 2024,MUSI,4100,2,16838,Chamber Music,Bertman,David Garry,8,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4100,3,16839,Chamber Music,Bertman,David Garry,21,0,0,0,0,0,0,4.0
+Spring 2024,PETR,3310,1,16840,Petroleum Production Economics,Qin,Guan,7,1,0,0,0,0,0,3.793
+Spring 2024,LAW,6369,3,16841,Legal Analysis and Writing,Hastings,Madison Alexandra Nicole,0,0,0,0,0,8,0,
+Spring 2024,PETR,6302,2,16843,Reservoir Engineering II,Thakur,Ganesh Chandra,2,1,0,0,0,0,0,3.557
+Spring 2024,PETR,6351,2,16844,Intro to Petroleum Engineering,Farouq-Ali,Syed,4,0,0,0,0,0,0,4.0
+Spring 2024,PETR,6364,2,16845,Origin & Dev Oil & Gas Resvrs,Zargar,Zeinab,1,0,0,0,0,0,0,4.0
+Spring 2024,MUED,3102,1,16846,Brasses,Bell,Priscilla Garrett,10,6,2,0,0,0,0,3.444
+Spring 2024,ANTH,6315,1,16848,Sem-Ethnographic Anlys,Ghazali,Marwa,5,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4315,1,16849,Human Motivation,Knee,Clifford R,15,2,1,0,0,0,0,3.759
+Spring 2024,ACCT,2301,7,16851,Prin of Financial Accounting,Sykes,Mary Reeves,34,24,10,8,2,0,6,3.136
+Spring 2024,ACCT,2301,8,16852,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,20,39,32,35,12,0,20,2.262
+Spring 2024,ACCT,3366,6,16853,Financial Reporting Frameworks,Parthasarathy,Kiran M,13,8,22,4,2,0,13,2.497
+Spring 2024,GENB,5304,1,16855,Business Ethics for Accountant,Brant Jr,Robert Edward,0,5,1,0,0,0,0,2.888
+Spring 2024,GENB,7304,1,16856,Bus Ethics for Accountants,Brant Jr,Robert Edward,3,15,2,0,0,0,0,3.083
+Spring 2024,CIVE,6338,1,16858,Advanced Steel Design,Mercan,Bulent,8,8,0,0,0,0,0,3.479
+Spring 2024,ARTS,3300,1,16863,Advanced Drawing,Meza,Edgar,14,1,1,0,0,0,1,3.833
+Spring 2024,ARTS,3300,2,16864,Advanced Drawing,Peterson,John Ben,19,1,0,0,0,0,0,3.95
+Spring 2024,COSC,3337,1,16865,Data Science I,Rizk,Nouhad J,20,33,28,13,11,0,12,2.387
+Spring 2024,COSC,4348,1,16866,Intro Game Art and Animation,Yun,Changhoon,79,16,2,2,3,0,2,3.563
+Spring 2024,COSC,6348,1,16867,Intro Game Art and Animation,Yun,Changhoon,7,2,0,0,0,0,0,3.814
+Spring 2024,COSC,6374,1,16868,Parallel Computations,Wu,Panruo,3,2,0,0,0,0,0,3.666
+Spring 2024,PSYC,2305,14,16869,Intro to Methods in Psychology,Babalola,Olusegun,73,13,9,2,1,0,1,3.528
+Spring 2024,PSYC,2305,21,16871,Intro to Methods in Psychology,Yoruk,Harun,36,25,6,3,8,0,2,2.958
+Spring 2024,PSYC,2305,26,16873,Intro to Methods in Psychology,Babalola,Olusegun,61,23,6,0,3,0,7,3.463
+Spring 2024,NUTR,4345,1,16875,The Obesity Epidemic,Alastuey,Lisa L,50,32,6,2,0,0,2,3.397
+Spring 2024,HIST,2327,1,16876,Chicano History to 1910,Hernandez,Jose A,13,1,0,0,1,0,0,3.667
+Spring 2024,HIST,3311,1,16877,Civil War and Reconstruction,Deyle,Steven H,15,15,1,0,2,0,1,3.212
+Spring 2024,HIST,3328,1,16879,"Colonial America, 1492-1776",Clavin,Matthew J,13,9,7,3,1,0,2,2.889
+Spring 2024,ARTS,3312,1,16880,Intaglio,Masterson,Patrick D,13,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,3341,2,16882,Biothermodynamics,Aglyamov,Salavat,12,6,1,0,0,0,0,3.579
+Spring 2024,PSYC,2330,7,16884,Biological Psychology,Gehm,Kevan H,10,13,10,1,4,0,2,2.649
+Spring 2024,MUSI,6300,3,16885,Intro Res Method in Musicology,Vansteenburg,Jessica N,5,4,0,0,0,0,0,3.592
+Spring 2024,OPTO,8696,1,16886,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,28,0,
+Spring 2024,OPTO,8338,1,16887,Recent Developments/Round,Wheat,Joe L,11,15,4,0,0,0,0,3.244
+Spring 2024,OPTO,8384,1,16888,Practice Management II,Davis,Mark K,16,11,1,0,0,0,0,3.441
+Spring 2024,MUSA,6141,5,16892,Graduate Recital II,Cho,Eunghee,0,1,0,0,0,0,0,3.33
+Spring 2024,MUSA,6143,3,16893,Graduate Recital IV,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,1302,12,16894,First Year Writing II,Julian,Jennifer La'Vonne,18,0,0,1,0,0,0,3.842
+Spring 2024,ENGL,1302,25,16895,First Year Writing II,Koulen,Marisa Theresa,17,0,1,1,0,0,0,3.615
+Spring 2024,ENGL,1302,67,16896,First Year Writing II,Ornell,Colby,10,10,1,0,3,0,1,2.931
+Spring 2024,ENGL,1302,70,16897,First Year Writing II,Sicinski,Michael J,6,8,0,0,5,0,7,2.544
+Spring 2024,ENGL,1302,71,16898,First Year Writing II,Penzien,Eugene Norman,12,4,1,1,5,0,2,2.682
+Spring 2024,ENGL,1302,72,16899,First Year Writing II,Worley,Sharon J,9,5,4,3,2,0,1,2.667
+Spring 2024,ENGL,1302,73,16900,First Year Writing II,Worley,Sharon J,6,10,0,2,4,0,3,2.545
+Spring 2024,ENGL,1302,78,16901,First Year Writing II,Garcia,Serena Mari,15,5,0,1,4,0,0,3.027
+Spring 2024,ENGL,1302,79,16902,First Year Writing II,Garcia,Serena Mari,10,9,2,2,2,0,0,2.907
+Spring 2024,ENGL,1302,80,16903,First Year Writing II,Garcia,Serena Mari,15,10,0,0,0,0,0,3.508
+Spring 2024,ENGL,1302,82,16904,First Year Writing II,Stewart-Steele,Heather Marie,12,4,0,0,1,0,6,3.432
+Spring 2024,ENGL,1302,83,16905,First Year Writing II,Stewart-Steele,Heather Marie,10,7,1,0,1,0,6,3.298
+Spring 2024,ENGL,1302,84,16906,First Year Writing II,Stewart-Steele,Heather Marie,12,4,0,0,5,0,3,2.779
+Spring 2024,ENGL,1302,87,16908,First Year Writing II,Moore,Kelly L,8,6,4,0,1,0,0,3.035
+Spring 2024,ENGL,1302,89,16909,First Year Writing II,Edens,Jenifer,13,2,3,1,0,0,0,3.386
+Spring 2024,ENGL,1302,90,16910,First Year Writing II,Braniger,Leslie,6,11,2,0,0,0,0,3.193
+Spring 2024,ENGL,1302,92,16911,First Year Writing II,Bass,Kasey Dawn,17,1,0,0,0,0,0,3.926
+Spring 2024,ENGL,1302,93,16912,First Year Writing II,Edens,Jenifer,11,5,1,0,1,0,0,3.334
+Spring 2024,ENGL,1302,94,16913,First Year Writing II,Edens,Jenifer,10,5,3,0,0,0,0,3.334
+Spring 2024,ENGL,1302,95,16914,First Year Writing II,McAlister,Susan Barbara,13,3,1,1,0,0,0,3.592
+Spring 2024,ENGL,1302,96,16915,First Year Writing II,Horton,Lara,2,7,8,1,1,0,0,2.334
+Spring 2024,ENGL,1302,97,16916,First Year Writing II,Horton,Lara,10,5,1,0,2,0,0,3.112
+Spring 2024,ENGL,1302,110,16917,First Year Writing II,Mandia,Christopher Peter,9,13,2,1,0,0,0,3.134
+Spring 2024,ENGL,1302,111,16918,First Year Writing II,Wingard,Jennifer L,21,3,0,0,0,0,1,3.848
+Spring 2024,ENGL,1302,112,16919,First Year Writing II,Butler,Paul G,7,9,2,1,0,0,0,3.106
+Spring 2024,ENGL,1302,113,16920,First Year Writing II,O'Connor,Bevin,16,3,0,0,0,0,0,3.721
+Spring 2024,ENGL,1302,114,16921,First Year Writing II,Horton,Lara,8,9,4,0,2,0,2,2.856
+Spring 2024,ENGL,1302,115,16922,First Year Writing II,O'Connor,Bevin,12,7,0,0,0,0,0,3.545
+Spring 2024,ENGL,1302,116,16923,First Year Writing II,Sahi,Aishwarya,15,2,0,2,0,0,0,3.492
+Spring 2024,ENGL,1302,117,16924,First Year Writing II,Raza,Iqra,15,2,0,1,1,0,0,3.526
+Spring 2024,ENGL,1302,119,16926,First Year Writing II,Raza,Iqra,18,1,0,0,0,0,0,3.843
+Spring 2024,ENGL,1302,120,16927,First Year Writing II,Julian,Jennifer La'Vonne,14,0,2,3,0,0,0,3.333
+Spring 2024,ENGL,1302,121,16928,First Year Writing II,Stockwell,Patrick Edward,18,0,0,0,0,0,1,4.0
+Spring 2024,ENGL,1302,122,16929,First Year Writing II,Pogue,Donovan A,9,2,2,1,1,0,2,3.023
+Spring 2024,ENGL,1302,123,16930,First Year Writing II,Berg,Caleb J.,10,6,3,0,0,0,0,3.316
+Spring 2024,ENGL,1302,100,16931,First Year Writing II,Kunasek,Caleb,7,6,2,0,3,0,1,2.723
+Spring 2024,ENGL,1302,101,16932,First Year Writing II,Braniger,Leslie,6,10,5,0,1,0,2,2.804
+Spring 2024,ENGL,1302,102,16933,First Year Writing II,Spencer,Jaxson Matthew,15,2,1,1,0,0,0,3.614
+Spring 2024,ENGL,1302,103,16934,First Year Writing II,Braniger,Leslie,8,5,7,2,0,0,2,2.834
+Spring 2024,ENGL,1302,104,16935,First Year Writing II,Pachuca,Adrian,11,5,2,0,0,0,1,3.408
+Spring 2024,ENGL,1302,105,16936,First Year Writing II,Raines,Daniel,10,5,2,0,1,0,1,3.186
+Spring 2024,ENGL,1302,106,16937,First Year Writing II,Pachuca,Adrian,12,2,2,1,1,0,0,3.204
+Spring 2024,ENGL,1302,107,16938,First Year Writing II,Ornell,Colby,5,6,4,0,4,0,0,2.369
+Spring 2024,ENGL,1302,109,16940,First Year Writing II,Wei,Weixiao,3,6,5,5,0,0,0,2.264
+Spring 2024,ARTS,3370,1,16941,Traditional Photography,Casagranda,Madison Anne,10,3,1,0,0,0,0,3.572
+Spring 2024,POLC,3313,1,16942,Contemporary Poli Phil Policy,Williams,Brandon,16,1,1,1,0,0,1,3.632
+Spring 2024,LAW,6369,4,16943,Legal Analysis and Writing,Fazal,Fermeen,0,0,0,0,0,9,0,
+Spring 2024,LAW,5342,2,16944,Prof Writing Strategies,Vagenas,Georgia Nick,5,7,0,0,0,0,0,3.389
+Spring 2024,BIOE,5317,2,16945,Intro to Biomedical Imaging,Gifford,Howard,1,1,0,0,0,0,0,3.665
+Spring 2024,BIOE,6346,2,16946,Advanced Medical Imaging,Gifford,Howard,1,2,0,0,0,0,0,3.443
+Spring 2024,DANC,2202,1,16948,Sophomore Technique,Ozsoy,Firat Kazbek,12,4,1,0,0,0,0,3.531
+Spring 2024,ENGL,4385,1,16949,Fiction Forms,Turchi,Peter D,12,3,3,1,0,0,1,3.386
+Spring 2024,MUSI,1120,1,16950,University Chorus,Basili,Franco,6,0,0,0,0,0,0,3.945
+Spring 2024,MUSI,1220,1,16952,Class Piano I,Van Kekerix,Todd Evan,13,2,0,0,0,0,1,3.779
+Spring 2024,ENGI,4198,4,16955,Independent Study,Claydon,Frank J,0,0,0,0,0,16,0,
+Spring 2024,COMD,8392,1,16956,COMD Advanced Research Methods,Dial,Heather Raye,2,0,0,0,0,0,0,4.0
+Spring 2024,HLT,2320,3,16957,Introduction to Public Health,Proctor,Robin Ann,89,15,3,2,2,0,1,3.628
+Spring 2024,HLT,3380,2,16958,Culture and Health,Fedor Amador,Theresa Marie,45,9,2,4,0,0,1,3.517
+Spring 2024,BUSI,4305,1,16960,Business Ethics for Accountant,Brant Jr,Robert Edward,3,12,0,0,0,0,0,3.288
+Spring 2024,BUSI,4305,2,16962,Business Ethics for Accountant,Brant Jr,Robert Edward,2,2,0,0,0,0,0,3.5
+Spring 2024,PHED,1306,1,16963,Emergency Care & First Aid,Monreal,Daniel Joseph,33,3,0,1,0,0,0,3.82
+Spring 2024,PHED,1306,2,16964,Emergency Care & First Aid,Brown,Korey J,33,2,0,0,0,0,0,3.943
+Spring 2024,WGSS,2360,7,16966,Introduction to LGBT Studies,Stone,Lauren Michelle,11,9,2,0,1,0,0,3.218
+Spring 2024,ECE,3366,1,16967,Intro To Digital Signal Proc,Sheth,Bhavin R,16,9,1,0,0,0,0,3.59
+Spring 2024,ECE,5357,1,16970,Intro to Cybersecurity,Pan,Miao,28,16,3,0,0,0,0,3.539
+Spring 2024,ECE,6112,1,16971,Department Colloquium,Nguyen,Hien V,0,0,0,0,0,3,1,
+Spring 2024,LAW,5120,1,16972,Texas Legal Research,Dykes,Christopher,6,13,0,0,0,0,1,3.385
+Spring 2024,ECE,6318,1,16973,Converters & Applications,Krishnamoorthy,Harish Sarma,3,1,0,0,0,0,0,3.75
+Spring 2024,ECE,6343,1,16975,Renewable Energy,Rajashekara,Kaushik,9,12,2,0,0,0,1,3.347
+Spring 2024,MIS,7373,1,16980,Bus Appls Database Mgt Sys I,Grimes,George M,20,6,0,0,3,0,1,3.379
+Spring 2024,ECE,2202,5,16981,Circuit Analysis II,Ramachandran,Deepa,4,5,3,1,0,0,1,2.796
+Spring 2024,ECE,2202,6,16982,Circuit Analysis II,Ramachandran,Deepa,12,8,8,0,2,0,0,2.9
+Spring 2024,PSYC,7399,14,16987,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,6322,1,16989,Sport Media & Public Relations,Walsh,David W,4,6,2,0,0,0,1,3.112
+Spring 2024,ENGL,1301,50,16990,First Year Writing I,Murray,Christopher Brean,12,2,0,0,2,0,3,3.354
+Spring 2024,ENGL,1302,124,16991,First Year Writing II,Horton,Lara,5,10,4,0,1,0,4,2.785
+Spring 2024,ENGL,1302,125,16992,First Year Writing II,Woodward,Marshall B,13,2,1,0,0,0,2,3.75
+Spring 2024,ENGL,1302,126,16993,First Year Writing II,Mengesha,Abigail Mulatu,10,5,0,0,2,0,1,3.235
+Spring 2024,ENGL,1302,128,16994,First Year Writing II,Bellomy,Charlotte Seychelles,13,1,1,0,2,0,2,3.314
+Spring 2024,ENGL,1302,129,16995,First Year Writing II,Berg,Caleb J.,15,3,1,0,0,0,0,3.737
+Spring 2024,ENGL,8399,4,16997,Doctoral Dissertation,Mazella,David S,0,0,0,0,0,1,0,
+Spring 2024,CUIN,7398,1,16998,Independent Study,Brower,Samuel Richard,2,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7360,1,16999,Intl SW:A Comparative Approach,Leung,Yuk-Hi Patrick,8,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8399,5,17001,Doctoral Dissertation,Butler,Paul G,1,0,0,0,0,3,0,4.0
+Spring 2024,MUSI,4379,1,17002,History of Jazz II,Marmolejo,Noe J,6,1,0,0,0,0,0,3.763
+Spring 2024,BZAN,6353,2,17003,Res Design-Probs Busi Anlytcs,Aron,Ravi,4,9,0,0,0,0,0,3.308
+Spring 2024,MATH,3321,6,17004,Engineering Mathematics,Labate,Demetrio,9,13,4,4,5,0,0,2.439
+Spring 2024,MUSI,6120,1,17005,Percussion Ensemble,Wilkins,Blake M,3,0,0,0,0,0,0,4.0
+Spring 2024,SGNL,1301,5,17006,Elementary Sign Language I,Brittain,Terrell,2,8,8,0,0,0,1,2.557
+Spring 2024,MUED,3106,1,17008,Percussion,Warren,Paul Alexander,8,9,0,0,0,0,0,3.49
+Spring 2024,IART,2300,1,17009,The Arts in Houston,Newkirk,Elizabeth Diane,15,3,0,1,0,0,1,3.632
+Spring 2024,ENGL,8399,7,17010,Doctoral Dissertation,Harris,Francine Julia,1,0,0,0,0,0,0,4.0
+Spring 2024,MARK,7347,1,17011,Sales Analytics,Habel,Johannes,6,0,0,0,0,0,0,4.0
+Spring 2024,POLS,3313,4,17012,Intro Internatl Relatns,Ozsut,Melda,31,2,3,0,1,0,2,3.676
+Spring 2024,THEA,7399,1,17013,Masters Thesis,Coen,Elizabeth Manya,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1276,1,17016,Applied Jazz Percussion,Hubley,Robert L,1,0,0,0,0,0,0,3.67
+Spring 2024,PCOL,6498,5,17017,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Spring 2024,ENGL,8399,8,17018,Doctoral Dissertation,Boswell,Robert L,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,6360,1,17019,Biomolecular Engr Fundamentals,Willson,Richard,11,9,0,0,0,0,0,3.583
+Spring 2024,ENGL,8399,9,17020,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6350,1,17024,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,11,17026,Masters Thesis,Derrick,Jaye L,0,0,0,0,0,1,0,
+Spring 2024,ACCT,5301,1,17028,Financial and Managerial Acct,Kuruvilla,Mohan,12,3,3,2,0,0,7,3.267
+Spring 2024,INDE,2333,2,17029,Engineering Statistics I,Diaz Martinez,Neil Orlando,1,8,11,2,0,0,0,2.304
+Spring 2024,INDE,2331,2,17030,Computer Applications for IE,Wiggins,Nathanial David,15,1,0,0,0,0,0,3.896
+Spring 2024,ENGL,7699,2,17032,Thesis,Prufer,Kevin D,2,0,0,0,0,0,0,4.0
+Spring 2024,MECE,2334,2,17033,Thermodynamics,Love,Holley Carole,2,0,1,0,0,0,0,3.223
+Spring 2024,COSC,2425,3,17034,Computer Org & Architecture,Long,Kevin B,31,38,8,1,4,0,5,3.11
+Spring 2024,COSC,2425,5,17036,Computer Org & Architecture,Mantini,Pranav,77,43,17,1,5,0,9,3.266
+Spring 2024,CUIN,4332,1,17038,Literacy Assess Rdg Writing,Schorzman,Emma,26,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,3398,1,17039,Independent Study,Phan,Trang Anh Thuc,2,0,0,0,1,0,0,2.667
+Spring 2024,INDS,4180,2,17041,Design Internship,Kimbrough,Mark S,2,0,0,0,0,0,0,3.835
+Spring 2024,ENGL,8399,11,17043,Doctoral Dissertation,Parsons,Alexander M,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,6308,1,17044,Computer Architecture,Long,Kevin B,1,0,0,0,0,0,0,4.0
+Spring 2024,INDS,3370,1,17045,Advanced Design Systems,Feng,Jeff Feng,2,0,0,0,0,0,0,3.835
+Spring 2024,PSYC,7399,15,17052,Masters Thesis,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Spring 2024,ENGL,7399,2,17053,Essay,Nelson,Antonya,2,0,0,0,0,0,0,4.0
+Spring 2024,SPEC,6355,1,17054,Creat & Prod Thinking for G/T,Carp,Charlotte Lynn,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7399,3,17057,Essay,Divakaruni,Chitra B,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8399,12,17059,Doctoral Dissertation,Stock,Lorraine K,0,0,0,0,0,1,0,
+Spring 2024,INDS,2160,2,17060,Materials and Manufac Methods,Wells,Adam C,3,12,0,0,0,0,0,3.156
+Spring 2024,ENGL,8699,11,17062,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8399,13,17065,Doctoral Dissertation,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6381,2,17066,Information Visualization,Shastri,Dvijesh J,4,4,1,0,0,0,0,3.333
+Spring 2024,THEA,2344,1,17071,American Drama,Coen,Elizabeth Manya,11,15,2,0,1,0,0,3.116
+Spring 2024,CIVE,4337,1,17074,Transportation Engineering,Joskowicz,Isaac,38,6,0,0,0,0,0,3.826
+Spring 2024,NUTR,2332,7,17075,Intro To Human Nutrition,Yoon,Cynthia Yursun,94,164,54,16,9,0,8,2.908
+Spring 2024,ENGL,7399,4,17076,Essay,Voskuil,Lynn M,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7699,5,17079,Thesis,Turchi,Peter D,2,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6167,5,17092,Research Practicum A,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6326,1,17095,Applied Double Bass,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,12,17096,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,1,0,
+Spring 2024,CIVE,6338,2,17098,Advanced Steel Design,Mercan,Bulent,2,0,0,0,0,0,0,3.67
+Spring 2024,CIVE,6350,4,17099,Advanced Mechs of Matls,Ballarini,Roberto,0,0,1,0,0,0,5,1.67
+Spring 2024,CIVE,6361,2,17100,Engineering Hydrology,Rifai,Hanadi S,0,1,0,0,0,0,1,3.33
+Spring 2024,CIVE,6391,3,17101,Envrn Engr Microbiology,Rodrigues,Debora Frigi,4,3,0,0,0,0,0,3.43
+Spring 2024,ECE,8699,9,17102,Doctoral Dissertation,Fu,Xin,3,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,6388,2,17103,Hazardous Waste Proceses,Rixey,William G,2,0,0,0,0,0,0,3.835
+Spring 2024,CHEE,3321,3,17104,Analytical Methods Chem Engr,Conrad,Jacinta C,2,0,0,0,0,0,1,4.0
+Spring 2024,CHEE,3333,2,17105,Chem Engr Thermodyn II,Zerze,Gul,1,0,0,0,0,0,2,4.0
+Spring 2024,CHEE,3363,2,17111,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,3367,2,17112,Process Modeling and Control,Kaspar,Michael,0,2,1,0,0,0,0,2.667
+Spring 2024,PSYC,7399,17,17118,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,1,0,
+Spring 2024,ACCT,3367,6,17119,Intermediate Accounting I,Gamble,George O,2,5,2,0,0,0,0,2.927
+Spring 2024,ENGL,1302,130,17122,First Year Writing II,Denton,Amy,15,3,0,1,1,0,3,3.5
+Spring 2024,THEA,6399,1,17127,Masters Thesis,Coen,Elizabeth Manya,2,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8199,9,17132,Doctoral Dissertation,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,7358,1,17133,Programming in R - Fina Appls,Li,Yu,18,2,0,0,0,0,1,3.9
+Spring 2024,HLT,4310,4,17138,Program Planning for Hlt Prof,Bennett,Kristin C,31,4,1,0,1,0,2,3.703
+Spring 2024,ACCT,2302,12,17139,Prin of Managerial Accounting,Seltz,Joe D,39,19,12,5,3,0,3,3.132
+Spring 2024,ECE,6327,2,17140,Smart Grid Systems,Li,Xingpeng,0,3,1,0,2,0,3,1.833
+Spring 2024,HIST,8688,2,17152,Dissertation Proposal,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2024,PSYC,7399,19,17184,Masters Thesis,Fetterman,Adam Kent,0,0,0,0,0,2,0,
+Spring 2024,CIVE,2332,2,17185,Mechanics of Solids,Zamiran,Siavash,0,2,0,0,0,0,0,3.0
+Spring 2024,CIVE,8498,3,17211,Doctoral Research,Lee,Hyongki,0,0,0,0,0,5,0,
+Spring 2024,BIOE,8598,26,17212,Doctoral Research,Pollonini,Luca,0,0,0,0,0,2,0,
+Spring 2024,ARTS,3384,1,17215,Sound Art,Cone,Marcus Andrew,9,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,4331,4,17216,Federal Income Tax,Meade,Janet,1,3,19,13,3,0,3,1.59
+Spring 2024,PSYC,7399,20,17217,Masters Thesis,Borjon,Jeremy Isaac,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,14,17223,Masters Thesis,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Spring 2024,BZAN,6354,2,17228,DB Mgt Tools Bus Analytics,Grimes,George M,22,4,2,0,0,0,0,3.714
+Spring 2024,MIS,7375,1,17229,Transaction Processing Systems,Messinger,Jacob Nelson,16,3,0,0,0,0,0,3.738
+Spring 2024,ENTR,7335,1,17231,Entreprnl Profit & Cash Mgt,Becker,Charles D,5,2,2,0,0,0,0,3.26
+Spring 2024,ENTR,7337,1,17232,Entrepreneur Cap & Legal Forms,Wilbur,Stephen,10,6,0,0,0,0,1,3.563
+Spring 2024,INDE,6333,2,17238,Probability Stat For Engineers,Chung,Christopher,10,5,2,0,1,0,1,3.241
+Spring 2024,BCHS,6298,2,17239,Special Problems,Widger,William R,0,0,0,0,0,2,0,
+Spring 2024,BIOL,7124,3,17241,Cell Biology Seminar,Lekven,Arne,0,0,0,0,0,8,0,
+Spring 2024,SOC,7399,1,17258,Masters Thesis,Savage,Scott Vandenburgh,0,0,0,0,0,1,0,
+Spring 2024,SOC,6399,4,17259,Masters Thesis,Lee,Shayne,0,0,0,0,0,1,0,
+Spring 2024,SOC,7399,2,17262,Masters Thesis,Monserud,Maria Aleksandrovna,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8399,13,17266,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGI,2304,13,17267,Technical Communications,Wilson,Chad A,14,2,0,0,2,0,0,3.463
+Spring 2024,ENGI,2304,10,17277,Technical Communications,Salvo,Deborah C,14,3,1,0,0,0,1,3.796
+Spring 2024,BIOE,8598,27,17279,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2024,PSYC,7399,21,17281,Masters Thesis,Ng,Vincent,2,0,0,0,0,0,0,4.0
+Spring 2024,HIST,4399,2,17285,Senior Honors Thesis,Harwell,Debbie Z,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,3336,4,17286,Mechanics II,Metrovich,Brian,2,3,4,0,0,0,0,2.778
+Spring 2024,CIVE,8398,8,17287,Doctoral Research,Zhang,Ruda,0,0,0,0,0,1,0,
+Spring 2024,ARTS,2316,3,17290,Fundamentals of Painting,Willis,William H,17,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8699,2,17291,Doctoral Dissertation,Johnston,Craig Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,PHIL,1301,5,17293,Intro To Philosophy,Haaga,Curtis W,32,15,2,0,0,0,1,3.639
+Spring 2024,MATH,8698,28,17295,Doctoral Research,Cappanera,Loic,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8498,4,17298,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,2,0,
+Spring 2024,BCHS,8999,3,17300,Doctoral Dissertation,Sen,Mehmet,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8240,10,17302,Doctoral Recital I,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8199,6,17308,Doctoral Dissertation Defense,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8399,3,17314,Doctoral Dissertation,Clark,Jennifer H,1,0,0,0,0,1,0,4.0
+Spring 2024,POLS,8699,4,17318,Doctoral Dissertation,Clark,Jennifer H,0,0,0,0,0,1,0,
+Spring 2024,POLS,8699,6,17320,Doctoral Dissertation,Kennedy,Ryan P,0,0,0,0,0,1,0,
+Spring 2024,ENGL,4304,1,17330,Varieties of English,Duran,Chatwara,22,5,0,0,1,0,2,3.655
+Spring 2024,FINA,7A20,3,17331,Capital Markets,Wu,Guojun,23,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8240,11,17334,Doctoral Recital I,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,8999,4,17338,Doctoral Dissertation,Schwartz,Robert J,1,0,0,0,0,0,0,4.0
+Spring 2024,SCM,4362,2,17345,Demand and Supply Integration,Li,Meng,23,8,1,0,1,0,0,3.486
+Spring 2024,MUSA,6304,4,17351,Conducting,Koppel,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,2317,9,17352,Intro to Psychology Statistics,Steinberg,Lynne,4,4,12,1,3,0,20,2.208
+Spring 2024,PSYC,2319,6,17353,Intro to Social Psychology,Ravey,Eriksen,38,26,8,2,1,0,1,3.258
+Spring 2024,SOCI,1301,15,17356,Introduction To Sociology,Cooper,Chelsey Wells,41,1,0,0,0,0,0,3.953
+Spring 2024,SOCI,1301,16,17357,Introduction To Sociology,Colbert,Sharla Stettnisch,32,4,2,1,1,0,0,3.666
+Spring 2024,MARK,6398,1,17358,Research,Herman,Carl,5,0,0,0,0,0,0,4.0
+Spring 2024,PHLA,6120,1,17359,Leadership Concepts I,Varkey,Divya A,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,2312,4,17362,Intermediate Spanish II,Ruffino,Maythe,4,10,8,0,0,0,2,2.728
+Spring 2024,ECE,8498,30,17363,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Spring 2024,ECE,8699,10,17364,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Spring 2024,PEP,8699,4,17365,Doctoral Dissertation,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8298,9,17366,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,1,
+Spring 2024,HDFS,1300,15,17372,Dev of Contemporary Families,Jordan,Erica F,30,12,1,0,0,0,2,3.644
+Spring 2024,HDFS,2314,10,17374,Human Dev and Interventions,Schoger,Kimberly,53,2,0,0,0,0,0,3.952
+Spring 2024,MECE,8298,53,17378,Doctoral Research,Floryan,Daniel,0,0,0,0,0,3,0,
+Spring 2024,MECE,6399,9,17382,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,7399,8,17383,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8598,54,17384,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8298,7,17389,Doctoral Research,Li,Hongyi,0,0,0,0,0,3,0,
+Spring 2024,PSYC,6398,19,17393,Independent Studies,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7399,24,17394,Masters Thesis,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8699,11,17395,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8240,12,17396,Doctoral Recital I,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8298,8,17397,Doctoral Research,Momen,Mostafa,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8498,5,17398,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Spring 2024,ENGL,7699,8,17406,Thesis,Berger,Jason,1,0,0,0,0,0,0,4.0
+Spring 2024,MIS,8999,1,17408,Doctoral Dissertation in MIS,Aron,Ravi,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8241,7,17412,Doctoral Recital II,Hester,Timothy E,3,0,0,0,0,0,0,3.78
+Spring 2024,MUSA,6220,1,17413,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,1502,13,17414,Elementary Spanish II,Hernandez-Vargas,Saul,11,6,2,0,0,0,1,3.404
+Spring 2024,ECE,8699,14,17416,Doctoral Dissertation,Nguyen,Hien V,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8398,10,17417,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Spring 2024,COSC,6323,2,17422,Statistical Method in Research,Pavlidis,Ioannis T,4,3,0,4,1,0,0,2.417
+Spring 2024,PSYC,6398,20,17425,Independent Studies,Francis,David J,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8498,6,17430,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Spring 2024,BIOL,4399,2,17439,Senior Honors Thesis,Sen,Mehmet,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8398,11,17440,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2024,COMM,1303,6,17441,Writing for Communicators,Lyn,Robyn,29,16,9,1,8,0,7,2.889
+Spring 2024,CIVE,8498,7,17442,Doctoral Research,Li,Hongyi,0,0,0,0,0,3,0,
+Spring 2024,MUSA,8240,13,17445,Doctoral Recital I,Clayton Vasquez,Cynthia L,0,0,0,0,0,0,0,
+Spring 2024,PSYC,6393,11,17449,Clinical Research Practicum,Woods,Steven Paul,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8398,12,17451,Doctoral Research,Momen,Mostafa,0,0,0,0,0,4,0,
+Spring 2024,MUSA,8242,8,17452,Doctoral Recital III,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6657,1,17453,Research Practicum B,Ostrin,Lisa,2,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6198,25,17454,Spec Prob-Physio Optics,Nurminen,Lauri Oskari,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7392,4,17455,Psychology Practicum,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8699,15,17461,Doctoral Dissertation,Han,Zhu,3,0,0,0,0,0,0,4.0
+Spring 2024,MECE,7399,9,17467,Masters Thesis,Liu,Dong,0,0,0,0,0,0,0,
+Spring 2024,MECE,8399,43,17471,Doctoral Dissertation,Franchek,Matthew,0,0,0,0,0,2,0,
+Spring 2024,MECE,8398,50,17475,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Spring 2024,MECE,8398,51,17476,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8320,16,17485,Doctoral Applied Music,Hughes,Mark Alan,2,0,0,0,0,0,0,4.0
+Spring 2024,FINA,8398,3,17488,Special Problems,Hitzemann,Steffen,2,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8699,15,17494,Doctoral Dissertation,Cescon,Marzia,0,0,0,0,0,2,0,
+Spring 2024,ENGL,3399,1,17496,Senior Honors Thesis,Duran,Chatwara,0,0,0,0,0,0,0,
+Spring 2024,MUSA,8240,15,17497,Doctoral Recital I,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,8199,1,17498,Dissertation,Leung,Yuk-Hi Patrick,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8399,46,17504,Doctoral Dissertation,Ardebili,Haleh,0,0,0,0,0,1,0,
+Spring 2024,COSC,7399,130,17505,Masters Thesis,Vilalta,Ricardo,0,0,0,0,0,1,0,
+Spring 2024,BIOE,4302,2,17509,Numerical Analysis for BME,An,Ran,1,0,0,0,0,0,0,3.67
+Spring 2024,HON,4398,6,17511,Independent Study,Modaff,Abigail,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8598,28,17516,Doctoral Research,Akay,Yasemin M,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,27,17517,Doctoral Research,Akay,Yasemin M,0,0,0,0,0,1,0,
+Spring 2024,PEP,8699,8,17520,Doctoral Dissertation,Ogunrinde,Joyce,2,0,0,0,0,0,0,4.0
+Spring 2024,BUSI,4396,4,17523,Business Internship,Newman,Michael Ray,0,0,0,0,0,4,0,
+Spring 2024,FINA,4396,2,17525,Finance Internship,Kumar,Praveen,0,0,0,0,0,12,0,
+Spring 2024,ECON,6351,1,17543,Economic Forecasting,Maden,Bitaran Jang,6,6,1,0,0,0,0,3.512
+Spring 2024,ECON,6353,1,17544,Capital Market Economics,Peru Durayalage,Dhanushka Arunasiri,7,4,1,0,0,0,0,3.473
+Spring 2024,ECON,4385,1,17548,Monetary Policy,Papell,David H,7,10,6,0,0,0,0,3.029
+Spring 2024,PHYS,2325,3,17556,University Physics I (lecture),Forrest,Rebecca L,20,12,18,3,1,0,5,2.84
+Spring 2024,PHYS,2325,5,17558,University Physics I (lecture),Freelon,Byron Kendall,20,32,37,1,2,0,18,2.728
+Spring 2024,PHYS,3309,1,17564,Intermediate Mechanics,Stokes,Donna,1,2,3,1,1,0,3,2.208
+Spring 2024,CUIN,8342,1,17565,Social Justice and Equity,Batt,Joanna,11,1,2,0,0,0,0,3.666
+Spring 2024,ARED,2310,3,17566,Intro Critical Visual Culture,Ripley,Lindsay N,15,8,2,0,0,0,0,3.375
+Spring 2024,ARED,2310,2,17567,Intro Critical Visual Culture,Chung,Sheng Kuan,17,4,2,0,1,0,0,3.459
+Spring 2024,CLAS,3307,2,17569,Greek & Roman Myths of Heroes,Due Hackney,Casey L,62,21,14,6,0,0,6,3.266
+Spring 2024,JWST,2372,1,17573,The Bible & Modern Pop Culture,Tamber-Rosenau,Caryn M,8,4,4,1,0,0,0,3.118
+Spring 2024,SPAN,2311,7,17580,Intermediate Spanish I,del Castillo Garza,Alejandro,6,11,6,1,2,0,0,2.73
+Spring 2024,SPAN,2312,1,17581,Intermediate Spanish II,Morales Utria,Yordanis,10,12,4,0,1,0,0,3.038
+Spring 2024,SPAN,2312,5,17582,Intermediate Spanish II,Malacara Sanchez,Jonathan Jorge,3,4,12,0,0,0,5,2.405
+Spring 2024,JAPN,1502,1,17588,Elementary Japanese II,Ji,Fang,13,6,2,0,0,0,3,3.461
+Spring 2024,JAPN,1502,3,17590,Elementary Japanese II,Ji,Fang,18,5,1,0,0,0,1,3.75
+Spring 2024,WCL,4356,1,17599,World Film and Film Theory,Carrera,Alessandro,21,5,1,2,0,0,0,3.506
+Spring 2024,CUIN,4350,2,17602,Multiple Teaching Strategies,Latiolais,Cheryl S,6,2,0,0,0,0,1,3.709
+Spring 2024,CUIN,3351,1,17603,Class Interact Science-Math,Manuel,Mariam A,10,1,0,0,0,0,0,3.909
+Spring 2024,ARCH,7601,7,17605,Architecture Design Studio VI,Zweig,Peter J,6,3,0,0,0,0,0,3.667
+Spring 2024,ARCH,2501,25,17607,Architecture Design Studio IV,Olwi,Asmaa,7,6,1,0,0,0,0,3.358
+Spring 2024,GEOL,1147,4,17622,Introductory Meteorology Lab,Rappenglueck,Bernhard,3,6,0,1,1,0,2,2.758
+Spring 2024,ELCS,8361,2,17625,Public & Community Relations,Shockley,Gerald,6,2,0,0,0,0,0,3.75
+Spring 2024,MANA,7338,1,17628,Org Power Politics & Culture,Abbott,Jeanna L,24,2,0,0,0,0,0,3.91
+Spring 2024,MANA,7339,3,17629,Leadership Development,Witt,Lawrence A,26,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,2301,1,17632,Intro to Physical Anthropology,McElvaney,Katherine Anne,15,20,12,5,1,0,5,2.824
+Spring 2024,MANA,7357,1,17633,Fund of Diversity Equity & Inc,Baldwin,Cheryl,7,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,4363,1,17634,"Race, Racialization & Culture",De Genova,Nicholas Paul,7,9,1,0,0,0,1,3.334
+Spring 2024,GEOL,3145,2,17636,Strctrl Geology Lab,Murphy,Michael,4,2,1,0,0,0,0,3.334
+Spring 2024,ANTH,3316,1,17639,Society and Culture of India,Majumder,Sarasij,20,1,2,1,0,0,2,3.557
+Spring 2024,ANTH,4338,1,17643,Visual Anthropology,Routon,Erin Danielle,20,3,0,1,0,0,0,3.654
+Spring 2024,RELS,2350,1,17653,Introduction to Islam,Haq,Muhammad Nisarul,27,17,2,0,1,0,1,3.454
+Spring 2024,RELS,2340,1,17654,Introduction to Hinduism,Ullrey,Aaron Michael,13,15,7,5,2,0,6,2.636
+Spring 2024,RELS,2372,1,17655,Bible and Modern Pop Culture,Tamber-Rosenau,Caryn M,10,5,0,1,0,0,0,3.479
+Spring 2024,RELS,3337,1,17656,Theologies from the Margins,Pegoda,Andrew Joseph,7,1,6,2,3,0,6,2.334
+Spring 2024,ENGL,2340,1,17661,Cosmic Narratives,Wood,Barry Albert,12,13,2,0,2,0,4,2.956
+Spring 2024,MANA,6383,2,17662,Strategic Managment,Carlin,Barbara A,9,3,0,0,0,0,0,3.75
+Spring 2024,FINA,6335,1,17663,Managerial Finance,Wu,Guojun,14,0,0,0,0,0,0,4.0
+Spring 2024,ECON,4376,1,17664,Industrial Organization,Szabo,Andrea,3,5,10,0,0,0,2,2.666
+Spring 2024,SOC,3300,1,17665,Intro to Sociological Theory,Grigorian,Stella,17,9,6,1,2,0,4,3.029
+Spring 2024,SOC,3314,1,17667,Juvenille Delinquency,Gallo,Joseph Ralph,30,4,2,2,1,0,1,3.538
+Spring 2024,SOC,3316,2,17668,Sociology of Sport,Haltom,Trenton Matthews,20,11,2,3,4,0,3,3.017
+Spring 2024,SOC,3344,2,17670,Sociology of Aging,Davis,Mary A,45,3,1,0,2,0,0,3.719
+Spring 2024,SOC,3342,1,17673,Sociology of Work,Lorence,Jon P,12,15,3,0,0,0,2,3.344
+Spring 2024,SOC,3373,1,17675,Comparative Family Structures,Monserud,Maria Aleksandrovna,28,9,1,2,1,0,2,3.488
+Spring 2024,SOC,3382,1,17676,Sociology of Drug Use & Recove,Adams,Jennifer Lauren,39,4,1,0,0,0,0,3.849
+Spring 2024,ENGL,3306,1,17679,Shakespeare-Major Works,Mikics,David,7,9,0,0,0,0,2,3.438
+Spring 2024,ENGL,3316,1,17680,Lit of Victorian Age,Guajardo,Paul,11,2,0,0,0,0,1,3.795
+Spring 2024,ENGL,3350,2,17681,Am Lit To 1865,Berger,Jason,23,6,0,0,0,0,0,3.702
+Spring 2024,ENGL,3367,1,17683,Gay and Lesbian Literature,Snediker,Michael,13,12,1,0,0,0,0,3.5
+Spring 2024,ENGL,6324,1,17688,Non-Fiction Prose Workshop,Flynn,Nicholas,9,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8323,1,17691,Master Workshop: Narrative,Boswell,Robert L,4,2,0,0,0,0,0,3.667
+Spring 2024,CUIN,8310,1,17695,Laboratory of Practice,Hutchison,Laveria F,6,0,0,0,0,0,0,3.945
+Spring 2024,ELED,4312,1,17697,Science in the Elem School II,Bailer,Jill,20,3,0,0,0,0,0,3.87
+Spring 2024,ELED,4312,4,17700,Science in the Elem School II,Wong,Sissy S,32,1,0,0,0,0,0,3.96
+Spring 2024,ELED,4312,5,17701,Science in the Elem School II,Wong,Sissy S,32,1,0,0,0,0,0,3.95
+Spring 2024,CHEM,1322,1,17702,Honors Fund of Chem 2,Hoffman,David M,12,9,7,1,1,0,0,3.0
+Spring 2024,SOCI,1301,7,17706,Introduction To Sociology,Cooper,Chelsey Wells,49,5,4,0,1,0,1,3.645
+Spring 2024,CHEM,4373,1,17707,Survey of Physical Chemistry,Carrasquillo M,Edwin,7,16,9,0,1,0,3,2.818
+Spring 2024,BIOL,4323,1,17709,Immunology,Peng,Weiyi,21,21,5,0,0,0,2,3.242
+Spring 2024,ENGI,1331,2,17710,Computing for Engineers,Kota,Venkata Krishna Tulasi,15,4,1,2,0,0,4,3.485
+Spring 2024,CUIN,4341,1,17712,Teaching Math Problem Solving,Cutler,Carrie Sybil,22,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,2501,27,17713,Architecture Design Studio IV,Murray,Cara,5,5,4,0,0,0,0,3.095
+Spring 2024,BCHS,3304,3,17715,General Biochemistry I,Fox,Robert O,14,24,9,0,0,0,2,3.141
+Spring 2024,ENTR,3310,6,17716,Entrepreneurship,Boles,James Read,10,3,0,0,0,0,0,3.718
+Spring 2024,ENTR,4330,2,17718,Entrepreneurial Costs/Budgets,Becker,Charles D,15,13,4,2,1,0,3,3.077
+Spring 2024,ENTR,4340,1,17720,Entrepreneurial Capital,Rios,Eduardo Javier,14,16,1,0,0,0,0,3.324
+Spring 2024,MARK,3338,1,17724,Intro to Marketing Analytics,Luo,Bowen,70,61,11,2,3,0,6,3.275
+Spring 2024,MARK,3338,2,17725,Intro to Marketing Analytics,Luo,Bowen,63,71,10,3,1,0,8,3.286
+Spring 2024,ENGL,3331,3,17727,Beg Creative Writing-Poetry,Abdelwahab,Maha Ahmed Ibraheem,11,1,1,0,0,0,1,3.744
+Spring 2024,MARK,7379,1,17728,Sales Leadership,McAndrews,Craig D,4,1,0,0,0,0,0,3.602
+Spring 2024,FINA,3332,5,17729,Prin of Financial Management,Suleymanov,Masim,83,69,44,16,3,0,3,3.028
+Spring 2024,MATH,4364,2,17730,Intro to Numerical Analysis,Morgan,Jeffrey,18,20,9,0,2,0,10,2.987
+Spring 2024,MATH,2305,5,17731,Discrete Mathematics,Xhabli,Blerina,19,14,18,8,7,0,12,2.46
+Spring 2024,MATH,1324,3,17732,Finite Math with Applications,Caglar,Atife,62,30,38,10,32,0,16,2.411
+Spring 2024,MATH,2318,2,17733,Linear Algebra,Cappanera,Loic,14,16,10,1,4,0,13,2.763
+Spring 2024,IDNS,2112,2,17737,Precalculus SEP Workshop,Pattison,Donna,9,2,4,2,0,0,3,3.039
+Spring 2024,HIST,4361,1,17745,20th Century Genocides,Guenther,Irene V,15,5,0,0,0,0,2,3.75
+Spring 2024,POLS,3353,1,17748,Policy & Administration,Belco,Michelle Helene,19,3,0,0,0,0,0,3.909
+Spring 2024,BIOL,4302,1,17749,Galapago! Rsch Lrng Abroad,Hanke,Marc H,18,1,0,0,0,0,1,3.895
+Spring 2024,HON,3377,1,17750,Amer Legal History: Civil War,Erwing,Douglas A,9,1,0,0,0,0,0,3.867
+Spring 2024,ENGL,1301,54,17756,First Year Writing I,Feizbakhsh Tavana,Zahra,11,3,2,0,1,0,2,3.314
+Spring 2024,WGSS,2350,17,17762,Intro To Women's Studies,Bustillo,Anneliese,16,3,6,2,3,0,0,2.834
+Spring 2024,ELCS,6380,2,17769,Educational Planning & Policy,McKinney,Lonnie Lyle,7,4,1,0,0,0,0,3.5
+Spring 2024,COMM,4328,1,17770,Broadcast & Film Writing,Vaughan,Thomas Michael,17,2,1,0,0,0,1,3.767
+Spring 2024,COMM,4335,1,17773,Crisis Communication,Graham,Catherine Burch,12,14,4,0,2,0,1,3.021
+Spring 2024,SCM,4301,2,17775,Logistics Management,Tibodeau,Dale,18,22,3,1,0,0,0,3.28
+Spring 2024,ENGL,1302,131,17776,First Year Writing II,Kroger,Ann Gabriel,11,8,3,0,2,0,1,3.042
+Spring 2024,ENGL,1302,132,17777,First Year Writing II,Kroger,Ann Gabriel,10,8,4,0,0,0,3,3.183
+Spring 2024,BIOL,4311,1,17779,Genomic Data Analysis,Meisel,Richard P,19,1,0,0,1,0,1,3.715
+Spring 2024,BIOL,6311,1,17780,Genomic Data Analysis,Meisel,Richard P,6,1,0,0,0,0,0,3.857
+Spring 2024,SCM,4330,4,17782,Bus Modeling and Dec Analysis,Cossick,Kathy L,3,0,1,2,1,0,2,2.286
+Spring 2024,SCM,4350,2,17783,Strategic Supply Management,Wayhan,Victor Brian,31,10,0,1,0,0,0,3.62
+Spring 2024,SCM,4362,3,17784,Demand and Supply Integration,Dillibe,Onyinye,3,4,1,0,0,0,0,3.291
+Spring 2024,SOCW,7340,2,17785,Clinical Practice with Child,Rivera,Jaime,22,3,0,0,1,0,0,3.731
+Spring 2024,MIS,7375,2,17788,Transaction Processing Systems,Messinger,Jacob Nelson,9,8,0,0,0,0,0,3.413
+Spring 2024,ENGL,2316,1,17789,Literature and Culture,Pogue,Donovan A,7,3,0,0,2,0,0,3.111
+Spring 2024,MECE,2334,3,17790,Thermodynamics,Huang,Yi-Chun,23,24,7,0,0,0,4,3.266
+Spring 2024,SGNL,1302,4,17791,Elementary Sign Language II,Brittain,Robyn Michelle,5,7,3,3,0,0,1,2.704
+Spring 2024,MECE,4343,1,17792,Thermal Design,Zhao,Bo,37,62,16,1,0,0,1,3.138
+Spring 2024,MECE,6336,1,17793,Engineering Heat Transfer,Ghasemi,Hadi,3,4,0,0,0,0,0,3.381
+Spring 2024,ACCT,2301,9,17794,Prin of Financial Accounting,Zhu,Limin,7,19,22,11,6,0,3,2.296
+Spring 2024,ACCT,2301,10,17795,Prin of Financial Accounting,Sykes,Mary Reeves,22,11,5,3,2,0,6,3.185
+Spring 2024,SOCW,7367,6,17796,Social Policy Analysis,Borja,Sharon G,21,4,0,0,2,0,0,3.556
+Spring 2024,ENGL,1302,133,17798,First Year Writing II,Sicinski,Michael J,8,9,0,0,1,0,0,3.204
+Spring 2024,ENGL,1302,134,17799,First Year Writing II,Lee,Nathanael D,10,5,0,1,1,0,2,3.197
+Spring 2024,ENGL,1302,136,17801,First Year Writing II,Denton,Amy,9,5,1,0,3,0,1,2.834
+Spring 2024,EDS,6342,1,17802,Intro to Machine Learning,Kulkarni,Yashashree,29,25,7,1,0,0,0,3.323
+Spring 2024,ENGL,1302,137,17803,First Year Writing II,Al-Bedawi,Layla,7,3,2,2,4,0,0,2.352
+Spring 2024,EDS,6340,1,17804,Introduction to Data Science,Kulkarni,Yashashree,65,5,0,0,0,0,0,3.952
+Spring 2024,EDS,6344,1,17805,AI for Engineers,Kulkarni,Yashashree,58,2,0,0,0,0,0,3.978
+Spring 2024,ENGL,1302,139,17807,First Year Writing II,Islam,Muhammad Nurul,17,0,0,0,0,0,2,3.864
+Spring 2024,ACCT,3368,4,17812,Intermediate Accounting II,Sun,Xue,11,22,14,0,0,0,2,2.929
+Spring 2024,COMD,3385,2,17813,Speech Science,Hein Machado,Sofia,11,11,1,0,0,0,0,3.42
+Spring 2024,ACCT,4335,3,17815,Financial Statement Auditing,Kuruvilla,Mohan,11,9,7,3,1,0,4,2.839
+Spring 2024,COMD,3381,1,17818,Audiology,Andrews,Chereece N,22,12,0,0,0,0,0,3.666
+Spring 2024,PHIL,1361,5,17820,Philosophy and the Arts,Drapela,Nick Gerard,8,14,14,3,4,0,7,2.396
+Spring 2024,PHIL,1361,6,17821,Philosophy and the Arts,Mag Uidhir,Christopher Domh,126,55,4,0,8,0,6,3.489
+Spring 2024,PSYC,4343,1,17822,Perception,Tamber-Rosenau,Benjamin J,10,18,11,4,0,0,4,2.814
+Spring 2024,PHIL,3377,1,17827,Philosophy of Religion,Oliveira,Luis RG,26,6,0,0,1,0,1,3.667
+Spring 2024,PHIL,3354,1,17828,Medical Ethics,Determeyer,Peggy Lee,10,2,0,0,0,0,0,3.778
+Spring 2024,COMD,7192,1,17829,Advanced Practicum,Eckert,Janet F,0,1,0,0,0,0,0,3.33
+Spring 2024,SOCW,8344,1,17830,Research Methods IV,Walton,Quenette,5,1,0,0,0,0,0,3.833
+Spring 2024,COMD,2376,1,17831,Anatomy for Communication,Daniels,Stephanie K,19,15,16,7,1,0,17,2.776
+Spring 2024,KIN,3304,3,17837,Human Structure & Phys Perform,Hunt,Rebekah,4,20,14,6,3,0,2,2.347
+Spring 2024,ARCH,3112,2,17839,Topics in Design Media,Woodfill,Celeste Ponce,2,8,2,0,0,0,1,3.11
+Spring 2024,ARCH,3112,4,17840,Topics in Design Media,Noldt,Peter,13,2,0,0,1,0,0,3.563
+Spring 2024,ARCH,3112,3,17841,Topics in Design Media,Murray,Cara,11,2,2,0,0,0,0,3.468
+Spring 2024,ARCH,3112,5,17842,Topics in Design Media,Noldt,Peter,7,7,0,0,1,0,0,3.355
+Spring 2024,ARCH,3112,6,17843,Topics in Design Media,Noldt,Peter,14,0,0,0,0,0,1,3.764
+Spring 2024,ARCH,3112,7,17844,Topics in Design Media,Noldt,Peter,9,3,0,0,1,0,0,3.284
+Spring 2024,ARCH,3112,8,17845,Topics in Design Media,Noldt,Peter,3,6,0,0,0,0,3,3.26
+Spring 2024,ARCH,3112,9,17846,Topics in Design Media,Noldt,Peter,9,7,0,0,1,0,0,3.392
+Spring 2024,ARCH,3112,11,17847,Topics in Design Media,Jackson,Megan H,15,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,3112,12,17848,Topics in Design Media,Jackson,Megan H,14,0,0,0,1,0,0,3.733
+Spring 2024,ARCH,3112,14,17849,Topics in Design Media,Smith,Joshua S,15,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,3112,15,17850,Topics in Design Media,Kudless,Andrew Justin,14,0,0,0,0,0,1,4.0
+Spring 2024,ACCT,7390,1,17851,Contrl & Secur of Finan Inform,Brant Jr,Robert Edward,16,13,1,0,0,0,0,3.555
+Spring 2024,CNE,2211,1,17854,Construction Engr Fundamentals,Safa,Mahdi,0,1,0,0,0,0,0,3.0
+Spring 2024,CIVE,2332,3,17856,Mechanics of Solids,Zamiran,Siavash,4,6,1,0,0,0,0,3.273
+Spring 2024,POLC,1311,1,17857,Public Policy Laboratory,Sands,Sara,14,8,1,1,0,0,1,3.362
+Spring 2024,POLC,3315,1,17858,Policy Res Methods Stat & Reg,Gottlieb,Jessica Anne,6,6,5,1,0,0,1,2.926
+Spring 2024,KIN,4350,2,17859,Sport Marketing,Ogunrinde,Joyce,21,20,3,0,0,0,4,3.379
+Spring 2024,POLC,4390,1,17860,Public Policy Internship,Cross,Renee Danielle,8,0,0,0,0,0,0,4.0
+Spring 2024,NUTR,3330,2,17861,Mgmt in Food & Nutr Systems,Haubrick,Kevin,3,5,0,0,0,0,0,3.251
+Spring 2024,ACCT,4335,4,17865,Financial Statement Auditing,Rousseau,Linette Marie,14,11,4,0,0,0,2,3.424
+Spring 2024,COMD,3322,1,17866,Code-Switching Ling Justice,Mills,Monique T,28,1,1,0,2,0,2,3.625
+Spring 2024,ACCT,5335,3,17867,Financial Statement Auditing,Rousseau,Linette Marie,0,1,0,0,0,0,0,3.33
+Spring 2024,ACCT,7320,1,17870,Intro to Data Analytics-Acct,Miles,Carolyn A,11,6,1,0,0,0,0,3.501
+Spring 2024,HIST,3351,1,17897,Work&Family-Modern Eur,Boyd,Sarah Fishman,17,25,3,1,2,0,4,3.098
+Spring 2024,HIST,2314,1,17898,Global Civilization since 1500,Bhattacharya,Nandini Saradindu,7,2,0,0,0,0,2,3.741
+Spring 2024,HIST,3301,1,17903,Latin American Hist Thru Film,Howard,Philip,9,9,5,2,3,0,5,2.573
+Spring 2024,HIST,6382,1,17907,Research in Public History,Klieman,Kairn,8,0,0,0,0,0,0,4.0
+Spring 2024,STAT,3331,2,17909,Statistical Anal Bus Appl I,Wiley,Briceon C,117,110,89,41,6,0,34,2.77
+Spring 2024,CUIN,7355,1,17910,Team & Org Leadership,Hausmann,Robert Carl,9,0,1,0,0,0,0,3.833
+Spring 2024,LAW,5342,3,17911,Prof Writing Strategies,Warren,Jill,4,7,1,0,0,0,0,3.278
+Spring 2024,HIST,1301,50,17912,The U.S. to 1877,Vale,Timothy Eli,20,3,1,0,1,0,0,3.6
+Spring 2024,LAW,6321,3,17913,Professional Responsibility,Knake,Renee N,21,13,2,0,0,0,0,3.399
+Spring 2024,LAW,6321,4,17914,Professional Responsibility,Davis,Megan Leigh-Wilson,11,20,2,0,0,0,0,3.273
+Spring 2024,ARTS,3313,3,17915,Silkscreen,Bender,Hannah,10,3,0,0,0,0,0,3.718
+Spring 2024,LAW,6369,8,17916,Legal Analysis and Writing,Simmons,Laurel Ellis Parker,0,0,0,0,0,8,0,
+Spring 2024,ARTS,3315,1,17917,Monoprint/Monotype Printmaking,Alderson,Saran,12,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5116,1,17918,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,14,0,
+Spring 2024,LAW,5117,1,17919,Advocacy Board TWO,Lawrence,Jim E,0,0,0,0,0,6,0,
+Spring 2024,LAW,5125,1,17920,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,14,0,
+Spring 2024,LAW,5128,1,17921,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,69,0,
+Spring 2024,LAW,5129,1,17922,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,26,0,
+Spring 2024,LAW,5130,1,17923,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,42,0,
+Spring 2024,ARTS,7310,3,17924,Printmaking Studio,Alderson,Saran,4,0,0,0,0,0,0,4.0
+Spring 2024,BZAN,7320,5,17925,Bus Modeling For Comp Adv,Murray,Michael J,6,2,1,0,0,0,1,3.519
+Spring 2024,POLC,3322,1,17926,Public Policy Analysis,Heller,Blake Harrison,5,4,0,0,0,0,0,3.446
+Spring 2024,LAW,7318,1,17928,WRS: Corp Criminal Liability,Gilchrist,Gregory,6,4,1,0,0,0,0,3.455
+Spring 2024,LAW,5471,1,17929,Street Law II,Cohen,Lisa Elaine,2,3,0,0,0,0,0,3.4
+Spring 2024,LAW,5341,1,17932,Disabilities and the Law,Roberts,Jessica,17,16,2,1,0,8,0,3.324
+Spring 2024,LAW,5244,1,17934,Employee Benefits & Compen,Benskin,Krisa Renee,2,1,1,0,0,3,0,3.333
+Spring 2024,ELCS,8360,1,17937,Studies Post Secondary Educatn,Hernandez,Belkis Pamela,4,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5101,1,17940,Health Law Research,Lawson,Emily Woolard,5,5,0,0,0,3,0,3.401
+Spring 2024,LAW,5225,1,17941,Financial Products Taxation,Gupta,Ajay,2,6,0,0,0,4,0,3.374
+Spring 2024,LAW,6307,1,17947,Sports Law,Cooper,Brian Michael,10,14,0,0,0,0,0,3.403
+Spring 2024,LAW,6336,1,17950,The Law and Theology,Buckles,Johnny R,5,8,0,0,0,8,0,3.334
+Spring 2024,LAW,5317,1,17951,Trademark/Unfair Competition,Gebru,Aman K,4,3,1,0,0,7,0,3.21
+Spring 2024,COMM,4368,2,17954,Public Relations Campaigns,Ni,Lan,16,2,0,0,0,0,0,3.889
+Spring 2024,HLT,1353,5,17957,Personal Health,Shamblin,Angel Ann,111,5,1,1,3,0,0,3.813
+Spring 2024,PSYC,3334,1,17958,Psychology & Law,Inman,Tonya N,57,34,9,4,6,0,7,3.176
+Spring 2024,PSYC,3338,1,17959,Psychology of Older Adults,Mustafa,Andrea Iman,75,3,0,1,0,0,0,3.907
+Spring 2024,HLT,3300,2,17960,Social Health and Wellness,Farmer,Jennifer,72,12,10,0,1,0,2,3.559
+Spring 2024,PSYC,6334,1,17961,Foundations of Health Psyc,Atherton,Olivia Emile,6,1,0,0,0,0,0,3.81
+Spring 2024,GOVT,2305,7,17970,"US Govt: Congress,Pres & Crts",Badas,Alex,36,89,67,40,11,0,3,2.361
+Spring 2024,GOVT,2306,4,17971,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,35,54,17,5,3,0,5,2.951
+Spring 2024,GOVT,2306,12,17972,US and Texas Const/Politics,Littlepage,Kelley G,98,95,28,9,3,0,13,3.18
+Spring 2024,GOVT,2306,15,17973,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,75,78,14,1,4,0,1,3.2
+Spring 2024,POLS,3312,2,17977,"Arguments, Data, Politics",Hanna,Tom Leard,28,5,3,0,0,0,1,3.685
+Spring 2024,POLS,3312,4,17978,"Arguments, Data, Politics",Kharmats,Polina G,27,4,1,0,1,0,2,3.697
+Spring 2024,POLS,4348,1,17979,Cont. Islam Political Thought,Contractor,Cyrus Ali,9,2,0,1,0,0,1,3.583
+Spring 2024,POLS,3365,1,17982,"Polls, Public Opinion, Democra",Cole,Jeffrey Bryan,12,12,1,1,0,0,1,3.321
+Spring 2024,POLS,3360,1,17986,Politics & Mass Media,Archer,Allison Michelle Nam,19,19,1,0,1,0,0,3.392
+Spring 2024,POLS,3386,1,17992,Criminal Law,Abbott Jr,Kenneth Wayne,39,1,0,0,0,0,0,3.909
+Spring 2024,HLT,3325,3,17994,Medical Terminology,Burk,Kelly Ann,133,5,6,0,0,0,4,3.854
+Spring 2024,ARCH,3311,1,17995,Topics in Design History,Bassi Cendra,Giovanna Maria,13,2,0,0,0,0,0,3.823
+Spring 2024,ARCH,3311,2,17998,Topics in Design History,Ramirez,Enrique,10,2,2,0,1,0,0,3.311
+Spring 2024,ARCH,3311,3,17999,Topics in Design History,Ramaswamy,Deepa,7,8,4,0,0,0,0,3.175
+Spring 2024,ARCH,3391,1,18000,Preservation of 20th Cent Arch,Brune,Geoffrey,9,1,1,0,0,0,0,3.697
+Spring 2024,CHEE,3363,3,18001,Fluid Mechanics for Chem Engrs,Malamataris,Nikolaos,0,1,1,0,0,0,1,2.5
+Spring 2024,CHEE,5377,1,18003,Intro To Polymer Science,Karim,Alamgir,5,0,0,0,0,0,0,3.868
+Spring 2024,GHL,2155,1,18007,Event Implementation,Haskell,Rebecca Erin,70,0,0,1,2,0,2,3.791
+Spring 2024,GHL,4346,1,18009,Texas Wine and Food Experience,Taylor,David C,10,0,0,0,0,0,0,4.0
+Spring 2024,BUSI,4350,12,18019,Business Law and Ethics,Williams,John M,135,16,4,1,0,0,7,3.776
+Spring 2024,MANA,6A32,5,18021,Organizational Behavior & Mgt,Witt,Lawrence A,25,0,0,0,0,0,0,4.0
+Spring 2024,ARTH,3302,1,18022,Contemporary Art Criticism,Rubinstein,Raphael,2,5,4,0,0,0,0,2.728
+Spring 2024,ARTH,6302,1,18023,Contemporary Art Criticism,Rubinstein,Raphael,4,0,0,0,0,0,0,4.0
+Spring 2024,SOC,3315,2,18024,Sexuality and Society,Baumle,Amanda K,23,12,7,3,2,0,2,3.043
+Spring 2024,GHL,6381,1,18025,Strategic Decisions in Hosp.,DeFranco,Agnes L,6,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3300,3,18028,Advanced Drawing,Peterson,John Ben,19,0,0,0,0,0,1,3.983
+Spring 2024,ARLD,6371,1,18030,Museum Programming,Veneman,Katherine A,6,0,0,0,0,0,0,4.0
+Spring 2024,ARLD,6381,1,18032,Arts and Health in Practice,Townsend,Jennifer Dawn,5,2,0,0,0,0,0,3.714
+Spring 2024,COSC,4377,1,18035,Intro To Computer Networks,Long,Kevin B,39,141,16,0,1,0,0,3.102
+Spring 2024,MUED,2342,1,18036,Music for Children,Schlosser,Emily Elizabeth,17,3,0,0,0,0,0,3.85
+Spring 2024,BZAN,6360,1,18037,Capstone Practicum in BZAN I,Abbott,Jeanna L,7,0,0,0,0,0,0,3.811
+Spring 2024,BZAN,6361,1,18038,Capstone Practicum in BZAN II,Abbott,Jeanna L,3,2,0,0,0,0,0,3.6
+Spring 2024,MIS,3371,2,18039,Transaction Processing Sys I,Messinger,Jacob Nelson,8,13,1,1,0,0,0,3.217
+Spring 2024,FINA,7A10,2,18042,Valuation,Liu,Zesong,9,6,1,0,1,0,1,3.314
+Spring 2024,FINA,7A10,3,18043,Valuation,Liu,Zesong,14,4,0,0,5,0,0,2.885
+Spring 2024,FINA,4330,6,18044,Corporate Finance,Liu,Zesong,21,16,6,1,0,0,0,3.25
+Spring 2024,ACCT,2301,11,18051,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,20,27,35,23,4,0,12,2.451
+Spring 2024,ARCH,3312,2,18055,Topics in Design Media,Noldt,Peter,10,5,0,0,0,0,1,3.623
+Spring 2024,ARTS,3358,1,18057,Clay Processes,Mayer,Anna W,15,1,0,0,0,0,0,3.855
+Spring 2024,ACCT,7320,2,18064,Intro to Data Analytics-Acct,Miles,Carolyn A,12,0,0,0,0,0,1,3.863
+Spring 2024,ACCT,7380,1,18065,Advanced Corporate Taxation,Chen,Xi,9,4,0,0,0,0,0,3.565
+Spring 2024,MUSI,6180,1,18066,Advanced Acting for Opera,Belcher,Kathleen,9,0,0,0,0,0,0,4.0
+Spring 2024,BZAN,6357,1,18068,BZAN-Frameworks & Methods,Ma,Xiao,34,1,0,0,0,0,0,3.934
+Spring 2024,MUSI,6200,2,18083,Accompanying Seminar,Suits,Brian J,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8303,1,18086,Seminar in Music Theory,Koozin,Timothy,7,1,0,0,0,0,0,3.834
+Spring 2024,COSC,3360,3,18088,Operating Systems,Rincon Castro,Carlos Alberto,49,33,20,5,4,0,13,3.051
+Spring 2024,ACCT,3377,3,18099,Cost Accounting,Serrato,Darlene Marie  Bohac,14,19,9,3,3,0,11,2.86
+Spring 2024,ACCT,4379,1,18100,Enterprise Risk Management,Neely,Gregory Wayne,7,1,0,0,0,0,0,3.875
+Spring 2024,THEA,6294,2,18102,Design and Production Studio,Vlahos,Kalliope,1,1,0,0,0,0,0,3.5
+Spring 2024,ACCT,5372,2,18107,Intro-Data Analytics in ACCT,Miles,Carolyn A,0,0,1,0,1,0,0,1.0
+Spring 2024,MATH,3379,2,18112,Introductn to Higher Geometry,May,Jennifer Ruhnow,11,13,9,0,1,0,2,2.961
+Spring 2024,MECE,4398,3,18118,Independent Study,Bering,Edgar A,3,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,3312,5,18119,Topics in Design Media,Smith,Joshua S,12,3,0,0,0,0,0,3.734
+Spring 2024,MARK,7380,1,18126,Advanced Marketing Analytics,Hess,James D,7,1,0,0,0,0,0,3.875
+Spring 2024,FINA,7324,1,18128,Inv & Portfolio Mgt Project I,Shoss,Robert L,9,1,0,0,0,0,0,3.834
+Spring 2024,FINA,7325,1,18129,Inv & Portfolio Mgt Project II,Shoss,Robert L,9,1,0,0,0,0,0,3.834
+Spring 2024,FINA,7355,1,18131,Stochas Calc & Comptl Finance,Pirrong,Stephen Craig,1,5,0,0,0,0,0,3.387
+Spring 2024,FINA,7380,1,18132,Real Estate Finance,Bruce,Andrew James,2,2,0,0,0,0,0,3.5
+Spring 2024,PSYC,3347,1,18148,Problems of Normal Life,Anderson,Jill Annette,47,25,5,0,1,0,0,3.504
+Spring 2024,PSYC,3347,2,18149,Problems of Normal Life,Anderson,Jill Annette,41,30,5,1,0,0,0,3.412
+Spring 2024,INDS,6398,2,18159,Independent Study,Wells,Adam C,1,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,4105,2,18160,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,51,2,
+Spring 2024,ACCT,4106,2,18161,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,19,0,
+Spring 2024,ACCT,5379,1,18162,Enterprise Risk Management,Neely,Gregory Wayne,2,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,7362,1,18163,Tax Research,Meade,Janet,5,2,0,0,0,0,0,3.761
+Spring 2024,ACCT,7384,1,18164,Enterprise Risk Management,Neely,Gregory Wayne,11,1,0,0,0,0,0,3.917
+Spring 2024,BUSI,4336,1,18165,Consulting-Small Business Need,Becker,Charles D,11,4,0,0,0,0,0,3.623
+Spring 2024,SOCW,8345,1,18166,Research Methods V,Borja,Sharon G,3,1,0,0,0,0,0,3.75
+Spring 2024,MATH,2415,11,18167,Calculus III,Winkle,James J,70,32,30,23,25,0,19,2.565
+Spring 2024,FINA,3332,7,18172,Prin of Financial Management,Chisholm,Darla,8,20,31,11,2,0,7,2.255
+Spring 2024,MATH,1332,2,18173,Contemporary Mathematics,Chern,Haley Nicole,22,26,23,9,5,0,14,2.553
+Spring 2024,MATH,1332,3,18174,Contemporary Mathematics,Hafeez,Shahinda,4,11,12,8,4,0,4,2.026
+Spring 2024,CHEM,4336,1,18175,Fundamentl Biochemistry,Do,Loi H,3,6,10,0,0,0,0,2.666
+Spring 2024,PSYC,3339,4,18176,Intro To Clinical Psychology,Healy,Nathaniel Andrew,24,32,11,3,3,0,5,2.959
+Spring 2024,BIOE,8598,29,18181,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Spring 2024,CHEM,3133,1,18182,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,3,7,6,0,0,0,0,2.771
+Spring 2024,CUIN,6319,1,18186,Instr Design & Tech 2nd Lang,Leon,Maredil Josefina,3,3,0,1,0,0,0,3.143
+Spring 2024,COSC,8398,132,18189,Doctoral Research,Yan,Feng,0,0,0,0,0,2,0,
+Spring 2024,COSC,8698,132,18191,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Spring 2024,COSC,6398,132,18194,Special Problems,Yan,Feng,0,0,0,0,0,1,0,
+Spring 2024,COSC,6321,1,18195,Research Methods in COSC,Gnawali,Omprakash D,0,0,0,0,0,21,0,
+Spring 2024,GEOL,7323,1,18199,Borehole Geophysics,Stewart,Robert R,9,2,0,0,0,0,0,3.698
+Spring 2024,MAS,2340,2,18201,Intro Mexican American Studies,Rodriguez,Andre,8,8,2,0,1,0,1,3.175
+Spring 2024,PSYC,2301,6,18202,Introduction to Psychology,Henderson,Perla R,36,29,8,3,0,0,2,3.216
+Spring 2024,PSYC,2301,7,18203,Introduction to Psychology,Walker,Jesse Hilliard,22,8,6,1,1,0,1,3.272
+Spring 2024,WGSS,3322,1,18204,Intersectionalities,Pegoda,Andrew Joseph,7,9,8,1,2,0,2,2.606
+Spring 2024,MUSA,1332,1,18209,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1334,3,18210,Applied Clarinet,Potiomkin,Alexander,2,1,0,0,0,0,0,3.777
+Spring 2024,ECE,5319,1,18214,Introduction to Nanotechnology,Brankovic,Stanko R,1,2,0,0,0,0,0,3.003
+Spring 2024,ECE,6306,1,18215,Introduction to Nanotechnology,Brankovic,Stanko R,4,1,0,0,0,0,0,3.668
+Spring 2024,ARCH,6376,1,18219,Urban Determinants,Rogers,Susan,17,10,0,0,0,0,0,3.556
+Spring 2024,NURS,6355,1,18224,Mgmt of Hlth Dsordrs Across Lf,Harrison,Lutricia,0,1,0,0,0,0,0,3.0
+Spring 2024,NURS,6356,1,18225,Mgmt of Hlth Dsordrs Acrs Lfsp,Tahmasbi,Sherin,0,0,0,0,0,1,0,
+Spring 2024,NURS,3310,1,18226,Prof Role Dev & Practice Issue,Kirk,Terry D,16,5,0,1,0,0,1,3.636
+Spring 2024,NURS,3311,1,18227,Health Assess Across Life Span,Kantala,Nadine,3,19,0,2,0,0,3,2.958
+Spring 2024,NURS,3315,1,18229,Pathophysiology,Edwards-Maddox,Shermel Vinese,5,17,0,5,0,0,4,2.815
+Spring 2024,NURS,4521,1,18230,Community Health Nursing,McWilliams,Lenora A,25,3,0,0,0,0,1,3.893
+Spring 2024,MATH,3325,1,18233,Transition to Advanced Math,Josic,Kresimir,6,11,8,2,2,0,1,2.575
+Spring 2024,SPAN,7302,1,18238,Adv Research & Writing Seminar,Hasbun,Rodrigo,10,0,0,0,0,0,0,4.0
+Spring 2024,ECE,6346,1,18240,Vlsi Design,Joardar,Biresh Kumar,9,15,1,0,0,0,1,3.188
+Spring 2024,ARTH,2389,1,18245,Modern and Contemporary Art,Tolleson,Maxwell,19,20,2,0,4,0,2,3.082
+Spring 2024,IART,2300,2,18247,The Arts in Houston,Harris,Jeanette Joy,14,2,1,1,0,0,2,3.501
+Spring 2024,MECE,2334,4,18250,Thermodynamics,Love,Holley Carole,0,1,2,0,0,0,0,2.553
+Spring 2024,BIOE,5318,1,18252,Intro to Biomed Informatics,Akay,Metin,14,4,0,0,0,0,0,3.778
+Spring 2024,BIOE,6345,1,18253,Biomedical Informatics,Akay,Metin,11,2,0,0,0,0,1,3.745
+Spring 2024,CIVE,3331,2,18256,Environmental Engineering,Shaffer,Devin,12,16,13,1,0,0,4,2.803
+Spring 2024,CIVE,3332,1,18257,Engineering Materials,Mo,Larry Yi-Lung,29,11,3,0,0,0,1,3.628
+Spring 2024,CIVE,6350,3,18259,Advanced Mechs of Matls,Ballarini,Roberto,6,2,3,0,1,0,9,3.0
+Spring 2024,BIOL,3324,50,18268,Human Physiology,Dryer,Stuart E,17,13,18,1,0,0,0,2.979
+Spring 2024,MUSA,6220,2,18269,Applied Violin,Austin,Alan S,2,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,3112,18,18275,Topics in Design Media,Murray,Cara,14,1,0,0,0,0,0,3.911
+Spring 2024,INDS,2170,2,18276,Digital Sketch Techniques I,Kimbrough,Mark S,9,8,2,2,1,0,0,3.045
+Spring 2024,CUIN,7398,2,18277,Independent Study,Hausmann,Robert Carl,3,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2302,13,18278,Prin of Managerial Accounting,Weber,Catherine K,23,50,23,11,2,0,5,2.789
+Spring 2024,ECE,5346,1,18281,Vlsi Design,Joardar,Biresh Kumar,1,2,0,0,0,0,0,3.223
+Spring 2024,GEOL,8698,1,18285,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,4,0,
+Spring 2024,GEOL,8998,3,18287,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8698,2,18288,Doctoral Research,Castagna,John P,0,0,0,0,0,1,0,
+Spring 2024,FINA,4341,1,18289,Commercial Bank Management,Lara,Alexander J,41,0,1,0,0,0,0,3.921
+Spring 2024,MUSA,8330,1,18295,Doctoral Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,1,18296,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Spring 2024,ECON,4399,1,18300,Senior Honors Thesis,Wang,Fan,1,0,0,0,0,0,0,4.0
+Spring 2024,NUTR,6302,1,18303,Adv Medical Nutrition Therapy,Ferrell,Carla Denise,6,3,1,0,0,0,0,3.467
+Spring 2024,MECE,6364,2,18314,Phase Transform in Materials,Selvamanickam,Venkat,1,0,0,0,0,0,0,3.67
+Spring 2024,MECE,6364,3,18315,Phase Transform in Materials,Selvamanickam,Venkat,0,3,0,0,0,0,0,3.22
+Spring 2024,ARTS,4398,10,18322,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Spring 2024,INDE,6370,1,18327,Operation Research-Digital Sim,Khator,Suresh K,0,2,1,0,0,0,0,2.777
+Spring 2024,THEA,6377,1,18328,Draping for Theatrical Costume,Niederer,Barbara,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8698,3,18330,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,1,0,
+Spring 2024,ECE,8498,31,18331,Doctoral Research,Joardar,Biresh Kumar,0,0,0,0,0,0,0,
+Spring 2024,ECE,8398,31,18332,Doctoral Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Spring 2024,ENTR,4393,2,18333,RED Labs Pre-accelerator,Wilbur,Stephen,8,3,2,2,0,0,0,3.111
+Spring 2024,ENTR,7393,2,18334,RED Labs Pre-accelerator,Wilbur,Stephen,3,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,6393,3,18335,Internship in Higher Education,Carales,Vincent D,5,0,0,0,0,0,0,3.868
+Spring 2024,COMM,4399,1,18336,Senior Honors Thesis,Camaj,Lindita,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,1302,70,18337,The U.S. Since 1877,Lira,Karla Aisen,38,7,2,0,1,0,0,3.701
+Spring 2024,FINA,7324,2,18338,Inv & Portfolio Mgt Project I,Shoss,Robert L,3,0,0,0,0,0,0,3.89
+Spring 2024,FINA,7325,2,18341,Inv & Portfolio Mgt Project II,Shoss,Robert L,3,0,0,0,0,0,0,3.89
+Spring 2024,GEOL,8998,4,18346,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,2,0,
+Spring 2024,COMD,7391,2,18348,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,2,0,0,0,0,0,0,3.835
+Spring 2024,ENGL,6302,1,18351,Creative Writing Pedagogy,Colombe,Audrey A,5,0,0,0,0,0,0,4.0
+Spring 2024,COMD,7391,4,18352,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,3,0,0,0,0,0,0,3.89
+Spring 2024,COMD,7391,5,18353,Clinic in Speech Lang Disorder,Lantaco,Perla Judith,3,0,0,0,0,0,0,3.78
+Spring 2024,COMD,7391,6,18354,Clinic in Speech Lang Disorder,Trevino,Alexandra Hanson,3,0,0,0,0,0,0,3.78
+Spring 2024,COMD,7391,7,18355,Clinic in Speech Lang Disorder,Sims,Frankie B,2,1,0,0,0,0,0,3.557
+Spring 2024,COMD,7391,8,18356,Clinic in Speech Lang Disorder,Townsend,Alayna,3,0,0,0,0,0,0,3.67
+Spring 2024,COMD,7391,9,18357,Clinic in Speech Lang Disorder,Townsend,Alayna,3,0,0,0,0,0,0,3.78
+Spring 2024,COMD,7391,16,18358,Clinic in Speech Lang Disorder,Walker,Dionne A,3,0,0,0,0,0,0,3.67
+Spring 2024,COMD,7391,17,18359,Clinic in Speech Lang Disorder,Cizek,Laura S,3,0,0,0,0,0,0,3.78
+Spring 2024,COMD,7391,18,18360,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,2,1,0,0,0,0,0,3.667
+Spring 2024,COMD,7391,19,18361,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,2,0,0,0,0,0,0,3.67
+Spring 2024,COMD,7392,9,18363,Adv Pract Sp & Lang Dis,Guerra,Teresa Evangelina,1,0,0,0,0,0,0,3.67
+Spring 2024,COMD,7392,11,18365,Adv Pract Sp & Lang Dis,Schaff,Carrie Allyson,4,0,0,0,0,0,0,3.835
+Spring 2024,COMD,7392,12,18366,Adv Pract Sp & Lang Dis,Schaff,Carrie Allyson,1,0,0,0,0,0,0,3.67
+Spring 2024,PHOP,6767,5,18371,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8998,7,18375,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8998,8,18378,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,7,0,
+Spring 2024,BCHS,8999,5,18381,Doctoral Dissertation,Briggs,James M,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8999,4,18382,Doctoral Dissertation,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8699,5,18383,Doctoral Dissertation,LaVoy,Emily Claire-Pyle,0,0,0,0,0,3,0,
+Spring 2024,GCEE,6320,1,18384,Global Climate: Physical Model,Li,Hongyi,5,0,1,0,0,0,0,3.722
+Spring 2024,COMD,6340,1,18387,Augmentative and Alternative C,Thiessen,Amber L,27,19,2,0,0,0,0,3.521
+Spring 2024,GEOL,8398,3,18389,Doctoral Research,Mann,Paul,0,0,0,0,0,4,0,
+Spring 2024,ECON,8391,1,18396,PhD Internship,Yi,Kei-Mu,0,0,0,0,0,1,0,
+Spring 2024,POLS,8999,27,18397,Doctoral Dissertation,Casellas,Jason,0,0,0,0,0,2,0,
+Spring 2024,BZAN,6356,2,18398,Adv DB Mgt Tools Bus Analytics,Grimes,George M,6,1,0,0,0,0,0,3.857
+Spring 2024,FINA,7376,2,18399,Energy Trading,Smith III,Edwin A,1,0,1,0,0,0,1,2.67
+Spring 2024,MANA,8395,1,18400,Teaching Practicum,Carlin,Barbara A,3,0,0,0,0,0,0,4.0
+Spring 2024,SCM,7335,3,18401,Logistics Management,Sahin,Funda,3,3,0,0,0,0,0,3.5
+Spring 2024,CIVE,4363,2,18402,Concrete Design,Mercan,Bulent,16,14,3,2,1,0,0,3.148
+Spring 2024,CIVE,4369,2,18403,Foundation Engineering,Phatak,Tejasree Mohan,9,16,4,1,1,0,0,2.904
+Spring 2024,ECE,4371,1,18405,Advanced Telecommunications,Han,Zhu,41,16,0,0,0,0,0,3.679
+Spring 2024,ECE,4117,1,18406,Telecommunications Laboratory,Han,Zhu,57,0,0,0,0,0,0,3.994
+Spring 2024,MECE,3338,2,18407,Dynamic & Control of Mech Syst,Yang,Wenhua,10,11,20,1,1,0,0,2.643
+Spring 2024,MECE,3381,2,18408,Finite Elements for Mech Engr,Joshi,Shailendra Pramod,8,22,7,0,0,0,0,2.938
+Spring 2024,MECE,3336,6,18410,Mechanics II,Yang,Wenhua,10,38,61,5,3,0,0,2.334
+Spring 2024,MECE,2334,5,18411,Thermodynamics,Yang,Wenhua,18,39,43,15,9,0,0,2.259
+Spring 2024,CIVE,2332,5,18412,Mechanics of Solids,Phatak,Tejasree Mohan,8,15,17,9,4,0,0,2.189
+Spring 2024,ECE,3331,4,18413,Program Appl in Elec Comp Engr,Sheth,Bhavin R,50,29,16,4,0,0,0,3.199
+Spring 2024,ECE,2202,11,18414,Circuit Analysis II,Csutak,Sebastian,4,29,61,11,0,0,0,2.112
+Spring 2024,GEOL,8998,11,18416,Doctoral Research,Sager,William W,0,0,0,0,0,1,0,
+Spring 2024,CIVE,3434,1,18417,Fluid Mech and Hydraulic Engr,Saladi,Krishna Rishi Vijay,16,16,2,0,0,0,0,3.295
+Spring 2024,GERM,3381,3,18419,German Cinema,Kleinheider,Julia D,19,11,6,0,0,0,0,3.288
+Spring 2024,CUIN,8399,7,18421,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,2,0,
+Spring 2024,CUIN,8399,8,18422,Doctoral Dissertation,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Spring 2024,KIN,4398,1,18423,Independent Study,Cottingham,Michael,5,0,0,0,0,0,0,4.0
+Spring 2024,LAW,6347,10,18426,Secured Financing,Dole,Richard F,0,2,0,0,0,6,0,3.33
+Spring 2024,ELCS,8330,1,18428,Statistical Analyses,Templeton,Toni,9,0,0,0,0,0,0,3.927
+Spring 2024,MIS,4378,4,18429,Admin of Computer-Based MIS,Kniffen,Richard Chad,6,47,4,0,0,0,1,3.035
+Spring 2024,GEOL,8398,5,18432,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8399,18,18434,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Spring 2024,MARK,7381,1,18435,Technology Commercialization,Kamal,Saiyid Zafar,6,2,0,0,0,0,0,3.833
+Spring 2024,ENTR,7381,1,18436,Technology  Commercialization,Kamal,Saiyid Zafar,1,0,0,0,0,0,0,3.67
+Spring 2024,POLS,8999,28,18439,Doctoral Dissertation,Kistner,Michael,0,0,0,0,0,0,0,
+Spring 2024,POLS,8999,1,18440,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,4,0,
+Spring 2024,HDFS,4316,2,18445,Dynamics of Family Relations,Schroder,Kathleen Anne,32,11,0,0,1,0,1,3.629
+Spring 2024,HDFS,4325,3,18448,Theory to Practice in HDFS,Jordan,Erica F,32,6,0,0,0,0,0,3.799
+Spring 2024,HLT,3381,4,18451,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,84,17,1,0,0,0,0,3.749
+Spring 2024,PCOL,6198,3,18458,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6393,12,18460,Clinical Research Practicum,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7399,8,18462,Essay,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7699,9,18463,Thesis,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6210,1,18470,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7399,2,18473,Masters Thesis,Robinson,Alexander C,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6143,4,18474,Graduate Recital IV,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,6,18479,Doctoral Research,Robinson,Alexander C,0,0,0,0,0,2,0,
+Spring 2024,GEOL,8398,7,18481,Doctoral Research,Murphy,Michael,0,0,0,0,0,2,0,
+Spring 2024,ENGL,8698,4,18482,Graduate Research,Nelson,Antonya,0,0,0,0,0,2,0,
+Spring 2024,GHL,6384,1,18483,Gourmet Night Management,Haskell,Rebecca Erin,5,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,17,18484,Doctoral Applied Music,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Spring 2024,ENTR,7393,1,18486,RED Labs Pre-accelerator,Wilbur,Stephen,8,0,0,0,1,0,0,3.519
+Spring 2024,ENGL,8698,5,18499,Graduate Research,Divakaruni,Chitra B,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,6,18503,Graduate Research,Shepley,Nathan,0,0,0,0,0,1,0,
+Spring 2024,PCEU,8998,5,18504,Doctoral Research,Guo,Bin,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6398,6,18507,Special Problems,Trivedi,Meghana,0,0,0,0,0,2,0,
+Spring 2024,CUIN,8310,3,18508,Laboratory of Practice,Reis,Nancy,2,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8998,15,18510,Doctoral Research,Sun,Jiajia,0,0,0,0,0,2,0,
+Spring 2024,MUSA,6342,2,18511,Applied French Horn,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7399,3,18514,Masters Thesis,Sun,Jiajia,0,0,0,0,0,1,0,
+Spring 2024,ENTR,6398,1,18517,Research,Gonzalez,Liana,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,4372,1,18518,Literature and the Environment,Vollrath,Lesli A,6,1,0,0,0,0,0,3.763
+Spring 2024,PSYC,8199,1,18524,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,1,0,
+Spring 2024,SPAN,6398,10,18527,Special Problems,Lopez Otero,Julio Cesar,0,0,1,0,0,0,0,1.67
+Spring 2024,ENGL,8399,20,18528,Doctoral Dissertation,Davies,Daniel,0,0,0,0,0,1,0,
+Spring 2024,POLS,8699,7,18529,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Spring 2024,GEOL,6399,1,18530,Masters Thesis,Khan,Shuhab D,2,0,0,0,0,0,0,4.0
+Spring 2024,COMD,7391,23,18535,Clinic in Speech Lang Disorder,Cizek,Laura S,1,0,0,0,0,0,0,3.67
+Spring 2024,MIS,4374,5,18536,Info Technology Project Mgmt,Jagtap,Pankaj,11,14,2,0,0,0,0,3.223
+Spring 2024,ENGL,3341,1,18545,Bus & Prof Writing,Butler,Paul G,14,3,0,0,0,0,1,3.746
+Spring 2024,GEOL,8399,1,18549,Doctoral Dissertation,Zhou,Hua-Wei,1,0,0,0,0,0,0,4.0
+Spring 2024,WGSS,3322,2,18550,Intersectionalities,Pegoda,Andrew Joseph,4,4,8,0,6,0,7,1.97
+Spring 2024,PHLS,8396,2,18554,Doctoral Research,Smith,Nathan G,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6398,7,18555,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Spring 2024,MUSI,6198,27,18556,Research,Yon,Kirsten A,9,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,1,18570,Special Problems in Repertoire,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8999,2,18575,Doctoral Dissertation,Zheng,Yingcai,1,0,0,0,0,0,0,4.0
+Spring 2024,THEA,3374,1,18578,Intelligent Lighting,Webb,Matthew Clark,6,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8999,3,18579,Doctoral Dissertation,Rappenglueck,Bernhard,2,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,1501,24,18580,Arc/Int Arc Design Studio II,Perez Lopez,Elena Maria,4,2,6,0,0,0,2,2.723
+Spring 2024,GEOL,8698,5,18582,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8399,2,18584,Doctoral Dissertation,Stewart,Robert R,1,0,0,0,0,2,0,4.0
+Spring 2024,GEOL,8998,19,18585,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,3,0,
+Spring 2024,GEOL,8399,3,18586,Doctoral Dissertation,Zheng,Yingcai,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,6398,5,18588,Special Problems,Camaj,Lindita,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,6498,3,18595,Special Problems,Hao,Jiukuan,2,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,6298,1,18596,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8399,21,18599,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Spring 2024,CHEE,4322,1,18600,Chemical Engineering Design II,Gopalakrishnan,Murali,66,9,0,0,0,0,0,3.783
+Spring 2024,PSYC,3331,3,18602,Psychology of Gender,Martinez,Anjelica M,26,9,1,2,0,0,1,3.553
+Spring 2024,PCEU,6498,5,18606,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,3,0,
+Spring 2024,PSYC,6398,23,18615,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,3,0,
+Spring 2024,MUSI,8296,8,18624,Doctoral Essay,Pollack,Howard J,1,0,0,0,0,1,0,4.0
+Spring 2024,HIST,2311,2,18635,Western Civilization to 1450,Patterson,Catherine F,11,16,5,1,1,0,0,2.952
+Spring 2024,GEOL,7399,5,18636,Masters Thesis,Khan,Shuhab D,2,0,0,0,0,1,0,4.0
+Spring 2024,ARTS,2356,1,18638,Fundamentals of Photo/DM,Krouba,Blya Ange Ernestine,7,5,0,0,0,0,1,3.501
+Spring 2024,ECE,8298,41,18643,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,3,0,
+Spring 2024,SOC,7399,5,18645,Masters Thesis,Katz,Sheila,2,0,0,0,0,1,0,4.0
+Spring 2024,GEOL,8398,8,18651,Doctoral Research,Castagna,John P,0,0,0,0,0,3,0,
+Spring 2024,GEOL,8698,6,18652,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,2,0,
+Spring 2024,ENGL,8399,22,18654,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,2,0,
+Spring 2024,ECE,7399,6,18660,Masters Thesis,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8698,8,18662,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,22,18665,Doctoral Research,Wen,Mingjian,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6212,1,18667,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7399,6,18668,Masters Thesis,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8598,22,18670,Doctoral Research,Yao,Yan,0,0,0,0,0,3,0,
+Spring 2024,PCOL,6498,6,18671,Special Problems,Wu,Mingfu,0,0,0,0,0,0,0,
+Spring 2024,PCOL,6398,8,18672,Special Problems,Wu,Mingfu,0,0,0,0,0,0,0,
+Spring 2024,GEOL,8398,9,18675,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8198,2,18681,Doctoral Research,Grabow,Lars C,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8396,3,18682,Doctoral Research,Arbona,Consuelo,0,0,0,0,0,2,0,
+Spring 2024,MUSA,8243,10,18685,Doctoral Lecture Recital,Jones,Timothy J,0,0,0,0,0,0,0,
+Spring 2024,MUSI,8296,9,18688,Doctoral Essay,Snyder,John L,2,0,0,0,0,1,0,4.0
+Spring 2024,GEOL,7399,7,18690,Masters Thesis,Fu,Qi,0,0,0,0,0,1,0,
+Spring 2024,PSYC,3339,5,18694,Intro To Clinical Psychology,Smit,Tanya,34,4,0,0,0,0,2,3.921
+Spring 2024,COSC,1437,7,18695,Introduction to Programming,Biediger,Daniel Edward,66,16,15,3,12,0,16,3.074
+Spring 2024,PCOL,6498,10,18699,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6398,10,18700,Special Problems,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6498,11,18703,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6398,11,18704,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6298,11,18705,Special Problems,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2024,HIST,6399,3,18707,Masters Thesis,Young,Nancy Beck,0,0,0,0,0,1,0,
+Spring 2024,PHCA,8311,1,18715,Proposal Development,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8598,1,18720,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8398,10,18721,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Spring 2024,ARED,4345,2,18723,Art in Elem & Secondary School,Chung,Sheng Kuan,5,3,0,0,0,0,0,3.625
+Spring 2024,ARED,6345,3,18725,Art in Elem & Secondary School,Chung,Sheng Kuan,4,0,0,0,0,0,0,3.918
+Spring 2024,SOC,7399,7,18730,Masters Thesis,Tuthill,Zelma,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8699,2,18732,Doctoral Dissertation,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Spring 2024,THEA,6303,1,18735,Scenic Structures,Vlahos,Kalliope,0,1,0,0,0,0,0,2.67
+Spring 2024,CIVE,8498,9,18740,Doctoral Research,Momen,Mostafa,0,0,0,0,0,3,0,
+Spring 2024,CUIN,8393,7,18742,Adv Internship & Prac,Dogan,Bulent,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,8998,4,18744,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2024,MATH,6398,27,18754,Special Problems,Papadakis,Emanuel Ioannis,0,0,0,0,0,1,0,
+Spring 2024,ARTS,4398,3,18755,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,11,18757,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,2,0,
+Spring 2024,PSYC,6393,13,18760,Clinical Research Practicum,Williams,Michael W,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8398,13,18763,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,3,0,
+Spring 2024,ENGL,4399,2,18764,Senior Honors Thesis,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8298,4,18773,Doctoral Research,Xu,Ben,0,0,0,0,0,2,0,
+Spring 2024,MIS,3376,6,18781,Busn Appls Database Mgmt I,Scamell,Richard W,20,12,14,2,2,0,3,2.907
+Spring 2024,MECE,8298,3,18783,Doctoral Research,Song,Gangbing,0,0,0,0,0,6,0,
+Spring 2024,MUSI,8398,2,18790,Research in Pedagogy,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8320,18,18794,Doctoral Applied Music,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2024,SCM,4302,2,18798,Energy Supply Chain,Venugopal,Kalyanaraman,40,20,5,0,0,0,0,3.513
+Spring 2024,MUSA,6430,1,18803,Applied Flute,Dorough,Aralee,2,0,0,0,0,0,0,3.835
+Spring 2024,MUSA,6142,1,18804,Graduate Recital III,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,8398,5,18813,Special Problems,George,Thomas J,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8698,9,18823,Doctoral Research,Mann,Paul,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8320,19,18828,Doctoral Applied Music,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Spring 2024,SUBS,6310,2,18830,Flow Assurance,Hallai,Julian,1,0,0,0,0,0,0,4.0
+Spring 2024,SUBS,6310,3,18831,Flow Assurance,Hallai,Julian,1,1,0,0,0,0,0,3.5
+Spring 2024,MUSA,8242,9,18833,Doctoral Recital III,Weber,Mary E,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8699,14,18836,Doctoral Dissertation,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2024,DRAM,1310,15,18838,Introduction to Theatre,Brincks,Alan,35,5,5,1,3,0,0,3.334
+Spring 2024,PHLS,8999,4,18841,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8398,12,18849,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8398,14,18852,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8298,6,18867,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8320,20,18868,Doctoral Applied Music,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,3311,2,18870,Methods/Tech in Bilingual Educ,Leon,Maredil Josefina,16,3,0,0,0,0,0,3.807
+Spring 2024,FINA,8398,6,18871,Special Problems,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,4361,6,18872,Second Language Methodology,Li,Miao,18,4,0,0,0,0,0,3.698
+Spring 2024,MARK,8398,2,18873,Special Problems,Patrick-Ralhan,Vanessa M,1,0,0,0,0,0,0,4.0
+Spring 2024,MIS,8399,1,18874,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6204,3,18877,Conducting,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Spring 2024,DRAM,1310,16,18879,Introduction to Theatre,Brincks,Alan,30,8,5,4,1,0,1,3.292
+Spring 2024,MUSA,6214,1,18885,Applied Harpsichord,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,6398,2,18886,Research,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2024,ACCT,8398,3,18889,Special Problems,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,28,18890,Research,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,15,18896,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Spring 2024,BIOE,6399,7,18897,Masters Thesis,Horton,Renita Elillian,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8399,6,18902,Doctoral Dissertation,Romero,Todd,0,0,0,0,0,1,0,
+Spring 2024,ECE,7399,7,18905,Masters Thesis,Prasad,Saurabh,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8298,5,18907,Doctoral Research,Chen,Tian,0,0,0,0,0,2,0,
+Spring 2024,ARTS,4398,4,18908,Independent Study,Suber,Anthony,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2330,2,18912,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,16,18913,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6424,2,18916,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6100,3,18917,Chamber Music,Hester,Timothy E,5,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8698,12,18919,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,4,0,
+Spring 2024,BIOE,8498,3,18920,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Spring 2024,ACCT,8699,2,18929,Doctoral Dissertation,Crawford,Steven,2,0,0,0,0,0,0,4.0
+Spring 2024,POLS,8399,1,18932,Doctoral Dissertation,Marcinek,Elizabeth Nicole Simas,0,0,0,0,0,1,0,
+Spring 2024,PSYC,2319,7,18942,Intro to Social Psychology,Anderson,Jill Annette,26,26,10,0,4,0,2,2.991
+Spring 2024,SOCW,7367,1,18952,Social Policy Analysis,Pang,Melanie Espinosa,31,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8296,1,18957,Doctoral Essay,Pollack,Howard J,1,0,0,0,0,0,0,4.0
+Spring 2024,CNST,1330,1,19030,Graphics I,Clark,Peter J,21,25,8,2,0,0,3,3.084
+Spring 2024,CNST,2341,1,19031,Construction Documents,Murphy,Kevin Michael,62,30,8,0,1,0,2,3.466
+Spring 2024,ELET,2105,1,19032,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,23,0,0,0,0,0,1,4.0
+Spring 2024,ELET,2303,1,19033,Digital Systems,Zouridakis,George,10,21,9,0,0,0,1,2.959
+Spring 2024,ELET,2305,1,19034,Semicond Devices & Circuits,Talusani,Pratap Reddy,29,12,0,0,0,0,1,3.691
+Spring 2024,ELET,2307,30,19035,Electrical-Electronic Circuits,Moges,Mequanint A,9,12,8,2,0,0,1,2.882
+Spring 2024,ELET,3112,2,19036,Rotating Machine Controls Lab,Fan,Lei,7,2,1,1,0,0,1,3.364
+Spring 2024,ELET,3301,1,19037,Linear Systems Analysis,Barbieri,Enrique,6,20,17,4,1,0,2,2.487
+Spring 2024,ELET,3312,1,19038,Plc's & Motor Control Systems,Fan,Lei,10,4,2,0,0,0,0,3.376
+Spring 2024,ELET,3402,1,19039,Communications Circuits,Velusamy,Gandhimathi,17,7,2,0,0,0,0,3.513
+Spring 2024,ELET,3403,1,19041,Sensor Applications,Yuan,Xiaojing,10,11,3,0,0,0,0,3.278
+Spring 2024,ELET,3405,1,19043,Microprocessor Architecture,Soneja,Chandrayee,24,12,4,0,1,0,0,3.374
+Spring 2024,ELET,3425,1,19046,Embedded Systems,Moges,Mequanint A,4,8,5,0,0,0,0,2.902
+Spring 2024,ELET,4208,1,19047,Senior Project Laboratory,Moges,Mequanint A,9,20,1,0,0,0,0,3.399
+Spring 2024,ELET,4303,1,19049,Power Distribution & Transmiss,Shireen,Wajiha,8,9,5,0,1,0,0,2.914
+Spring 2024,ELET,4308,1,19050,Senior Project,Moges,Mequanint A,10,15,2,0,0,0,0,3.272
+Spring 2024,ELET,4319,1,19051,Elec Power Sys & Industry Prac,Fan,Lei,12,11,2,0,0,0,0,3.36
+Spring 2024,ELET,4421,1,19054,Computer Networks,Hu,Bin,14,11,6,1,0,0,0,3.146
+Spring 2024,HDCS,1300,1,19056,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,34,11,3,0,0,0,2,3.577
+Spring 2024,HDCS,1300,2,19057,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,39,6,1,0,1,0,1,3.717
+Spring 2024,HDCS,3300,1,19058,Org Decisions,Stewart,Quentin K,15,8,0,1,0,0,2,3.542
+Spring 2024,HDCS,3303,1,19059,Retailing and Consumer Science,Jacobs,Karen S,19,4,2,0,1,0,1,3.488
+Spring 2024,HDCS,4300,1,19060,Research Concepts in Hdcs,Gatterson,Beverly,27,14,3,1,0,0,0,3.408
+Spring 2024,HDCS,4302,1,19061,Apparel Analysis,Gatterson,Beverly,40,6,2,0,2,0,0,3.627
+Spring 2024,HDCS,4386,1,19062,Communication Strategies,Hitchman Sr,Cal M,33,2,0,0,0,0,0,3.905
+Spring 2024,HDCS,4394,1,19063,Internship in RCS,Ezell,Shirley D,2,0,0,0,0,0,0,4.0
+Spring 2024,HRD,6396,1,19064,Internship in Human Res. Dev.,Edwards,Malaika,3,0,0,0,0,0,0,4.0
+Spring 2024,TECH,1301,1,19065,Intro to Data Analytics Tools,Roberts,Phyllis Rayburn,24,16,4,1,0,0,3,3.371
+Spring 2024,MECT,1364,30,19066,Materials & Processes,Afrin,Samia,5,16,4,3,2,0,1,2.6
+Spring 2024,MECT,3155,30,19068,Strength Materials Lab,Al Ibadi,Adnan,11,7,0,0,1,0,0,3.438
+Spring 2024,MECT,3155,31,19069,Strength Materials Lab,Al Ibadi,Adnan,13,5,1,0,0,0,1,3.597
+Spring 2024,MECT,3331,30,19070,Applied Thermodynamics,El Nahas,Medhat A,1,0,10,0,1,0,0,1.945
+Spring 2024,MECT,3342,30,19071,Elements of Plant Design,El Nahas,Medhat A,1,16,16,0,0,0,0,2.535
+Spring 2024,MECT,3358,30,19073,Dynamics of Mechanisms,Basaran,Burak,7,7,10,11,3,0,5,2.131
+Spring 2024,MECT,3360,30,19075,Automated Manufacturing System,Koirala,Bikram,21,11,3,3,1,0,1,3.256
+Spring 2024,MECT,3365,30,19078,Computer-Aided Design I,El Nahas,Medhat A,0,15,20,1,0,0,1,2.352
+Spring 2024,MECT,3367,30,19080,Quality Control Technology,Afrin,Samia,7,10,7,0,1,0,0,2.933
+Spring 2024,TECH,3365,1,19081,Appl of Discrete Mthds in Tech,Telles,John E,15,8,1,0,0,0,2,3.597
+Spring 2024,TECH,3365,2,19082,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,37,6,3,0,2,0,2,3.597
+Spring 2024,TEPM,6302,20,19083,Leadership and Team Building,Hopkins,Ronald K,1,0,0,0,0,0,0,4.0
+Spring 2024,MECT,4275,30,19085,Senior Design Project I,Zhu,Weihang,11,8,0,0,0,0,0,3.544
+Spring 2024,MECT,3318,30,19086,Fluid Mechanics Applications,Alba,Kamran,2,10,7,2,4,0,5,2.213
+Spring 2024,MECT,3118,30,19087,Fluid Mechanic Application Lab,Al Ibadi,Adnan,11,8,0,0,0,0,2,3.562
+Spring 2024,MECT,3118,31,19088,Fluid Mechanic Application Lab,Al Ibadi,Adnan,11,6,2,0,1,0,0,3.234
+Spring 2024,HDCS,4374,1,19090,Entrepreneurial E-Tailing,Johnson,Olivia,11,7,4,3,0,0,0,3.04
+Spring 2024,MECT,1330,30,19091,Engineering Graphics,Fan,Zheng,5,12,3,0,0,0,5,3.018
+Spring 2024,MECT,4372,30,19093,Materials Technology,Robles Hernandez,Francisco C,11,11,10,0,4,0,2,2.667
+Spring 2024,MECT,4172,30,19094,Materials Tech Lab,Al Ibadi,Adnan,2,4,2,0,0,0,0,3.083
+Spring 2024,CNST,3205,1,19095,Construction Safety Management,Hart,Lee J,44,1,0,0,0,0,0,3.978
+Spring 2024,ELET,3112,1,19096,Rotating Machine Controls Lab,Fan,Lei,3,2,0,0,0,0,0,3.732
+Spring 2024,BTEC,3301,30,19097,Genomics/Proteomics & Bioinfo.,Flavier,Albert B,7,16,11,0,6,0,3,2.425
+Spring 2024,HRD,6302,1,19098,Design & Management E-Learning,Nair,Maya,6,3,0,0,1,0,0,3.168
+Spring 2024,TEPM,6395,1,19099,Integration Project,Carden,Lila L,8,1,0,0,0,0,0,3.816
+Spring 2024,CNST,6360,1,19100,Computer Applications in CM,Kim,Kinam,14,25,15,1,0,0,0,2.969
+Spring 2024,CNST,6360,2,19101,Computer Applications in CM,Kim,Kinam,1,0,0,0,0,0,0,4.0
+Spring 2024,CNST,6380,1,19102,Leed & Green Const Princ in CM,Chang,Chi Chung,20,0,1,0,0,0,0,3.795
+Spring 2024,CNST,4341,1,19103,Project Controls,Bouhou,Nour-El Imane,19,37,23,1,0,0,0,3.008
+Spring 2024,CNST,3351,1,19104,Construction Estimating II,Siddiqui,Muhammad Ali,32,21,2,0,0,0,0,3.509
+Spring 2024,TECH,4310,1,19105,Future of Energy & Environment,Breaux,James William,30,5,1,0,1,0,2,3.658
+Spring 2024,TECH,6360,1,19106,Exp Design & Data Analysis,Thornton,Brandon,12,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6301,1,19107,Project Management Principles,Sherman,Dennis Louis,41,1,0,0,1,0,0,3.884
+Spring 2024,CNST,2345,1,19109,Contract Doc Capital Projects,Beadle,Dwight D,36,17,2,0,0,0,0,3.618
+Spring 2024,CNST,3365,1,19110,Cost Estimating Capital Projec,Glumac,Carmel,8,7,2,0,0,0,2,3.392
+Spring 2024,CNST,2325,1,19111,Process and Industrial Subsyst,Zayas,Frederick A,2,8,9,0,0,0,0,2.666
+Spring 2024,CNST,6390,1,19112,Leadership for Const Managers,Connors,Jayme P,35,0,0,0,0,0,0,4.0
+Spring 2024,DIGM,4396,30,19113,Internship in Digital Media,Liao,Tony Chung-Li,7,1,0,0,0,0,0,3.875
+Spring 2024,ELET,2103,1,19114,Digital Systems Laboratory,Gallardo,Victor Jaime,18,5,1,0,0,0,0,3.667
+Spring 2024,ELET,2300,1,19115,Introductn To C++ Programming,Malki,Heidar A,2,2,5,1,0,0,1,2.467
+Spring 2024,HRD,3351,1,19116,Instructional Design for HRD,Pereira-Leon,Maura Josefina,3,12,8,0,0,0,0,2.768
+Spring 2024,SCLT,2362,32,19117,Intro To Logistics Technology,Kidd,Margaret A,6,15,0,1,0,0,0,3.002
+Spring 2024,SCLT,2380,30,19118,Distribution Channels,Elliott,Stephen Dwight,33,29,10,3,5,0,3,3.013
+Spring 2024,CNST,1301,1,19119,Constructn Materials & Methods,Zaheri,Mohammad J,37,43,4,0,0,0,0,3.377
+Spring 2024,CNST,2321,1,19120,Mechanical & Electrical System,Beadle,Dwight D,61,37,10,0,0,0,0,3.472
+Spring 2024,CNST,2351,1,19121,Construction Estimating I,Liggin,Gregory G,29,34,17,2,0,0,0,3.098
+Spring 2024,CNST,3265,1,19122,Construction Layout & Site Dvp,Moghaddam,Hassan,0,18,20,1,0,0,1,2.529
+Spring 2024,CNST,4302,1,19123,Construction Law and Ethics,Ducran,Denis George,11,60,11,0,1,0,0,2.98
+Spring 2024,CNST,4331,1,19124,Construction Management II,Khan,Taimoor,14,1,0,0,0,0,0,3.713
+Spring 2024,CIS,1332,20,19125,Intro Information Technology,Ratner,Edward,91,15,5,0,1,0,2,3.659
+Spring 2024,CIS,2334,30,19126,Information Systems Applicatns,Detillier,Bret James,100,50,27,8,6,0,24,3.149
+Spring 2024,CIS,2337,30,19127,Fund of Information Security,Lee,Kyu In,51,52,12,0,2,0,2,3.248
+Spring 2024,CIS,2348,20,19128,Info Systems Appl Development,Ratner,Edward,36,28,44,0,8,0,20,2.67
+Spring 2024,CIS,3343,31,19129,Info Systems Analysis & Design,Faiyaz,Sajida,16,20,7,0,0,0,1,3.286
+Spring 2024,CIS,3347,30,19130,IS Infrastructure & Networking,Peddoju,Suresh Kumar,36,12,4,0,0,0,2,3.615
+Spring 2024,SCLT,3384,30,19131,Logistics Tech and Processes,Wang,Kailai,39,20,8,1,1,0,1,3.324
+Spring 2024,SCLT,3387,30,19132,Procurement,Velarde,Jose Manuel,47,21,10,2,3,0,5,3.257
+Spring 2024,SCLT,4312,30,19133,Inventory & Materials Handling,Kennedy,Elizabeth Heyn,50,1,0,0,2,0,0,3.799
+Spring 2024,TEPM,6307,1,19134,Advanced Project Management,Sherman,Dennis Louis,5,1,0,0,0,0,0,3.888
+Spring 2024,CIS,6396,1,19135,Internship in Infor. Security,Lee,Kyu In,1,0,0,0,0,0,0,4.0
+Spring 2024,ELET,1400,1,19136,Circuit Theory and Lab I,Barbieri,Enrique,7,10,12,6,1,0,19,2.509
+Spring 2024,ELET,1401,1,19139,Circuit Theory and Lab II,Barbieri,Enrique,5,6,25,6,0,0,2,2.23
+Spring 2024,HRD,4344,20,19141,Designing E-Learning,Bennett,LaTasha,28,9,1,0,1,0,1,3.539
+Spring 2024,DIGM,2352,34,19142,Digital Photography,Bebawi,Mark George,36,18,2,0,0,0,3,3.454
+Spring 2024,SCLT,3385,30,19143,Transport Economics and Policy,Blount,James,43,45,1,1,1,0,1,3.359
+Spring 2024,BTEC,4319,30,19144,Microbial Biotechnology,Flavier,Albert B,2,13,12,3,0,0,0,2.412
+Spring 2024,BTEC,3321,30,19145,Good Manufacturing Practices,Aghoghovbia-Pugh,Alero,4,18,18,10,3,0,1,2.12
+Spring 2024,CNST,3210,1,19147,Safety for Industrial Projects,Zayas,Frederick A,5,8,6,0,2,0,0,2.714
+Spring 2024,BTEC,3317,30,19148,Biotech Regulatory Environment,Flavier,Albert B,13,16,10,3,4,0,5,2.602
+Spring 2024,CNST,3372,1,19149,Soil Mechanics & Foundations,Meyer,Joseph Ray,55,29,3,0,0,0,1,3.556
+Spring 2024,MECT,4172,31,19151,Materials Tech Lab,Al Ibadi,Adnan,2,10,4,0,1,0,0,2.764
+Spring 2024,FORE,6371,20,19152,World Futures,Hines,Andrew Lewis,5,0,0,0,0,0,0,3.802
+Spring 2024,TMTH,3360,5,19153,Applied Technical Statistics,Thornton,Brandon,6,11,5,0,1,0,1,2.999
+Spring 2024,FORE,6395,1,19154,Master's Project in Foresight,Hines,Andrew Lewis,3,0,0,0,0,0,0,3.89
+Spring 2024,HRD,3340,30,19155,Principles of HRD,Hattier,Beth,30,16,2,0,1,0,1,3.483
+Spring 2024,MECT,4188,20,19157,Ethics in Engineering Tech,Bose,Anima B,9,26,6,0,0,0,0,3.073
+Spring 2024,CIS,4338,20,19160,Advanced Database Concepts,Miertschin,Susan L,22,17,9,0,0,0,1,3.264
+Spring 2024,CIS,4375,30,19161,Project Management & Practice,Martinez,Jose C,14,16,10,0,0,0,0,3.108
+Spring 2024,FORE,6333,20,19163,Systems Thinking,Schultz,Wendy L,11,1,0,0,0,0,0,3.889
+Spring 2024,FORE,6398,1,19165,Special Problems in Foresight,Hines,Andrew Lewis,4,0,0,0,0,0,0,3.918
+Spring 2024,HRD,3340,2,19166,Principles of HRD,Shirmohammadi,Melika,15,3,1,0,1,0,0,3.517
+Spring 2024,HRD,3346,1,19167,Performance Assessment & Eval,Del Grande,Lisa,36,8,0,0,0,0,1,3.766
+Spring 2024,HDCS,1300,3,19168,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,39,9,2,0,0,0,2,3.681
+Spring 2024,HDCS,1300,4,19169,Human Ecosystems & Tech Change,Selzer,Lori Michele,4,21,17,1,0,0,5,2.69
+Spring 2024,HDCS,3300,2,19170,Org Decisions,Hitchman Sr,Cal M,35,7,3,0,0,0,4,3.638
+Spring 2024,CNST,4315,1,19171,Steel Construction,Chang,Chi Chung,35,54,2,0,0,0,0,3.301
+Spring 2024,SCLT,3340,30,19172,Geography for GSC,Henson,Alfred Bernard,21,7,1,0,0,0,2,3.576
+Spring 2024,FORE,6311,20,19173,Introduction to Foresight,Sweeney,John Arthur,3,0,0,0,0,0,0,4.0
+Spring 2024,CIS,2336,30,19174,Web Application Development,Huang,Yueqin,47,19,5,0,4,0,12,3.374
+Spring 2024,TEPM,6307,20,19175,Advanced Project Management,Sherman,Dennis Louis,3,1,0,0,0,0,0,3.668
+Spring 2024,CNST,6380,2,19176,Leed & Green Const Princ in CM,Chang,Chi Chung,29,1,0,0,0,0,0,3.901
+Spring 2024,BTEC,3200,30,19177,Biotech Research Methods,Ibrahim,Eman Refaat,11,2,0,1,0,0,0,3.643
+Spring 2024,BTEC,4350,30,19178,Biotechnology Capstone II,Khan,Abdul Latif,42,1,0,0,0,0,0,3.908
+Spring 2024,GRET,6335,20,19179,Regional Retail Markets,Ezell,Shirley D,3,0,0,0,1,0,0,3.0
+Spring 2024,GRET,6333,2,19180,Retail Mgmt Cross-Cultural,Gatterson,Beverly,3,0,1,0,0,0,0,3.5
+Spring 2024,SCLT,4389,30,19181,Practicum in Supply Chain,Kidd,Margaret A,18,8,2,0,1,0,0,3.346
+Spring 2024,FORE,6319,20,19183,Proseminar in Foresight,McBride,Yasamina,18,2,0,0,0,0,0,3.9
+Spring 2024,ELET,2300,2,19184,Introductn To C++ Programming,Pollonini,Luca,17,6,5,4,4,0,6,2.769
+Spring 2024,BTEC,1322,30,19185,Introduction to Biotechnology,Ibrahim,Eman Refaat,10,1,0,0,0,0,0,3.849
+Spring 2024,HDCS,4393,20,19187,Internship in RCS,Ezell,Shirley D,18,1,1,0,0,0,0,3.834
+Spring 2024,ELET,2103,2,19188,Digital Systems Laboratory,Gallardo,Victor Jaime,13,2,0,0,0,0,1,3.867
+Spring 2024,ELET,2105,2,19189,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,18,0,0,0,0,0,1,4.0
+Spring 2024,CNST,1361,1,19191,Construction Management I,Beadle,Dwight D,65,8,2,0,2,0,0,3.74
+Spring 2024,CNST,3155,1,19192,Const Materials & Testing,Meyer,Joseph Ray,43,27,4,0,0,0,0,3.518
+Spring 2024,CNST,3301,1,19193,Constructn Equipment & Methods,Al-Nahhas,Amer Faisal,30,44,16,2,1,0,2,3.075
+Spring 2024,CNST,3331,1,19194,Constructn Plan and Scheduling,Lyon,Eva Yaneth,48,14,1,1,0,0,0,3.6
+Spring 2024,CNST,3355,1,19195,Strength of Construction Mtrls,Hossain,Sk Amjad,45,26,3,0,1,0,1,3.52
+Spring 2024,ELET,2300,3,19198,Introductn To C++ Programming,Lent,Marino Ricardo,6,13,9,3,5,0,10,2.407
+Spring 2024,MECT,3331,31,19199,Applied Thermodynamics,El Nahas,Medhat A,1,7,12,1,6,0,0,1.791
+Spring 2024,TEPM,6301,20,19200,Project Management Principles,Sherman,Dennis Louis,19,0,0,0,0,0,1,3.983
+Spring 2024,CIS,6399,2,19201,Master's Thesis,Zhang,Yunpeng,1,0,0,0,0,0,0,4.0
+Spring 2024,TECH,3365,3,19202,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,28,13,0,2,0,0,1,3.558
+Spring 2024,HRD,4352,1,19203,Facilitation Strategies,Clancy,James Patrick,19,4,0,0,0,0,0,3.797
+Spring 2024,HRD,4352,30,19204,Facilitation Strategies,Polesello,Daiane,12,5,4,0,1,0,0,3.152
+Spring 2024,HRD,4396,30,19205,Internship in HRD,Polesello,Daiane,11,2,1,0,0,0,0,3.596
+Spring 2024,DIGM,3356,30,19210,ePublishing,Alters,Monika Joanna,15,13,5,0,1,0,1,3.109
+Spring 2024,DIGM,4375,30,19214,Package Design,De Vega,Jaime M,21,0,0,0,0,0,0,3.969
+Spring 2024,DIGM,4379,20,19216,Transmedia Marketing,Lee,Seo Yoon,59,27,3,0,0,0,1,3.548
+Spring 2024,CNST,4302,30,19218,Construction Law and Ethics,Escobar,C Mauricio,11,2,0,0,0,0,0,3.719
+Spring 2024,SCLT,4375,30,19219,Global Supply Chain,Velarde,Jose Manuel,46,16,1,0,2,0,1,3.59
+Spring 2024,SCLT,4387,30,19220,Financial Evaluation For SCM,Reyes,Jorge,35,13,6,0,1,0,0,3.449
+Spring 2024,SCLT,4389,31,19221,Practicum in Supply Chain,Henson,Alfred Bernard,30,0,0,0,0,0,0,3.978
+Spring 2024,SCLT,6314,40,19222,Measurement and Evaluation,Bian,Zheyong,3,3,1,0,0,0,0,3.38
+Spring 2024,ELET,4345,30,19224,App of Fuel Cell Technology,Bose,Anima B,0,0,0,0,1,0,0,0.0
+Spring 2024,BTEC,3302,30,19225,Molecular Genetics and Biotech,Lin,Yuheng,9,10,6,1,0,0,1,3.0
+Spring 2024,MECT,4345,30,19226,Applications of Fuel Cell,Bose,Anima B,3,9,3,0,0,0,1,2.978
+Spring 2024,TEPM,6391,1,19227,Project Management Seminar,Carden,Lila L,9,0,0,0,0,0,0,3.963
+Spring 2024,SCLT,3376,30,19228,Global Trade Intermediaries,Crockett,Brianne,29,7,0,0,1,0,0,3.658
+Spring 2024,HDCS,4369,2,19229,Entrepreneurship,Kellough,James David,44,4,1,0,1,0,0,3.767
+Spring 2024,TMTH,3360,1,19230,Applied Technical Statistics,Dick,Deanna L,4,17,12,3,2,0,2,2.448
+Spring 2024,BTEC,1322,1,19231,Introduction to Biotechnology,Ibrahim,Eman Refaat,26,9,2,0,0,0,0,3.666
+Spring 2024,BTEC,3320,30,19232,Intro to QA/QC in BTEC,Parikh,Tina,5,6,5,1,0,0,1,2.902
+Spring 2024,HDCS,1300,5,19234,Human Ecosystems & Tech Change,Ginwright,Alexis Jordan,16,26,2,1,4,0,1,3.108
+Spring 2024,HDCS,4380,1,19235,Merchandising,Jacobs,Karen S,10,17,8,1,1,0,0,2.83
+Spring 2024,TEPM,6305,20,19236,Project Manager Tools,Sherman,Dennis Louis,2,1,0,0,0,0,1,3.667
+Spring 2024,HRD,6301,1,19237,Leadership Development in HRD,Edwards,Malaika,12,6,1,0,0,0,1,3.614
+Spring 2024,SCLT,3381,31,19238,Industrial and Consumer Sales,Cassler,Daniel,18,5,0,0,0,0,0,3.711
+Spring 2024,DIGM,1350,30,19239,Graphics for Digital Media,Beyl,Charles Eugene,14,8,4,0,1,0,5,3.149
+Spring 2024,SCLT,3389,30,19242,Transportation Law,Henson,Alfred Bernard,60,43,6,0,0,0,0,3.438
+Spring 2024,TMTH,3360,6,19243,Applied Technical Statistics,Daniel,Patrick Nathanial,6,19,8,0,0,0,1,2.939
+Spring 2024,DIGM,3370,30,19244,Two Dimensional Animation,Snyder,Philip Charles,32,4,5,0,0,0,0,3.53
+Spring 2024,TEPM,6308,1,19246,Project Procurement Practices,Conover,Sharon Cecilia,9,0,0,0,0,0,0,3.963
+Spring 2024,BTEC,6302,30,19248,Intro to Regulatory Affairs,Flavier,Albert B,3,1,2,0,0,0,0,3.112
+Spring 2024,BTEC,6303,30,19249,Protein Engineering Technology,Flavier,Albert B,2,6,4,0,0,0,0,2.778
+Spring 2024,MECT,3355,30,19250,Strength of Materials,Basaran,Burak,1,5,28,8,6,0,1,1.654
+Spring 2024,CIS,3343,30,19252,Info Systems Analysis & Design,Faiyaz,Sajida,23,21,2,0,0,0,1,3.571
+Spring 2024,CIS,3368,30,19254,Adv Info Systems Development,Dobretsberger,Otto,18,17,5,0,1,0,1,3.228
+Spring 2024,CNST,6320,1,19255,Cost Analysis and Bidding,Eldin,Neil N,28,0,0,0,1,0,0,3.862
+Spring 2024,MECT,4276,30,19256,Senior Design Project II,Afrin,Samia,8,22,0,0,0,0,0,3.289
+Spring 2024,CNST,6320,2,19258,Cost Analysis and Bidding,Eldin,Neil N,30,0,0,0,0,0,0,4.0
+Spring 2024,CNST,6330,1,19259,Project Planning & Management,Eldin,Neil N,18,12,0,0,0,0,0,3.6
+Spring 2024,CNST,6330,2,19260,Project Planning & Management,Eldin,Neil N,12,6,0,0,0,0,0,3.667
+Spring 2024,DIGM,1350,31,19262,Graphics for Digital Media,Beyl,Charles Eugene,10,10,3,0,2,0,3,3.014
+Spring 2024,MECT,4188,21,19263,Ethics in Engineering Tech,Bose,Anima B,16,20,5,0,0,0,0,3.252
+Spring 2024,BTEC,4300,30,19264,Principles of Bioinformatics,Balan,Venkatesh,9,6,9,0,0,0,1,2.89
+Spring 2024,HRD,3351,20,19265,Instructional Design for HRD,Pereira-Leon,Maura Josefina,10,25,4,0,0,0,0,3.086
+Spring 2024,HRD,6303,20,19266,Assessment & Evaluation in Hrd,Shin,Daeun,6,0,0,0,1,0,0,3.429
+Spring 2024,HRD,6304,1,19267,Research in Human Resource Dev,Greer,Tomika,6,12,2,0,0,0,1,3.2
+Spring 2024,HRD,6352,30,19268,Inst Design for Training Envir,Laville,Johann,9,1,0,0,0,0,0,3.801
+Spring 2024,CIS,4365,30,19269,Database Management,Hu,Renjie,34,26,1,0,0,0,0,3.46
+Spring 2024,CIS,3368,31,19270,Adv Info Systems Development,Dobretsberger,Otto,14,8,9,0,0,0,4,3.119
+Spring 2024,MECT,1365,30,19271,Elements Materials & Processes,Wari,Ezra Tsegaye,7,21,6,7,2,0,2,2.474
+Spring 2024,CNST,4331,2,19272,Construction Management II,Menendez,Daniel,6,24,1,0,0,0,1,3.14
+Spring 2024,SCLT,6320,40,19273,Procurement Strategies,Wang,Kailai,6,1,0,0,0,0,0,3.81
+Spring 2024,CNST,6308,1,19274,Data Analysis in Construc Mgmt,Gao,Lu,87,0,0,0,0,0,0,4.0
+Spring 2024,TLIM,3300,20,19277,Leadership & Innovation Fund,Evans,Gerald S,27,6,0,0,0,0,0,3.698
+Spring 2024,TLIM,3340,20,19278,Org Leadership & Supervision,Evans,Gerald S,254,5,6,0,4,0,1,3.832
+Spring 2024,TLIM,3345,30,19279,Human Resources in Technology,Evans,Ruth Ann,54,28,7,3,2,0,1,3.372
+Spring 2024,TLIM,3355,30,19280,Project Management Principles,Moore,George P,49,21,4,1,1,0,1,3.479
+Spring 2024,TLIM,3363,31,19281,Technical Communications,Piercy,Penelope Junker,23,7,1,1,0,0,3,3.563
+Spring 2024,TLIM,3363,32,19282,Technical Communications,Bracken II,William Terry,36,4,1,0,2,0,0,3.628
+Spring 2024,TLIM,3363,33,19283,Technical Communications,Tangeman,Anthony C,22,14,1,0,3,0,0,3.292
+Spring 2024,TLIM,3363,21,19284,Technical Communications,Piercy,Penelope Junker,17,18,4,0,1,0,1,3.126
+Spring 2024,TLIM,3363,30,19285,Technical Communications,Tangeman,Anthony C,21,19,3,0,3,0,1,3.246
+Spring 2024,TLIM,3363,20,19286,Technical Communications,Tangeman,Anthony C,17,15,4,2,2,0,1,3.133
+Spring 2024,TLIM,3365,30,19287,Team Leadership,Feriante,Chris,39,5,2,0,0,0,1,3.711
+Spring 2024,TLIM,4341,30,19288,Production & Service Operation,Cao,Shun,29,6,1,3,0,0,0,3.539
+Spring 2024,TLIM,4341,32,19289,Production & Service Operation,Cao,Shun,14,4,2,1,0,0,0,3.429
+Spring 2024,TLIM,4341,31,19290,Production & Service Operation,Chance,Michael Dean,24,13,0,0,0,0,0,3.542
+Spring 2024,TLIM,4341,20,19291,Production & Service Operation,Chance,Michael Dean,26,14,0,0,0,0,0,3.568
+Spring 2024,TLIM,4342,30,19292,Quality Improvement Methods,O'Kelley,Donna K,12,24,5,1,4,0,3,2.848
+Spring 2024,TLIM,4342,32,19293,Quality Improvement Methods,Chance,Michael Dean,30,13,5,2,1,0,0,3.301
+Spring 2024,TLIM,4342,31,19294,Quality Improvement Methods,Chance,Michael Dean,14,21,9,0,4,0,1,2.834
+Spring 2024,TLIM,4350,30,19295,Occup Safety & Envir Health,Freedkin,Aaron Samuel,47,8,1,2,0,0,1,3.644
+Spring 2024,TLIM,4371,31,19296,Leading Change in the Wrkplace,Mehring,Brian George,9,15,3,0,0,0,1,3.247
+Spring 2024,TLIM,4372,20,19297,Proposal and Project Writing,Thomas,Jamie M,2,12,5,1,0,0,3,2.75
+Spring 2024,TLIM,4390,30,19298,Current Issues Ldshp & Innov,Mehring,Brian George,17,3,1,0,0,0,1,3.636
+Spring 2024,CNST,3185,3,19299,Construction Experience,Lyon,Eva Yaneth,42,5,3,0,1,0,3,3.641
+Spring 2024,CNST,3265,2,19300,Construction Layout & Site Dvp,Lupher,Jacob John,22,10,4,0,1,0,2,3.405
+Spring 2024,ELET,4326,1,19301,Power Converter Circuits,Shireen,Wajiha,6,10,3,0,0,0,0,3.175
+Spring 2024,ELET,4126,1,19302,Power Converter Circuits Lab,Shireen,Wajiha,18,0,0,0,0,0,0,3.945
+Spring 2024,ELET,6331,1,19303,Fund of Medical Imaging,Zouridakis,George,2,0,0,0,0,0,1,3.835
+Spring 2024,HDCS,6300,30,19308,Quan. & Stat. Methods in HDCS,Greer,Tomika,6,1,0,0,0,0,0,3.81
+Spring 2024,HDCS,1300,6,19310,Human Ecosystems & Tech Change,Gatterson,Beverly,44,2,2,0,0,0,2,3.861
+Spring 2024,HDCS,3304,1,19311,Visual Merchandising,Mudd,Blake Stevens,15,5,1,0,1,0,0,3.47
+Spring 2024,SCLT,2362,33,19312,Intro To Logistics Technology,Kidd,Margaret A,9,0,2,0,0,0,4,3.426
+Spring 2024,SCLT,3381,32,19313,Industrial and Consumer Sales,Cassler,Daniel,25,15,1,0,2,0,0,3.327
+Spring 2024,SCLT,2362,31,19314,Intro To Logistics Technology,Cassler,Daniel,13,17,3,0,0,0,1,3.173
+Spring 2024,ELET,4351,1,19317,Biomedical Data Mining,Pollonini,Luca,14,0,0,0,0,0,0,3.906
+Spring 2024,TLIM,3330,31,19318,Innovation Principles,Mehring,Brian George,10,5,8,1,0,0,2,2.959
+Spring 2024,TEPM,6302,1,19319,Leadership and Team Building,Hopkins,Ronald K,16,1,0,0,0,0,0,3.864
+Spring 2024,TEPM,6303,1,19320,Risk Assessment in Project Mgm,Rypien,David V,8,1,0,0,0,0,1,3.926
+Spring 2024,TEPM,6305,1,19321,Project Manager Tools,Sherman,Dennis Louis,14,0,0,0,0,0,0,3.976
+Spring 2024,TEPM,6306,1,19322,Project Management Office,Rypien,David V,11,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6306,20,19323,Project Management Office,Rypien,David V,3,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6308,20,19324,Project Procurement Practices,Conover,Sharon Cecilia,4,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6391,20,19325,Project Management Seminar,Carden,Lila L,2,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6304,1,19326,Quality Improvemnt in Proj Mgt,Kovach,Jamison,10,0,0,0,0,0,0,4.0
+Spring 2024,TLIM,3350,30,19327,Emergency Management Principle,Freedkin,Aaron Samuel,20,12,3,0,0,0,0,3.382
+Spring 2024,CIS,3367,30,19328,Cloud Computing Architecture,Martinez,Jose C,20,20,5,0,2,0,2,3.199
+Spring 2024,DIGM,1350,32,19329,Graphics for Digital Media,Dawson,Michael John,19,0,0,0,0,0,8,3.983
+Spring 2024,HDCS,1300,7,19330,Human Ecosystems & Tech Change,Mudd,Blake Stevens,37,9,2,0,1,0,0,3.633
+Spring 2024,FORE,6396,1,19331,Internship,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Spring 2024,DIGM,1376,30,19335,User Experience (UX)Principles,Rodwell,Elizabeth Ann,112,64,21,4,8,0,8,3.238
+Spring 2024,DIGM,2325,32,19336,Info Tech Applications,Hargrove,Mark Stephen,44,51,12,1,1,0,7,3.172
+Spring 2024,HDCS,3300,3,19339,Org Decisions,Stewart,Quentin K,19,13,3,0,1,0,1,3.334
+Spring 2024,SCLT,3375,30,19340,Maritime Operations,Blount,James,10,13,3,0,1,0,0,3.16
+Spring 2024,SCLT,6314,1,19341,Measurement and Evaluation,Bian,Zheyong,34,23,0,0,0,0,0,3.678
+Spring 2024,SCLT,6320,1,19342,Procurement Strategies,Wang,Kailai,24,0,0,0,0,0,0,3.959
+Spring 2024,TLIM,3360,30,19343,Law & Ethics-Tech & Innovation,Feriante,Chris,61,19,17,0,0,0,0,3.44
+Spring 2024,ELET,4331,1,19345,Medical Imaging,Zouridakis,George,2,3,0,0,0,0,1,3.532
+Spring 2024,HRD,6302,2,19346,Design & Management E-Learning,Rainbolt,Hilary,11,7,2,0,0,0,0,3.45
+Spring 2024,HRD,6359,20,19347,Trends in Org Development,Kjerfve,Tania M,4,6,1,1,0,0,0,3.166
+Spring 2024,ELET,6351,1,19348,Biomedical Data Mining,Pollonini,Luca,43,0,0,0,0,0,1,4.0
+Spring 2024,ELET,6354,1,19350,Biomedical Image Analysis,Merchant,Fatima Aziz,1,0,0,0,0,0,1,3.67
+Spring 2024,ELET,4354,1,19351,Biomedical Image Analysis,Merchant,Fatima Aziz,8,10,4,0,0,0,0,3.107
+Spring 2024,HRD,3310,2,19352,Talent Management,Edwards,Malaika,28,18,1,1,0,0,1,3.349
+Spring 2024,MECT,2354,30,19353,Introduction to Mechanics,Basaran,Burak,3,5,9,5,2,0,0,2.056
+Spring 2024,TMTH,3360,2,19355,Applied Technical Statistics,Telles,John E,22,10,5,0,5,0,6,2.993
+Spring 2024,TEPM,6395,20,19356,Integration Project,Carden,Lila L,3,0,0,0,0,0,0,4.0
+Spring 2024,TLIM,3331,20,19357,Innovation Development,Crawley,David L,7,0,3,0,0,0,3,3.268
+Spring 2024,TLIM,3330,32,19358,Innovation Principles,Mehring,Brian George,7,10,3,1,1,0,0,2.895
+Spring 2024,CNST,6307,1,19361,Stati and Optimiz Method in CM,Senouci,Ahmed,12,7,0,0,0,0,0,3.475
+Spring 2024,DIGM,4378,30,19363,Senior Project,Snyder,Philip Charles,19,8,3,1,0,0,1,3.398
+Spring 2024,HRD,3350,20,19364,Workforce Diversity and Global,Polesello,Daiane,20,9,1,0,0,0,1,3.578
+Spring 2024,HRD,4344,30,19365,Designing E-Learning,Bennett,LaTasha,26,2,1,0,0,0,0,3.817
+Spring 2024,HRD,4350,30,19366,Org Dev & Consulting,Polesello,Daiane,13,5,1,0,0,0,0,3.632
+Spring 2024,MECT,4331,30,19367,Heat Transfer Applications,Alba,Kamran,8,3,2,1,0,0,1,3.215
+Spring 2024,CIS,4365,31,19368,Database Management,Hu,Renjie,36,21,0,0,0,0,1,3.533
+Spring 2024,CNST,4220,20,19369,Comp CM & Emerging Practices,Coble,Lana Kay,48,4,0,0,0,0,1,3.923
+Spring 2024,CIS,4375,20,19371,Project Management & Practice,Schlager,Alexander,31,7,6,0,0,0,0,3.523
+Spring 2024,CIS,4375,31,19372,Project Management & Practice,Martinez,Jose C,24,18,2,0,0,0,0,3.463
+Spring 2024,BTEC,3200,31,19373,Biotech Research Methods,Ibrahim,Eman Refaat,13,2,0,0,0,0,0,3.867
+Spring 2024,CNST,1330,2,19374,Graphics I,Clark,Peter J,11,11,6,2,0,0,1,2.989
+Spring 2024,ELET,4105,1,19375,Senior Design Lab in EPET,Shi,Jian,24,0,0,0,0,0,0,4.0
+Spring 2024,ELET,4103,1,19376,Power Transmission Lab,Shireen,Wajiha,9,2,0,0,0,0,0,3.758
+Spring 2024,TLIM,3330,30,19377,Innovation Principles,Crawley,David L,6,6,11,0,2,0,2,2.441
+Spring 2024,TLIM,3371,30,19378,Budgeting and Financial Princ,Burns,Maria,60,0,0,0,1,0,0,3.913
+Spring 2024,HRD,3310,3,19380,Talent Management,Shakir,Khalimah,13,6,0,0,1,0,1,3.484
+Spring 2024,SCLT,4380,30,19384,Quality Systems,Singh,Gulshan,27,45,7,0,1,0,0,3.217
+Spring 2024,HRD,6399,1,19385,Master's Thesis,Greer,Tomika,0,0,0,0,0,0,0,
+Spring 2024,CIS,2348,30,19386,Info Systems Appl Development,Lendasse,Amaury,16,0,1,0,0,0,0,3.844
+Spring 2024,CIS,2336,31,19387,Web Application Development,Faiyaz,Sajida,28,16,8,0,0,0,3,3.442
+Spring 2024,TLIM,4342,33,19389,Quality Improvement Methods,O'Kelley,Donna K,16,26,6,0,0,0,1,3.263
+Spring 2024,DIGM,4378,31,19390,Senior Project,Alters,Monika Joanna,18,0,0,0,0,0,0,3.927
+Spring 2024,DIGM,1300,20,19391,Introduction to Digital Media,Liao,Pamara F,27,19,3,1,1,0,3,3.301
+Spring 2024,CNST,2351,2,19393,Construction Estimating I,Liggin,Gregory G,19,35,10,2,1,0,1,3.03
+Spring 2024,CNST,3205,2,19394,Construction Safety Management,Hart,Lee J,24,2,0,0,0,0,0,3.923
+Spring 2024,CNST,3331,2,19395,Constructn Plan and Scheduling,Lyon,Eva Yaneth,32,19,1,1,1,0,0,3.457
+Spring 2024,CNST,3351,2,19396,Construction Estimating II,Siddiqui,Muhammad Ali,18,6,2,0,0,0,0,3.539
+Spring 2024,CIS,3320,20,19397,Information Visualization,Ratner,Edward,41,25,3,3,7,0,3,3.097
+Spring 2024,CIS,4355,30,19398,Information Systems Operations,Peddoju,Suresh Kumar,51,44,13,2,6,0,2,3.138
+Spring 2024,HRD,6359,30,19399,Trends in Org Development,Waight,Consuelo L,8,2,0,0,0,0,0,3.833
+Spring 2024,TEPM,6304,20,19400,Quality Improvemnt in Proj Mgt,Kovach,Jamison,5,0,0,0,0,0,1,4.0
+Spring 2024,HDCS,2301,2,19401,Consumer Science,Stewart,Juliana Floriene,28,14,3,1,4,0,0,3.147
+Spring 2024,HDCS,3303,2,19402,Retailing and Consumer Science,Grami,Zina Monjia,21,14,8,0,2,0,3,3.097
+Spring 2024,HDCS,3304,2,19403,Visual Merchandising,Stewart,Barbara L,7,30,10,1,0,0,1,2.896
+Spring 2024,HDCS,4303,2,19404,Merchandising Systems,Johnson,Olivia,6,19,7,1,1,0,2,2.824
+Spring 2024,CIS,3351,20,19405,Intrusion Detect & Incid Resp,Nsoh,Jovita T,44,3,0,0,1,0,0,3.813
+Spring 2024,HRD,4350,1,19406,Org Dev & Consulting,Clancy,James Patrick,16,6,3,0,0,0,0,3.428
+Spring 2024,MECT,4350,30,19407,Principles of Mechatronics,Fan,Zheng,17,0,0,0,0,0,0,3.903
+Spring 2024,MECT,4364,30,19411,Smart Manuf Systems Design,Hadi,Mahmoud,8,22,4,0,0,0,0,3.03
+Spring 2024,TLIM,4335,20,19414,Communicating Innovation,Crawley,David L,2,1,2,0,1,0,0,2.555
+Spring 2024,HDCS,3376,3,19417,Resources in Technology Entrep,Robinson,Ebony M,8,17,6,1,1,0,1,2.909
+Spring 2024,CIS,3347,31,19418,IS Infrastructure & Networking,Martinez,Jose C,34,8,8,2,6,0,0,3.001
+Spring 2024,ELET,4103,2,19428,Power Transmission Lab,Shireen,Wajiha,5,0,0,0,1,0,0,3.168
+Spring 2024,HDCS,1300,8,19429,Human Ecosystems & Tech Change,Mudd,Blake Stevens,44,2,1,0,0,0,2,3.887
+Spring 2024,MECT,3318,31,19430,Fluid Mechanics Applications,Mohan,Gowtham,7,8,3,2,2,0,0,2.622
+Spring 2024,CNST,6308,2,19433,Data Analysis in Construc Mgmt,Gao,Lu,49,1,0,0,0,0,0,3.987
+Spring 2024,ENGL,4387,1,19435,SR Writing Proj CW: Fiction,Boswell,Robert L,14,1,0,0,0,0,0,3.955
+Spring 2024,TLIM,4378,31,19436,Senior Project,Feriante,Chris,23,1,1,0,0,0,0,3.84
+Spring 2024,DIGM,4378,32,19441,Senior Project,Liao,Tony Chung-Li,24,10,1,0,0,0,0,3.619
+Spring 2024,ELET,6318,1,19444,Analysis of Data Networks,Yuan,Xiaojing,2,0,0,0,0,0,0,4.0
+Spring 2024,CNST,6375,1,19445,BIM Applications for CM,Din,Zia Ud,50,4,0,0,0,0,0,3.883
+Spring 2024,TEPM,6301,40,19446,Project Management Principles,Sherman,Dennis Louis,7,1,0,0,0,0,0,3.916
+Spring 2024,TEPM,6302,40,19447,Leadership and Team Building,Hopkins,Ronald K,4,4,0,0,0,0,0,3.583
+Spring 2024,TEPM,6304,40,19448,Quality Improvemnt in Proj Mgt,Kovach,Jamison,5,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6305,40,19449,Project Manager Tools,Sherman,Dennis Louis,1,1,0,0,0,0,1,3.665
+Spring 2024,TEPM,6303,40,19450,Risk Assessment in Project Mgm,Rypien,David V,1,1,0,0,0,0,0,3.5
+Spring 2024,TEPM,6308,40,19451,Project Procurement Practices,Conover,Sharon Cecilia,4,0,0,0,0,0,0,4.0
+Spring 2024,SCLT,4386,20,19452,Project Logistics,Poisler,Marco A,11,0,0,0,1,0,0,3.502
+Spring 2024,HDCS,3384,1,19454,Consumer Sales,Mudd,Blake Stevens,42,6,2,0,0,0,1,3.774
+Spring 2024,BTEC,2322,20,19455,Introduction to Biopython,Chitrala,Kumaraswamy Naidu,21,3,0,0,1,0,0,3.667
+Spring 2024,TECH,1301,2,19456,Intro to Data Analytics Tools,Thornton,Brandon,35,6,1,2,2,0,1,3.493
+Spring 2024,TECH,1301,3,19457,Intro to Data Analytics Tools,Shin,Daeun,16,5,6,0,1,0,2,3.191
+Spring 2024,MECT,4330,30,19459,Valve Design,Andampour,Iraj,11,11,1,0,0,0,0,3.334
+Spring 2024,FORE,6355,20,19460,Alternative Perspectives,Cowart,Adam David,5,0,0,0,0,0,0,4.0
+Spring 2024,HRD,6353,1,19462,Methods of Adult Learning,Shirmohammadi,Melika,9,0,0,0,1,0,0,3.534
+Spring 2024,HRD,6304,30,19464,Research in Human Resource Dev,Kjerfve,Tania M,2,3,1,0,0,0,0,3.222
+Spring 2024,GHL,8188,1,19465,Ph.D. Colloquium,Back,KiJoon,0,0,0,0,0,6,0,
+Spring 2024,PHLS,7303,2,19466,Internship II,Zatopek,Audrey,0,0,0,0,0,12,0,
+Spring 2024,CNST,2360,1,19469,Communication in Construction,Escobar,C Mauricio,42,17,1,0,0,0,0,3.634
+Spring 2024,BTEC,4301,30,19470,Principles of Bioprocessing,Lin,Yuheng,12,12,2,0,0,0,0,3.435
+Spring 2024,BTEC,4101,30,19471,Principle of Bioprocessing Lab,Lin,Yuheng,12,11,3,0,0,0,0,3.397
+Spring 2024,ELET,6318,40,19476,Analysis of Data Networks,Yuan,Xiaojing,2,0,0,0,0,0,0,4.0
+Spring 2024,ELET,6351,40,19477,Biomedical Data Mining,Pollonini,Luca,1,1,0,0,0,0,0,3.665
+Spring 2024,BTEC,6302,40,19481,Intro to Regulatory Affairs,Flavier,Albert B,1,0,0,0,0,0,0,3.67
+Spring 2024,BTEC,6303,40,19482,Protein Engineering Technology,Flavier,Albert B,2,3,1,0,0,0,0,3.002
+Spring 2024,DIGM,4398,31,19483,Independent Study,Liao,Tony Chung-Li,7,0,0,0,0,0,0,4.0
+Spring 2024,CIS,3368,32,19484,Adv Info Systems Development,Peddoju,Suresh Kumar,19,8,6,1,2,0,4,3.102
+Spring 2024,DIGM,4398,32,19486,Independent Study,Rodwell,Elizabeth Ann,11,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6310,1,19488,Applied Piano,Hester,Timothy E,7,0,0,0,0,0,0,3.906
+Spring 2024,MUSA,6310,2,19489,Applied Piano,Morgulis,Tali,5,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6310,3,19490,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Spring 2024,COMD,8391,1,19491,COMD Research,Dial,Heather Raye,0,0,0,0,0,1,0,
+Spring 2024,COMD,8391,3,19493,COMD Research,Maher,Lynn M,0,0,0,0,0,1,0,
+Spring 2024,COMD,8391,4,19494,COMD Research,Bunta,Ferenc,0,0,0,0,0,1,0,
+Spring 2024,COMD,8391,5,19495,COMD Research,Joshi,Ashwini,0,0,0,0,0,1,0,
+Spring 2024,CIS,6324,1,19496,Cybersecurity Risk Management,Conklin,William A,6,0,0,0,0,0,0,4.0
+Spring 2024,COMD,8391,6,19497,COMD Research,Castilla-Earls,Anny,0,0,0,0,0,1,0,
+Spring 2024,PEP,8350,1,19498,HHP Candidacy Project Research,Layne,Charles S,4,0,0,0,0,0,0,4.0
+Spring 2024,CIS,4339,31,19499,Enterprise Appls Development,Wu,Xuqing,108,15,6,0,0,0,3,3.678
+Spring 2024,CIS,6324,40,19503,Cybersecurity Risk Management,Conklin,William A,7,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6320,1,19505,Applied Violin,Lo,Mann-Wen,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6320,2,19506,Applied Violin,Yon,Kirsten A,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8499,2,19507,Doctoral Document,Dirst,Matthew C,1,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6303,20,19508,Risk Assessment in Project Mgm,Rypien,David V,11,0,0,0,0,0,1,3.91
+Spring 2024,TLIM,3363,22,19512,Technical Communications,Piercy,Penelope Junker,16,14,5,1,1,0,2,3.064
+Spring 2024,MUSI,8301,1,19514,Seminar in Perform Pedagogy,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Spring 2024,HDFS,2314,12,19524,Human Dev and Interventions,Boykin,Jelisa Denae,29,14,3,2,3,0,2,3.235
+Spring 2024,HDFS,4316,1,19527,Dynamics of Family Relations,Laird,Helen Marie,12,16,10,3,2,0,1,2.698
+Spring 2024,HDFS,4318,1,19528,Parent-Child Relationships,Laird,Helen Marie,12,22,9,0,0,0,0,2.985
+Spring 2024,HLT,4397,1,19533,Selected Topics in Health,Drenner,Kelli Linn,10,2,2,0,2,0,3,3.125
+Spring 2024,PHLS,8399,1,19536,Doctoral Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Spring 2024,PHLS,7398,1,19540,Candidacy Research,Smith,Bradley,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8199,1,19541,Dissertation,Smith,Bradley,1,0,0,0,0,2,0,4.0
+Spring 2024,PHLS,8199,3,19542,Dissertation,Margulis,Milena A,0,0,0,0,0,1,0,
+Spring 2024,PHLS,7303,1,19544,Internship II,McCoy,Leah,0,0,0,0,0,11,0,
+Spring 2024,PHLS,8310,1,19549,Psych of Learning in STEM,Master,Allison,7,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8327,1,19550,Longit Analy in Psy/Educ Res,Wiesner,Margit F,7,1,0,0,0,0,0,3.71
+Spring 2024,PHLS,8335,1,19551,Sem-Adv Top-Human Development,Master,Allison,5,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,7317,1,19552,Cog. & Affective Bases of Beh,Lukingbeal,Patrick Livingston,24,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7301,1,19617,Capstone Project,Khan,Shuhab D,0,1,0,0,0,0,0,3.0
+Spring 2024,PHIL,3305,1,19649,Hist of 18Th Century Phil,Morrison,Iain P D,5,7,1,0,1,0,1,3.024
+Spring 2024,PHIL,3361,1,19662,Aesthetics,Mag Uidhir,Christopher Domh,20,10,1,0,1,0,2,3.49
+Spring 2024,PHIL,3332,1,19666,Philosophy of Language,Buckner,Cameron J,14,15,5,0,0,0,1,3.119
+Spring 2024,PHIL,3321,1,19669,Logic III,Garson,James W,5,2,2,0,3,0,3,2.555
+Spring 2024,PHIL,3350,1,19671,Ethics,Coates,Daniel J,19,14,0,0,0,0,2,3.626
+Spring 2024,PHIL,6396,1,19675,Seminar in Hist of Phil,Hattab,Helen,9,2,0,0,0,0,0,3.728
+Spring 2024,PHIL,6395,1,19678,Seminar Philos Problems,Weisberg,Joshua,12,0,0,0,0,0,0,3.945
+Spring 2024,PHIL,6395,2,19680,Seminar Philos Problems,Sommers,Tamler S,14,0,0,0,0,0,0,3.976
+Spring 2024,MATH,5334,1,19701,Complex Analysis,Ji,Shanyu,3,2,0,0,0,0,0,3.534
+Spring 2024,MATH,5344,1,19702,Intro to Scientific Computing,Morgan,Jeffrey,6,1,0,0,0,0,0,3.81
+Spring 2024,MATH,5350,1,19703,Intro To Differential Geometry,Ru,Min,2,2,0,0,0,0,3,3.583
+Spring 2024,MATH,6367,1,19704,Optimization Theory,He,Jiwen,6,5,0,0,0,0,1,3.635
+Spring 2024,MATH,6377,1,19705,Math of Machine Learning,Azencott,Robert Guy,4,3,1,0,0,0,0,3.416
+Spring 2024,MATH,6397,1,19706,Selected Topics in Math,Mang,Andreas,26,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6397,2,19707,Selected Topics in Math,Ott,William R,20,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6397,3,19708,Selected Topics in Math,Vershynina,Anna,14,2,0,0,0,0,0,3.813
+Spring 2024,MATH,6397,4,19709,Selected Topics in Math,Timofeyev,Ilya,22,2,0,0,0,0,0,3.834
+Spring 2024,MATH,6397,5,19739,Selected Topics in Math,Niu,Yabo,2,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6397,6,19750,Selected Topics in Math,Arregoces,Luis A,13,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,1302,3,19767,College Physics II (lecture),McElhenny,Brian Patrick,69,58,43,7,8,0,15,2.932
+Spring 2024,MATH,4351,1,19769,Calculus on Manifolds,Wu,Yingying,8,2,0,0,0,0,4,3.767
+Spring 2024,PHYS,2325,7,19770,University Physics I (lecture),Miller,John H,22,39,46,4,0,0,31,2.706
+Spring 2024,PHYS,6354,1,19772,Methods of Math Physics II,Weglein,Arthur B,3,1,0,1,0,0,0,3.134
+Spring 2024,PHYS,7397,1,19774,Selected Topics in Phy,Ratti,Claudia,20,0,0,0,0,0,0,3.934
+Spring 2024,PHYS,7397,2,19775,Selected Topics in Phy,Varghese,Oomman K,5,2,0,0,0,0,0,3.809
+Spring 2024,FINA,6387,4,19928,Managerial Analysis,Berta,Dominique,6,2,0,0,0,0,0,3.75
+Spring 2024,GENB,7397,1,19929,Selected Topics,Wilbur,Stephen,8,0,0,0,0,0,0,3.835
+Spring 2024,GENB,7397,2,19930,Selected Topics,Webb,James R,9,2,1,0,0,0,0,3.722
+Spring 2024,PHYS,4337,1,19931,Intro Solid State Phy,Ting,Chin Sen,3,7,1,0,0,0,1,3.242
+Spring 2024,ACCT,7397,1,19937,Selected Topics in Accounting,Crawford,Steven,9,5,0,0,0,0,0,3.619
+Spring 2024,ACCT,7397,2,19940,Selected Topics in Accounting,Lu,Tong,6,0,0,0,0,0,0,4.0
+Spring 2024,ECON,3334,3,19953,Intermediate Macroeconomics,Cubas Norando,German,2,13,6,2,0,0,4,2.695
+Spring 2024,ECON,3368,1,19954,Economics of Health Care,Zhivan,Natalia A,13,10,5,3,1,0,1,2.917
+Spring 2024,ECON,4335,1,19955,Economic Growth Theory,Vollrath,Dietrich E,8,18,0,0,0,0,1,3.193
+Spring 2024,POLS,3394,1,19962,Sel Topics Pol Theory Method,Hawley,Michael C,7,6,3,0,2,0,0,2.981
+Spring 2024,INAR,4501,3,19990,Interior Arch Studio VIII,Soto,Carlos E,6,3,0,0,0,0,0,3.557
+Spring 2024,CUIN,4397,1,20118,Selected Topics in C&I,Manuel,Mariam A,5,0,0,0,0,0,1,4.0
+Spring 2024,CUIN,8390,4,20122,Dissertation in Practice,Hausmann,Robert Carl,0,0,0,0,0,3,0,
+Spring 2024,CUIN,8390,3,20124,Dissertation in Practice,Hale,Margaret Ann,1,0,0,0,0,7,0,4.0
+Spring 2024,ECON,3377,1,20138,Economics of Public Finance,Craig,Steven G,13,28,2,0,1,0,0,3.227
+Spring 2024,ECON,3332,3,20151,Intermediate Microeconomics,Troncoso,Pablo A,16,12,6,0,0,0,5,3.226
+Spring 2024,ECON,3365,1,20158,Labor Economics,Hossain,Md Shahadath,24,27,8,0,1,0,0,3.244
+Spring 2024,ECON,4395,1,20159,Topics - Applied Econometrics,Szabo,Andrea,8,4,14,1,0,0,2,2.801
+Spring 2024,ECON,4363,1,20160,Political Economy,Ujhelyi,Gergely,3,8,4,5,1,0,6,2.365
+Spring 2024,MATH,2305,3,20171,Discrete Mathematics,Heier,Gordon,11,26,7,0,14,0,12,2.368
+Spring 2024,MATH,3339,2,20172,Statistics for the Sciences,Wang,Wenshuang,87,50,22,11,16,0,11,2.954
+Spring 2024,MATH,6397,8,20173,Selected Topics in Math,Niu,Yabo,13,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6397,9,20174,Selected Topics in Math,Ryan,John M,5,0,0,0,0,0,1,4.0
+Spring 2024,ARCH,6311,1,20175,Topics in Design History,Bassi Cendra,Giovanna Maria,1,0,1,0,0,0,0,2.835
+Spring 2024,ARCH,6311,2,20176,Topics in Design History,Ramaswamy,Deepa,1,0,0,0,0,0,0,3.67
+Spring 2024,MATH,2305,6,20178,Discrete Mathematics,Winkle,James J,7,16,20,31,3,0,2,1.943
+Spring 2024,NUTR,6314,1,20179,Gender & Culture Issin Phy Act,Alastuey,Lisa L,10,1,0,0,1,0,0,3.556
+Spring 2024,ATP,7297,1,20180,Case Study Prep & Submission,Knoblauch,Mark Alan,15,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6304,1,20181,Visual Studies IV,Plauche',Roya,24,4,0,0,0,0,0,3.751
+Spring 2024,CHEM,1311,3,20217,Fundamentals of Chemistry,Czernuszewicz,Roman S,20,39,88,28,54,0,52,1.704
+Spring 2024,ECON,8335,1,20219,Macroeconometrics,Sorensen,Bent E,7,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8365,1,20221,Labor Economics II,Juhn,Chinhui,9,0,0,0,0,0,0,3.78
+Spring 2024,ECON,7387,1,20222,Eco Anlysis-Urbn Areas,Kohlhase,Janet E,8,0,0,0,0,0,0,4.0
+Spring 2024,ECON,7395,1,20223,Selected Topics,Yi,Kei-Mu,5,2,0,0,0,0,0,3.714
+Spring 2024,MANA,4346,3,20225,Leadership Development,Lozano Garcia,Miguel Angel,36,6,2,0,0,0,0,3.75
+Spring 2024,MANA,4358,2,20226,Compensation and Benefits,Zamanipour,Tina,6,3,1,0,0,0,2,3.5
+Spring 2024,MANA,7322,1,20227,Qual-Perf Mgmt in Healthcare,Kroger,Edward John,4,1,0,0,0,0,0,3.734
+Spring 2024,MANA,7347,1,20230,Environm & Social Governance,Chiu,Shih-chi,10,3,0,0,0,0,0,3.718
+Spring 2024,MIS,3360,5,20231,Systems Analysis and Design,Knighton,William B,31,23,9,0,0,0,0,3.349
+Spring 2024,MIS,3370,5,20233,Info Systems Development Tools,Zamarripa,Ivan,15,15,10,6,1,0,12,2.787
+Spring 2024,MANA,7362,1,20236,Leading Change,Carlin,Barbara A,20,2,1,0,0,0,1,3.783
+Spring 2024,MANA,7375,1,20238,Global Leadership,Sauerwald,Steve,14,1,0,0,0,0,0,3.889
+Spring 2024,MIS,4397,1,20239,Selected Topics in MIS,Wang,Cheng,39,2,0,0,0,0,0,3.959
+Spring 2024,MIS,4397,2,20241,Selected Topics in MIS,Decarlo,Paul Jarrod,40,0,0,0,0,0,0,3.992
+Spring 2024,MIS,4397,3,20242,Selected Topics in MIS,Scott,Carl P,20,5,0,0,0,0,0,3.708
+Spring 2024,MIS,4397,4,20243,Selected Topics in MIS,Hosseini,Leila,5,2,3,0,1,0,3,2.879
+Spring 2024,MIS,4397,5,20244,Selected Topics in MIS,Lewis,Michael Joseph,5,5,0,1,0,0,3,3.273
+Spring 2024,MIS,4397,6,20245,Selected Topics in MIS,Eierdam,Richard R,22,4,3,0,0,0,3,3.655
+Spring 2024,MIS,4397,7,20246,Selected Topics in MIS,Gonzalez Jr,Frederick,28,0,0,0,0,0,1,4.0
+Spring 2024,MIS,4397,8,20247,Selected Topics in MIS,Messinger,Jacob Nelson,11,5,4,0,0,0,0,3.301
+Spring 2024,NUTR,6117,1,20249,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,9,0,
+Spring 2024,NUTR,6218,1,20250,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,1,0,
+Spring 2024,NUTR,6319,1,20252,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,6,0,
+Spring 2024,MIS,7373,2,20253,Bus Appls Database Mgt Sys I,Scamell,Richard W,3,1,1,0,1,0,0,2.888
+Spring 2024,MIS,7378,2,20254,Info.Tech Management & Control,Kniffen,Richard Chad,3,1,0,0,0,0,0,3.75
+Spring 2024,MIS,7397,1,20255,Selected Topics in MIS,Pena,Juan F,56,2,0,0,0,0,1,3.96
+Spring 2024,MIS,7397,2,20256,Selected Topics in MIS,Hosseini,Leila,7,2,1,0,0,0,0,3.369
+Spring 2024,MIS,7397,3,20257,Selected Topics in MIS,Cooper,Randolph B,9,5,1,1,3,0,4,2.842
+Spring 2024,MIS,7397,4,20258,Selected Topics in MIS,Campbell,Phillip James,7,2,2,0,0,0,0,3.545
+Spring 2024,MIS,7397,5,20259,Selected Topics in MIS,Lewis,Michael Joseph,9,11,0,0,0,0,0,3.45
+Spring 2024,MIS,7397,6,20260,Selected Topics in MIS,Lewis,Michael Joseph,3,3,0,0,0,0,0,3.5
+Spring 2024,CHEM,1312,3,20261,Fundamentals of Chemistry 2,Carrasquillo M,Edwin,4,16,17,3,5,0,15,2.266
+Spring 2024,MIS,7397,7,20262,Selected Topics in MIS,Gonzalez Jr,Frederick,13,0,0,0,0,0,0,4.0
+Spring 2024,MIS,7397,8,20263,Selected Topics in MIS,Messinger,Jacob Nelson,17,13,0,0,0,0,0,3.523
+Spring 2024,ECON,3334,5,20265,Intermediate Macroeconomics,Thornton,Rebecca Achee,5,4,7,8,5,0,10,1.805
+Spring 2024,MANA,4397,1,20266,Selected Topics in Mana,Kroger,Edward John,5,1,0,0,0,0,0,3.888
+Spring 2024,MANA,4397,2,20267,Selected Topics in Mana,Salaiz,Ashley,38,2,0,0,0,0,0,3.967
+Spring 2024,MANA,7397,1,20268,Selected Topics in Management,Wesley Jr,Curtis LEONUS,6,1,0,0,0,0,1,3.904
+Spring 2024,MANA,4397,3,20269,Selected Topics in Mana,Thompson,Joseph Lee,46,10,1,2,1,0,0,3.628
+Spring 2024,ARCH,4397,1,20271,Selected Topics,Race,Bruce Alan,1,7,1,0,0,0,0,3.073
+Spring 2024,ARCH,6397,1,20272,Sel Tpcs-Arc/Urbn Desgn,Race,Bruce Alan,2,2,0,0,0,0,0,3.5
+Spring 2024,CIS,1332,30,20276,Intro Information Technology,Peddoju,Suresh Kumar,25,11,5,0,2,0,1,3.31
+Spring 2024,CIS,3330,30,20279,Info Systems in Organizations,Detillier,Bret James,2,72,63,2,2,0,3,2.461
+Spring 2024,ARCH,6397,2,20281,Sel Tpcs-Arc/Urbn Desgn,Story,Jon Kevin,1,0,0,0,0,0,0,3.67
+Spring 2024,LAW,5357,2,20286,Evidence,Crump,David L,12,8,1,0,0,0,0,3.398
+Spring 2024,ARCH,1501,26,20294,Arc/Int Arc Design Studio II,Benjamin,Gregory,9,4,0,0,0,0,0,3.616
+Spring 2024,ARCH,1501,28,20297,Arc/Int Arc Design Studio II,Smith,Joshua S,8,4,1,0,0,0,0,3.513
+Spring 2024,CIS,6321,40,20307,Principles of Cybersecurity,Lee,Kyu In,3,0,0,0,0,0,0,4.0
+Spring 2024,CIS,6325,40,20314,Network Security,Conklin,William A,7,0,0,0,2,0,0,3.111
+Spring 2024,ARCH,5500,13,20389,Architecture Design Studio IX,Roldan Caballero,Jose Manuel,10,16,2,0,0,0,0,3.25
+Spring 2024,ARCH,5500,15,20400,Architecture Design Studio IX,Johnson,Matthew W,11,3,0,0,0,0,0,3.739
+Spring 2024,CHEM,6322,1,20428,Statistcl Thermodynamcs,Lubchenko,Vassiliy,14,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,6321,1,20439,Quantum Chemistry,Yang,Ding-Shyue,4,4,0,0,0,0,0,3.541
+Spring 2024,CHEM,6375,1,20440,Physical Inorganic Chem II,Brgoch,Jakoah,8,8,0,0,0,0,0,3.5
+Spring 2024,CHEM,6394,1,20441,Sel Tops-Organic Chm,Miljanic,Ognjen S,5,1,0,0,0,0,0,3.723
+Spring 2024,FREN,3320,1,20446,Intro to French Literature,Giacchetti,Claudine A,7,0,4,1,0,0,0,3.056
+Spring 2024,FREN,3318,1,20463,History of French Cinema,Vredenburgh,Amanda Jane,6,4,2,0,0,0,1,3.278
+Spring 2024,FREN,3319,1,20464,History of the French Cinema,Vredenburgh,Amanda Jane,4,4,0,0,0,0,0,3.459
+Spring 2024,BCHS,4397,1,20469,Topics-Biochem & Biophys Sci,Gunaratne,Preethi H,23,4,0,0,0,0,0,3.791
+Spring 2024,BCHS,6297,1,20472,Sel Tops Biochem & Biophys Sci,Schwartz,Robert J,1,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5296,1,20473,International Energy Contracts,Nadorff,Norman J,15,16,1,0,0,0,0,3.386
+Spring 2024,BCHS,6228,1,20475,Advanced Nucleic Acids,Sen,Mehmet,17,0,0,0,0,0,0,3.903
+Spring 2024,BIOL,6222,1,20483,Optical Methods Cell Biology,Rea,Michael A,2,6,0,0,0,0,0,3.456
+Spring 2024,BIOL,6397,2,20486,Selected Topics in Biology,Ziburkus,Jokubas,14,2,0,0,0,0,0,3.813
+Spring 2024,BIOL,6397,3,20487,Selected Topics in Biology,Khurana,Seema,5,1,0,0,0,0,0,3.723
+Spring 2024,BIOL,6320,1,20488,Molecular Biology,Chung,Sanghyuk,0,1,0,0,0,0,0,3.0
+Spring 2024,BIOL,6204,1,20489,Advanced Ecology & Evolution I,Crawford,Kerri M,9,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6205,1,20491,Adv Ecology & Evolution II,Graur,Dan,9,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6397,4,20492,Selected Topics in Biology,Nunez,Martin A,3,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6397,5,20493,Selected Topics in Biology,Albecker,Molly A,2,0,0,0,0,0,0,4.0
+Spring 2024,FINA,7397,1,20508,Selected Topics in Finance,Smith III,Edwin A,5,0,0,0,0,0,0,4.0
+Spring 2024,FINA,7397,3,20514,Selected Topics in Finance,Hitzemann,Steffen,3,0,0,0,0,0,0,4.0
+Spring 2024,FINA,4397,3,20518,Selected Topics in Finance,Stewart,Marcus,18,18,2,0,0,0,3,3.412
+Spring 2024,ARAB,3340,1,20521,Modern & Rational in Islam,El-Badawi,Emran,5,10,1,0,0,0,2,3.106
+Spring 2024,FINA,8397,2,20524,Selected Topics in Finance,Susmel,Raul,5,0,0,0,0,0,0,4.0
+Spring 2024,FINA,8330,1,20528,Seminar in Corporate Finance,Kumar,Praveen,4,1,0,0,0,0,0,3.668
+Spring 2024,FINA,7A97,1,20529,Selected Topics in Finance,Levy,Clayton V,9,0,0,0,0,0,1,3.853
+Spring 2024,FINA,7A97,2,20530,Selected Topics in Finance,Shoss,Robert L,22,0,1,0,0,0,0,3.899
+Spring 2024,FINA,7A97,3,20531,Selected Topics in Finance,Shoss,Robert L,17,0,1,0,0,0,0,3.871
+Spring 2024,ARAB,1502,3,20533,Beginning Arabic II,Hefter,Thomas H,7,2,2,0,0,0,1,3.485
+Spring 2024,KORE,1502,1,20536,Beginning Korean II,Back,Eunkyung Lee,4,4,0,2,3,0,0,2.308
+Spring 2024,BIOL,4320,1,20538,Molecular Biology,Chung,Sanghyuk,7,26,10,0,4,0,0,2.625
+Spring 2024,BIOL,4397,1,20539,Selected Topics in Biology,Albecker,Molly A,38,0,0,0,0,0,1,3.931
+Spring 2024,BIOL,4397,2,20540,Selected Topics in Biology,Nunez,Martin A,15,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,1197,1,20541,Selected Topics in Biology,Ogletree-Hughes,Monique L,24,4,3,3,0,0,2,3.451
+Spring 2024,BIOL,1197,2,20542,Selected Topics in Biology,Ogletree-Hughes,Monique L,28,5,0,0,0,0,0,3.848
+Spring 2024,KORE,1502,3,20543,Beginning Korean II,Back,Eunkyung Lee,7,1,0,0,0,0,1,3.793
+Spring 2024,BIOL,4397,3,20545,Selected Topics in Biology,Wayne,Chad M,24,14,0,0,0,0,0,3.562
+Spring 2024,KORE,2312,1,20546,Intermediate Korean II,Back,Eunkyung Lee,12,5,1,1,0,0,0,3.456
+Spring 2024,CHIN,3350,2,20547,Chinese Culture Through Films,McArthur,Charles M,6,6,3,1,0,0,1,3.063
+Spring 2024,GERM,3369,1,20550,World War I in Literature,Glass,Hildegard,0,0,2,0,0,0,2,1.835
+Spring 2024,GERM,4397,1,20551,Slctd Topic-Ger Lng&Lit,Glass,Hildegard,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,2414,41,20553,Calculus II,May,Jennifer Ruhnow,42,44,50,33,43,0,33,2.044
+Spring 2024,MATH,1342,4,20560,Elementary Statistical Methods,Kim,Jae Youn,82,100,98,24,48,0,56,2.388
+Spring 2024,ECON,6394,1,20561,Tpcs-Eco of Socl Issue,Verchenko,Olesia,2,1,0,0,0,0,0,3.667
+Spring 2024,ECON,6394,2,20562,Tpcs-Eco of Socl Issue,Obrizan,Maksym,9,1,0,0,0,0,0,3.9
+Spring 2024,ECON,6394,3,20563,Tpcs-Eco of Socl Issue,Nivievskyi,Oleg,0,1,0,0,0,0,0,3.0
+Spring 2024,SOCI,1301,3,20564,Introduction To Sociology,Cooper,Chelsey Wells,44,5,1,4,3,0,2,3.416
+Spring 2024,SOC,6350,1,20565,Sociology of the Body,Kwan,Samantha S,9,2,0,0,0,0,0,3.728
+Spring 2024,SOC,6341,1,20566,Sem in Formal Organizations,Hwang,Hyunseok,14,1,0,0,0,0,0,3.889
+Spring 2024,SOC,3301,2,20567,Intro to Sociological Research,Kwan,Samantha S,15,8,5,0,0,0,2,3.298
+Spring 2024,SOC,3312,2,20568,Sociology of Deviance,Nelson,Steven M,36,7,6,3,2,0,1,3.291
+Spring 2024,SOC,3327,1,20569,Racial and Ethnic Relations,Smith,Chance Adam,32,5,3,0,4,0,5,3.304
+Spring 2024,SOC,3338,1,20570,Punishment in the U.S.,Colbert,Sharla Stettnisch,15,16,4,1,1,0,1,3.189
+Spring 2024,SOC,3357,1,20571,Urban Sociology,Brailey,Carla,30,3,1,2,1,0,3,3.568
+Spring 2024,SOC,3365,1,20572,Sociology of Education,Lee,Shayne,33,12,0,0,2,0,1,3.546
+Spring 2024,SOC,3371,1,20573,Sociology of Family,Lee,Shayne,32,13,1,0,0,0,0,3.638
+Spring 2024,SOC,3397,2,20575,Sel-Topics in Sociology,Langa,Neema Michael,4,1,0,0,0,0,0,3.734
+Spring 2024,POPH,2300,1,20576,Intro to Population Health,Bruce,Marino A,8,4,0,1,0,0,0,3.538
+Spring 2024,GEOL,1104,1,20577,Historical Geology Lab,Hauptvogel,Daniel William,9,3,1,0,0,0,0,3.514
+Spring 2024,GEOL,1104,2,20578,Historical Geology Lab,Hauptvogel,Daniel William,7,0,0,0,0,0,0,3.906
+Spring 2024,GEOL,1304,1,20579,Historical Geology,Copeland,Peter,20,19,15,7,1,0,2,2.785
+Spring 2024,GEOL,3380,1,20581,Physical Meteorology,Jiang,Xun,18,9,0,0,0,0,0,3.618
+Spring 2024,GEOL,6337,1,20582,Atmospheric Physics,Jiang,Xun,13,1,0,0,0,0,0,3.929
+Spring 2024,SPAN,1501,21,20585,Elementary Spanish I,Ruffino,Gustavo,13,7,4,0,0,0,3,3.224
+Spring 2024,SPAN,1502,23,20587,Elementary Spanish II,Falahasl,Hamideh,5,8,8,2,1,0,3,2.611
+Spring 2024,GEOL,4332,1,20590,Applications of GPS & LIDAR,Wang,Guoquan,7,3,0,0,0,0,0,3.667
+Spring 2024,GEOL,6323,1,20592,Applications of GPS & LIDAR,Wang,Guoquan,4,0,0,0,0,0,0,3.918
+Spring 2024,GEOL,4367,1,20593,Geochemical Reaction Modeling,Capuano,Regina M,5,6,6,1,1,0,1,2.667
+Spring 2024,GEOL,6346,1,20594,Geochem Water-Rock Systems,Capuano,Regina M,6,2,0,0,0,0,0,3.75
+Spring 2024,GEOL,4342,1,20595,Big Data in Env Science,Choi,Yunsoo,5,0,0,0,0,0,0,3.802
+Spring 2024,GEOL,7311,1,20596,Data analytics,Choi,Yunsoo,11,1,0,0,0,0,0,3.779
+Spring 2024,GEOL,4350,1,22726,Geomorphology,Carlson,Brandee Nicole,21,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,6313,1,22727,Applied Geomorphology,Carlson,Brandee Nicole,16,0,0,0,0,0,1,4.0
+Spring 2024,GEOL,4397,1,22728,Selected Topics-Geology,Zheng,Youtong,1,2,1,0,0,0,0,3.0
+Spring 2024,GEOL,6397,1,22729,Selected Topics in Geology,Zheng,Youtong,4,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,2301,13,22732,Prin of Financial Accounting,Sykes,Mary Reeves,19,12,8,3,1,0,6,3.177
+Spring 2024,GENB,5336,1,22733,Consulting for Small Bus Needs,Becker,Charles D,1,0,0,0,0,0,0,4.0
+Spring 2024,JAPN,2312,1,22736,Intermediate Japanese II,Ji,Fang,6,7,3,0,0,0,0,3.249
+Spring 2024,JAPN,2312,2,22737,Intermediate Japanese II,Ji,Fang,5,3,2,0,0,0,1,3.201
+Spring 2024,LAW,6369,9,22738,Legal Analysis and Writing,Kerney,Felicia Lynn,0,0,0,0,0,7,0,
+Spring 2024,ACCT,2302,14,22740,Prin of Managerial Accounting,Weber,Catherine K,16,21,23,3,1,0,1,2.796
+Spring 2024,ACCT,7374,1,22742,Data Analytics Comp Tech Acct,Seijas,Nuria S,2,1,0,0,0,0,0,3.667
+Spring 2024,IDNS,4397,1,22743,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,6,0,0,0,0,0,0,4.0
+Spring 2024,IDNS,4397,2,22744,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,6,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,3133,2,22745,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,2,11,2,0,1,0,0,2.854
+Spring 2024,ACCT,3371,4,22746,Accounting Information Systems,Seijas,Nuria S,27,15,8,0,0,0,0,3.42
+Spring 2024,LAW,6369,10,22748,Legal Analysis and Writing,Bray,Simone Rene,0,0,0,0,0,8,0,
+Spring 2024,ACCT,4380,2,22751,Contro & Sec Intern Fin Inform,Brant Jr,Robert Edward,1,1,0,0,0,0,0,3.5
+Spring 2024,LAW,5379,1,22752,Copyright Law,Fagundes,Dave,8,11,3,0,0,0,0,3.227
+Spring 2024,LAW,5217,1,22753,Fraud and Abuse,Cordova,Laura Marie Kidd,7,7,0,0,0,3,0,3.429
+Spring 2024,LAW,6337,1,22757,Appellate Civil Rights Clinic,Siegel,Martin Jonathan,1,2,0,0,0,0,0,3.443
+Spring 2024,MARK,3337,5,22758,Professional Selling,Ahearne,Michael,96,84,31,6,9,0,12,3.092
+Spring 2024,COMM,6362,1,22763,Twentieth Cent Popular Culture,Platenburg,Gheni Nicole,6,3,1,0,0,0,1,3.467
+Spring 2024,COMM,7397,1,22765,Selected Topics - Comm,Olson,Beth M,3,2,0,0,1,0,0,2.89
+Spring 2024,COMM,6339,1,22766,Multicultural Health Communica,Yamasaki,Jill S,7,0,1,0,0,0,0,3.709
+Spring 2024,COMM,6308,1,22774,Persuasion,Huang,Yan,6,0,1,0,0,0,0,3.667
+Spring 2024,GEOL,6350,1,22776,Advanced Structural Geology,Murphy,Michael,11,3,0,0,0,0,0,3.739
+Spring 2024,GEOL,6384,1,22780,Petroleum Prospecting Workshop,Mann,Paul,5,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,5373,1,22789,Appl Data Analytics Tools-Acct,Miles,Carolyn A,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,6397,2,22791,Selected Topics in Geology,Castagna,John P,13,1,0,0,0,0,1,3.858
+Spring 2024,SPAN,2307,3,22795,Span for Heritage Learners I,Hernandez,Yanina,1,6,4,3,0,0,0,2.428
+Spring 2024,MARK,3365,3,22799,Intro to Digital Marketing,Lee,Byung Cheol,39,77,21,3,2,0,2,3.04
+Spring 2024,SPAN,4374,1,22802,Teach Span Heritage Learner,Fairclough,Marta A,13,6,4,0,0,0,2,3.406
+Spring 2024,GEOL,6397,3,22804,Selected Topics in Geology,Mann,Paul,4,1,0,0,0,0,1,3.866
+Spring 2024,MARK,4333,1,22807,Search Engine Marketing,Buffaloe,Bonnie Lora-Lee,25,9,0,2,0,0,0,3.547
+Spring 2024,GEOL,7329,1,22814,Direct Hydrocarbon Indicators,Castagna,John P,13,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5342,4,22815,Prof Writing Strategies,Martin,Amy,4,8,0,0,0,0,0,3.361
+Spring 2024,GEOL,7332,1,22816,Tect Interp Seismic Tomography,Suppe,John,6,0,0,0,0,0,0,3.89
+Spring 2024,GEOL,7339,1,22817,Microseismic,Li,Aibing,3,1,0,0,0,0,0,3.75
+Spring 2024,SCM,4330,5,22821,Bus Modeling and Dec Analysis,Chin,Wynne W,9,8,4,2,2,0,3,2.813
+Spring 2024,LAW,5421,3,22822,Business Organizations,Brantley,Maikieta Antoinette,38,29,2,1,0,0,0,3.401
+Spring 2024,SCM,7320,2,22824,Supply Chain Analytics,Murray,Michael J,9,5,1,0,0,0,1,3.423
+Spring 2024,LAW,5266,1,22825,Tax of Exempt Orgs,Buckles,Johnny R,2,2,0,0,0,2,0,3.418
+Spring 2024,LAW,6357,1,22827,Children's Rights,Marrus,Ellen,3,7,0,0,0,0,0,3.399
+Spring 2024,IDNS,2136,1,22828,Data Structures SEP Workshop,Pattison,Donna,16,6,2,1,0,0,2,3.48
+Spring 2024,MARK,4338,2,22829,Marketing Research,Wang,Yu,20,6,2,0,0,0,0,3.584
+Spring 2024,IDNS,2197,1,22831,Top-Natrl Sci & Mth,Pattison,Donna,1,3,0,2,0,0,2,2.61
+Spring 2024,LAW,6203,1,22832,Bankruptcy Tax,May,Harold N,1,2,1,0,0,0,0,3.165
+Spring 2024,LAW,5416,1,22833,Civil Justice Clinic I,Krasny,Frederick A,2,4,0,0,0,0,0,3.388
+Spring 2024,LAW,5224,1,22834,Civil Justice Clinic II,Marquez,Ryan Michael,0,1,0,0,0,0,0,3.33
+Spring 2024,LAW,6301,1,22837,Civil Justice Clinic II,Marquez,Ryan Michael,0,1,0,0,0,0,0,3.33
+Spring 2024,KIN,1304,1,22838,Public Hlt Issues in Phys/Obes,Johnston,Craig Allen,75,39,7,0,4,0,7,3.445
+Spring 2024,LAW,5211,1,22839,Energy and the Environment,Landers,Daniella Denise,4,5,0,0,0,0,1,3.444
+Spring 2024,LAW,6335,1,22840,Entertainment Law Clinic,Barks,Justen S,0,4,0,0,0,0,0,3.33
+Spring 2024,LAW,7304,1,22842,WRS: Bioethics,Koch,Valerie Gutmann,6,3,1,0,0,0,0,3.401
+Spring 2024,LAW,6207,17,22843,Lawyering Skills & Strategy II,Esterholm,Melissa Hurter,8,8,0,0,0,0,0,3.397
+Spring 2024,LAW,6207,18,22844,Lawyering Skills & Strategy II,Thornton,Nicole Kumari,3,11,1,0,0,0,0,3.221
+Spring 2024,LAW,6207,19,22845,Lawyering Skills & Strategy II,Thornton,Nicole Kumari,5,9,0,0,0,0,0,3.357
+Spring 2024,LAW,5351,1,22846,Juvenile Law,Marrus,Ellen,6,8,0,0,0,0,0,3.381
+Spring 2024,LAW,5259,1,22847,State & Local Tax,Chadha,Jayash M,3,1,1,0,0,0,0,3.334
+Spring 2024,SOC,3335,1,22848,Sociology of Punishment,Smith,Chance Adam,40,1,1,0,3,0,2,3.63
+Spring 2024,KIN,1352,1,22850,"Foundations of KIN, HLT, FIT",Ojemaye,Lukachukwu Fitzgerald,35,10,2,0,1,0,1,3.57
+Spring 2024,KIN,1352,2,22851,"Foundations of KIN, HLT, FIT",Ojemaye,Lukachukwu Fitzgerald,27,10,3,3,4,0,1,3.1
+Spring 2024,COMM,3313,1,22853,Data-Driven Storytelling,Camaj,Lindita,11,12,0,0,0,0,2,3.493
+Spring 2024,LAW,6306,1,22858,The Law of Patient Care,Ewer,Michael S,4,12,0,0,0,0,0,3.436
+Spring 2024,LAW,5230,1,22859,Mergers and Acquisitions,Ragazzo,Robert A,8,11,0,0,0,0,0,3.352
+Spring 2024,LAW,6331,1,22865,Military Justice Clinic II,Marquez,Jason R,0,2,0,0,0,0,0,3.33
+Spring 2024,LAW,5411,1,22867,Military Justice Clinic,Marquez,Jason R,0,1,0,0,0,0,0,3.33
+Spring 2024,LAW,6322,1,22870,Military Justice Clinic,Marquez,Jason R,0,1,0,0,0,0,0,3.33
+Spring 2024,LAW,7342,1,22873,WRS: Transnat'l Petroleum Law,Cardenas Garcia,Julian Jose,6,6,0,0,0,0,0,3.528
+Spring 2024,COMM,3349,1,22875,Nonverbal Communication,Lee,Jaesub,18,11,2,1,0,0,0,3.396
+Spring 2024,COMM,3363,1,22891,Global & Multicultural Adv.,Choi,Ho Joon,9,4,0,0,0,0,0,3.743
+Spring 2024,LAW,5197,1,22896,Selected Topics,Simmons,Laurel Ellis Parker,0,0,0,0,0,12,0,
+Spring 2024,WCL,3342,1,22898,Tales of East Asian Cities,Li,Melody Yunzi,9,3,0,0,1,0,1,3.36
+Spring 2024,CHIN,3342,1,22900,Tales of East Asian Cities,Li,Melody Yunzi,12,0,0,0,0,0,0,3.918
+Spring 2024,LAW,5197,2,22901,Selected Topics,Davis,Megan Leigh-Wilson,0,0,0,0,0,12,0,
+Spring 2024,LAW,5197,3,22903,Selected Topics,Heard,Whitney W,0,0,0,0,0,12,0,
+Spring 2024,LAW,5197,4,22906,Selected Topics,Reed,Hilary S,0,0,0,0,0,11,0,
+Spring 2024,LAW,6241,1,22908,Licensing & Tech Transfer,Brucculeri,Louis,2,3,0,0,0,0,0,3.532
+Spring 2024,LAW,5340,1,22910,Marital Property Rights,Oldham,J Thomas,4,7,1,0,0,6,0,3.388
+Spring 2024,WCL,1101,1,22917,Introduction to Languages,Wang,Wei,12,8,3,0,0,0,1,3.334
+Spring 2024,WCL,1101,2,22918,Introduction to Languages,Wang,Wei,8,6,5,1,3,0,2,2.695
+Spring 2024,WCL,1101,3,22919,Introduction to Languages,Wang,Wei,12,5,5,0,0,0,3,3.288
+Spring 2024,INDI,3397,1,22924,Topics in India Studies,Nairang,Arif Hayat,1,0,0,0,0,0,0,3.67
+Spring 2024,POLS,3382,1,22925,Pols/Religion in South Asia,Nairang,Arif Hayat,12,3,1,0,0,0,4,3.605
+Spring 2024,LAW,5297,1,22927,Selected Topics,Diamond,Nicholas,2,3,0,0,0,0,0,3.4
+Spring 2024,LAW,5297,2,22928,Selected Topics,Raine,Susan Patricia,4,6,0,0,0,4,0,3.4
+Spring 2024,LAW,5297,3,22930,Selected Topics,Gratz,Andrew,4,6,0,0,0,0,0,3.4
+Spring 2024,COMM,4365,1,22933,Digital PR and Advertising,Choi,Ho Joon,20,6,0,0,0,0,3,3.68
+Spring 2024,LAW,5297,4,22934,Selected Topics,Martin,Scott Andrew,3,3,0,0,0,2,0,3.5
+Spring 2024,LAW,5297,5,22935,Selected Topics,Drake,Alyson,8,7,1,0,0,1,0,3.376
+Spring 2024,LAW,5297,6,22936,Selected Topics,Drake,Alyson,5,10,0,0,0,2,0,3.399
+Spring 2024,LAW,5297,7,22937,Selected Topics,Weems,Christine,3,5,0,0,0,6,0,3.334
+Spring 2024,COMM,4372,1,22943,"Media, Power, and Society",Bhat,Nandikoor R Prashanth,27,2,0,0,0,0,1,3.897
+Spring 2024,RELS,3380,1,22946,Intro to Asian Religions,Huynh,Trung,7,1,1,0,1,0,1,3.3
+Spring 2024,COMM,4380,1,22948,Live Sports Production,Crowe,Craig Warren,15,0,0,0,0,0,0,4.0
+Spring 2024,SEDE,7340,2,22951,Reading in Middle and Secondar,Russell IV,Glen Curtis,16,2,2,0,1,0,0,3.492
+Spring 2024,CUST,8378,1,22953,Current Issues in Educ,Hutchison,Laveria F,18,2,0,0,0,0,0,3.867
+Spring 2024,CUIN,8381,1,22955,Research Methods,Thomas,Dustine J,18,0,0,0,2,0,0,3.6
+Spring 2024,CUIN,7365,1,22958,Theoretical Models/Rdg,Qiu,Tairan,2,0,0,0,0,0,0,4.0
+Spring 2024,POLS,3333,1,22962,Comparative Elections,Lubotzky,Asher,13,13,3,1,0,0,2,3.201
+Spring 2024,POLS,4396,1,22963,Sel Top-Comp & Intl Pol,Lubotzky,Asher,4,1,1,1,0,0,0,3.237
+Spring 2024,PSYC,4397,1,22975,Selected Topics in Psychology,Grigorenko,Elena L,4,0,0,0,0,0,0,3.918
+Spring 2024,LAW,5297,9,22976,Selected Topics,Willis,Tasha L,0,1,0,0,0,0,0,3.33
+Spring 2024,LAW,5497,1,22991,Selected Topics,Willis,Tasha L,0,1,0,0,0,0,0,3.33
+Spring 2024,POLS,3334,1,22993,Comparative Political Behavior,Jung,Jae Hee,9,10,6,0,0,0,1,3.186
+Spring 2024,LAW,5397,1,22994,Selected Topics,Willis,Tasha L,0,2,0,0,0,0,0,3.33
+Spring 2024,LAW,5397,2,22996,Selected Topics,Barks,Justen S,0,2,0,0,0,0,0,3.33
+Spring 2024,LAW,5397,3,22997,Selected Topics,Willis,Tasha L,0,4,0,0,0,1,0,3.33
+Spring 2024,LAW,5397,4,23003,Selected Topics,Hanson,Lawrence W,3,4,0,0,0,0,0,3.381
+Spring 2024,POLS,3397,1,23004,Selected Topics in Public Law,Abbott Jr,Kenneth Wayne,10,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5397,5,23006,Selected Topics,Trujillo,Elizabeth I,5,4,1,0,0,0,1,3.301
+Spring 2024,LAW,5397,6,23007,Selected Topics,Booth,Kelly Dingle,6,8,0,0,0,1,0,3.405
+Spring 2024,POLS,3357,1,23008,Constitutnl Law-Civ Lib,Abbott Jr,Kenneth Wayne,29,7,0,0,0,0,1,3.778
+Spring 2024,LAW,5397,7,23009,Selected Topics,Hawash,Michael,3,5,0,0,0,8,0,3.375
+Spring 2024,WCL,3397,2,23011,Selected Topics in WCL,Choi,Jin Aeng,13,2,2,0,0,0,1,3.647
+Spring 2024,PSYC,6304,1,23013,Fndtns-Dev Psy,Borjon,Jeremy Isaac,9,0,0,0,0,0,0,4.0
+Spring 2024,SCLT,2362,34,23025,Intro To Logistics Technology,Cassler,Daniel,1,18,11,0,1,0,2,2.506
+Spring 2024,JWST,3397,1,23027,Selected Topics Jewish Studies,Lubotzky,Asher,1,2,0,0,0,0,0,3.113
+Spring 2024,LAW,5197,5,23028,Selected Topics,Gomez,Alissa R,0,0,0,0,0,12,0,
+Spring 2024,LAW,5197,6,23029,Selected Topics,Brem,Katherine B,0,0,0,0,0,12,0,
+Spring 2024,LAW,5197,7,23030,Selected Topics,Brownell,Robert Bruce Anthony,1,5,0,0,0,3,0,3.387
+Spring 2024,LAW,5697,1,23031,Selected Topics,Cabot,Jessica Anna,1,1,0,0,0,0,0,3.5
+Spring 2024,CUIN,3302,1,23033,Social Education,Thomas,Dustine J,22,1,0,0,1,0,0,3.805
+Spring 2024,CUIN,3302,2,23034,Social Education,Thomas,Dustine J,17,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,3111,2,23035,Educational Tech Elem Teachers,Davis,Kelly M,10,2,0,1,0,0,0,3.514
+Spring 2024,CUIN,3111,3,23036,Educational Tech Elem Teachers,Davis,Kelly M,16,0,0,0,0,0,0,4.0
+Spring 2024,ELED,3322,4,23039,Elem Reading Phonics Instructn,Alba,Celeste,16,1,0,0,0,0,0,3.941
+Spring 2024,CUIN,4375,2,23042,Classroom Management,Castillo,Bernadette Marie,17,0,0,0,0,0,0,3.961
+Spring 2024,CUIN,3316,6,23044,Prekindergarten Curr & Instr,Katz,Denise Annette,17,0,0,0,0,0,0,3.942
+Spring 2024,POLS,3354,1,23049,Law and Society,Martinez,Elizabeth Stukes,23,9,6,2,0,0,1,3.35
+Spring 2024,POLS,3344,1,23051,Inter'l Law & Law of War,Tiede,Lydia B,9,10,6,0,0,0,2,3.133
+Spring 2024,POLS,3381,1,23052,Political Psychology,Jenke,Elizabeth,12,9,6,0,0,0,0,3.173
+Spring 2024,POLS,3397,2,23054,Selected Topics in Public Law,Kennedy,Ryan P,9,6,1,1,1,0,0,3.148
+Spring 2024,POLS,3331,1,23055,American Foreign Policy,Chatagnier,John Tyson,14,11,7,3,0,0,4,3.029
+Spring 2024,ELED,3320,1,23056,Survey Literature Child Adol,Tyson,Eleanore S,17,1,0,0,0,0,0,3.871
+Spring 2024,ELED,3320,3,23057,Survey Literature Child Adol,Anagnostopoulos,Jordan,28,2,0,0,0,0,0,3.911
+Spring 2024,ELED,4320,4,23058,Social Studies Ele Sch,Ford,Haley Michelle Grimland,17,1,0,0,1,0,0,3.702
+Spring 2024,ELED,4320,5,23059,Social Studies Ele Sch,Ford,Haley Michelle Grimland,24,0,0,0,0,0,0,3.959
+Spring 2024,CUIN,4332,5,23060,Literacy Assess Rdg Writing,Reis,Nancy,27,2,0,0,1,0,0,3.789
+Spring 2024,WCL,4396,1,23085,Selected Topics in WCL,Zaretsky,Robert D,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4397,2,23094,Selected Topics in Psychology,Hernandez,Arturo E,9,0,0,0,0,0,0,4.0
+Spring 2024,COMD,1333,2,23100,Intro to Comm Sci & Disorders,BeCoats,Brandi Lailoni,12,11,1,0,0,0,0,3.417
+Spring 2024,PSYC,6397,1,23108,Sel Top in Psychology,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7397,1,23115,Selected Topics in Psychology,Sharp,Carla,3,0,0,0,0,0,0,4.0
+Spring 2024,BZAN,6360,2,23117,Capstone Practicum in BZAN I,Abbott,Jeanna L,18,0,0,0,0,0,0,3.872
+Spring 2024,BZAN,6361,2,23119,Capstone Practicum in BZAN II,Abbott,Jeanna L,19,0,2,0,0,0,0,3.731
+Spring 2024,WCL,3368,1,23121,Pop Cultures and World Media,Nguyen,Duy,4,7,4,0,0,0,3,2.802
+Spring 2024,PSYC,6300,1,23122,Stat for Psy,Lai,Keke,12,14,3,0,0,0,0,3.276
+Spring 2024,WCL,4378,1,23124,Cultures of Dissent,Nguyen,Duy,2,0,2,0,0,0,0,3.083
+Spring 2024,PSYC,4343,2,23130,Perception,Tamber-Rosenau,Benjamin J,8,27,6,1,0,0,4,2.914
+Spring 2024,AAMS,4397,1,23141,Selected Topics in AAMS,Nguyen,An,4,1,1,0,0,0,0,3.5
+Spring 2024,HON,3310,1,23145,Creativity at Work,Rayneard,Max James Anthony,32,10,2,0,0,0,2,3.637
+Spring 2024,ELCS,7330,1,23150,Admin of Higher Educ I,Hernandez,Belkis Pamela,15,2,0,0,0,0,0,3.863
+Spring 2024,HON,3397,1,23151,Honors Selected Topics,Price,Daniel M,22,1,1,0,0,0,1,3.861
+Spring 2024,ELCS,8397,1,23154,Sem Top Ed Ldshp&Cul St,Zou,Yali,6,0,0,0,0,0,0,3.89
+Spring 2024,ELCS,8355,1,23156,Policy Pol & Gov of Education,McKinney,Lonnie Lyle,9,5,0,0,1,0,0,3.4
+Spring 2024,ENRG,4397,1,23159,Sel Topics-Enrgy & Sustainblty,Debrah,Akua Asamoah,10,4,0,1,0,0,0,3.445
+Spring 2024,ENRG,4397,2,23160,Sel Topics-Enrgy & Sustainblty,Vollrath,Lesli A,8,2,0,0,0,0,0,3.8
+Spring 2024,HON,3397,2,23163,Honors Selected Topics,Modaff,Abigail,20,1,0,0,0,0,0,3.874
+Spring 2024,CUIN,8370,2,23165,Intro to Educational Research,Chauvot,Jennifer B,8,1,0,0,1,0,0,3.401
+Spring 2024,HON,4397,1,23167,Honors Selected Topics,Guenther,Irene V,21,1,0,0,0,0,0,3.955
+Spring 2024,HON,3397,3,23170,Honors Selected Topics,Rainbow,David,10,2,0,0,0,0,1,3.778
+Spring 2024,PSYC,7394,1,23171,Sel Topics-Clinical Psychology,Venta,Amanda Cristina,6,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,3350,1,23173,Science Comm Strategies,Sharp,Rita Evelyn,21,2,2,0,0,0,0,3.72
+Spring 2024,PHIL,3395,1,23178,Selected Topics in Phil,Zaretsky,Robert D,11,3,5,0,0,0,0,3.298
+Spring 2024,PSYC,8393,1,23188,Sel Top-Indstrl/Org Psy,Sabat,Isaac Emmanuel,5,2,0,0,0,0,0,3.667
+Spring 2024,GEOL,4397,2,23205,Selected Topics-Geology,Zhang,Honghai,0,2,1,2,0,0,1,2.066
+Spring 2024,GEOL,6397,5,23209,Selected Topics in Geology,Zhang,Honghai,3,1,1,0,0,0,0,3.268
+Spring 2024,PSYC,4397,3,23210,Selected Topics in Psychology,Leasure,Jennifer Leigh,15,19,10,1,0,0,2,2.993
+Spring 2024,PSYC,6397,2,23211,Sel Top in Psychology,Leasure,Jennifer Leigh,1,1,0,0,0,0,0,3.665
+Spring 2024,LAW,7305,1,23212,WRS: Hot Topic Crim Law & Proc,Thompson,Sandra Guerra,4,6,0,0,0,0,1,3.4
+Spring 2024,CNST,6399,1,23214,Thesis,Din,Zia Ud,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,6377,1,23221,Intro To Polymer Science,Karim,Alamgir,11,2,0,0,0,0,0,3.77
+Spring 2024,CHEE,6377,2,23222,Intro To Polymer Science,Karim,Alamgir,2,0,0,0,0,0,0,3.835
+Spring 2024,SPAN,3350,1,23223,Women in Hispanic Literature,Sisk,Christina L,7,2,1,0,0,0,0,3.567
+Spring 2024,SPAN,3375,1,23224,US Hispanic Culture & Civiliza,Ventura,Gabriela Baeza,9,3,1,0,1,0,0,3.31
+Spring 2024,CHEE,5367,1,23226,Advanced Process Control,Nikolaou,Michael,2,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,6367,1,23227,Advanced Proc Control,Nikolaou,Michael,4,1,0,0,0,0,0,3.866
+Spring 2024,CNST,6397,1,23228,Sel Tops-Construction Managemt,Gao,Lu,31,0,0,0,0,0,0,3.989
+Spring 2024,CHEE,6367,2,23229,Advanced Proc Control,Nikolaou,Michael,10,0,0,0,0,0,1,3.967
+Spring 2024,CNST,6397,2,23230,Sel Tops-Construction Managemt,Gao,Lu,5,1,0,0,0,0,0,3.833
+Spring 2024,CHEE,5383,1,23234,Advanced Unit Operations,Kaushik,Krishna R,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,3395,1,23240,Selected Topics Am Gov,Sims,Nancy Lou,19,4,0,0,0,0,1,3.783
+Spring 2024,PSYC,2301,50,23261,Introduction to Psychology,Saiyed,Amna Shabbir,14,0,1,0,0,0,1,3.867
+Spring 2024,PSYC,2301,51,23262,Introduction to Psychology,Saiyed,Amna Shabbir,18,1,1,0,0,0,1,3.817
+Spring 2024,POLS,3310,50,23265,Intro to Political Theory,Gish,Dustin,11,12,0,0,0,0,2,3.507
+Spring 2024,POLS,3396,1,23272,Sel Topics Comp Internatl Pol,Williamson,Jonathan Lyle,0,0,0,0,0,0,0,
+Spring 2024,HON,3397,4,23273,Honors Selected Topics,Bland,Laura Elizabeth,25,0,0,0,0,0,0,4.0
+Spring 2024,HON,3397,5,23274,Honors Selected Topics,Trninic,Marina,18,4,0,0,0,0,0,3.788
+Spring 2024,HON,3331,1,23276,Intro to Civic Engagement,Lawler,Janet Marie,5,1,0,0,0,0,0,3.778
+Spring 2024,ENRG,3310,2,23278,Intro to Energy & Sustainblty,Jacobsen,Nicolas Fisher,17,5,0,2,0,0,1,3.528
+Spring 2024,GOVT,2306,51,23279,US and Texas Const/Politics,Belco,Michelle Helene,22,0,0,0,0,0,0,3.985
+Spring 2024,HON,3397,6,23298,Honors Selected Topics,Hallmark,Terrell L,9,0,0,0,0,0,0,4.0
+Spring 2024,HIST,1301,8,23300,The U.S. to 1877,Clavin,Matthew J,41,66,40,20,16,0,16,2.489
+Spring 2024,HIST,1301,51,23301,The U.S. to 1877,Johnson,Michele R,104,54,21,9,5,0,9,3.228
+Spring 2024,HIST,1301,52,23302,The U.S. to 1877,Johnson,Michele R,95,51,20,10,11,0,9,3.118
+Spring 2024,HIST,1301,53,23303,The U.S. to 1877,Ramos,Raul,124,43,11,4,8,0,4,3.416
+Spring 2024,HIST,1302,55,23304,The U.S. Since 1877,Buzzanco,Robert,198,65,12,3,7,0,11,3.52
+Spring 2024,HIST,1302,56,23305,The U.S. Since 1877,Buzzanco,Robert,77,15,2,3,3,0,5,3.587
+Spring 2024,HIST,1302,57,23306,The U.S. Since 1877,Harwell,Debbie Z,38,40,14,2,2,0,3,3.149
+Spring 2024,HIST,1302,58,23307,The U.S. Since 1877,Rector,Josiah John,231,62,17,2,10,0,6,3.52
+Spring 2024,HIST,1302,59,23308,The U.S. Since 1877,Sbardellati,John,105,121,29,11,15,0,16,3.013
+Spring 2024,HIST,1302,61,23310,The U.S. Since 1877,Deyle,Steven H,10,14,5,2,2,0,1,2.818
+Spring 2024,HIST,2303,3,23313,The Historian's Craft,McNally,David Joseph,5,10,0,0,0,0,1,3.443
+Spring 2024,MECE,3363,2,23314,Intro To Fluid Mechanics,Lee,Myoungkyu,7,21,18,1,2,0,8,2.579
+Spring 2024,LAW,5297,10,23317,Selected Topics,Matlock,Gregory Michael,2,2,0,0,0,0,0,3.418
+Spring 2024,LAW,5297,11,23318,Selected Topics,Cook,Steven D,6,7,1,0,0,5,0,3.428
+Spring 2024,LAW,5297,12,23319,Selected Topics,Borrett,Carmen Christine,3,1,0,0,0,5,0,3.668
+Spring 2024,LAW,5297,13,23320,Selected Topics,Borrego,Theodore R,4,5,0,0,0,5,0,3.444
+Spring 2024,PSYC,8397,1,23321,Selected Topics in Psychology,Damian,Rodica Ioana,10,0,0,0,0,0,0,3.967
+Spring 2024,MECE,5397,2,23323,Selected Topics,Liu,Dong,14,16,5,1,0,0,0,3.121
+Spring 2024,PSYC,3310,3,23325,Indstrl-Orgnztnl Psy,Ng,Vincent,25,6,5,1,1,0,2,3.456
+Spring 2024,MECE,5397,3,23326,Selected Topics,Song,Gangbing,23,45,3,0,0,0,2,3.272
+Spring 2024,MECE,5397,4,23328,Selected Topics,Joshi,Shailendra Pramod,12,26,18,0,0,0,3,2.858
+Spring 2024,MECE,5397,5,23329,Selected Topics,Agrawal,Ashutosh,27,27,0,0,0,0,0,3.537
+Spring 2024,LAW,5397,9,23330,Selected Topics,Nguyen,Hung T,0,4,8,0,0,0,0,2.388
+Spring 2024,LAW,5397,10,23331,Selected Topics,Warren,Gina S,12,18,0,0,0,0,0,3.444
+Spring 2024,LAW,5397,11,23332,Selected Topics,Chandler,Seth J,6,6,1,0,0,0,0,3.385
+Spring 2024,LAW,5397,12,23333,Selected Topics,Hester,Tracy,4,7,0,0,0,1,0,3.394
+Spring 2024,MECE,6335,1,23334,Heat Transf/Phase Chng,Liu,Dong,14,3,1,1,0,0,1,3.596
+Spring 2024,HIST,2314,3,23335,Global Civilization since 1500,Gharala,Norah Linda Andrews,18,9,2,0,2,0,4,3.259
+Spring 2024,IDNS,1141,5,23336,Chemistry I SEP Workshop,Pattison,Donna,10,8,4,2,0,0,4,3.07
+Spring 2024,LAW,7397,1,23337,Selected Topics,Gomez,Alissa R,4,7,0,0,0,0,0,3.394
+Spring 2024,HIST,2321,1,23338,Study of Early Civilizations,Neumann,Kristina Marie,4,13,10,3,1,0,2,2.42
+Spring 2024,MECE,6397,2,23340,Selected Topics,Floryan,Daniel,7,3,0,0,0,0,0,3.568
+Spring 2024,HON,2341,15,23341,Classics of Modernity,Trninic,Marina,13,2,0,0,0,0,0,3.691
+Spring 2024,HON,2341,16,23342,Classics of Modernity,Trninic,Marina,12,2,0,0,0,0,0,3.716
+Spring 2024,HON,2341,17,23343,Classics of Modernity,Werner,Andrew Timothy,11,2,0,0,0,0,0,3.77
+Spring 2024,MECE,6361,1,23344,Mechanical Behavior/Materials,Ryou,Jae-Hyun,18,14,2,0,0,0,1,3.393
+Spring 2024,ENGL,2361,15,23347,Western World Lit II--Honors,Trninic,Marina,0,2,0,0,0,0,0,3.33
+Spring 2024,ENGL,2361,16,23348,Western World Lit II--Honors,Trninic,Marina,2,1,0,0,0,0,0,3.557
+Spring 2024,ENGL,2361,17,23349,Western World Lit II--Honors,Werner,Andrew Timothy,1,1,0,0,0,0,0,3.665
+Spring 2024,MECE,6397,3,23350,Selected Topics,Agrawal,Ashutosh,5,4,0,0,0,0,0,3.666
+Spring 2024,COMM,3331,1,23351,Communication in the Family,Uhrick,Jan,29,6,1,2,2,0,1,3.417
+Spring 2024,MECE,6397,4,23352,Selected Topics,Song,Gangbing,17,4,1,0,1,0,1,3.565
+Spring 2024,MECE,6397,5,23354,Selected Topics,Cescon,Marzia,6,6,0,0,1,0,1,3.205
+Spring 2024,HIST,2328,1,23360,Chicano History since 1910,San Miguel Jr,Guadalupe,17,6,5,0,2,0,4,3.134
+Spring 2024,HIST,2367,1,23362,History of Mexico,Hernandez,Jose A,25,0,0,1,0,0,0,3.885
+Spring 2024,ARCH,3312,6,23366,Topics in Design Media,Gonzales,Michael A,18,0,0,0,0,0,0,3.982
+Spring 2024,HIST,3330,1,23372,Afro-Amer His To 1865,Reed,Linda,7,8,5,0,0,0,1,3.166
+Spring 2024,GEOL,1303,3,23375,Physical Geology,Lytwyn,Jennifer N,6,10,17,5,3,0,6,2.341
+Spring 2024,HIST,3362,1,23380,Rise & Fall of Soviet Union,Golubev,Alexey Valeryevich,9,18,3,1,0,0,3,3.15
+Spring 2024,HIST,3369,1,23382,Colonial Mexico,Gharala,Norah Linda Andrews,13,7,7,0,1,0,4,3.025
+Spring 2024,HIST,3385,1,23384,Ottoman Empire I,Yuksel,Emire Cihan,15,15,0,0,3,0,2,3.182
+Spring 2024,HIST,3395,1,23386,Sel Top-European Hist,Glass,Hildegard,4,3,0,0,0,0,1,3.524
+Spring 2024,HIST,3397,1,23389,Sel Tops-African History,Chery,Tshepo Morongwa,6,7,1,0,1,0,1,3.155
+Spring 2024,HIST,4348,1,23391,Early Modern England,Patterson,Catherine F,8,1,2,1,1,0,0,3.026
+Spring 2024,PSYC,7397,2,23393,Selected Topics in Psychology,Bick,Johanna R,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6397,3,23394,Sel Top in Psychology,Bick,Johanna R,9,0,0,0,0,0,0,3.89
+Spring 2024,HIST,4363,1,23395,Capstone in US History,Reed,Linda,8,3,3,0,0,0,0,3.381
+Spring 2024,MECT,2354,32,23396,Introduction to Mechanics,Afrin,Samia,7,6,5,2,2,0,0,2.651
+Spring 2024,ANTH,2304,1,23398,Intro To Language and Culture,Majumder,Sarasij,27,13,2,2,0,0,1,3.335
+Spring 2024,HIST,4390,1,23399,Capstone in Public History,Harwell,Debbie Z,7,4,3,0,0,0,1,3.262
+Spring 2024,PSYC,7397,3,23400,Selected Topics in Psychology,Woods,Steven Paul,0,0,0,0,0,6,0,
+Spring 2024,HIST,6300,1,23401,Rdgs in Global History,Chakrabarti,Pratik,2,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,3348,1,23403,Anthropology of Religion,Rasmussen,Susan J,32,0,0,0,0,0,3,4.0
+Spring 2024,ANTH,3350,1,23404,"Women, Health and Culture",Ghazali,Marwa,24,1,0,0,0,0,0,3.947
+Spring 2024,HLT,4306,1,23406,Women's Health Issues,Solari Williams,Kayce D,60,17,1,0,0,0,0,3.646
+Spring 2024,HLT,4306,2,23407,Women's Health Issues,Solari Williams,Kayce D,44,28,3,1,0,0,2,3.5
+Spring 2024,ANTH,4331,1,23408,Medical Anthropology,Rasmussen,Susan J,17,0,0,0,0,0,1,4.0
+Spring 2024,ANTH,4361,1,23410,Migration / Borders / Citizens,Small,Ivan Victor,16,1,0,1,0,0,4,3.741
+Spring 2024,HIST,6346,1,23411,Readings in Imperialism,Ittmann,Karl,5,1,0,0,1,0,0,3.333
+Spring 2024,HIST,6358,1,23414,U.S Historiography from 1877,Rector,Josiah John,9,1,0,0,0,0,0,3.867
+Spring 2024,HIST,6370,1,23416,Adv Research & Writ Sem,Ramos,Raul,10,0,0,0,0,0,0,3.967
+Spring 2024,HIST,6383,1,23418,Topics in Public Hist,Neumann,Kristina Marie,10,4,0,0,0,0,0,3.644
+Spring 2024,HLT,4307,5,23423,Research and Eval in Health,Carmack,Chakema,24,10,0,0,1,0,0,3.591
+Spring 2024,CNST,2360,2,23424,Communication in Construction,Sheppard,Travis,35,16,3,0,0,0,2,3.593
+Spring 2024,CNST,1325,1,23425,Process & Industrial Construct,Ponnusamy,Ravi Chandran,7,4,0,0,0,0,0,3.636
+Spring 2024,CNST,4397,2,23428,Sel Tops in Construction Mgmt,Kim,Kinam,1,2,0,0,0,0,0,3.333
+Spring 2024,INDI,3397,2,23430,Topics in India Studies,Vijayalakshmi,Thangavel,1,0,0,0,0,0,0,4.0
+Spring 2024,HLT,4317,2,23434,Found of Epi in Public Health,Drenner,Kelli Linn,9,10,8,3,1,0,0,2.742
+Spring 2024,CUIN,7340,1,23436,Issues in Math Education,Weiland,Travis,15,0,1,0,0,0,0,3.854
+Spring 2024,CUIN,7397,1,23439,Selected Topics in CUIN,Cutler,Carrie Sybil,5,0,0,0,0,0,0,4.0
+Spring 2024,HIST,4387,1,23441,Capstone in Latin Am History,Howard,Philip,6,2,3,0,0,0,2,3.153
+Spring 2024,PSYC,6397,4,23443,Sel Top in Psychology,Yoshida,Hanako,22,1,0,1,0,0,0,3.833
+Spring 2024,HIST,3397,2,23445,Sel Tops-African History,Vijayalakshmi,Thangavel,1,0,0,0,0,0,0,4.0
+Spring 2024,INDS,3501,3,23446,Industrial Design Studio VI,Feng,Jeff Feng,6,6,0,0,0,0,0,3.445
+Spring 2024,GEOL,7340,1,23453,Machine Learning for Geo,Sun,Jiajia,4,0,0,0,0,0,0,3.918
+Spring 2024,ELCS,6310,3,23461,Strategic Engagement,Davis,Bradley,12,0,0,1,0,0,0,3.769
+Spring 2024,ELCS,6302,1,23465,Decision Making School Ldrs,Horner,Glenda Sue,13,2,0,0,0,0,0,3.867
+Spring 2024,HISP,2373,1,23466,Spanish Culture and Civ,Solino,Maria Elena,11,5,2,1,2,0,4,2.938
+Spring 2024,ELCS,6302,3,23470,Decision Making School Ldrs,Butcher,Keith,27,3,0,0,1,0,0,3.742
+Spring 2024,ELCS,6321,1,23473,Instructional Leadership II,Butcher,Keith,19,2,0,0,1,0,0,3.757
+Spring 2024,ELCS,6391,1,23475,Practicum in the Principalship,Klussmann,Duncan Foster,23,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,6304,3,23477,Law & Policy for School Leader,Klussmann,Duncan Foster,14,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,6320,4,23478,Instructional Leadership I,Butcher,Keith,7,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8313,3,23480,Issues for Urban Education Adm,Shockley,Gerald,3,1,0,0,0,0,0,3.75
+Spring 2024,ELCS,8361,3,23482,Public & Community Relations,Shockley,Gerald,4,1,0,0,0,0,0,3.8
+Spring 2024,EDRS,8381,3,23484,Rsch Mthds in Educ,Johnson,Detra DeVerne,4,0,0,0,0,0,0,3.918
+Spring 2024,INDS,6355,1,23499,Integrated Design Research,Vos,Gordon A,0,0,0,0,0,0,0,
+Spring 2024,LAW,5389,1,23500,Immigration Law,Morales,Daniel I,9,17,0,0,0,0,0,3.372
+Spring 2024,LAW,7397,2,23505,Selected Topics,Guggenberger,Nikolas,3,5,1,0,0,1,0,3.259
+Spring 2024,LAW,7397,3,23506,Selected Topics,Trujillo,Elizabeth I,5,6,0,0,0,0,0,3.395
+Spring 2024,LAW,7345,1,23507,WRS: Law and A.I.,Salib,Peter,6,6,0,0,0,0,0,3.39
+Spring 2024,LAW,7338,1,23509,WRS: Texas v. United States,Berman,Emily,2,7,0,0,0,0,0,3.369
+Spring 2024,SPEC,6349,1,23510,Intro to Educ of Gifted/Talent,Carp,Charlotte Lynn,1,0,0,0,0,0,0,4.0
+Spring 2024,SPEC,8376,1,23511,Res Meth Low Incid Pops,Carp,Charlotte Lynn,9,1,1,0,0,0,0,3.727
+Spring 2024,GOVT,2305,14,23512,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,68,105,36,13,10,0,13,2.875
+Spring 2024,GOVT,2305,15,23513,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,29,41,20,1,3,0,3,2.958
+Spring 2024,GOVT,2305,16,23514,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,17,12,13,4,6,0,0,2.571
+Spring 2024,POLS,3355,1,23516,Judicial Process,Tiede,Lydia B,10,9,4,0,3,0,1,2.847
+Spring 2024,POLS,3316,2,23518,Stats for Political Scientists,Karimov,Samad,11,11,11,0,1,0,4,2.854
+Spring 2024,POLS,3316,3,23519,Stats for Political Scientists,Karimov,Samad,9,10,5,3,1,0,10,2.81
+Spring 2024,ENGL,6300,1,23520,College Tchg-Lang & Lit in Eng,Shepley,Nathan,15,0,0,0,0,0,0,3.956
+Spring 2024,ENGL,6321,1,23521,Fictional Forms and Techniques,Peynado,Brenda,8,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,6362,1,23522,Middle-English Literature,Davies,Daniel,5,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7322,1,23523,Advncd Poetry Workshop,Flynn,Nicholas,10,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7323,1,23524,Advncd Fiction Workshop,Nelson,Antonya,10,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7380,1,23525,History of Poetry and Poetics,Davies,Daniel,10,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7335,1,23526,Sociolinguistics,Zentz,Lauren R,9,0,0,0,0,0,0,3.963
+Spring 2024,ENGL,8341,1,23527,Shakes Coms and Hists,Christensen,Ann C,4,2,0,0,1,0,0,3.19
+Spring 2024,SOCW,6305,4,23529,Social Work Research,Rose,Alexis Lee,17,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8386,1,23530,Topics in Postcolonial Studies,Majumder,Auritro,6,1,0,0,0,0,0,3.857
+Spring 2024,SOCW,6307,4,23531,Policy in the Soc Environment,Vogel,Alicia Nicole,15,0,2,0,0,0,0,3.765
+Spring 2024,ENGL,8397,1,23532,Special Topics in CSA,Ellis,Amanda,10,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7325,4,23533,Individuals: Adv Clinical Prac,Viverette,April C,27,1,0,0,0,0,0,3.964
+Spring 2024,SOCW,7325,5,23534,Individuals: Adv Clinical Prac,Mayes,Kimberly,18,2,0,0,0,0,0,3.9
+Spring 2024,ENGL,7396,1,23535,Topics in Language & Literatre,Voskuil,Lynn M,7,1,0,0,0,0,0,3.793
+Spring 2024,ENGL,7396,2,23536,Topics in Language & Literatre,Ehlers,Sarah E,11,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7396,3,23537,Topics in Language & Literatre,Lee,Eunjeong,4,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7343,1,23539,Families: Adv Clinical Practic,Miyawaki,Christina E,23,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7343,2,23540,Families: Adv Clinical Practic,Cheung,Monit,21,2,0,0,0,0,0,3.913
+Spring 2024,SOCW,7343,3,23541,Families: Adv Clinical Practic,Cheung,Monit,23,1,0,0,0,0,0,3.958
+Spring 2024,SOCW,7343,4,23542,Families: Adv Clinical Practic,McMorris,Saralyn Dionne,19,0,0,0,2,0,0,3.619
+Spring 2024,BTEC,6325,30,23543,Molecular Techniques,Khan,Abdul Latif,6,4,0,0,0,0,0,3.666
+Spring 2024,BTEC,6325,40,23544,Molecular Techniques,Khan,Abdul Latif,3,2,0,0,0,0,0,3.666
+Spring 2024,SOCW,7337,1,23545,Crit Cinical Case Form & Diag,Berger Cardoso,Jodi A,19,2,0,0,0,0,0,3.905
+Spring 2024,SOCW,7337,2,23546,Crit Cinical Case Form & Diag,Berger Cardoso,Jodi A,23,2,0,0,0,0,0,3.92
+Spring 2024,SOCW,7337,3,23547,Crit Cinical Case Form & Diag,Taylor,Patricia G,21,0,0,0,0,0,1,4.0
+Spring 2024,BTEC,4100,30,23548,Principles Bioinformatics Lab,Balan,Venkatesh,5,6,2,0,0,0,0,3.18
+Spring 2024,BTEC,4249,30,23549,Biotechnology Capstone I,Chitrala,Kumaraswamy Naidu,5,1,0,0,0,0,0,3.833
+Spring 2024,ELET,4309,20,23550,Object-Oriented Applicatn Prog,Lent,Marino Ricardo,10,11,8,0,1,0,1,3.033
+Spring 2024,SOCW,7342,1,23551,Clinical Social Work Praxis,Parks,Steven Lee,24,2,0,0,0,0,0,3.923
+Spring 2024,SOCW,7342,2,23552,Clinical Social Work Praxis,Jacobs,Alexandra L,21,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7342,3,23553,Clinical Social Work Praxis,Parks,Steven Lee,23,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7342,4,23554,Clinical Social Work Praxis,Parks,Steven Lee,30,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7342,5,23555,Clinical Social Work Praxis,Parks,Steven Lee,28,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7342,6,23556,Clinical Social Work Praxis,Mendoza,Yvonne Anette,29,1,0,0,0,0,0,3.967
+Spring 2024,SOCW,7342,7,23557,Clinical Social Work Praxis,Cabrera,Alberto,18,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7342,8,23558,Clinical Social Work Praxis,Parks,Steven Lee,21,2,0,0,0,0,0,3.913
+Spring 2024,SOCW,7397,1,23561,Selected Topics in Social Work,Pang,Melanie Espinosa,11,0,0,0,0,0,0,4.0
+Spring 2024,ELET,6331,40,23562,Fund of Medical Imaging,Zouridakis,George,1,0,0,0,0,0,0,3.67
+Spring 2024,COSC,1336,5,23564,Computer Science & Program,Rincon Castro,Carlos Alberto,56,35,10,6,5,0,17,3.125
+Spring 2024,COSC,3340,2,23565,Intro. to Automata and Comp.,Verma,Rakesh M,7,19,21,6,4,0,18,2.316
+Spring 2024,TEPM,6306,40,23566,Project Management Office,Rypien,David V,2,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6307,40,23567,Advanced Project Management,Sherman,Dennis Louis,3,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6391,40,23568,Project Management Seminar,Carden,Lila L,3,0,0,0,0,0,0,4.0
+Spring 2024,TEPM,6395,40,23569,Integration Project,Carden,Lila L,5,0,0,0,0,0,0,3.934
+Spring 2024,COSC,6397,1,23570,Topics Computer Science,Lin,Sen,17,8,0,0,0,0,0,3.706
+Spring 2024,COSC,6342,1,23572,Machine Learning,Mukherjee,Arjun,15,15,1,0,0,0,2,3.335
+Spring 2024,COSC,4321,1,23573,Immersive Technology & Spatial,Yun,Changhoon,37,3,4,2,0,0,3,3.544
+Spring 2024,COSC,3371,1,23574,Cybersecurity,Huang,Shou-Hsuan Stephen,17,21,8,1,1,0,2,3.028
+Spring 2024,COSC,6397,2,23575,Topics Computer Science,Yun,Changhoon,2,0,0,0,0,0,0,4.0
+Spring 2024,COSC,3337,2,23577,Data Science I,Shah,Shishir,36,3,1,0,0,0,1,3.842
+Spring 2024,COSC,3380,3,23578,Database Systems,Hilford,Victoria,42,55,15,3,2,0,3,3.123
+Spring 2024,HIST,2322,1,23738,Modern Civilizations,Yuksel,Emire Cihan,18,7,0,0,2,0,6,3.334
+Spring 2024,ENGL,3315,1,23739,The Romantic Movement,Lecourt,Sebastian Joseph,14,13,1,0,0,0,1,3.429
+Spring 2024,ENGL,3323,1,23740,Development of Lit Crit & Thry,Majumder,Auritro,9,8,0,0,0,0,1,3.432
+Spring 2024,ENGL,3352,1,23741,19th Century American Fiction,Yang,Sunny Chen,10,9,1,1,1,0,0,3.122
+Spring 2024,ENGL,3362,1,23742,Women in Literature,Christensen,Ann C,12,7,2,4,1,0,2,2.911
+Spring 2024,ENGL,3363,1,23743,African-American Fiction,Harrell,Haylee C,24,3,0,0,0,0,1,3.852
+Spring 2024,ENGL,4315,1,23746,Sociolinguistics,Zentz,Lauren R,15,1,2,0,0,0,3,3.722
+Spring 2024,ENGL,4396,1,23748,SR Experience Seminar Topics,Lee,Eunjeong,14,1,0,0,0,0,0,3.823
+Spring 2024,ENGL,3301,4,23750,Intro To Literary Studies,Backus,Margot Gayle,9,6,1,0,0,0,1,3.418
+Spring 2024,ENGL,3332,1,23751,Beg Crea Writing: Nonfiction,Colombe,Audrey A,9,1,0,0,0,0,2,3.9
+Spring 2024,ENGL,4373,1,23755,"Film, Text, and Politics",Wong,Karen Y,8,5,3,1,0,0,3,3.118
+Spring 2024,ENGL,4384,1,23756,SR Writing Proj CW: Poetry,Harris,Francine Julia,4,3,0,0,0,0,1,3.619
+Spring 2024,ENGL,2318,1,23758,Creation and Perform of Lit,Belieu,Erin Colleen,16,9,2,0,1,0,3,3.452
+Spring 2024,ENGL,2350,2,23760,Writing the Global City,Bass,Kasey Dawn,18,0,0,0,2,0,0,3.6
+Spring 2024,AAS,3394,1,23953,Selected Topics Afr Am Stdy,Langa,Neema Michael,0,2,2,1,0,0,0,2.2
+Spring 2024,AAS,4330,1,23954,The Black Church in America,Johnson,Alexander Emmitt Maurice,16,4,0,3,1,0,1,3.223
+Spring 2024,ANTH,4380,1,23955,Field Methods in Anthropology,Chase,Arlen F,2,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,4382,1,23956,Archaeology Lab Methods,Chase,Arlen F,2,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,4391,1,23957,Archaeological Field Work I,Chase,Arlen F,2,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,4392,1,23958,Archaeological Field Work II,Chase,Arlen F,2,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,3342,1,23982,Food and Culture,Sen,Debarati,16,9,3,0,0,0,2,3.453
+Spring 2024,PCEU,7340,1,24005,Advanced Drug Delivery,Chow,Diana Shu-Lian,22,4,1,0,0,0,0,3.778
+Spring 2024,HON,4391,1,24007,Modernity Revisited,Barnes,Michael,15,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5297,14,24008,Selected Topics,Zorn,Matthew,10,12,0,0,0,0,1,3.395
+Spring 2024,LAW,7397,4,24009,Selected Topics,Gebru,Aman K,5,6,0,0,0,0,0,3.395
+Spring 2024,LAW,6347,2,24017,Secured Financing,Moll,Douglas Keith,5,9,0,0,0,35,0,3.404
+Spring 2024,LAW,5343,1,24018,Employment Law,Swift,Kenneth Richard,13,15,2,0,0,0,1,3.4
+Spring 2024,ARED,2310,4,24019,Intro Critical Visual Culture,Ripley,Lindsay N,13,6,2,0,1,0,2,3.319
+Spring 2024,HRD,3346,20,24022,Performance Assessment & Eval,Norman,Joanna,11,1,0,0,1,0,0,3.565
+Spring 2024,HRD,3350,21,24023,Workforce Diversity and Global,Lopez,Johana,19,8,1,1,0,0,1,3.586
+Spring 2024,HRD,3351,2,24024,Instructional Design for HRD,Pereira-Leon,Maura Josefina,24,25,1,0,0,0,1,3.394
+Spring 2024,HRD,4344,2,24026,Designing E-Learning,Bennett,LaTasha,47,3,0,0,0,0,0,3.927
+Spring 2024,HRD,4396,1,24027,Internship in HRD,Owens-Shepard,Toya,20,0,0,0,0,0,1,3.967
+Spring 2024,ELED,4311,11,24028,Science in Elementary School I,Shelton,Laura,3,1,5,0,0,0,0,2.814
+Spring 2024,ELED,4312,11,24029,Science in the Elem School II,Shelton,Laura,3,1,5,0,0,0,0,2.814
+Spring 2024,CUIN,7397,2,24031,Selected Topics in CUIN,Gronseth,Susie L B,10,0,0,0,0,0,0,3.967
+Spring 2024,CUIN,7397,3,24032,Selected Topics in CUIN,Dogan,Bulent,17,0,0,0,0,0,0,3.981
+Spring 2024,CUIN,7316,1,24033,Design Online Educ Resources,Ahlf,Michael,29,0,0,0,0,0,1,3.989
+Spring 2024,GHL,1320,2,24039,Foodservice Management,Sirsat,Sujata Ashok,30,6,4,1,0,0,1,3.473
+Spring 2024,DIGM,2353,30,24041,Page Layout and Design,De Vega,Jaime M,41,9,6,0,1,0,1,3.538
+Spring 2024,GHL,4397,1,24044,Selected Topics Hosp Mgt,Kim,Jaewook,6,0,0,0,0,0,1,4.0
+Spring 2024,GHL,4397,2,24047,Selected Topics Hosp Mgt,Doudna,Simone P,6,7,1,0,0,0,0,3.428
+Spring 2024,GHL,4397,3,24049,Selected Topics Hosp Mgt,Doudna,Simone P,12,5,0,0,1,0,0,3.518
+Spring 2024,DIGM,2357,30,24050,Content Strategy & Development,Alters,Monika Joanna,35,16,6,0,0,0,1,3.41
+Spring 2024,DIGM,2376,30,24053,UX Principles 2,Rodwell,Elizabeth Ann,96,2,0,0,0,0,1,3.976
+Spring 2024,DIGM,3351,30,24054,Individ Comm Processes,Dawson,Michael John,20,5,2,0,2,0,2,3.402
+Spring 2024,GHL,7366,2,24058,Hosp. Management Strategies,Rockett,Gregory,5,1,0,0,0,0,0,3.723
+Spring 2024,DIGM,3354,30,24060,Visual Production,Snyder,Philip Charles,19,7,1,0,2,0,2,3.334
+Spring 2024,GHL,8305,1,24062,Grant Writing in Hosp Industry,Sirsat,Sujata Ashok,6,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6365,1,24064,Tourism and Travel,Draper,Jason A,6,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6397,1,24065,Selected Topics,Kim,Jaewook,8,0,0,0,0,0,0,4.0
+Spring 2024,DIGM,3357,30,24066,Social Media Apps & Analytics,Liao,Pamara F,24,6,2,0,0,0,0,3.543
+Spring 2024,GHL,6397,2,24067,Selected Topics,Doudna,Simone P,4,2,0,0,0,0,1,3.777
+Spring 2024,GHL,6382,1,24068,Meth of Res in Hospitality Ind,Legendre,Jungyoung Shin,5,0,0,0,0,0,1,4.0
+Spring 2024,DIGM,4351,30,24069,Portfolio Development for DIGM,Hargrove,Mark Stephen,51,2,0,0,0,0,2,3.912
+Spring 2024,DIGM,4372,30,24073,DIGM Production Management,Hargrove,Mark Stephen,13,19,4,1,0,0,1,3.189
+Spring 2024,ARCH,1501,32,24080,Arc/Int Arc Design Studio II,LaRose,Katherine Gail,6,6,1,0,0,0,0,3.359
+Spring 2024,ARCH,1501,34,24082,Arc/Int Arc Design Studio II,Handanovic,Dijana,8,3,2,0,0,0,1,3.411
+Spring 2024,ARCH,3501,21,24280,Architecture Design Studio VI,Roldan Caballero,Jose Manuel,5,8,2,0,0,0,0,3.178
+Spring 2024,CNST,6308,40,24292,Data Analysis in Construc Mgmt,Gao,Lu,2,0,0,0,0,0,0,4.0
+Spring 2024,CNST,6320,40,24293,Cost Analysis and Bidding,Eldin,Neil N,4,0,0,0,0,0,0,4.0
+Spring 2024,CNST,6330,40,24294,Project Planning & Management,Eldin,Neil N,1,3,0,0,0,0,0,3.25
+Spring 2024,CNST,6380,40,24296,Leed & Green Const Princ in CM,Chang,Chi Chung,3,0,0,0,0,0,0,4.0
+Spring 2024,CNST,6390,40,24297,Leadership for Const Managers,Connors,Jayme P,2,0,0,0,0,0,0,4.0
+Spring 2024,LAW,7397,6,24299,Selected Topics,Chandler,Seth J,4,3,0,0,0,0,1,3.383
+Spring 2024,HDFS,1311,4,24300,Personal Dev and College Succ,Sidwell,Jane Catherine,19,15,4,1,0,0,1,3.316
+Spring 2024,GHL,3197,1,24302,Selected Topics in Hospitality,Ginapp,Kathrine,18,2,0,0,0,0,0,3.933
+Spring 2024,ENGL,4376,1,24307,Robin Hood in Culture,Stock,Lorraine K,3,3,3,0,0,0,0,2.89
+Spring 2024,ENGL,7396,5,24309,Topics in Language & Literatre,Stock,Lorraine K,1,0,0,0,0,0,0,4.0
+Spring 2024,ELET,4302,1,24325,Data Communication Systems,Soneja,Chandrayee,8,16,1,0,0,0,0,3.214
+Spring 2024,ELET,6316,1,24328,Network Routing Algo and Prot,Velusamy,Gandhimathi,5,0,0,0,0,0,0,3.868
+Spring 2024,POLC,2312,1,24329,Intro to Econ Policy Analysis,Heath,Katelyn,4,10,2,0,1,0,0,2.961
+Spring 2024,POLS,3385,1,24330,Introduction to Law,Zendeh Del,Jonathan,23,12,3,0,0,0,0,3.474
+Spring 2024,POLC,4344,1,24332,Policy and Global Justice,Holman,Mirya R,12,6,2,0,0,0,0,3.5
+Spring 2024,ELET,6396,2,24335,Master's Project,Pollonini,Luca,1,0,0,0,0,0,0,3.67
+Spring 2024,POLC,4398,1,24336,Independent Study,Cross,Renee Danielle,5,0,0,0,0,0,0,4.0
+Spring 2024,POLC,4397,2,24338,Selected Topics Public Policy,Koelling,Peter,0,1,2,0,0,0,0,2.333
+Spring 2024,HDFS,3300,4,24341,Educational Psychology,Kamdar-Sharif,Amber,72,40,14,4,0,0,5,3.319
+Spring 2024,HDFS,3317,4,24346,Prenatal and Infant Developmt,Frankel,Leslie Ann,11,23,3,1,0,0,1,3.088
+Spring 2024,HDFS,3317,5,24347,Prenatal and Infant Developmt,Frankel,Leslie Ann,19,13,2,1,2,0,2,3.145
+Spring 2024,HDFS,4317,3,24349,Intro to Early Child Dev,Jelsma,Elizabeth,9,13,8,1,1,0,2,2.854
+Spring 2024,HDFS,4318,5,24352,Parent-Child Relationships,Storch,Jill Frenchman,13,11,6,0,1,0,3,3.055
+Spring 2024,LAW,5323,2,24355,Conflict of Laws,Ten Cate,Irene,2,7,0,0,0,9,0,3.369
+Spring 2024,LAW,7326,1,24356,WRC: Supreme Court Term,Dow,David R,3,7,0,0,0,0,0,3.399
+Spring 2024,HLT,2320,4,24357,Introduction to Public Health,Solari Williams,Kayce D,95,16,5,2,0,0,1,3.687
+Spring 2024,HLT,3304,3,24358,Child and Adolescent Health,Shamblin,Angel Ann,73,11,2,3,1,0,1,3.656
+Spring 2024,HLT,3301,5,24360,Health Behavior Theories,Hudson-Gillan,Gail,54,10,1,0,0,0,0,3.785
+Spring 2024,HLT,3301,6,24361,Health Behavior Theories,Hudson-Gillan,Gail,54,10,1,0,0,0,0,3.775
+Spring 2024,HLT,3301,7,24362,Health Behavior Theories,Ripperger-Suhler,Ken,44,13,5,2,1,0,0,3.457
+Spring 2024,ELET,4397,1,24363,Selected Topics in Elet,Shi,Jian,22,1,0,0,0,0,0,3.899
+Spring 2024,BUSI,4397,1,24366,Selected Topics in GENB,Bean,Gregory S,14,0,0,0,0,0,0,4.0
+Spring 2024,PUBL,6311,1,24368,Public Admin and Policy Impl,Koelling,Peter,13,2,0,0,0,0,0,3.889
+Spring 2024,PUBL,6313,1,24369,Fundamentals Policy Analysis,Pinto,Pablo M,12,2,0,0,0,0,1,3.692
+Spring 2024,PUBL,6325,1,24370,Capstone Problem Project,Koelling,Peter,5,2,1,0,0,0,0,3.5
+Spring 2024,PUBL,6349,1,24371,Seminar in Non-Profit Mgmt,Glaus Late,Kimberly,3,1,0,0,0,0,0,3.585
+Spring 2024,PUBL,6350,1,24372,Public Management,Sands,Sara,8,3,1,0,0,0,0,3.528
+Spring 2024,PUBL,6415,1,24373,Decision Sci. for Publ Affairs,Vallejo,Agustin,17,2,0,0,0,0,1,3.825
+Spring 2024,CHEE,6365,1,24377,Fund of Catalysis,Grabow,Lars C,11,3,0,0,0,0,0,3.739
+Spring 2024,CHEE,6365,2,24378,Fund of Catalysis,Grabow,Lars C,1,0,0,0,0,0,0,3.67
+Spring 2024,HLT,3306,3,24381,Environmental Health,Rafique,Kiran Sajid,95,22,6,2,0,0,2,3.643
+Spring 2024,CHEE,6397,1,24383,Selected Topics,Vekilov,Peter,18,0,0,0,0,0,0,3.853
+Spring 2024,CHEE,6327,1,24384,Exprmntl Mthds in Chem Engr,Donnelly,Vincent M,26,1,0,0,5,0,0,3.303
+Spring 2024,HLT,4310,5,24385,Program Planning for Hlt Prof,Markowitz,Eliz,26,9,3,1,0,0,2,3.479
+Spring 2024,HLT,4310,6,24386,Program Planning for Hlt Prof,Markowitz,Eliz,29,6,5,2,0,0,0,3.413
+Spring 2024,HLT,4307,6,24387,Research and Eval in Health,Ripperger-Suhler,Ken,17,10,6,1,0,0,2,3.187
+Spring 2024,ELCS,8395,1,24388,Dissertation in practice,Davis,Bradley,6,0,0,0,0,3,0,4.0
+Spring 2024,ELCS,8695,1,24389,Dissertation in Practice,Davis,Bradley,1,0,0,0,0,1,0,4.0
+Spring 2024,GHL,6197,1,24396,Selected Topics,Back,KiJoon,6,0,0,0,0,0,0,4.0
+Spring 2024,HLT,4392,5,24397,Field Work in Community Health,Farmer,Jennifer,48,2,0,0,0,0,1,3.927
+Spring 2024,HLT,4392,6,24398,Field Work in Community Health,Farmer,Jennifer,47,4,0,0,0,0,0,3.889
+Spring 2024,HLT,4392,7,24399,Field Work in Community Health,Proctor,Robin Ann,44,1,2,0,0,0,0,3.887
+Spring 2024,HLT,4392,8,24400,Field Work in Community Health,Proctor,Robin Ann,42,4,1,0,0,0,2,3.837
+Spring 2024,TECH,6360,40,24410,Exp Design & Data Analysis,Thornton,Brandon,3,1,0,0,0,0,0,3.75
+Spring 2024,GRET,6333,40,24411,Retail Mgmt Cross-Cultural,Gatterson,Beverly,5,1,0,0,1,0,0,3.333
+Spring 2024,GRET,6335,40,24412,Regional Retail Markets,Ezell,Shirley D,3,3,0,0,1,0,0,3.047
+Spring 2024,FORE,6311,40,24413,Introduction to Foresight,Sweeney,John Arthur,8,0,0,0,0,0,0,4.0
+Spring 2024,FORE,6319,40,24414,Proseminar in Foresight,McBride,Yasamina,4,0,0,0,0,0,0,3.918
+Spring 2024,FORE,6333,40,24417,Systems Thinking,Schultz,Wendy L,9,0,1,0,0,0,1,3.8
+Spring 2024,FORE,6355,40,24418,Alternative Perspectives,Cowart,Adam David,6,0,0,0,0,0,0,3.89
+Spring 2024,FORE,6371,40,24419,World Futures,Hines,Andrew Lewis,7,0,0,0,0,0,0,3.953
+Spring 2024,FORE,6395,40,24420,Master's Project in Foresight,Hines,Andrew Lewis,4,0,0,0,0,0,0,4.0
+Spring 2024,FORE,6398,40,24422,Special Problems in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Spring 2024,SCLT,4396,1,24619,Internship in Supply Chain,Kidd,Margaret A,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,2325,9,24620,University Physics I (lecture),Bittner,Eric R,3,12,5,5,3,0,2,2.226
+Spring 2024,PSYC,4397,4,24652,Selected Topics in Psychology,Alward,Beau Andrew,39,2,1,0,0,0,1,3.905
+Spring 2024,HDCS,4375,1,24678,Strategies in Digital Retail,Rifai,Rana Ihsan,28,1,2,0,0,0,1,3.817
+Spring 2024,KIN,4345,1,24864,Econ and Finc Aspects of Sport,Walsh,David W,7,10,23,6,1,0,2,2.354
+Spring 2024,ARCH,6311,3,24888,Topics in Design History,Ramirez,Enrique,4,0,0,0,0,0,1,4.0
+Spring 2024,CUIN,3302,5,24889,Social Education,Thomas,Dustine J,16,0,1,0,0,0,0,3.902
+Spring 2024,ENGL,1302,140,24903,First Year Writing II,Yates,Kaitlyn,17,3,0,1,3,0,0,3.113
+Spring 2024,ENGL,1302,141,24905,First Year Writing II,Yates,Kaitlyn,16,6,0,2,0,0,0,3.39
+Spring 2024,PHLS,6391,4,24906,Counseling Methods &Techniques,Hurt,Kara Marie,10,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,6391,5,24907,Counseling Methods &Techniques,Hurt,Kara Marie,6,0,1,1,0,0,0,3.375
+Spring 2024,PHLS,7303,3,24910,Internship II,Lee,Jungeun,0,0,0,0,0,11,0,
+Spring 2024,PHLS,6315,3,24911,Career Counseling,Zatopek,Audrey,16,1,0,0,0,0,0,3.883
+Spring 2024,PETR,7344,1,24913,Adv Reservoir Simulation,Lee,Kyung Jae,12,1,0,0,0,0,0,3.771
+Spring 2024,PETR,7344,2,24914,Adv Reservoir Simulation,Lee,Kyung Jae,0,2,0,0,0,0,0,3.0
+Spring 2024,PETR,6340,1,24915,Unconventional Resource Engr,Ehlig-Economides,Christine A,3,2,1,0,0,0,0,3.333
+Spring 2024,PETR,6340,2,24916,Unconventional Resource Engr,Ehlig-Economides,Christine A,1,0,0,0,0,0,0,4.0
+Spring 2024,SPEC,8395,1,24918,Dissertation in Practice,Santi,Kristi L,3,0,0,0,0,0,0,3.89
+Spring 2024,INDE,6334,1,24921,Predictive Data Analytics,Lin,Ying,10,16,0,0,0,0,0,3.41
+Spring 2024,PETR,5397,1,24922,Selected Topics,Ehlig-Economides,Christine A,0,0,1,0,0,0,0,2.0
+Spring 2024,PETR,6397,1,24923,Selected Topics,Ehlig-Economides,Christine A,0,0,1,0,0,0,0,2.0
+Spring 2024,ARTS,3301,2,24924,Life Drawing,Souvorova,Daria,10,7,0,0,0,0,1,3.549
+Spring 2024,ARTS,6301,2,24925,Life Drawing Studio,Souvorova,Daria,1,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4380,1,24937,Professional Practices,Barrera,Debra,16,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,6386,1,24938,Professional Practices,Barrera,Debra,7,0,0,0,0,0,0,4.0
+Spring 2024,ARTH,3301,1,24943,Critical Theory,Meza,Abinadi,10,1,0,4,0,0,0,3.133
+Spring 2024,ARTH,6301,1,24945,Critical Theory,Meza,Abinadi,5,0,0,0,0,0,0,4.0
+Spring 2024,ARTH,3304,1,24946,Virtual Curating,Rubinstein,Raphael,5,2,1,0,0,0,0,3.418
+Spring 2024,ARTH,6304,1,24947,Virtual Curating,Rubinstein,Raphael,1,0,0,0,0,0,0,3.67
+Spring 2024,ARTH,3337,1,24948,"Contemporary Art, 1980-Present",Harren,Natilee O,25,20,5,0,2,0,1,3.218
+Spring 2024,ARTH,6394,1,24949,Sel Top in Art History,Harren,Natilee O,6,0,0,0,0,0,0,3.835
+Spring 2024,ARTH,6320,1,24951,Reading 20th & 21st Cent Photo,Tipton,Cammie J,0,1,0,0,0,0,0,3.0
+Spring 2024,ARTH,3382,1,24952,Northern Renaissance,Nevitt Jr,Hugh R,18,2,0,0,0,0,0,3.834
+Spring 2024,ARTH,6321,1,24953,Northern Renaissance Art,Nevitt Jr,Hugh R,4,0,0,0,0,0,1,4.0
+Spring 2024,ARTH,4380,1,24954,Museums & Problem of Display,Zalman,Sandra,4,4,0,0,0,0,0,3.418
+Spring 2024,ARTH,6380,1,24955,Museums & Problem of Display,Zalman,Sandra,5,0,0,0,0,0,1,3.868
+Spring 2024,EDS,6397,1,24957,Selected Topics,Kulkarni,Yashashree,57,1,0,0,0,0,0,3.886
+Spring 2024,EDS,6397,2,24958,Selected Topics,Kulkarni,Yashashree,71,6,0,0,0,0,1,3.922
+Spring 2024,MIS,7397,9,24959,Selected Topics in MIS,Jagtap,Pankaj,13,10,0,0,0,0,0,3.508
+Spring 2024,MIS,7376,2,24960,Systems Analysis and Design,Ruff,Eniscia R,16,0,0,0,0,0,0,4.0
+Spring 2024,HLT,4307,7,24961,Research and Eval in Health,Kamdar-Sharif,Amber,17,11,6,1,0,0,0,3.229
+Spring 2024,HLT,4307,8,24962,Research and Eval in Health,Haq,Arooba A,13,11,7,2,2,0,0,2.81
+Spring 2024,FINA,7A97,4,24963,Selected Topics in Finance,Berta,Dominique,1,0,0,0,0,0,2,3.67
+Spring 2024,FINA,4397,4,24985,Selected Topics in Finance,Kapatos,Nick Gus,15,6,0,0,0,0,0,3.604
+Spring 2024,PETR,6397,3,24987,Selected Topics,Qin,Guan,56,0,0,0,0,0,0,3.9
+Spring 2024,SPEC,8395,2,24988,Dissertation in Practice,Hawkins,Jacqueline McLean,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8395,2,24992,Dissertation in practice,Butcher,Keith,0,0,0,0,0,5,0,
+Spring 2024,ELCS,8395,3,24993,Dissertation in practice,Johnson,Detra DeVerne,0,0,0,0,0,2,0,
+Spring 2024,ELCS,8395,4,24994,Dissertation in practice,Klussmann,Duncan Foster,0,0,0,0,0,2,0,
+Spring 2024,ELCS,8395,5,24995,Dissertation in practice,Peters-Hawkins,April,2,0,0,0,0,3,0,3.835
+Spring 2024,ELCS,8395,6,24996,Dissertation in practice,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,1,0,4.0
+Spring 2024,ELCS,8395,7,24997,Dissertation in practice,Hassett,Kristen Spring,1,0,0,0,0,0,0,4.0
+Spring 2024,ARTH,4394,1,24998,Sel Tops in Art History,Harren,Natilee O,4,2,0,0,1,0,0,3.143
+Spring 2024,ARTH,6394,2,24999,Sel Top in Art History,Harren,Natilee O,5,0,0,0,0,0,0,3.934
+Spring 2024,GEOL,7330,1,25000,Potntl Fld Mtds-Geophys,Sun,Jiajia,9,2,0,0,0,0,0,3.818
+Spring 2024,ELCS,8695,2,25001,Dissertation in Practice,Butcher,Keith,1,0,0,0,0,2,0,4.0
+Spring 2024,ELCS,8695,5,25004,Dissertation in Practice,Peters-Hawkins,April,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8695,6,25005,Dissertation in Practice,Snodgrass Rangel,Virginia Walker,0,0,0,0,0,1,0,
+Spring 2024,ARTH,6394,3,25007,Sel Top in Art History,Koontz,Rex A,11,0,0,0,0,0,1,4.0
+Spring 2024,ARTH,3394,1,25009,Sel Tops in Art History,Sicinski,Michael J,18,4,0,0,1,0,0,3.58
+Spring 2024,ARTH,6394,4,25010,Sel Top in Art History,Sicinski,Michael J,3,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4397,1,25013,Sel Topics in Fine Arts,Meza,Abinadi,16,2,0,0,0,0,0,3.889
+Spring 2024,ARTS,3330,3,25015,Intermediate Graphic Design,Lopez,Jonathan Christopher,3,11,4,1,0,0,4,2.964
+Spring 2024,COMM,4397,1,25017,Selected Topics Communication,Trupiano,Jerome,16,11,0,0,0,0,1,3.715
+Spring 2024,AAS,4370,1,25020,Sem. African American Studies,Green,Tara T,13,4,3,1,0,0,1,3.302
+Spring 2024,AAS,2320,1,25021,Intro To African American Stdy,Smith,Marlon Antoine,17,16,3,2,0,0,0,3.202
+Spring 2024,AAS,2320,4,25023,Intro To African American Stdy,Muhammad Murphy,Wilma Denae,26,4,5,1,1,0,2,3.379
+Spring 2024,AAS,2320,5,25024,Intro To African American Stdy,Thompson,Kevin Bernard,35,3,1,1,0,0,0,3.784
+Spring 2024,AAS,2320,6,25025,Intro To African American Stdy,Poindexter-Sylvers,Carole Jean,28,2,2,2,2,0,3,3.344
+Spring 2024,AAS,2320,7,25026,Intro To African American Stdy,Wright,Kelechi Chinyere,38,1,0,0,0,0,1,3.949
+Spring 2024,AAS,2330,1,25027,Black Liberation Theology,Walker,Alan,12,3,0,0,0,0,2,3.822
+Spring 2024,AAS,3301,1,25028,Hip Hop History and Culture,Williams,Christopher Wayne,13,5,0,0,1,0,1,3.492
+Spring 2024,AAS,3349,1,25029,AFAM Political Legal Studies,Putman,Eronn A,11,9,0,0,0,0,0,3.534
+Spring 2024,BZAN,6350,2,25035,Quant Found for Busi Analytics,Venugopal,Kalyanaraman,17,0,1,0,2,0,0,3.434
+Spring 2024,LAW,5197,8,25042,Selected Topics,Hastings,Madison Alexandra Nicole,0,0,0,0,0,11,0,
+Spring 2024,ARCH,3312,7,25044,Topics in Design Media,Tobar Martinez,Joaquin,14,0,0,0,0,0,1,4.0
+Spring 2024,ARCH,3312,8,25045,Topics in Design Media,Clovis,Sam,12,2,0,0,0,0,1,3.857
+Spring 2024,CUIN,6307,1,25056,Change and Diffusion,Hausmann,Robert Carl,12,0,0,0,0,0,0,4.0
+Spring 2024,MARK,3337,6,25096,Professional Selling,Moceri,Grace,85,9,2,0,0,0,2,3.823
+Spring 2024,GENB,7393,1,25101,Business Consulting Lab I,Galvani,Paul,2,0,0,0,0,0,0,4.0
+Spring 2024,GENB,7394,1,25102,Business Consulting Lab II,Galvani,Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,ENTR,3310,7,25109,Entrepreneurship,Richards,Sean Wesley,0,9,0,0,0,0,0,3.0
+Spring 2024,PSYC,3334,2,25114,Psychology & Law,Capuozzo,Kristen Irene,16,58,22,4,6,0,10,2.704
+Spring 2024,ENTR,4397,1,25115,Sel Topics in Entrepreneurship,McCormick,Kelly,33,1,1,0,0,0,0,3.867
+Spring 2024,MARK,3338,3,25117,Intro to Marketing Analytics,Wang,Yu,12,11,0,2,0,0,0,3.333
+Spring 2024,MARK,4379,3,25118,Personal Branding,Richards,Sean Wesley,22,6,0,0,0,0,0,3.609
+Spring 2024,PSYC,3310,4,25120,Indstrl-Orgnztnl Psy,Thomas,Kalifa Nailah,46,20,5,0,4,0,3,3.444
+Spring 2024,MARK,4397,1,25156,Selected Topics in Mkt,Pogge,Joe M,26,7,1,0,0,0,1,3.735
+Spring 2024,MARK,7393,1,25158,Business Consulting Lab I,Galvani,Paul,3,0,0,0,0,0,0,4.0
+Spring 2024,MARK,7394,1,25159,Business Consulting Lab II,Galvani,Paul,3,0,0,0,0,0,0,4.0
+Spring 2024,MARK,7332,2,25160,Social Media Marketing,Gavin,Daniel Yaakov,12,4,0,0,0,0,1,3.75
+Spring 2024,MARK,7397,3,25161,Selected Topics in Marketing,Franco,Rodi L,4,2,1,0,0,0,0,3.287
+Spring 2024,GENB,7304,3,25162,Bus Ethics for Accountants,Brant Jr,Robert Edward,1,4,0,0,0,0,0,3.332
+Spring 2024,FINA,7397,4,25164,Selected Topics in Finance,Khumawala,Saleha B,2,0,0,0,0,0,0,4.0
+Spring 2024,BUSI,4305,3,25165,Business Ethics for Accountant,Brant Jr,Robert Edward,2,3,0,0,0,0,0,3.532
+Spring 2024,ACCT,7397,3,25166,Selected Topics in Accounting,Kraten,Michael,10,1,1,0,0,0,0,3.75
+Spring 2024,ACCT,7390,2,25167,Contrl & Secur of Finan Inform,Brant Jr,Robert Edward,4,6,0,0,0,0,0,3.532
+Spring 2024,ACCT,7374,2,25168,Data Analytics Comp Tech Acct,Seijas,Nuria S,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7396,6,25180,Topics in Language & Literatre,Backus,Margot Gayle,6,0,0,0,0,0,0,3.945
+Spring 2024,ENTR,3310,8,25187,Entrepreneurship,Wilbur,Stephen,108,73,15,0,2,0,2,3.416
+Spring 2024,ARCH,6112,3,25191,Topics in Design Media,Murray,Cara,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGI,1331,12,25194,Computing for Engineers,Kowal,Marsha Christine,14,4,7,0,3,0,7,2.834
+Spring 2024,FINA,4376,1,25198,Energy Trading Systems,Pena,Juan F,86,15,4,1,1,0,2,3.71
+Spring 2024,ENGI,1331,1,25199,Computing for Engineers,Burleson,Daniel W,31,20,15,1,1,0,3,3.21
+Spring 2024,ENGI,1331,6,25200,Computing for Engineers,Claydon,Frank J,37,23,10,0,0,0,3,3.315
+Spring 2024,ACCT,7320,3,25201,Intro to Data Analytics-Acct,Miles,Carolyn A,1,0,0,0,0,0,0,4.0
+Spring 2024,ACCT,5397,2,25203,Selected Topics in Accounting,Kraten,Michael,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,6397,1,25206,Topics in Span-Amer Lit,Ventura,Gabriela Baeza,8,3,0,0,0,0,2,3.787
+Spring 2024,SPAN,6353,1,25207,Contrastive Analysis,Gutierrez,Manuel J,5,3,0,0,0,0,1,3.584
+Spring 2024,ARTS,2348,1,25208,Digital Tools,Scott,Caitlin,9,2,0,1,1,0,1,3.232
+Spring 2024,ARTS,2348,2,25209,Digital Tools,Hillerbrand,Stephan C,13,1,1,0,0,0,0,3.624
+Spring 2024,SPAN,6356,1,25210,Spanish Syntax,Lopez Otero,Julio Cesar,5,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3383,1,25211,Digital Fabrication,Clarke,Chelsea,3,7,2,0,0,0,0,3.166
+Spring 2024,ARTS,6397,1,25212,Sel Topics/Studio Arts,Clarke,Chelsea,5,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,6395,1,25213,Topics-Lang&Linguistics,Goodin-Mayeda,Carrie Elizabeth,4,1,0,0,0,0,0,3.866
+Spring 2024,ARTS,6396,1,25214,Sel Topics in Fine Arts Media,Giampietro,Francis A,5,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3396,1,25215,Selected Tops Studio Practice,Dupre,Roslyn M,12,0,0,0,0,0,0,3.918
+Spring 2024,ARCH,6112,6,25216,Topics in Design Media,Noldt,Peter,2,0,0,0,0,0,0,3.835
+Spring 2024,ARCH,6112,7,25217,Topics in Design Media,Noldt,Peter,1,0,0,0,0,0,1,4.0
+Spring 2024,ARCH,6112,8,25218,Topics in Design Media,Noldt,Peter,0,1,0,0,0,0,0,3.0
+Spring 2024,ARCH,6112,9,25219,Topics in Design Media,Noldt,Peter,1,1,0,0,0,0,0,3.5
+Spring 2024,ARCH,6112,11,25220,Topics in Design Media,Jackson,Megan H,5,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6112,12,25221,Topics in Design Media,Jackson,Megan H,1,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6112,14,25222,Topics in Design Media,Smith,Joshua S,1,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6112,15,25223,Topics in Design Media,Kudless,Andrew Justin,4,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6112,18,25224,Topics in Design Media,Murray,Cara,3,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,6376,1,25227,Spanish & Transatlantic Film,Solino,Maria Elena,6,1,0,0,0,0,0,3.763
+Spring 2024,SPAN,7338,1,25228,Publishing Theory & Practice,Kanellos,Nicolas,12,0,0,0,0,0,0,4.0
+Spring 2024,HLT,3381,5,25230,Hlt Promotn & Disease Preventn,Markowitz,Eliz,55,27,1,0,0,0,0,3.571
+Spring 2024,HON,2341,37,25232,Classics of Modernity,Mikics,David,2,3,0,0,0,0,0,3.268
+Spring 2024,ENGL,2361,37,25233,Western World Lit II--Honors,Mikics,David,1,1,0,0,0,0,0,3.5
+Spring 2024,COSC,3360,1,25242,Operating Systems,Cheng,Albert M K,13,33,18,7,8,0,38,2.406
+Spring 2024,COSC,7336,1,25244,Advanced NLP,Verma,Rakesh M,2,3,0,0,1,0,0,2.888
+Spring 2024,PEP,7397,1,25245,Adv Selected Topic Human Perf,LaVoy,Emily Claire-Pyle,7,0,0,0,0,0,0,4.0
+Spring 2024,COSC,3320,1,25247,Algorithms and Data Structures,Hourani,Khalid Maen,57,68,14,2,0,0,7,3.288
+Spring 2024,ARCH,3397,1,25249,Selected Topics,Truitt,William C,8,9,2,0,0,0,3,3.368
+Spring 2024,PSYC,3310,5,25251,Indstrl-Orgnztnl Psy,Babalola,Olusegun,52,36,6,1,3,0,1,3.424
+Spring 2024,PSYC,3339,6,25255,Intro To Clinical Psychology,Li,Xinge,52,25,2,0,0,0,0,3.591
+Spring 2024,ARCH,6312,2,25259,Topics in Design Media,Noldt,Peter,1,1,1,0,0,0,0,3.0
+Spring 2024,ARCH,6312,3,25260,Topics in Design Media,Smith,Joshua S,4,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,4397,3,25262,Topics-Biochem & Biophys Sci,Yi,Ping,12,1,0,0,0,0,1,3.948
+Spring 2024,MIS,4397,11,25263,Selected Topics in MIS,Wadiwala,Mohammad A,21,2,0,0,0,0,2,3.913
+Spring 2024,WCL,6397,1,25264,Selected Topics in WCL,Vijayalakshmi,Thangavel,2,0,0,0,0,0,0,4.0
+Spring 2024,HIST,1301,1,25271,The U.S. to 1877,McDonald,Eric John,150,125,36,5,3,0,9,3.245
+Spring 2024,HIST,1301,3,25272,The U.S. to 1877,McDonald,Eric John,145,120,33,12,17,0,3,3.064
+Spring 2024,HIST,1301,2,25273,The U.S. to 1877,McDonald,Eric John,127,139,29,14,12,0,9,3.077
+Spring 2024,SOCW,7339,2,25274,Prof. Grant Writing for SW,Stagg,Helen Ruth,7,0,0,0,1,0,0,3.5
+Spring 2024,CIS,6322,20,25276,Secure Enterprise Computing,Burke,Ross,24,1,1,0,0,0,0,3.859
+Spring 2024,CIS,6322,40,25277,Secure Enterprise Computing,Burke,Ross,11,1,0,0,0,0,0,3.944
+Spring 2024,CIS,6357,1,25278,Control Systems Security,Venkataramani,Suresh,14,1,0,0,0,0,0,3.889
+Spring 2024,DANC,1202,1,25279,Ballet I Part II,Ozsoy,Firat Kazbek,9,0,0,0,0,0,1,4.0
+Spring 2024,CIS,6326,30,25280,Critical Thinking in Info Sec,Conklin,William A,20,5,3,0,0,0,0,3.525
+Spring 2024,CIS,6326,40,25281,Critical Thinking in Info Sec,Conklin,William A,17,0,0,2,0,0,0,3.667
+Spring 2024,CIS,6378,30,25282,Data Science for Cybersecurity,Zhang,Yunpeng,24,3,0,0,0,0,0,3.877
+Spring 2024,CIS,6378,40,25283,Data Science for Cybersecurity,Zhang,Yunpeng,7,2,0,0,0,0,1,3.741
+Spring 2024,SOCW,7347,1,25284,SW Practice & Interv in School,Jennings,Sheara Williams,14,3,1,0,0,0,0,3.722
+Spring 2024,SOCW,7347,2,25285,SW Practice & Interv in School,Jennings,Sheara Williams,8,2,0,0,0,0,1,3.8
+Spring 2024,DANC,2323,1,25286,Dance in Film,Estrada,Maria Gabriela,27,12,2,1,0,0,1,3.461
+Spring 2024,SOCW,7397,2,25288,Selected Topics in Social Work,Bromfield,Nicole,13,3,0,0,0,0,0,3.813
+Spring 2024,SOCW,7397,3,25289,Selected Topics in Social Work,Bromfield,Nicole,9,0,0,0,0,0,1,4.0
+Spring 2024,DANC,4110,2,25290,Dance Ensemble,Lockett,KeyAira,5,0,0,0,0,0,0,4.0
+Spring 2024,DANC,4197,1,25291,Selected Topics,Prokop,Travis Cooper,11,0,0,0,0,0,0,3.97
+Spring 2024,DANC,4204,1,25292,Jazz Dance III,Prokop,Travis Cooper,11,1,0,0,0,0,0,3.834
+Spring 2024,SOCW,7302,1,25293,SW in Health Care Settings,Charles,Janea Nicole Adams,27,1,0,0,0,0,0,3.964
+Spring 2024,DANC,4305,1,25295,Senior Project with Career Mgt,Chapman,Teresa Lynn,6,3,1,0,0,0,0,3.5
+Spring 2024,HLT,4307,9,25297,Research and Eval in Health,Fedor Amador,Theresa Marie,19,14,0,1,0,0,1,3.422
+Spring 2024,CIS,3320,21,25301,Information Visualization,Ratner,Edward,53,38,1,2,8,0,6,3.154
+Spring 2024,HLT,4320,3,25302,Admin of Health Services,Haq,Arooba A,40,9,1,0,0,0,0,3.688
+Spring 2024,HLT,4320,4,25303,Admin of Health Services,Haq,Arooba A,25,23,0,0,0,0,0,3.5
+Spring 2024,SOCW,7366,2,25306,Grief/Bereave Therapy,Bhatt,Riya V,24,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6312,4,25307,Topics in Design Media,Gonzales,Michael A,3,0,0,0,0,0,0,4.0
+Spring 2024,THEA,1340,2,25309,Fundamentals of Acting,Potrykus,Samantha Burns,13,4,0,0,0,0,1,3.609
+Spring 2024,SCM,4367,3,25311,Process and Quality Management,Miller,Bradley D,2,2,2,0,0,0,0,3.055
+Spring 2024,SCM,4351,3,25312,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,1,2,0,0,0,0,0,3.443
+Spring 2024,ENGI,1100,7,25330,Introduction To Engineering,Burleson,Daniel W,27,15,8,5,3,0,2,2.977
+Spring 2024,TLIM,3330,34,25333,Innovation Principles,Crawley,David L,5,3,16,0,2,0,1,2.194
+Spring 2024,PSYC,2320,6,25334,Abnormal Psychology,Mattuck,Shira Regina,14,27,20,10,8,0,0,2.309
+Spring 2024,PSYC,2301,8,25336,Introduction to Psychology,Schoolfield,Lucy,69,10,0,0,1,0,0,3.833
+Spring 2024,PSYC,4344,6,25338,Cultural Psychology,Beltran-Najera,Ilex,59,15,1,1,1,0,2,3.718
+Spring 2024,SOCW,6193,1,25340,SW Generalist Practicum 1,Gonzales,Shelley A,0,0,0,0,0,16,0,
+Spring 2024,SOCW,6194,1,25342,SW Generalist Practicum 2,Gonzales,Shelley A,0,0,0,0,0,132,0,
+Spring 2024,SOCW,7184,1,25343,SW Clinical Practicum 1,Gonzales,Shelley A,0,0,0,0,0,30,0,
+Spring 2024,SOCW,7185,1,25344,SW Clinical Practicum 2,Gonzales,Shelley A,0,0,0,0,0,138,0,
+Spring 2024,SOCW,7188,1,25345,Social Work Macro Practicum 1,Gonzales,Shelley A,0,0,0,0,0,6,0,
+Spring 2024,SOCW,7189,1,25346,Social Work Macro Practicum 2,Gonzales,Shelley A,0,0,0,0,0,17,0,
+Spring 2024,GEOL,6379,2,25347,Applied Biostratigraphy,Copeland,Peter,5,5,0,0,0,0,0,3.401
+Spring 2024,GEOL,6393,2,25348,Seismic Amplitude Interpretatn,Hilterman,Fred,6,8,0,0,0,0,0,3.452
+Spring 2024,GEOL,7324,1,25349,Rock Physics,Castagna,John P,2,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7333,1,25350,Seismic Wave & Ray Theory,Thomsen,Leon A,0,3,0,0,0,0,0,3.0
+Spring 2024,GEOL,7341,3,25352,Geophysical Data Processing,Zhou,Hua-Wei,3,0,0,0,0,0,0,3.89
+Spring 2024,THEA,4397,2,25356,Drama Workshop,Romero,Gregory John,7,0,0,0,0,0,0,4.0
+Spring 2024,COMD,7221,1,25357,Fluency Disorders,Thompson,Austin,19,0,0,0,0,0,0,3.896
+Spring 2024,THEA,6302,1,25362,Stage Machinery,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,7330,2,25363,Adv Thrys of Counseling,Perazzo,Patrizia,6,1,0,0,0,0,0,3.857
+Spring 2024,THEA,6396,1,25364,Selected Topics Theatre,Coen,Elizabeth Manya,3,0,0,0,0,0,0,4.0
+Spring 2024,THEA,6398,1,25366,Independent Study,Vlahos,Kalliope,0,1,0,0,0,0,0,3.33
+Spring 2024,ARLD,6335,1,25367,Leading Change in the Arts,Taylor,Glenn E,6,1,0,0,0,0,0,3.904
+Spring 2024,ARLD,6382,1,25369,Healthcare Policy and Research,Docwra,Caroline Nicole,9,0,0,0,0,0,0,4.0
+Spring 2024,ARLD,6398,1,25370,Special Prob in Arts Leadrshp,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,6339,1,25371,Big Data Analytics,Ordonez,Carlos,6,2,0,0,0,0,0,3.709
+Spring 2024,MUED,3104,2,25373,Strings,Hansen,Erin Melissa,6,5,5,0,2,0,0,2.667
+Spring 2024,MUED,6301,1,25374,Intro to Research in Music Edu,McGinnis,Emily Jane,2,1,0,0,0,0,1,3.667
+Spring 2024,MUED,8320,1,25375,Qualitative Research Methods,Derges,Julie D,4,0,0,0,0,0,0,3.835
+Spring 2024,BTEC,6105,30,25387,Bioprocessing Laboratory,Lin,Yuheng,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8334,2,25394,Research Counseling Psychology,Allan,Blake A,6,0,0,0,0,0,0,3.89
+Spring 2024,ARCH,6312,6,25398,Topics in Design Media,Tobar Martinez,Joaquin,3,0,0,0,0,0,0,4.0
+Spring 2024,ARCH,6312,7,25400,Topics in Design Media,Clovis,Sam,3,2,0,0,0,0,0,3.6
+Spring 2024,SOCW,8398,1,25401,Independent Study,Ali,Samira Bano,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,6317,1,25402,Inequality and Redistribution,Zhu,Ling,3,1,0,0,0,0,0,3.75
+Spring 2024,POLS,6367,1,25403,Seminar in Electoral Behavior,Marcinek,Elizabeth Nicole Simas,4,0,1,0,1,0,0,2.945
+Spring 2024,MUSI,1117,4,25405,Aural Skills II,Snyder,John L,7,7,4,0,0,0,0,3.093
+Spring 2024,HRD,6355,1,25406,Designing OD Interventions,Waight,Consuelo L,9,1,0,0,0,0,0,3.933
+Spring 2024,MUSI,1312,4,25408,Music Theory II,Snyder,John L,10,8,0,0,0,0,0,3.592
+Spring 2024,MUSI,2117,2,25409,Aural Skills IV,Lee,Ji Yeon,6,6,3,3,2,0,0,2.534
+Spring 2024,MUSI,2160,1,25410,German Diction,Suits,Brian J,10,18,3,0,1,0,1,3.043
+Spring 2024,MUSI,2214,2,25411,Techniques of Music Since 1900,Lee,Ji Yeon,14,4,0,0,0,0,1,3.613
+Spring 2024,MUSI,4251,1,25413,Advanced Performance Pedagogy,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Spring 2024,MIS,8396,1,25415,Research Practicum,Johnson,Norman A,2,0,0,0,0,0,0,4.0
+Spring 2024,MIS,8397,2,25416,Selected Topics in MIS,Chin,Wynne W,2,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,6395,2,25417,Topics-Lang&Linguistics,Arboleda,Paola,11,1,0,0,0,0,2,3.917
+Spring 2024,COSC,4315,1,25418,Programming Languages and Para,Ordonez,Carlos,32,29,6,5,1,0,13,3.183
+Spring 2024,POLS,3359,1,25419,Criminal Justice,Guerra,Cristina,23,9,2,2,0,0,0,3.5
+Spring 2024,GHL,6173,1,25421,Mgt Training Work Exp Prog II,Shepherd,Ashley,0,0,0,0,0,0,1,
+Spring 2024,MUSI,4365,1,25422,Contemporary Concert Music,Maroney,Marcus K,2,2,0,0,0,0,0,3.5
+Spring 2024,MUSI,4397,1,25423,Selected Topics in Music,Bertagnolli,Paul A,1,0,1,0,0,0,0,2.67
+Spring 2024,MUSI,6397,1,25424,Selected Topics-Music,Bertagnolli,Paul A,3,0,1,0,0,0,0,3.5
+Spring 2024,MUSI,4397,2,25426,Selected Topics in Music,Vansteenburg,Jessica N,4,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6397,2,25427,Selected Topics-Music,Vansteenburg,Jessica N,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4397,3,25428,Selected Topics in Music,Pollack,Howard J,6,2,0,0,1,0,0,3.333
+Spring 2024,MUSI,6397,3,25429,Selected Topics-Music,Pollack,Howard J,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,4364,2,25430,Numerical Methods,Johnsson,Lennart,11,22,2,0,2,0,5,3.072
+Spring 2024,MUSI,4397,4,25432,Selected Topics in Music,Guez,Jonathan Charles,3,1,0,0,0,0,0,3.75
+Spring 2024,MUSI,6397,4,25433,Selected Topics-Music,Guez,Jonathan Charles,6,0,0,0,0,0,0,3.89
+Spring 2024,MUSI,6397,5,25434,Selected Topics-Music,Caton,Kathryn L.,13,0,0,0,0,0,0,3.924
+Spring 2024,MUSI,6397,6,25435,Selected Topics-Music,Koozin,Timothy,12,3,0,0,0,0,0,3.778
+Spring 2024,MUSI,6397,7,25436,Selected Topics-Music,Bertagnolli,Paul A,1,3,1,1,0,0,0,2.722
+Spring 2024,MUSI,6397,8,25437,Selected Topics-Music,Guez,Jonathan Charles,6,3,0,0,0,0,1,3.667
+Spring 2024,MANA,7397,3,25460,Selected Topics in Management,Vera,Dusya M,10,0,0,0,0,0,0,3.967
+Spring 2024,ELET,4325,1,25461,Advanced Microcomputer Netwrks,Peddoju,Suresh Kumar,11,1,0,0,0,0,0,3.917
+Spring 2024,INTB,4397,1,25463,Selected Topics in Inb,Thompson,Joseph Lee,26,0,0,0,0,0,0,4.0
+Spring 2024,POLS,6331,1,25464,Seminar in Democratization,Kennedy,Ryan P,5,5,0,0,0,0,0,3.533
+Spring 2024,POLS,6341,1,25465,Modern Political Thought,Fumurescu,Alin,4,1,0,0,0,0,1,3.734
+Spring 2024,POLS,6396,1,25468,Selected Topics in Compar IR,Soules,Michael,7,0,1,0,0,0,0,3.668
+Spring 2024,POLS,6394,1,25469,Selected Topics in Methods,Hawley,Michael C,1,2,0,0,1,0,0,2.665
+Spring 2024,POLS,6384,1,25470,Survey Research Methods,Jung,Jae Hee,8,2,0,0,0,0,0,3.734
+Spring 2024,CIS,4397,30,25472,Selected Topics Comp Info Syst,Lindner,Peggy,9,2,0,0,0,0,1,3.788
+Spring 2024,MUSI,6351,2,25474,Applied Music Pedagogy,Van Kekerix,Todd Evan,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4397,5,25475,Selected Topics in Music,Wu,Cheng Hao,4,0,0,0,0,0,0,3.918
+Spring 2024,MUSI,6397,9,25476,Selected Topics-Music,Wu,Cheng Hao,4,0,0,0,0,0,0,3.918
+Spring 2024,HON,2341,18,25480,Classics of Modernity,Ferguson,Jamie H,6,5,0,0,0,0,1,3.515
+Spring 2024,ENGL,2361,18,25481,Western World Lit II--Honors,Ferguson,Jamie H,3,0,1,0,0,0,0,3.418
+Spring 2024,DANC,3103,1,25482,Junior Seminar in Somatics,Chapman,Teresa Lynn,12,2,0,0,0,0,0,3.81
+Spring 2024,PHLS,8346,1,25487,Pediatric Psychopharmacology,Smith,Bradley,8,0,0,0,0,0,0,3.835
+Spring 2024,ITAL,3307,1,25490,Italian Renaissance,Behr,Francesca D,9,10,6,0,0,0,2,3.028
+Spring 2024,ENGL,4332,1,25492,Modern and Contemporary Poetry,Snediker,Michael,13,5,0,0,0,0,0,3.612
+Spring 2024,MIS,3376,7,25493,Busn Appls Database Mgmt I,Grimes,George M,20,20,11,3,1,0,0,3.0
+Spring 2024,ECE,4198,1,25494,Independent Study,Chen,Yuhua,7,0,0,0,0,0,0,4.0
+Spring 2024,COMM,4397,2,25499,Selected Topics Communication,Grossman,Michael,30,0,0,0,0,0,0,4.0
+Spring 2024,PETR,2311,1,25500,Reservoir Petrophysics,Hathon,Lori A,3,5,0,0,0,0,0,3.334
+Spring 2024,PETR,2111,1,25501,Petroleum Petrophysics Lab,Hathon,Lori A,8,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,8398,2,25504,Independent Study,Walton,Quenette,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4189,1,25505,Senior Recital,Griffin,Randall S,2,0,0,0,0,0,0,4.0
+Spring 2024,GENB,8397,1,25506,Selected Topics Gen Bus Admin,Hu,Ye,27,0,0,0,0,0,0,3.988
+Spring 2024,GENB,8397,2,25507,Selected Topics Gen Bus Admin,Dimoka,Angelika,27,0,0,0,0,0,0,3.976
+Spring 2024,GENB,8397,3,25508,Selected Topics Gen Bus Admin,Aron,Ravi,23,4,0,0,0,0,0,3.791
+Spring 2024,POPH,3331,1,25509,Informatics & Digital Health,Valier,Helen K,5,1,0,1,0,0,0,3.476
+Spring 2024,INDE,6335,1,25510,Egr Administration,Chung,Christopher,3,1,0,0,0,0,0,3.833
+Spring 2024,MUSA,4189,2,25512,Senior Recital,Kauk,Brian Keith,1,0,0,0,0,0,0,4.0
+Spring 2024,CNE,3301,2,25514,Construction Safety Engr,Zamiran,Siavash,3,0,0,0,0,0,0,4.0
+Spring 2024,CNE,3322,1,25515,Construction Engineering Law,Safa,Mahdi,0,0,1,0,0,0,0,2.0
+Spring 2024,CNE,3322,2,25516,Construction Engineering Law,Safa,Mahdi,2,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,6397,3,25520,Sel Top-Biochm&Bphs Sci,Yi,Ping,8,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4189,3,25521,Senior Recital,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,3.89
+Spring 2024,CIVE,4363,3,25522,Concrete Design,Wu,Yuntian,0,1,0,0,0,0,0,3.33
+Spring 2024,CIVE,4363,4,25523,Concrete Design,Safa,Mahdi,16,8,1,0,0,0,0,3.494
+Spring 2024,ECE,1197,1,25524,Selected Topics,De La Rosa-Pohl,Diana,21,0,0,0,0,0,1,3.969
+Spring 2024,AAS,2320,8,25526,Intro To African American Stdy,Muhammad Murphy,Wilma Denae,31,2,6,0,0,0,1,3.582
+Spring 2024,AAS,2320,9,25527,Intro To African American Stdy,Pogue,Donovan A,23,9,4,2,1,0,1,3.206
+Spring 2024,IDNS,1102,2,25528,Physics 1302 Workshop,Pattison,Donna,17,7,2,0,0,0,1,3.602
+Spring 2024,HON,4397,3,25529,Honors Selected Topics,Mohan,Chandra,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1310,4,25530,Applied Piano,Van Kekerix,Todd Evan,1,1,0,0,0,0,0,3.5
+Spring 2024,CUIN,8329,3,25531,Academic Publishing/ Presentin,Gist,Conra D,6,0,0,0,0,0,2,3.89
+Spring 2024,WGSS,2360,3,25532,Introduction to LGBT Studies,Boffone,Trevor James,23,3,0,0,1,0,2,3.741
+Spring 2024,WGSS,3350,1,25533,Feminist Theory,Tuthill,Zelma,27,0,0,0,0,0,3,4.0
+Spring 2024,ELED,4314,12,25535,Mathematics in Elem School I,Shelton,Laura,3,1,5,0,0,0,0,2.814
+Spring 2024,BTEC,6105,40,25536,Bioprocessing Laboratory,Lin,Yuheng,2,0,0,0,0,0,0,4.0
+Spring 2024,BTEC,6305,40,25538,Bioprocessing in Biotechnology,Lin,Yuheng,2,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6323,1,25545,Immunology,Peng,Weiyi,9,5,0,0,0,0,0,3.596
+Spring 2024,MUSA,4189,4,25546,Senior Recital,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,2397,1,25548,Selected Topics,Li,Zhengwei,3,21,0,1,0,0,0,2.948
+Spring 2024,IART,3300,1,25550,Intro to Interdisciplinary Art,Noble,Melissa Lynn,20,0,0,0,0,0,1,3.967
+Spring 2024,MUSI,1110,3,25551,Jazz Orchestra,Marmolejo,Noe J,13,0,0,0,0,0,0,4.0
+Spring 2024,MUED,6313,1,25553,Psychology for Musicians,Meals,Cory Dewitt,4,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,2311,3,25554,"Color, Materials and Methods",Williams,Ian Harrison,9,9,1,2,0,0,2,3.316
+Spring 2024,GEOL,6351,1,25555,Basin Modeling,Van Wijk,Jolante W,9,0,0,0,0,0,0,3.853
+Spring 2024,CIVE,4381,5,25563,Satellite-based Geomatics,Lee,Hyongki,8,16,3,0,0,0,0,3.32
+Spring 2024,CIVE,5397,1,25564,Selected Topics,Li,Hongyi,16,11,0,0,0,0,0,3.605
+Spring 2024,ECE,3441,7,25565,Digital Logic Design,Csutak,Sebastian,20,62,21,1,0,0,0,2.971
+Spring 2024,ECE,3366,2,25567,Intro To Digital Signal Proc,Csutak,Sebastian,18,34,8,0,0,0,0,3.084
+Spring 2024,ECE,4437,1,25568,Embedded Microcomputer Systems,Chen,Yuhua,32,17,1,0,0,0,0,3.534
+Spring 2024,ECE,5357,2,25570,Intro to Cybersecurity,Pan,Miao,13,23,5,0,0,0,0,3.235
+Spring 2024,GEOL,1302,2,25571,Intro To Global Climate Change,Choi,Yunsoo,15,13,0,0,0,0,0,3.477
+Spring 2024,ARTS,4392,1,25573,Sel Top in Contemporary Art,Newsome,Marc,16,1,1,0,0,0,0,3.833
+Spring 2024,HIST,1302,2,25574,The U.S. Since 1877,Amaral,Lindsay Nicole,30,26,23,7,3,0,0,2.809
+Spring 2024,ARTS,4392,2,25575,Sel Top in Contemporary Art,Mayer,Anna W,5,2,1,0,0,0,0,3.418
+Spring 2024,ARTS,6394,1,25576,Sel Tops in Contemporary Art,Mayer,Anna W,3,2,0,0,0,0,0,3.534
+Spring 2024,MECE,5397,7,25577,Selected Topics,Ryou,Jae-Hyun,20,10,0,0,0,0,0,3.546
+Spring 2024,MECE,5397,8,25579,Selected Topics,Song,Gangbing,12,17,0,0,0,0,0,3.346
+Spring 2024,GEOL,8398,20,25587,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8698,13,25588,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Spring 2024,THEA,3384,1,25589,Scene Painting,Davis,Lauren E,11,0,0,0,0,0,0,4.0
+Spring 2024,INDS,3265,2,25592,Design Research Methods II,Jackson,Megan H,6,16,2,1,0,0,0,3.12
+Spring 2024,INDS,2165,2,25593,Design Research Methods I,Jackson,Megan H,2,12,0,0,0,0,2,3.261
+Spring 2024,ECE,5397,1,25594,Selected Topics,Becker,Aaron T,0,0,0,0,0,0,1,
+Spring 2024,ECE,6397,1,25595,Selected Topics,Canepa,Pieremanuele,9,7,0,0,0,0,0,3.604
+Spring 2024,ECE,6397,2,25596,Selected Topics,Chen,Jiefu,7,2,2,0,0,0,0,3.395
+Spring 2024,MECE,4399,4,25599,Senior Honors Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8362,2,25602,Innov Acad Assmt & Invt: RTI,Fields,Victoria Jean,5,0,0,0,0,0,0,4.0
+Spring 2024,ECE,6397,3,25613,Selected Topics,Han,Zhu,12,2,0,0,0,0,0,3.857
+Spring 2024,ECE,6339,1,25614,Biophotonics,Shih,Wei-Chuan,5,7,0,0,0,0,1,3.444
+Spring 2024,MECE,6397,7,25615,Selected Topics,Ardebili,Haleh,26,12,0,0,1,0,1,3.514
+Spring 2024,MARK,7399,1,25616,MS Marketing Prof Project,Koch,Steven F,12,1,0,0,0,0,0,3.872
+Spring 2024,MARK,7399,2,25617,MS Marketing Prof Project,Koch,Steven F,5,0,0,0,0,0,0,4.0
+Spring 2024,MATH,6397,7,25618,Selected Topics in Math,Charon,Nicolas,9,2,0,0,0,0,0,3.818
+Spring 2024,ENTR,4397,2,25619,Sel Topics in Entrepreneurship,McCormick,Kelly,61,11,4,0,0,0,0,3.724
+Spring 2024,LAW,7397,7,25631,Selected Topics,Watson,Amanda,3,8,0,0,0,1,0,3.393
+Spring 2024,CHIN,6373,1,25635,Chns Second Lang Curriculum,Wen,Xiaohong Sharon,1,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5397,13,25637,Selected Topics,Ginsburg,Richard Allen,7,4,2,0,0,0,0,3.334
+Spring 2024,BIOE,6310,1,25639,Drug Design and Delivery,Naash,Muna,7,4,0,0,0,0,0,3.666
+Spring 2024,MUSI,8300,2,25642,Doct Research Seminar,Derges,Julie D,3,0,0,0,0,0,0,3.78
+Spring 2024,MUSA,1328,1,25643,Applied Harp,Cowan,Hope Kathleen,1,0,0,0,0,0,0,4.0
+Spring 2024,SCM,4390,3,25647,Supply Chain Strategy,Smith,Gordon D,0,3,1,0,0,0,0,2.585
+Spring 2024,SCM,7390,2,25648,Global Supply Chain Strategy,Smith,Gordon D,6,2,0,0,0,0,0,3.668
+Spring 2024,MUSA,4189,5,25649,Senior Recital,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Spring 2024,ENTR,4397,3,25651,Sel Topics in Entrepreneurship,Boles,James Read,14,19,5,0,0,0,0,3.211
+Spring 2024,MECT,4323,30,25653,Application in Stress Analysis,Basaran,Burak,0,5,15,0,0,0,2,2.217
+Spring 2024,ENGL,4310,1,25655,His of English Language,Nelms,Jodi Lynn,22,6,2,0,0,0,0,3.623
+Spring 2024,MUSA,4189,6,25656,Senior Recital,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Spring 2024,ELET,6316,40,25657,Network Routing Algo and Prot,Velusamy,Gandhimathi,2,0,0,0,0,0,0,3.835
+Spring 2024,PCOL,6498,7,25658,Special Problems,Statsyuk,Alexander V,2,0,0,0,0,0,0,4.0
+Spring 2024,FINA,7397,5,25659,Selected Topics in Finance,Barcenas,Aurora Margarita,2,3,1,0,0,0,0,3.167
+Spring 2024,MARK,3337,7,25660,Professional Selling,Suki,Yara D,16,0,0,0,0,0,0,3.979
+Spring 2024,ARTH,3379,1,25662,History-20th & 21th Cent Photo,Tipton,Cammie J,12,3,6,0,2,0,0,2.971
+Spring 2024,ARTS,4397,2,25667,Sel Topics in Fine Arts,Foutz,Madelyn Mairie,14,0,0,0,0,0,1,4.0
+Spring 2024,IART,3395,1,25668,Sel Topics in Interdis Arts,Reed,John G,0,2,0,0,0,0,1,2.835
+Spring 2024,ARTS,6397,2,25669,Sel Topics/Studio Arts,Cone,Marcus Andrew,2,0,0,0,0,0,0,4.0
+Spring 2024,IART,3395,2,25670,Sel Topics in Interdis Arts,Cone,Marcus Andrew,3,0,0,0,0,0,0,4.0
+Spring 2024,IRW,1100,1,25671,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,21,4,
+Spring 2024,IRW,1100,2,25672,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,2,3,
+Spring 2024,IRW,1100,3,25673,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,1,0,
+Spring 2024,IRW,1100,4,25674,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,0,1,
+Spring 2024,CNE,2211,2,25681,Construction Engr Fundamentals,Safa,Mahdi,2,2,0,0,0,0,0,3.5
+Spring 2024,SGNL,2302,4,25682,Intermediate Sign Language II,Brittain,Terrell,6,7,4,0,0,0,0,3.079
+Spring 2024,ECE,2100,1,25683,Circuit Analysis Laboratory,Ramachandran,Deepa,7,0,0,0,0,0,0,3.859
+Spring 2024,PCOL,6498,3,25688,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Spring 2024,ANTH,6395,2,25691,Selected Topics in Ant,Ghazali,Marwa,5,0,0,0,0,0,0,4.0
+Spring 2024,ANTH,6395,4,25693,Selected Topics in Ant,Routon,Erin Danielle,7,0,0,0,0,0,0,3.906
+Spring 2024,MUSA,4189,7,25696,Senior Recital,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5297,1,25697,Selected Topics in Pharmacy,Tolleson,Shane Russell,3,2,0,0,0,0,0,3.6
+Spring 2024,PHLS,8399,2,25698,Doctoral Dissertation,de Dios,Marcel A,0,0,0,0,0,1,0,
+Spring 2024,PCEU,6498,6,25699,Special Problems,Liu,Xinli,3,0,0,0,0,0,0,4.0
+Spring 2024,SCLT,6399,1,25700,Master's Thesis,Bian,Zheyong,1,0,0,0,0,0,0,4.0
+Spring 2024,CEA,3421,1,25702,Introduction to Control System,Ramachandran,Deepa,8,0,0,0,0,0,0,4.0
+Spring 2024,CEA,3323,1,25703,Data Structures and Algorithms,Meh Chu,Chu,10,0,0,0,0,0,0,4.0
+Spring 2024,CEA,3312,1,25704,Computer Architecture,Meh Chu,Chu,9,0,0,0,0,0,0,3.89
+Spring 2024,SYSE,3340,1,25706,"Sys Integration, Verf & Vali",Diaz Martinez,Neil Orlando,9,7,1,0,0,0,0,3.529
+Spring 2024,HIST,1301,1,25708,The U.S. to 1877,McDonald,Eric John,36,27,3,0,0,0,7,3.42
+Spring 2024,FREN,4396,1,25709,Sel Topics-Fren-lang & culture,Vredenburgh,Amanda Jane,1,0,1,0,1,0,0,2.0
+Spring 2024,FREN,4397,1,25710,Sel Tops in French Literature,Giacchetti,Claudine A,1,1,1,0,1,0,0,2.25
+Spring 2024,SCLT,6397,30,25711,Selected Topics,Bian,Zheyong,11,4,1,0,0,0,0,3.708
+Spring 2024,ANTH,6342,1,25712,Food and Culture,Sen,Debarati,2,0,0,0,0,0,0,3.67
+Spring 2024,ANTH,6332,1,25713,Migration/Borders/Citizenship,Small,Ivan Victor,4,0,0,0,0,0,0,3.835
+Spring 2024,ANTH,6363,1,25714,"Race, Racialization",De Genova,Nicholas Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1300,3,25715,Applied Voice,Belcher,Daniel,6,1,0,0,0,0,0,3.904
+Spring 2024,PHYS,8698,1,25717,Doctoral Research,Cardoso Barato,Andre,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,3,25719,Doctoral Research,Bellwied,Rene,0,0,0,0,0,3,0,
+Spring 2024,PHYS,8698,7,25723,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8698,12,25728,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,13,25729,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8698,16,25732,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,20,25736,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,23,25739,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8698,24,25740,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8698,25,25741,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,28,25744,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,30,25746,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Spring 2024,SCLT,4397,30,25750,Selected Topics Supply Chain,Henson,Alfred Bernard,21,9,3,0,1,0,1,3.412
+Spring 2024,IART,3395,3,25751,Sel Topics in Interdis Arts,Sicinski,Michael J,1,0,0,0,1,0,0,2.0
+Spring 2024,SYSE,3355,1,25756,Systems Thinking,Diaz Martinez,Neil Orlando,6,2,1,0,0,0,0,3.629
+Spring 2024,MUED,2342,3,25758,Music for Children,Chapa,Julissa Y,18,1,2,0,0,0,1,3.762
+Spring 2024,GREK,4398,1,25759,Independent Study,Due Hackney,Casey L,1,0,0,0,0,0,0,4.0
+Spring 2024,PHIL,1321,6,25761,Logic I,Haaga,Curtis W,12,7,3,2,1,0,5,3.067
+Spring 2024,INDE,4331,3,25770,Anlysis-Ind Activties I,Schulze,Lawrence John Henry,1,3,1,0,0,0,0,3.066
+Spring 2024,MARK,3337,8,25781,Professional Selling,Ahearne,Michael,65,94,38,10,9,0,24,2.871
+Spring 2024,GEOL,4398,1,25782,Independent Study,Castagna,John P,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,6397,5,25784,Selected Topics,Becker,Aaron T,11,1,1,0,0,0,0,3.642
+Spring 2024,ANTH,3396,1,25787,Selected Tops in Cultural Anth,Nairang,Arif Hayat,3,3,0,1,1,0,1,2.709
+Spring 2024,PCOL,8998,2,25788,Doctoral Research,Boini,Krishna M,0,0,0,0,0,1,0,
+Spring 2024,NURS,6230,1,25789,Diagnostic Tests & Procedures,Ecby,Chanique,2,3,0,0,0,0,0,3.4
+Spring 2024,NURS,6331,1,25791,Advanced Pharmacotherapy,Kleinhans,Alicia Diane,3,1,1,0,0,0,0,3.4
+Spring 2024,NURS,6338,1,25792,Advanced Pathophysiology,Brohard,Cheryl L,3,0,0,0,0,0,2,4.0
+Spring 2024,NURS,8207,1,25793,Writing for Publication,Love,Mary Frances,2,0,0,0,0,0,1,4.0
+Spring 2024,NURS,8208,1,25794,DNP Seminar I,Connelly,Linda K,0,0,0,0,0,2,1,
+Spring 2024,NURS,8209,1,25795,DNP Seminar II,Connelly,Linda K,0,0,0,0,0,6,0,
+Spring 2024,NURS,8357,1,25796,Scholarly Project Disseminatio,Love,Mary Frances,0,0,0,0,0,6,0,
+Spring 2024,NURS,4314,1,25797,Nursing Research,Brohard,Cheryl L,6,3,0,0,0,0,0,3.667
+Spring 2024,NURS,4316,1,25798,Medical Surgical Concepts,Edwards-Maddox,Shermel Vinese,0,11,0,1,0,0,0,2.833
+Spring 2024,NURS,4417,1,25799,Medical Surgical Clinical,Kantala,Nadine,9,3,0,0,0,0,0,3.75
+Spring 2024,NURS,4217,1,25800,Maternal Newborn Women Clin,Ecby,Chanique,7,2,0,0,0,0,0,3.778
+Spring 2024,NURS,4215,1,25801,Maternal Newborn Women Hlth,Ecby,Chanique,0,9,0,0,0,0,0,3.0
+Spring 2024,SOC,3315,1,25813,Sexuality and Society,Adams,Jennifer Lauren,46,11,2,0,0,0,2,3.723
+Spring 2024,SOC,3337,1,25814,Women and Crime,Colbert,Sharla Stettnisch,15,10,2,2,1,0,5,3.2
+Spring 2024,PCOL,8998,5,25815,Doctoral Research,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2024,PETR,6397,4,25818,Selected Topics,Ehlig-Economides,Christine A,4,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6298,4,25819,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Spring 2024,MUSA,6300,1,25820,Applied Voice,Belcher,Daniel,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,1182,4,25821,Group Piano II,Van Kekerix,Todd Evan,7,3,1,0,0,0,1,3.545
+Spring 2024,MUSI,1182,5,25822,Group Piano II,Van Kekerix,Todd Evan,6,0,1,0,1,0,0,3.291
+Spring 2024,MUSI,1182,6,25823,Group Piano II,Van Kekerix,Todd Evan,12,0,0,0,0,0,2,3.945
+Spring 2024,CUIN,7390,3,25824,Instructional Design,Vyas,Anita,10,1,2,0,0,0,0,3.438
+Spring 2024,PCEU,6397,1,25826,PCEU Selected Topics,Chow,Diana Shu-Lian,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,6198,1,25827,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Spring 2024,PCEU,8298,1,25828,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Spring 2024,PCEU,8398,1,25829,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Spring 2024,POLS,3357,2,25832,Constitutnl Law-Civ Lib,Erwing,Douglas A,6,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1322,2,25837,Applied Viola,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,7393,2,25838,Internship and Practicum,Reyna,Ronda,5,0,0,0,0,0,0,4.0
+Spring 2024,ECE,6308,1,25839,Advanced Batteries,Yao,Yan,11,15,1,0,0,0,0,3.431
+Spring 2024,MUSA,1344,2,25841,Applied Trombone,Freeman,Phillip I,3,0,0,0,0,0,0,3.89
+Spring 2024,MUSA,6348,1,25842,Applied Euphonium,Fenske,Kevin,1,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6298,6,25843,Special Problems,Das,Joydip,1,0,0,0,0,0,0,4.0
+Spring 2024,INDE,7344,1,25844,Decision Modeling and Opt.,Xiang,Yisha,3,0,0,0,0,0,0,4.0
+Spring 2024,MECE,5397,9,25846,Selected Topics,Franchek,Matthew,10,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6398,9,25854,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Spring 2024,PCEU,6298,2,25858,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8311,4,25861,Lab of Practice-Lit Revw Devel,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8395,8,25863,Dissertation in practice,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6300,6,25870,Applied Voice,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6300,5,25871,Applied Voice,Vasquez,Hector A,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6300,4,25872,Applied Voice,Sonnenberg,Melanie,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6300,3,25873,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6300,2,25874,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6332,1,25877,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6340,2,25878,Applied Trumpet,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6410,3,25880,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,3.67
+Spring 2024,MUSA,3410,4,25881,Applied Piano,Norian,Gary,1,1,0,0,0,0,0,3.5
+Spring 2024,MUSA,2334,3,25882,Applied Clarinet,Potiomkin,Alexander,3,1,0,0,0,0,0,3.833
+Spring 2024,MATH,1351,5,25883,Intro to Geometric Reasoning,Hollyer,Virginia Leigh,26,42,36,10,18,0,16,2.279
+Spring 2024,WGSS,2350,18,25886,Intro To Women's Studies,Deremer,Melissa Gale,28,1,1,0,0,0,0,3.889
+Spring 2024,WGSS,3395,1,25887,Sel Tops in Women's Studies,Chatterjee,Shraddha,3,5,1,0,2,0,0,2.726
+Spring 2024,GEOL,8398,21,25890,Doctoral Research,Murphy,Michael,0,0,0,0,0,0,0,
+Spring 2024,BCHS,8798,1,25891,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2024,QSS,4393,1,25896,QSS Research Project,Chatagnier,John Tyson,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,8698,1,25897,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,2,0,
+Spring 2024,MUSA,4189,8,25898,Senior Recital,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,4396,3,25905,Senior Research Project,Cheek,Ann Oliver,1,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,5198,4,25909,Spec Prob Phys Optics,Kemp,Andrew P,0,0,0,0,0,16,0,
+Spring 2024,ANTH,6322,1,25915,Seminar in Medical Anth,Rasmussen,Susan J,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,2100,4,25919,Circuit Analysis Laboratory,Leigh,Kevin Benny,16,14,1,0,1,0,0,3.334
+Spring 2024,MUSI,8296,3,25921,Doctoral Essay,Guez,Jonathan Charles,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8398,1,25922,Research in Pedagogy,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,6317,1,25923,Theories & Research in SLA,Cole,Mikel Walker,19,0,0,0,0,0,0,3.983
+Spring 2024,GOVT,2306,17,25925,US and Texas Const/Politics,McDonald,John Terrence George,30,8,14,1,1,0,5,3.13
+Spring 2024,GOVT,2305,18,25927,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,15,18,11,4,0,0,6,2.869
+Spring 2024,MUSA,4189,9,25928,Senior Recital,Wagner,Elise L,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,7310,1,25929,Teaching Practicum,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Spring 2024,ENTR,4393,1,25930,RED Labs Pre-accelerator,Wilbur,Stephen,3,5,0,0,0,0,0,3.458
+Spring 2024,DANC,4397,1,25932,Selected Topics,Lockett,KeyAira,4,0,0,0,0,0,0,3.918
+Spring 2024,PCOL,6398,12,25933,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6498,4,25934,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Spring 2024,GEOL,6399,4,25936,Masters Thesis,Voarintsoa,Ny Riavo Gilbertinie,2,0,0,0,0,0,0,4.0
+Spring 2024,HIST,1301,27,25937,The U.S. to 1877,McDonald,Eric John,26,15,3,0,4,0,1,3.167
+Spring 2024,HIST,1302,34,25938,The U.S. Since 1877,Wilson,Ezell Lamont,52,1,4,0,3,0,7,3.656
+Spring 2024,SOCW,8695,1,25951,Pre-Dissertation Research,Ali,Samira Bano,1,0,0,0,0,0,0,3.67
+Spring 2024,PHYS,8998,2,25954,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8998,3,25955,Doctoral Research,Bellwied,Rene,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8998,5,25957,Doctoral Research,Chen,Shuo,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,6,25958,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,8,25960,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,10,25962,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Spring 2024,SAER,8321,1,25963,Survey Mthds in Educ,Zhang,Jie,7,0,0,0,0,0,0,3.906
+Spring 2024,PHYS,8998,11,25964,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,3,0,
+Spring 2024,PHYS,8998,12,25969,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,13,25970,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8998,15,25972,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8998,18,25975,Doctoral Research,Meier,Mark Albert,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,19,25976,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,23,25980,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Spring 2024,PHYS,8998,24,25981,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,26,25983,Doctoral Research,Stokes,Donna,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,29,25986,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8998,32,25989,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,34,25994,Doctoral Research,Vovchenko,Volodymyr,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,36,25996,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Spring 2024,PHYS,8698,37,25997,Doctoral Research,Mondaini,Rubem,0,0,0,0,0,2,0,
+Spring 2024,ECE,6111,7,26002,Graduate Research Seminar,Krishnan,Venkata,0,0,0,0,0,1,0,
+Spring 2024,GHL,6290,2,26004,Professional Paper I,Madera,Juan Manuel,2,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6290,3,26005,Professional Paper I,Maneethai,Dustin,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6190,2,26006,Hospitality Research Proposal,Shin,Min Jung,0,0,0,0,0,1,0,
+Spring 2024,GHL,6298,1,26007,Special Problems,Legendre,Jungyoung Shin,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6398,1,26008,Special Problems,Boger Jr,Carl A,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,3441,5,26009,Digital Logic Design,Sheth,Bhavin R,3,2,2,0,2,0,1,2.298
+Spring 2024,MECE,6384,2,26011,Methods of Applied Math I,Baxevanis,Theocharis,0,2,0,0,0,0,2,2.835
+Spring 2024,MECE,6384,3,26012,Methods of Applied Math I,Baxevanis,Theocharis,0,1,0,0,0,0,0,2.67
+Spring 2024,MECE,6361,2,26013,Mechanical Behavior/Materials,Ryou,Jae-Hyun,10,4,2,0,0,0,2,3.459
+Spring 2024,MECE,6361,3,26014,Mechanical Behavior/Materials,Ryou,Jae-Hyun,3,7,0,0,0,0,1,3.399
+Spring 2024,MECE,6334,2,26015,Convection Heat Transfr,Prosperetti,Andrea,0,0,1,0,0,0,3,1.67
+Spring 2024,MECE,6334,3,26016,Convection Heat Transfr,Prosperetti,Andrea,0,0,0,0,0,0,1,
+Spring 2024,MECE,6336,2,26018,Engineering Heat Transfer,Ghasemi,Hadi,1,4,0,0,0,0,0,3.134
+Spring 2024,PSYC,2319,8,26020,Intro to Social Psychology,Wu,Dongjie,31,25,13,6,0,0,4,3.023
+Spring 2024,MECE,6397,8,26021,Selected Topics,Cescon,Marzia,2,0,0,0,2,0,4,1.918
+Spring 2024,MECE,6397,9,26022,Selected Topics,Cescon,Marzia,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4398,1,26023,Independent Study,Zvolensky,Michael J,16,0,0,0,0,0,0,4.0
+Spring 2024,DIGM,2351,30,26030,Web Design,Faiyaz,Sajida,24,6,0,0,0,0,0,3.855
+Spring 2024,PHLS,8399,3,26031,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,1,0,
+Spring 2024,SPAC,6398,1,26032,Special Problems,Toups,Larry David,9,0,0,0,0,0,1,4.0
+Spring 2024,PHLS,7398,2,26033,Candidacy Research,Correa-Fernandez,Virmarie,0,0,0,0,0,2,0,
+Spring 2024,SPAC,6298,1,26034,Special Problems,Bell,Larry S,0,1,0,0,0,0,0,3.0
+Spring 2024,CIS,4357,30,26035,Digital Forensics,Lee,Kyu In,17,3,3,0,0,0,0,3.566
+Spring 2024,BIOE,5317,3,26037,Intro to Biomedical Imaging,Gifford,Howard,1,0,0,0,0,0,0,3.67
+Spring 2024,SPAN,6397,2,26039,Topics in Span-Amer Lit,Ventura,Gabriela Baeza,10,0,0,0,0,0,0,3.967
+Spring 2024,BIOE,6346,3,26040,Advanced Medical Imaging,Gifford,Howard,2,3,0,0,0,0,0,3.202
+Spring 2024,PCEU,8698,2,26041,Doctoral Research,Tam,Vincent H,0,0,0,0,0,1,0,
+Spring 2024,ECE,6397,6,26042,Selected Topics,Prasad,Saurabh,12,1,0,0,0,0,0,3.822
+Spring 2024,PSYC,3338,2,26043,Psychology of Older Adults,Saiyed,Amna Shabbir,98,19,2,1,0,0,0,3.676
+Spring 2024,PCEU,6698,1,26044,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Spring 2024,PHIL,1321,7,26045,Logic I,Haaga,Curtis W,16,9,15,3,11,0,19,2.247
+Spring 2024,ARCH,6302,1,26046,Visual Studies II,Olwi,Asmaa,7,2,1,0,0,0,0,3.468
+Spring 2024,GEOL,1103,9,26049,Physical Geology Lab,Hauptvogel,Daniel William,12,5,0,0,3,0,0,3.101
+Spring 2024,MANA,4331,3,26051,Current Issues Human Res Mgmt,Babalola,Olusegun,3,5,2,0,2,0,1,2.583
+Spring 2024,PSYC,4398,2,26052,Independent Study,Babcock,Julia,2,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,8399,3,26053,Doctoral Dissertation,Cuny,Gregory D,0,0,0,0,0,1,0,
+Spring 2024,CIS,6357,40,26055,Control Systems Security,Conklin,William A,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8699,3,26059,Doctoral Dissertation,Choi,Yunsoo,0,0,0,0,0,1,0,
+Spring 2024,MECE,6397,10,26060,Selected Topics,Franchek,Matthew,0,1,0,0,0,0,0,3.0
+Spring 2024,EDS,6348,1,26065,Intro to Cloud Computing,Kulkarni,Yashashree,30,3,0,0,0,0,0,3.939
+Spring 2024,EDS,6397,3,26067,Selected Topics,Kulkarni,Yashashree,59,1,0,0,0,0,0,3.895
+Spring 2024,SCM,7330,3,26070,Demand and Supply Integration,Hosseinabadi Farahani,Mehdi,15,10,0,0,0,0,0,3.494
+Spring 2024,GEOL,8999,8,26073,Doctoral Dissertation,Mann,Paul,1,0,0,0,0,0,0,4.0
+Spring 2024,COMD,8397,1,26075,Selected Topics in COMD,Schaff,Carrie Allyson,6,0,0,0,0,0,0,4.0
+Spring 2024,PCOL,6298,8,26079,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Spring 2024,FINA,7397,6,26080,Selected Topics in Finance,Stewart,Marcus,3,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4398,3,26081,Independent Study,Williams,Michael W,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8998,21,26083,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8999,9,26084,Doctoral Dissertation,Stewart,Robert R,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,1112,67,26085,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,9,5,0,0,0,2,2.908
+Spring 2024,LAW,5297,15,26086,Selected Topics,Larson,Blaine Andrew,1,2,0,0,0,0,0,3.443
+Spring 2024,CHEM,1112,68,26087,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,6,4,0,1,0,1,3.055
+Spring 2024,SOCW,8198,1,26090,Independent Study,Leung,Yuk-Hi Patrick,0,0,0,0,0,1,0,
+Spring 2024,PSYC,4344,7,26091,Cultural Psychology,Haddad,Sana,85,22,6,2,1,0,2,3.592
+Spring 2024,PSYC,4344,8,26092,Cultural Psychology,Haddad,Sana,79,17,12,5,3,0,4,3.38
+Spring 2024,ENGL,1302,140,26094,First Year Writing II,Braniger,Leslie,5,14,0,0,1,0,5,3.018
+Spring 2024,ENGL,1301,55,26095,First Year Writing I,Penzien,Eugene Norman,5,2,4,1,3,0,1,2.245
+Spring 2024,PSYC,7392,6,26096,Psychology Practicum,Atherton,Olivia Emile,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8699,4,26097,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,3,0,
+Spring 2024,INDS,3397,5,26098,Selected Topics,Kang,Chul Min,1,2,0,0,0,0,0,3.443
+Spring 2024,CIVE,2332,4,26100,Mechanics of Solids,Nakshatrala,Kalyana,4,9,19,0,1,0,3,2.445
+Spring 2024,CUIN,8312,1,26101,Seminar Bilingual/Multiling Ed,Li,Miao,7,0,0,0,0,0,0,3.953
+Spring 2024,MUED,7399,1,26102,Music Education Final Project,Hansen,Erin Melissa,0,0,0,0,0,0,0,
+Spring 2024,GEOL,8398,22,26104,Doctoral Research,Zheng,Youtong,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8995,1,26106,Pre-Dissertation Research,Narendorf,Sarah C,0,0,0,0,0,2,0,
+Spring 2024,GEOL,8399,5,26110,Doctoral Dissertation,Lapen,Thomas J,0,0,0,0,0,2,0,
+Spring 2024,GEOL,6399,6,26111,Masters Thesis,Carlson,Brandee Nicole,3,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8399,4,26112,Doctoral Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Spring 2024,PHLS,8199,6,26113,Dissertation,Obasi,Ezemenari M,0,0,0,0,0,0,0,
+Spring 2024,PHCA,7310,2,26114,Teaching Practicum,Thornton,James D,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,6335,1,26115,Digital Contrl Systems,Provence,Robert S,12,8,6,0,0,0,2,3.142
+Spring 2024,ENGL,7699,10,26117,Thesis,Peynado,Brenda,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,7398,3,26120,Candidacy Research,Margulis,Milena A,0,0,0,0,0,0,0,
+Spring 2024,CIVE,8598,6,26123,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Spring 2024,CHEM,1112,69,26124,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,1,0,0,0,2,3.063
+Spring 2024,PHLS,7393,5,26125,Internship and Practicum,Reyna,Ronda,5,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8698,14,26126,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Spring 2024,COMD,8193,1,26128,COMD Proseminar,Joshi,Ashwini,2,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8199,7,26129,Dissertation,Smith,Nathan G,0,0,0,0,0,2,0,
+Spring 2024,GEOL,8698,15,26131,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Spring 2024,OPTO,5198,2,26140,Spec Prob Phys Optics,Ostrin,Lisa,0,0,0,0,0,34,0,
+Spring 2024,OPTO,5198,3,26141,Spec Prob Phys Optics,Sapoznik,Kaitlyn Anne,0,0,0,0,0,44,0,
+Spring 2024,NUTR,4352,2,26142,Child and Adolescent Nutrition,Vollrath,Kirstin,25,32,10,1,2,0,0,3.02
+Spring 2024,IDNS,2297,1,26143,Top-Natrl Sci & Mth,Stokes,Donna,2,1,0,0,2,0,0,2.266
+Spring 2024,IDNS,2297,2,26144,Top-Natrl Sci & Mth,Stokes,Donna,9,1,2,0,1,0,0,3.257
+Spring 2024,PHLS,8199,8,26145,Dissertation,Correa-Fernandez,Virmarie,2,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,1112,70,26147,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,0,0,1,0,2,3.176
+Spring 2024,ENGL,6398,1,26148,Rd&Research in Lang&Lit,Kastely,James L,0,0,0,0,0,1,0,
+Spring 2024,HIST,1302,35,26149,The U.S. Since 1877,Wilson,Ezell Lamont,42,1,1,0,2,0,1,3.754
+Spring 2024,ECE,6498,3,26150,Research,Canepa,Pieremanuele,0,0,0,0,0,0,0,
+Spring 2024,ECE,6598,4,26151,Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Spring 2024,ECE,6329,2,26152,Power System Protection,Yellajosula,Jaya Raghavendra Arun Kumar,11,2,1,1,0,0,0,3.555
+Spring 2024,OPTO,8990,1,26154,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Spring 2024,OPTO,8991,1,26155,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8699,15,26158,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Spring 2024,HIST,1301,28,26159,The U.S. to 1877,McDonald,Eric John,21,18,5,2,3,0,0,3.034
+Spring 2024,PHOP,8299,8,26160,Doctoral Dissertation,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8698,1,26161,Doctoral Research,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6867,4,26162,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8798,1,26164,Doctoral Research,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6767,6,26165,Research Practicum A,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8698,2,26168,Doctoral Research,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6267,1,26169,Research Practicum A,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8898,1,26171,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6167,8,26172,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6757,6,26173,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8798,3,26174,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8199,10,26175,Doctoral Dissertation,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,6399,4,26178,Masters Thesis,Cedillo,Adela Cedillo,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,7399,4,26179,Masters Thesis,Cedillo,Adela Cedillo,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,7399,5,26180,Masters Thesis,Reed,Linda,0,0,0,0,0,1,0,
+Spring 2024,HIST,6399,5,26181,Masters Thesis,Reed,Linda,0,0,0,0,0,1,0,
+Spring 2024,HIST,6398,1,26182,Special Problems,Young,Nancy Beck,0,0,0,0,0,0,0,
+Spring 2024,HIST,8677,5,26183,Reading for Comps Exams,Golubev,Alexey Valeryevich,0,0,0,0,0,1,0,
+Spring 2024,HIST,8377,7,26186,Reading for Comps Exams,Goldberg,Mark A,0,0,0,0,0,1,0,
+Spring 2024,HIST,8999,9,26187,Doctoral Dissertation,Ramos,Raul,1,0,0,0,0,0,0,3.67
+Spring 2024,HIST,8699,3,26188,Doctoral Dissertation,Klieman,Kairn,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8399,7,26189,Doctoral Dissertation,Klieman,Kairn,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8399,8,26190,Doctoral Dissertation,Mizelle Jr,Richard M,0,0,0,0,0,1,0,
+Spring 2024,HIST,8399,9,26191,Doctoral Dissertation,Reed,Linda,0,0,0,0,0,1,0,
+Spring 2024,CLAS,3398,1,26192,Independent Study,Due Hackney,Casey L,2,0,0,0,0,0,0,3.835
+Spring 2024,LAW,6369,11,26193,Legal Analysis and Writing,Meshkin,Catherine Campbell,0,0,0,0,0,8,0,
+Spring 2024,ENGL,8398,1,26197,Graduate English Resrch,Peynado,Brenda,0,0,0,0,0,1,0,
+Spring 2024,WGSS,6398,1,26198,Special Probs in Women's Study,De Los Reyes Heredia,Jose Guillermo,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,1,26199,Adv Special Problem Human Perf,Johnston,Craig Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,1102,7,26203,Intro to Climate Change Lab,Wang,Yuxuan,14,5,1,0,1,0,0,3.46
+Spring 2024,CIVE,6322,1,26210,Stormwater Management,Wang,Keh-Han,2,2,0,0,0,0,0,3.583
+Spring 2024,CIVE,6322,2,26211,Stormwater Management,Wang,Keh-Han,1,2,0,0,0,0,0,3.443
+Spring 2024,CIVE,6353,1,26212,Beh-Dsn Prestress Concr,Kalliontzis,Dimitrios,4,1,0,0,0,0,0,3.734
+Spring 2024,CIVE,6353,2,26213,Beh-Dsn Prestress Concr,Kalliontzis,Dimitrios,1,0,0,0,0,0,1,4.0
+Spring 2024,CIVE,6373,1,26214,Exptl Methods Environ Engr,Louie,Stacey M,3,3,0,0,0,0,0,3.445
+Spring 2024,CIVE,6375,1,26216,Analysis/Desgn Offshore Struct,Vazquez,Jose H,13,1,0,0,0,0,0,3.952
+Spring 2024,CIVE,6375,2,26217,Analysis/Desgn Offshore Struct,Vazquez,Jose H,2,1,0,0,0,0,0,3.777
+Spring 2024,CIVE,7397,1,26221,Selected Topics,Zhang,Ruda,9,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7399,10,26227,Masters Thesis,Mann,Paul,0,0,0,0,0,0,0,
+Spring 2024,GEOL,8999,10,26228,Doctoral Dissertation,Wang,Guoquan,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,6398,2,26230,Rd&Research in Lang&Lit,Harrell,Haylee C,0,0,0,0,0,2,0,
+Spring 2024,POLC,4498,1,26232,Independent Study,Cross,Renee Danielle,2,0,0,0,0,0,0,4.0
+Spring 2024,POLC,4598,1,26233,Independent Study,Cross,Renee Danielle,3,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8699,4,26234,Doctoral Dissertation,Khan,Shuhab D,2,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8699,4,26235,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6352,5,26236,Directed Rsch in I/O Psyc,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8699,5,26238,Doctoral Dissertation,Golubev,Alexey Valeryevich,0,0,0,0,0,1,0,
+Spring 2024,HIST,8399,10,26239,Doctoral Dissertation,Golubev,Alexey Valeryevich,0,0,0,0,0,1,0,
+Spring 2024,HIST,8677,6,26241,Reading for Comps Exams,Bhattacharya,Nandini Saradindu,1,0,0,0,0,0,0,4.0
+Spring 2024,PETR,1111,2,26249,Intro to Petroleum Engineering,Hathon,Lori A,1,1,1,0,0,0,0,3.22
+Spring 2024,CIS,6358,30,26254,Secure Software Design,Nsoh,Jovita T,15,0,1,0,0,0,0,3.834
+Spring 2024,MATH,3339,7,26255,Statistics for the Sciences,Wang,Wenshuang,21,15,11,4,2,0,5,2.9
+Spring 2024,CIVE,6382,1,26258,Lidar Systems and Applications,Ekhtari,Nima,2,4,0,0,1,0,0,2.951
+Spring 2024,GHL,6190,3,26271,Hospitality Research Proposal,Boger Jr,Carl A,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8199,9,26272,Dissertation,Allan,Blake A,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8398,2,26273,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,PHLS,7398,4,26274,Candidacy Research,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Spring 2024,ENGL,8398,3,26275,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,0,0,
+Spring 2024,PCOL,8998,7,26276,Doctoral Research,Wu,Mingfu,0,0,0,0,0,0,0,
+Spring 2024,GEOL,8398,18,26280,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,2,0,
+Spring 2024,CIVE,7397,3,26281,Selected Topics,Milillo,Pietro,2,1,0,0,0,0,0,3.777
+Spring 2024,CIVE,7397,5,26283,Selected Topics,Xie,Surui,7,1,0,1,0,0,0,3.446
+Spring 2024,ENGL,8398,4,26287,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8398,5,26288,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8398,6,26289,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6498,7,26290,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Spring 2024,BCHS,4396,2,26291,Senior Research Project,Zhang,Shaun Xiaoliu,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,6398,3,26292,Rd&Research in Lang&Lit,Nelson,Antonya,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8398,7,26293,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,7,26294,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,2,0,
+Spring 2024,ENGL,8398,8,26295,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,8,26296,Graduate Research,Harrell,Haylee C,0,0,0,0,0,1,0,
+Spring 2024,PHYS,4399,5,26300,Senior Honors Thesis,Cherdack,Daniel David,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,8398,9,26301,Graduate English Resrch,Davies,Daniel,0,0,0,0,0,1,0,
+Spring 2024,CHEE,4398,1,26302,Independent Study,Zerze,Hasan,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7699,11,26303,Thesis,Belieu,Erin Colleen,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8199,11,26304,Doctoral Dissertation,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8798,4,26305,Doctoral Research,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7399,9,26306,Essay,Belieu,Erin Colleen,2,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8199,12,26307,Doctoral Dissertation,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Spring 2024,PHOP,8798,5,26308,Doctoral Research,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Spring 2024,MECE,6397,11,26309,Selected Topics,Joshi,Shailendra Pramod,6,0,0,0,0,0,1,3.725
+Spring 2024,PHOP,6167,9,26311,Research Practicum A,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8399,8,26312,Doctoral Dissertation,Szabo,Andrea,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,8399,9,26313,Doctoral Dissertation,Juhn,Chinhui,2,0,0,0,0,3,0,4.0
+Spring 2024,CHEE,4398,2,26317,Independent Study,Karim,Alamgir,2,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7399,10,26319,Essay,Shepley,Nathan,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,1103,10,26321,Physical Geology Lab,Hauptvogel,Daniel William,14,1,2,0,0,0,0,3.609
+Spring 2024,COSC,8298,116,26322,Doctoral Research,Lin,Sen,0,0,0,0,0,1,0,
+Spring 2024,THEA,3376,1,26323,Advanced Drafting,Vlahos,Kalliope,3,0,0,0,0,0,0,3.78
+Spring 2024,PCOL,6298,1,26324,Special Problems,Cuny,Gregory D,0,0,0,0,0,2,0,
+Spring 2024,PHCA,6297,1,26325,Selected Topics,Thornton,James D,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,6398,4,26328,Rd&Research in Lang&Lit,Boswell,Robert L,0,0,0,0,0,1,0,
+Spring 2024,COSC,6397,3,26329,Topics Computer Science,Das,Rathish,6,1,0,0,0,0,0,3.763
+Spring 2024,CHEE,4398,3,26330,Independent Study,Robertson,Megan L,3,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,6467,4,26333,Research Practicuum A,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8395,9,26334,Dissertation in practice,Hale,Margaret Ann,0,0,0,0,0,6,0,
+Spring 2024,ELCS,8695,8,26335,Dissertation in Practice,Hale,Margaret Ann,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8995,2,26336,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,3,0,
+Spring 2024,SOCW,8995,3,26337,Pre-Dissertation Research,Narendorf,Sarah C,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8995,4,26338,Pre-Dissertation Research,Walton,Quenette,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8398,3,26339,Independent Study,Scott Jr,Edward Douglas,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,3381,2,26340,Political Psychology,Jenke,Elizabeth,4,13,8,0,1,0,2,2.743
+Spring 2024,PSYC,8699,5,26341,Doctoral Dissertation,Derrick,Jaye L,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6399,16,26342,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,
+Spring 2024,MECE,4398,5,26343,Independent Study,Grigoriadis,Karolos,2,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,6394,2,26345,Sel Tops in Contemporary Art,Chae,John,6,0,0,0,0,0,0,4.0
+Spring 2024,THEA,6181,1,26346,Applying Method Des/Dramaturgy,Ferrarone,Jessica,7,0,0,0,1,0,0,3.376
+Spring 2024,THEA,6184,1,26347,Applying Methods in Dir/Styles,Cook,Rena R,12,0,0,0,0,0,0,3.973
+Spring 2024,ENGL,8399,24,26351,Doctoral Dissertation,Lee,Eunjeong,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8699,16,26357,Doctoral Dissertation,Lee,Eunjeong,0,0,0,0,0,1,0,
+Spring 2024,BCHS,8998,1,26358,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8898,1,26359,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Spring 2024,MATH,8999,4,26375,Doctoral Dissertation,Morgan,Jeffrey,1,0,0,0,0,0,0,4.0
+Spring 2024,BUSI,2305,7,26376,Business Statistics,Wiley,Briceon C,22,54,58,60,24,0,46,1.894
+Spring 2024,CHEE,8298,24,26377,Doctoral Research,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,0,0,
+Spring 2024,ENGL,8398,10,26380,Graduate English Resrch,Majumder,Auritro,0,0,0,0,0,1,0,
+Spring 2024,PHAR,5297,2,26387,Selected Topics in Pharmacy,Hussain,Tahir,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8995,5,26390,Pre-Dissertation Research,Leung,Yuk-Hi Patrick,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6202,1,26392,Applied Composition,Smith,Robert Thomas,1,1,0,0,0,0,0,3.335
+Spring 2024,CHEM,4399,1,26393,Senior Honors Thesis,Harth,Eva M,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEM,4399,2,26394,Senior Honors Thesis,Czader,Arkadiusz,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,24,26395,Doctoral Research,Suppe,John,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8699,5,26396,Doctoral Dissertation,Suppe,John,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8398,1,26397,Independent Study,McKinney,Lonnie Lyle,0,0,0,0,0,0,0,
+Spring 2024,ELCS,8398,2,26398,Independent Study,Horn,Catherine Lynn,0,0,0,0,0,3,0,
+Spring 2024,BIOL,6698,1,26400,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Spring 2024,BTEC,6399,30,26401,Thesis,Lin,Yuheng,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8399,43,26408,Doctoral Dissertation,Bittner,Eric R,0,0,0,0,0,1,0,
+Spring 2024,BTEC,6396,30,26409,Masters Project in BTEC,Lin,Yuheng,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,25,26410,Doctoral Research,Capuano,Regina M,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,9,26414,Graduate Research,Belieu,Erin Colleen,0,0,0,0,0,0,0,
+Spring 2024,BIOL,8898,2,26415,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8398,11,26417,Graduate English Resrch,Berger,Jason,0,0,0,0,0,2,0,
+Spring 2024,BIOL,8898,3,26418,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,10,26419,Graduate Research,Flynn,Nicholas,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8398,12,26433,Graduate English Resrch,Yang,Sunny Chen,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8698,11,26435,Graduate Research,Turchi,Peter D,0,0,0,0,0,1,0,
+Spring 2024,BCHS,8898,2,26447,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2024,SOCW,8398,4,26448,Independent Study,Narendorf,Sarah C,1,0,0,0,0,0,0,3.67
+Spring 2024,ENGL,8398,13,26451,Graduate English Resrch,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,CUST,8378,3,26458,Current Issues in Educ,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,7A33,3,26460,Mergers & Acquisitions I,Yerramilli,Vijay,4,0,0,0,0,0,0,3.918
+Spring 2024,PCOL,6398,13,26462,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Spring 2024,FINA,7A97,6,26463,Selected Topics in Finance,Berta,Dominique,5,0,0,0,0,0,1,3.67
+Spring 2024,FINA,7A97,7,26464,Selected Topics in Finance,Berta,Dominique,3,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6898,2,26466,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6498,8,26467,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6898,3,26468,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2024,BCHS,6698,1,26469,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,3,0,
+Spring 2024,PHYS,7399,4,26471,Masters Thesis,Chu,Ching Wu,1,0,0,0,0,0,0,3.67
+Spring 2024,PCEU,6398,1,26480,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Spring 2024,POLC,4198,1,26481,Independent Study,Cross,Renee Danielle,2,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8699,17,26486,Doctoral Dissertation,Li,Xingpeng,0,0,0,0,0,2,0,
+Spring 2024,BCHS,3304,6,26493,General Biochemistry I,Yeo,Hye-Jeong,11,40,4,0,1,0,6,2.954
+Spring 2024,ARLD,6391,1,26495,Internship in Arts Organizatn,Cachia,Amanda,2,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8298,6,26497,Doctoral Dissertation Research,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8398,5,26498,Doctoral Dissertation Research,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4197,2,26499,Selected Topics in Music,Fernando,Fleurette S,5,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8399,17,26500,Doctoral Dissertation,Kakadiaris,Ioannis A,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8699,22,26501,Doctoral Dissertation,Kakadiaris,Ioannis A,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6498,9,26506,Special Problems,Pennings,Steven C,0,0,0,0,0,2,0,
+Spring 2024,COSC,4398,10,26511,Independent Study,Bering,Edgar A,0,0,0,0,0,0,1,
+Spring 2024,COSC,4398,11,26512,Independent Study,Bering,Edgar A,0,0,0,0,0,5,0,
+Spring 2024,ENGL,8398,14,26513,Graduate English Resrch,Boswell,Robert L,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8698,16,26514,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Spring 2024,MUSI,8301,2,26516,Seminar in Perform Pedagogy,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,6398,7,26517,Rd&Research in Lang&Lit,Turchi,Peter D,0,0,0,0,0,1,0,
+Spring 2024,SCLT,4398,30,26521,Independent Study,Henson,Alfred Bernard,1,0,0,0,0,0,0,4.0
+Spring 2024,HDFS,4198,1,26523,Independent Study,Dunsmore,Julie C,1,0,0,0,0,0,1,4.0
+Spring 2024,CIS,6358,40,26525,Secure Software Design,Nsoh,Jovita T,8,0,1,0,0,0,2,3.778
+Spring 2024,PSYC,6365,9,26526,Dir Rsch in Dev Cog Beh Neuro,Borjon,Jeremy Isaac,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4399,4,26527,Senior Honors Thesis,Walker,Rheeda L,1,0,0,0,0,0,0,3.67
+Spring 2024,GEOL,8699,6,26528,Doctoral Dissertation,Curiale,Joseph A,1,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,8995,6,26529,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8998,1,26530,Doctoral Research,Zhang,Shaun Xiaoliu,0,0,0,0,0,1,0,
+Spring 2024,BCHS,8998,2,26531,Doctoral Research,Wang,Yuhong,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8798,1,26532,Doctoral Research,Meisel,Richard P,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6498,10,26533,Special Problems,Stuckert,Adam,0,0,0,0,0,2,0,
+Spring 2024,BIOE,8298,30,26534,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,29,26535,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,30,26536,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8898,5,26537,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8298,25,26538,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,3,0,
+Spring 2024,ECE,8699,18,26543,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,0,0,0,0,0,3,0,
+Spring 2024,MUSA,3430,3,26545,Applied Flute,Martin,Tyler Craig,2,0,0,0,0,0,0,4.0
+Spring 2024,EDS,6398,1,26547,Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2024,CNST,4345,1,26548,Reinforced Concrete Structures,Chang,Chi Chung,27,48,1,0,0,0,0,3.268
+Spring 2024,HIST,4394,1,26550,Sel Top-United States History,Klieman,Kairn,3,0,0,0,0,0,0,4.0
+Spring 2024,HIST,4391,1,26551,Public History Internship,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,3399,1,26552,Senior Honors Thesis,Guenther,Irene V,0,0,0,0,0,0,0,
+Spring 2024,MUSA,6200,1,26554,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6210,3,26555,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8399,6,26556,Doctoral Dissertation,Arbona,Consuelo,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8699,6,26557,Doctoral Dissertation,Margulis,Milena A,1,0,0,0,0,1,0,4.0
+Spring 2024,ELCS,8695,9,26617,Dissertation in Practice,Shockley,Gerald,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8395,10,26619,Dissertation in practice,Shockley,Gerald,0,0,0,0,0,2,1,
+Spring 2024,GEOL,6399,7,26623,Masters Thesis,Sager,William W,1,0,0,0,0,0,0,4.0
+Spring 2024,PHIL,6398,1,26624,Special Problems,Oliveira,Luis RG,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6398,2,26627,Special Problems,Kenyan,Erin Oeser,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8698,16,26629,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,2,0,
+Spring 2024,BIOL,8998,2,26630,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,
+Spring 2024,MUSA,6142,2,26639,Graduate Recital III,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8391,1,26640,Special Field Projects,McKinney,Lonnie Lyle,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,8398,25,26641,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Spring 2024,POLS,4398,4,26645,Independent Study,Hawley,Michael C,0,1,0,0,0,0,0,3.0
+Spring 2024,ELCS,8398,3,26646,Independent Study,McKinney,Lonnie Lyle,2,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,3334,3,26647,Introduction to Typography,Kim,Yoonkyung,2,10,1,0,1,0,3,2.786
+Spring 2024,DIGM,4398,33,26649,Independent Study,Liao,Pamara F,4,0,0,0,0,0,0,4.0
+Spring 2024,CHIN,3398,1,26651,Independent Study,Leung,Yuk-Hi Patrick,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4189,10,26656,Senior Recital,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,8898,3,26665,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2024,MECE,8598,56,26666,Doctoral Research,Zhao,Bo,0,0,0,0,0,1,0,
+Spring 2024,GHL,6326,1,26667,Catering Management,Ginapp,Kathrine,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8398,53,26668,Doctoral Research,Zhao,Bo,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8312,12,26673,Lab of Practice-Res Meth Devel,Butcher,Keith,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8312,13,26674,Lab of Practice-Res Meth Devel,Davis,Bradley,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8312,14,26675,Lab of Practice-Res Meth Devel,Johnson,Detra DeVerne,0,0,0,0,0,3,0,
+Spring 2024,ELCS,8312,15,26676,Lab of Practice-Res Meth Devel,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8312,16,26677,Lab of Practice-Res Meth Devel,Snodgrass Rangel,Virginia Walker,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8312,18,26679,Lab of Practice-Res Meth Devel,Peters-Hawkins,April,0,0,0,0,0,0,0,
+Spring 2024,ELCS,8312,19,26680,Lab of Practice-Res Meth Devel,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Spring 2024,ARTS,3331,2,26681,Graphic Design Software,So,Tom Wen-Meng,5,4,3,0,1,0,3,2.872
+Spring 2024,EDS,7399,1,26693,Master?s Thesis,Lindner,Peggy,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8398,19,26695,Doctoral Research,Li,Aibing,0,0,0,0,0,1,0,
+Spring 2024,BCHS,3396,2,26696,Senior Research Project,Yi,Ping,0,0,0,0,0,0,0,
+Spring 2024,COSC,4398,2,26697,Independent Study,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6498,4,26699,Special Problems,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6598,4,26700,Special Problems,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Spring 2024,MARK,7338,1,26701,Intro to Marketing Analytics,Luo,Bowen,24,2,0,0,0,0,1,3.936
+Spring 2024,CHEE,8598,25,26704,Doctoral Research,Wen,Mingjian,0,0,0,0,0,2,0,
+Spring 2024,INDE,7397,1,26705,Selected Topics,Xiang,Yisha,4,1,0,0,0,0,0,3.734
+Spring 2024,BCHS,8998,3,26707,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2024,ENGL,6698,3,26708,Research,Shepley,Nathan,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8998,3,26712,Doctoral Research,Liu,Xinli,0,0,0,0,0,2,0,
+Spring 2024,SOCW,7398,1,26713,Independent Study in SW,Gracely,Jill Marie,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,29,26715,Research,Belcher,Kathleen,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,4396,3,26716,Senior Research Project,Chung,Sanghyuk,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,8999,6,26718,Doctoral Dissertation,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6798,1,26724,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Spring 2024,ARTS,7398,1,26727,Independent Graduate Study,Clarke,Chelsea,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,8998,4,26728,Doctoral Research,Feng,Qin,0,0,0,0,0,2,0,
+Spring 2024,ARTS,7398,2,26731,Independent Graduate Study,Giampietro,Francis A,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6898,4,26736,Special Problems,Khan,Abdul Latif,0,0,0,0,0,1,0,
+Spring 2024,BCHS,6898,1,26738,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Spring 2024,BCHS,8998,6,26739,Doctoral Research,Gustafsson,Jan-Ake,0,0,0,0,0,1,0,
+Spring 2024,CIVE,6398,1,26742,Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6297,1,26751,Selected Topics in Biology,Daane,Jacob,0,0,0,0,0,11,0,
+Spring 2024,CIVE,8298,9,26752,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Spring 2024,BCHS,6297,2,26753,Sel Tops Biochem & Biophys Sci,Daane,Jacob,0,0,0,0,0,3,0,
+Spring 2024,ENGL,8698,12,26756,Graduate Research,Berger,Jason,0,0,0,0,0,1,0,
+Spring 2024,HIST,3399,2,26757,Senior Honors Thesis,Hernandez,Jose A,0,0,0,0,0,0,0,
+Spring 2024,ENGL,7399,12,26758,Essay,Ellis,Amanda,1,0,0,0,0,0,0,4.0
+Spring 2024,HLT,1353,6,26759,Personal Health,Vercher,Michelle Taylor,82,21,8,6,1,0,0,3.433
+Spring 2024,ECE,6198,3,26760,Research,Joardar,Biresh Kumar,0,0,0,0,0,2,0,
+Spring 2024,ECE,6298,4,26761,Research,Joardar,Biresh Kumar,0,0,0,0,0,2,0,
+Spring 2024,COMM,3383,2,26762,Non-linear Editing,Crowe,Craig Warren,23,7,2,0,0,0,2,3.563
+Spring 2024,ARTS,4398,5,26765,Independent Study,Giampietro,Francis A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8240,21,26769,Doctoral Recital I,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,8698,7,26770,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6298,7,26772,Special Problems,Yi,Ping,0,0,0,0,0,1,0,
+Spring 2024,GEOL,4398,8,26774,Independent Study,Copeland,Peter,0,0,0,0,0,1,0,
+Spring 2024,GEOL,4398,9,26775,Independent Study,Murphy,Michael,0,0,0,0,0,2,0,
+Spring 2024,GEOL,4398,10,26776,Independent Study,Carlson,Brandee Nicole,0,0,0,0,0,2,0,
+Spring 2024,GEOL,4398,11,26777,Independent Study,Stewart,Robert R,0,0,0,0,0,1,0,
+Spring 2024,PHAR,5297,3,26778,Selected Topics in Pharmacy,Rosario,Natalie,2,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8399,3,26779,Doctoral Dissertation,Krakowiak,Konrad,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8598,7,26780,Doctoral Research,Li,Hongyi,0,0,0,0,0,3,0,
+Spring 2024,INDE,4370,1,26787,Discrete Event Simulation,Khator,Suresh K,0,1,1,0,0,0,0,2.17
+Spring 2024,PSYC,7392,7,26790,Psychology Practicum,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,7399,5,26791,Masters Thesis,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6698,5,26799,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8998,5,26800,Doctoral Research,Graur,Dan,0,0,0,0,0,1,0,
+Spring 2024,CIVE,4397,1,26801,Selected Topics,Rahimi,Mohammad,8,1,0,0,0,0,0,3.816
+Spring 2024,POLS,3310,2,26802,Intro to Political Theory,Koganzon,Rita,5,15,6,2,4,0,8,2.417
+Spring 2024,BIOL,6798,2,26805,Special Problems,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6698,6,26806,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2024,BCIS,1305,4,26807,Business Computer Applications,Felvegi,Emese,141,43,35,3,12,0,12,3.248
+Spring 2024,ENGL,6698,4,26808,Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6498,12,26810,Special Problems,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2024,WGSS,3398,1,26811,Independent Study,Gregory,Elizabeth,0,1,0,0,0,0,0,2.67
+Spring 2024,MUSA,2330,3,26822,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,1330,3,26823,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4430,2,26824,Applied Flute,Martin,Tyler Craig,2,0,0,0,0,0,0,4.0
+Spring 2024,HDCS,4375,2,26825,Strategies in Digital Retail,Kellough,James David,30,0,0,0,3,0,1,3.616
+Spring 2024,WGSS,3398,2,26826,Independent Study,Gonzalez,Maria C,1,0,0,0,0,0,0,4.0
+Spring 2024,COMD,7190,1,26827,Graduate Seminar in Speech-L,Cizek,Laura S,23,0,0,0,0,0,0,3.986
+Spring 2024,ENGL,4399,3,26828,Senior Honors Thesis,Singh,Kavita Ashana,0,0,0,0,0,0,0,
+Spring 2024,ENGL,4399,4,26829,Senior Honors Thesis,Gonzalez,Maria C,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,4399,5,26830,Senior Honors Thesis,Duran,Chatwara,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6298,8,26831,Special Problems,O'Brien,John,0,0,0,0,0,1,0,
+Spring 2024,MECE,7399,15,26832,Masters Thesis,Ardebili,Haleh,2,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,8898,4,26833,Doctoral Research,Willson,Richard,0,0,0,0,0,2,0,
+Spring 2024,ELCS,8198,1,26838,Independent Study,Horn,Catherine Lynn,3,0,0,0,0,0,0,4.0
+Spring 2024,TLIM,4398,30,26840,Independent Study,Burns,Maria,3,0,0,0,0,0,0,4.0
+Spring 2024,HIST,6396,1,26841,Topics in Latin-American Hist,Gharala,Norah Linda Andrews,1,0,0,0,0,0,0,4.0
+Spring 2024,BTEC,6399,31,26842,Thesis,Balan,Venkatesh,0,0,0,0,0,3,0,
+Spring 2024,CUIN,8397,1,26843,Selected Topics in C&I,Gronseth,Susie L B,1,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,5198,1,26845,Spec Prob Phys Optics,Lambreghts,Kimberly,0,0,0,0,0,1,0,
+Spring 2024,PETR,5350,1,26846,Natural Gas Engineering,Farouq-Ali,Syed,7,2,0,0,0,0,0,3.704
+Spring 2024,PETR,6350,1,26847,Natural Gas Engineering,Farouq-Ali,Syed,6,2,0,0,0,0,0,3.709
+Spring 2024,ECON,8399,10,26864,Doctoral Dissertation,Papell,David H,1,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,6301,1,26874,The Teaching Profession,Ronduen,Lionnel Ganir,1,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,7398,2,26875,Independent Study in SW,Amtsberg,Donna K,1,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,5198,5,26879,Spec Prob Phys Optics,Lambreghts,Kimberly,0,0,0,0,0,10,0,
+Spring 2024,CUIN,8699,11,26880,Doctoral Dissertation,Gist,Conra D,0,0,0,0,0,1,0,
+Spring 2024,CHEE,5397,2,26881,Selected Topics,Powell,Joseph Broun,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8699,19,26887,Doctoral Dissertation,Jackson,David R,0,0,0,0,0,2,0,
+Spring 2024,MATH,4398,1,26893,Independent Study,Ordonez,Carlos,2,0,1,1,0,0,1,2.75
+Spring 2024,CIVE,8598,8,26894,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8242,10,26895,Doctoral Recital III,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,3.67
+Spring 2024,SCM,7330,5,26896,Demand and Supply Integration,Hosseinabadi Farahani,Mehdi,7,9,0,0,0,0,0,3.376
+Spring 2024,SCM,4380,3,26897,Enterprise Resource Planning,Pendyala,Raja,24,14,1,1,0,0,3,3.5
+Spring 2024,BTEC,6399,32,26918,Thesis,Khan,Abdul Latif,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6106,6,26920,Grad Large Ensemble,Koppel,Alexander,2,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,8399,6,26926,Doctoral Dissertation,Khan,Shuhab D,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4363,1,26929,Abnormal Child Psych,Salentine,Cassidy,41,27,4,2,0,0,0,3.419
+Spring 2024,PSYC,3347,3,26932,Problems of Normal Life,Anderson,Jill Annette,32,37,6,1,0,0,0,3.351
+Spring 2024,QSS,4393,4,26933,QSS Research Project,Peru Durayalage,Dhanushka Arunasiri,0,0,0,0,0,0,0,
+Spring 2024,BIOL,2102,25,26934,Anatomy & Physiology II (lab),Gill,Tejendra,6,12,3,2,0,0,0,2.985
+Spring 2024,BIOL,2102,26,26935,Anatomy & Physiology II (lab),Gill,Tejendra,7,12,2,0,0,0,3,3.27
+Spring 2024,PSYC,4398,4,26938,Independent Study,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Spring 2024,ECE,8699,20,26944,Doctoral Dissertation,Mayerich,David Matthew,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,6395,1,26946,Comprehensive Examination,Ni,Lan,0,0,0,0,0,4,0,
+Spring 2024,IDNS,2136,3,26948,Data Structures SEP Workshop,Pattison,Donna,10,4,3,3,3,0,4,2.667
+Spring 2024,COMM,6395,2,26953,Comprehensive Examination,Olson,Beth M,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8399,18,26985,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Spring 2024,MATH,8999,6,26989,Doctoral Dissertation,Labate,Demetrio,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,4398,4,26990,Independent Study,Rimer,Jeffrey,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,7399,8,26991,Masters Thesis,Contreras-Vidal,Jose Luis,0,1,0,0,0,0,0,3.0
+Spring 2024,MUSA,8320,49,26995,Doctoral Applied Music,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8241,15,26996,Doctoral Recital II,Brooks,Wayne A,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,8241,16,26997,Doctoral Recital II,Wagner,Elise L,1,0,0,0,0,0,0,3.67
+Spring 2024,MUSI,8296,10,26998,Doctoral Essay,Jones,Timothy J,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6142,3,26999,Graduate Recital III,Brooks,Wayne A,0,0,0,0,0,0,0,
+Spring 2024,PHIL,6398,2,27003,Special Problems,Oliveira,Luis RG,0,0,0,0,0,0,0,
+Spring 2024,ECE,8498,32,27012,Doctoral Research,Shi,Jian,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8298,12,27014,Doctoral Research,Milillo,Pietro,0,0,0,0,0,4,0,
+Spring 2024,CIVE,8498,10,27015,Doctoral Research,Milillo,Pietro,0,0,0,0,0,4,0,
+Spring 2024,CIVE,8198,3,27016,Doctoral Research,Momen,Mostafa,0,0,0,0,0,4,0,
+Spring 2024,CIVE,8198,4,27017,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,2,0,
+Spring 2024,GEOL,6399,8,27020,Masters Thesis,Copeland,Peter,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7399,11,27021,Masters Thesis,Copeland,Peter,1,0,0,0,0,0,0,4.0
+Spring 2024,PHIL,3398,1,27025,Independent Study,Mag Uidhir,Christopher Domh,1,0,0,0,0,0,0,4.0
+Spring 2024,BTEC,6396,31,27026,Masters Project in BTEC,Khan,Abdul Latif,2,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8298,13,27027,Doctoral Research,Xie,Surui,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8498,11,27028,Doctoral Research,Xie,Surui,0,0,0,0,0,2,0,
+Spring 2024,SPAN,6398,12,27029,Special Problems,Gellon,Sofia,1,0,1,0,0,0,0,3.165
+Spring 2024,BCHS,8898,5,27030,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,2,0,
+Spring 2024,BIOL,6398,8,27031,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6898,6,27032,Special Problems,Mohan,Chandra,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6400,2,27039,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,4351,2,27040,Fundamentals of Software Engr,Hilford,Victoria,37,28,8,1,0,0,0,3.369
+Spring 2024,PSYC,4398,5,27041,Independent Study,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8399,7,27042,Doctoral Dissertation,Gonzalez,Jorge E,0,0,0,0,0,0,0,
+Spring 2024,PHCA,6198,2,27047,SP- Outcomes Research,Varkey,Divya A,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6399,17,27048,Masters Thesis,Walker,Rheeda L,0,0,0,0,0,1,0,
+Spring 2024,DANC,4397,2,27049,Selected Topics,Valle,Toni Leago,1,0,0,0,0,0,0,4.0
+Spring 2024,PHOP,8698,3,27050,Doctoral Research,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4189,11,27051,Senior Recital,Maroney,Marcus K,1,0,0,0,0,0,0,4.0
+Spring 2024,MECT,6394,30,27053,MET Special Topics with Lab,Hadi,Mahmoud,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,6398,1,27056,Special Problems,Fu,Qi,0,0,0,0,0,1,0,
+Spring 2024,OPTO,7493,1,27057,General Clinic IIIA,Herring,Ralph Jay,0,0,0,0,0,2,0,
+Spring 2024,BCHS,8999,7,27058,Doctoral Dissertation,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Spring 2024,PHIL,6398,3,27059,Special Problems,Buckner,Cameron J,2,0,0,0,0,0,0,4.0
+Spring 2024,DIGM,4398,34,27061,Independent Study,Lendasse,Amaury,1,0,0,0,0,0,0,4.0
+Spring 2024,HLT,1353,7,27064,Personal Health,Vercher,Michelle Taylor,72,27,11,6,1,0,1,3.351
+Spring 2024,MIS,4372,1,27067,Transaction Processing Sys II,Messinger,Jacob Nelson,11,1,1,0,0,0,0,3.617
+Spring 2024,MUSI,3399,1,27068,Senior Honors Thesis,Koozin,Timothy,0,0,0,0,0,0,0,
+Spring 2024,BCHS,8998,7,27070,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Spring 2024,PCEU,8298,2,27073,Doctoral Research,Liu,Xinli,2,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,8199,1,27074,Dissertation,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Spring 2024,MARK,4390,1,27077,Marketing for Non-Profit Orgs,Franco,Rodi L,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8399,2,27078,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,2,0,
+Spring 2024,COMM,6395,3,27079,Comprehensive Examination,Camaj,Lindita,0,0,0,0,0,1,0,
+Spring 2024,POLC,6398,1,27081,Special Problems,Wong,Man Chiu,1,0,0,0,0,0,0,4.0
+Spring 2024,CHEE,4398,5,27085,Independent Study,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8999,5,27086,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Spring 2024,PHAR,5297,4,27087,Selected Topics in Pharmacy,Nguyen,Kimberly A,0,0,0,0,0,1,0,
+Spring 2024,PHAR,5297,5,27092,Selected Topics in Pharmacy,Wollen,Joshua T,1,0,0,0,0,0,0,4.0
+Spring 2024,PHAR,5297,6,27093,Selected Topics in Pharmacy,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7399,13,27094,Essay,Turchi,Peter D,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,7398,8,27095,Special Problems,Voskuil,Lynn M,1,0,0,0,0,0,0,3.67
+Spring 2024,ENGR,1304,1,27098,Engineering Graphics,Ray,Kyle A,19,14,3,0,1,0,0,3.262
+Spring 2024,BIOL,6798,5,27102,Special Problems,Sater,Amy,0,0,0,0,0,1,0,
+Spring 2024,MATH,4398,2,27103,Independent Study,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Spring 2024,PCOL,8298,2,27108,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2024,PCOL,8199,1,27109,Dissertation,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8999,1,27110,Doctoral Dissertation,Harold,Michael P,0,0,0,0,0,1,0,
+Spring 2024,GEOL,6399,9,27113,Masters Thesis,Murphy,Michael,0,0,0,0,0,1,0,
+Spring 2024,BIOL,8998,6,27114,Doctoral Research,Daane,Jacob,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7398,2,27115,Masters Research,Murphy,Michael,0,0,0,0,0,1,0,
+Spring 2024,MECE,7399,16,27116,Masters Thesis,Cescon,Marzia,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8398,16,27119,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,3,0,
+Spring 2024,ENGL,8698,13,27123,Graduate Research,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Spring 2024,ENGL,8398,15,27125,Graduate English Resrch,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8243,12,27128,Doctoral Lecture Recital,Snyder,John L,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,2,27130,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,5298,1,27131,Spec Prob Phys Optics,Kim,Jung-Sun,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8298,14,27133,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8999,3,27135,Doctoral Dissertation,Louie,Stacey M,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8198,5,27137,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8598,9,27138,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8498,5,27140,Doctoral Research,Du,Yuncheng,0,0,0,0,0,1,0,
+Spring 2024,MECE,8399,47,27143,Doctoral Dissertation,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6397,4,27144,Selected Topics,Doudna,Simone P,3,0,0,0,0,0,0,3.78
+Spring 2024,ENTR,4398,1,27145,Independent Study,Gonzalez,Liana,1,0,0,0,0,0,0,4.0
+Spring 2024,MIS,8999,2,27146,Doctoral Dissertation in MIS,Silva,Leiser O,0,0,0,0,0,1,0,
+Spring 2024,GEOL,6399,10,27148,Masters Thesis,Flynn III,James Howard,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,6197,1,27150,Selected Topics,Carp,Charlotte Lynn,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,8699,9,27151,Doctoral Dissertation,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,6399,1,27152,Masters Thesis,Arboleda,Paola,1,0,0,0,0,0,0,4.0
+Spring 2024,SPAN,7399,1,27154,Masters Thesis,Arboleda,Paola,1,0,0,0,0,0,0,4.0
+Spring 2024,TLIM,3363,34,27157,Technical Communications,Piercy,Penelope Junker,13,17,7,0,2,0,2,2.958
+Spring 2024,MUSA,8241,17,27160,Doctoral Recital II,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8399,5,27164,Doctoral Dissertation,Labate,Demetrio,1,0,0,0,0,0,0,4.0
+Spring 2024,SPEC,8395,3,27165,Dissertation in Practice,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6400,3,27167,Applied Voice,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,6141,6,27169,Graduate Recital II,Hester,Timothy E,1,0,0,0,0,0,0,3.67
+Spring 2024,TLIM,3360,31,27173,Law & Ethics-Tech & Innovation,Feriante,Chris,84,8,0,0,0,0,1,3.856
+Spring 2024,MUSA,4189,12,27174,Senior Recital,Jones,Timothy J,1,0,0,0,0,0,0,3.67
+Spring 2024,PSYC,7397,4,27175,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Spring 2024,ENGL,7699,12,27177,Thesis,Ferguson,Jamie H,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8699,3,27179,Doctoral Dissertation,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Spring 2024,COMM,4398,1,27180,Independent Study,Uhrick,Jan,3,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,7322,1,27181,Curric Dev in Sci Ed,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6498,8,27182,Special Problems,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6598,8,27183,Special Problems,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8398,50,27185,Research in Music Theory,Guez,Jonathan Charles,2,1,0,0,0,0,0,3.777
+Spring 2024,HDFS,2314,14,27186,Human Dev and Interventions,Fraser,Camille,26,10,6,1,3,0,8,3.124
+Spring 2024,COMM,6395,4,27188,Comprehensive Examination,Liu,Wenlin,0,0,0,0,0,2,0,
+Spring 2024,COMM,6395,5,27189,Comprehensive Examination,Huang,Yan,0,0,0,0,0,2,0,
+Spring 2024,PSYC,4399,5,27190,Senior Honors Thesis,Medina,Luis Daniel,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,6398,6,27193,Special Problems,Ni,Lan,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,7310,3,27195,Teaching Practicum,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Spring 2024,GOVT,2305,51,27197,"US Govt: Congress,Pres & Crts",LeVeaux,Christine,5,2,1,0,1,0,0,3.038
+Spring 2024,PCOL,8298,3,27198,Doctoral Research,Ruan,Ke-He,0,0,0,0,0,1,0,
+Spring 2024,PCOL,8199,3,27200,Dissertation,Ruan,Ke-He,0,0,0,0,0,1,0,
+Spring 2024,PSYC,8399,27,27202,Doctoral Dissertation,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Spring 2024,PSYC,4398,6,27204,Independent Study,Fetterman,Adam Kent,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4399,6,27205,Senior Honors Thesis,Capuozzo,Kristen Irene,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8598,57,27206,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Spring 2024,MECE,8298,30,27207,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Spring 2024,MECE,8598,58,27209,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,2,0,
+Spring 2024,COMD,8399,1,27210,Dissertation,Joshi,Ashwini,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8698,17,27212,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,2,0,
+Spring 2024,COMM,4398,2,27213,Independent Study,Yamasaki,Jill S,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,2350,3,27215,Applied Percussion,Hubley,Robert L,3,1,0,0,0,0,0,3.585
+Spring 2024,BIOL,6498,13,27216,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8598,31,27219,Doctoral Research,Wang,Lu,0,0,0,0,0,1,0,
+Spring 2024,COMM,4398,3,27220,Independent Study,Liu,Wenlin,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,6898,2,27221,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Spring 2024,MUSA,3434,3,27226,Applied Clarinet,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,3368,1,27227,World Environ History to 1800,Klieman,Kairn,17,12,6,1,0,0,2,3.213
+Spring 2024,MUSA,8241,18,27228,Doctoral Recital II,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,8301,3,27229,Seminar in Perform Pedagogy,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4378,1,27230,Applied Jazz Guitar,Petito,Gregory Michael,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,6398,2,27231,Special Problems,McNally,David Joseph,1,0,0,0,0,0,0,4.0
+Spring 2024,EDS,6398,2,27232,Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Spring 2024,CIVE,6396,1,27236,Master's Research Project,Shaffer,Devin,1,0,0,0,0,0,0,4.0
+Spring 2024,SCLT,6397,40,27238,Selected Topics,Bian,Zheyong,2,1,0,0,0,0,0,3.777
+Spring 2024,MUSA,4189,13,27241,Senior Recital,Reed,Gavin Davis,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6298,9,27244,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Spring 2024,MUSA,2300,8,27246,Applied Voice,Ceres,Emily Margaret,1,1,0,0,0,0,0,3.335
+Spring 2024,HLT,4397,2,27247,Selected Topics in Health,Nguyen,An,0,0,1,0,0,0,0,2.0
+Spring 2024,CUIN,8397,2,27249,Selected Topics in C&I,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Spring 2024,MANA,6398,1,27250,Research,Abbott,Jeanna L,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8399,5,27251,Doctoral Dissertation,Glennie,Craig Len,0,0,0,0,0,2,0,
+Spring 2024,MATH,8699,4,27252,Doctoral Dissertation,Labate,Demetrio,0,0,0,0,0,1,0,
+Spring 2024,MIS,4378,5,27253,Admin of Computer-Based MIS,Kniffen,Richard Chad,8,9,0,0,4,0,0,2.81
+Spring 2024,MECE,7399,17,27257,Masters Thesis,Wang,Su Su,0,0,0,0,0,0,0,
+Spring 2024,CIVE,8398,18,27259,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,
+Spring 2024,PUBL,6415,3,27262,Decision Sci. for Publ Affairs,Wong,Man Chiu,0,1,0,0,0,0,0,3.33
+Spring 2024,MATH,8399,6,27264,Doctoral Dissertation,Mamonov,Alexander V,0,0,0,0,0,1,0,
+Spring 2024,GHL,8399,1,27267,Dissertation I in Hosp. Admin,Boger Jr,Carl A,0,0,0,0,0,1,0,
+Spring 2024,GHL,8999,1,27268,Dissertation III in Hosp Admin,Madera,Juan Manuel,0,0,0,0,0,2,0,
+Spring 2024,GHL,8999,2,27269,Dissertation III in Hosp Admin,Legendre,Jungyoung Shin,0,0,0,0,0,1,0,
+Spring 2024,GHL,8999,3,27270,Dissertation III in Hosp Admin,Kim,Jaewook,0,0,0,0,0,1,0,
+Spring 2024,QSS,4393,6,27271,QSS Research Project,Saboury,Piruz,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8398,54,27272,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Spring 2024,MIS,8398,1,27274,Special Problems in MIS,Cooper,Randolph B,1,0,0,0,0,0,0,4.0
+Spring 2024,KIN,3301,3,27275,Design/Eval Phys Activity Prog,Graham,Marilynn Hadassah,28,17,3,1,1,0,0,3.407
+Spring 2024,SOCW,8995,7,27276,Pre-Dissertation Research,Ali,Samira Bano,0,0,0,0,0,1,0,
+Spring 2024,ECE,8298,42,27277,Doctoral Research,Shi,Jian,0,0,0,0,0,2,0,
+Spring 2024,CIVE,8298,15,27278,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,3,0,
+Spring 2024,CIVE,8198,6,27279,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Spring 2024,BIOL,6798,6,27280,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8398,27,27285,Doctoral Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2024,PEP,7398,4,27286,Adv Special Problem Human Perf,Layne,Charles S,2,0,0,0,0,0,0,3.835
+Spring 2024,CIVE,8298,16,27287,Doctoral Research,Wang,Keh-Han,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8498,12,27288,Doctoral Research,Wang,Keh-Han,0,0,0,0,0,1,0,
+Spring 2024,CIVE,6398,2,27289,Research,Wang,Keh-Han,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8399,11,27290,Doctoral Dissertation,Kalliontzis,Dimitrios,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8498,13,27293,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Spring 2024,TLIM,3363,35,27296,Technical Communications,Tangeman,Anthony C,9,16,5,1,4,0,1,2.733
+Spring 2024,SOC,3382,2,27301,Sociology of Drug Use & Recove,Adams,Jennifer Lauren,29,4,3,2,1,0,1,3.487
+Spring 2024,PEP,7398,5,27303,Adv Special Problem Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8399,7,27304,Doctoral Dissertation,Olshanskiy,Maxim Alexandrovich,0,0,0,0,0,1,0,
+Spring 2024,MUSI,8301,4,27309,Seminar in Perform Pedagogy,Weber,Mary E,0,0,0,0,0,0,0,
+Spring 2024,MUSA,8320,50,27311,Doctoral Applied Music,Koppel,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,MIS,7397,10,27312,Selected Topics in MIS,Messinger,Jacob Nelson,11,4,0,0,0,0,0,3.711
+Spring 2024,POLC,6198,1,27313,Special Problems,Koelling,Peter,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4198,1,27314,Independent Study,Hernandez,Arturo E,0,0,0,0,0,0,0,
+Spring 2024,ENGL,6398,8,27317,Rd&Research in Lang&Lit,Tejada,Roberto Jose,0,0,0,0,0,1,0,
+Spring 2024,HLT,3380,3,27318,Culture and Health,Solari Williams,Kayce D,26,15,2,1,1,0,0,3.371
+Spring 2024,SOCI,1301,6,27319,Introduction To Sociology,Colbert,Sharla Stettnisch,27,5,2,0,4,0,2,3.342
+Spring 2024,PHCA,8298,8,27320,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Spring 2024,PHCA,8398,6,27321,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,6298,3,27322,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,6398,2,27323,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,8397,3,27326,Selected Topics in Finance,Pirrong,Stephen Craig,2,2,0,0,0,0,0,3.583
+Spring 2024,PSYC,2319,9,27328,Intro to Social Psychology,Anderson,Jill Annette,18,42,8,1,1,0,0,3.038
+Spring 2024,PHLS,8399,8,27329,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8398,19,27330,Doctoral Research,Xie,Surui,0,0,0,0,0,1,0,
+Spring 2024,PCEU,6698,2,27331,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Spring 2024,PHYS,6301,1,27332,Fundamental Electrodynamics,Cherdack,Daniel David,0,1,0,0,0,0,0,2.67
+Spring 2024,PHYS,6305,1,27333,Fundamental Quantum Mechanics,Gunaratne,Gemunu,0,1,0,0,0,0,0,3.0
+Spring 2024,CIVE,8598,10,27334,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6398,24,27336,Independent Studies,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8399,17,27337,Doctoral Dissertation,Knee,Clifford R,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8698,18,27338,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,2,0,
+Spring 2024,GEOL,6398,2,27339,Special Problems,Flynn III,James Howard,0,0,0,0,0,1,0,
+Spring 2024,MIS,8999,3,27340,Doctoral Dissertation in MIS,Chin,Wynne W,0,0,0,0,0,1,0,
+Spring 2024,EDS,6398,3,27341,Research,Lendasse,Amaury,0,0,0,0,0,1,0,
+Spring 2024,EDS,6398,4,27342,Research,Lendasse,Amaury,0,0,0,0,0,1,0,
+Spring 2024,PCEU,8398,2,27344,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4399,7,27346,Senior Honors Thesis,Derrick,Jaye L,0,0,0,0,0,0,0,
+Spring 2024,MIS,8999,4,27347,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Spring 2024,FINA,8396,1,27348,Research Practicum,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,6399,2,27350,Master's Thesis,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Spring 2024,CIVE,7399,4,27351,Master's Thesis,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8399,9,27352,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7341,5,27353,Geophysical Data Processing,Zhou,Hua-Wei,8,5,0,0,0,0,0,3.641
+Spring 2024,MUSI,4198,30,27355,Independent Study,Bell,Priscilla Garrett,2,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8396,4,27356,Doctoral Research,Carmack,Chakema,0,0,0,0,0,2,0,
+Spring 2024,SCM,8999,1,27357,Dissertation,Li,Meng,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,8396,2,27358,Research Practicum,George,Thomas J,0,0,0,0,0,1,0,
+Spring 2024,ECE,8699,21,27359,Doctoral Dissertation,Chen,Yuhua,0,0,0,0,0,1,0,
+Spring 2024,MUSA,6140,3,27361,Graduate Recital I,Hester,Timothy E,0,0,0,0,0,0,0,
+Spring 2024,ARTS,7398,3,27362,Independent Graduate Study,Suber,Anthony,2,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,7398,4,27364,Independent Graduate Study,Ho,Jamie C,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8999,7,27365,Doctoral Dissertation,Olshanskiy,Maxim Alexandrovich,1,0,0,0,0,0,0,4.0
+Spring 2024,SOCW,8695,3,27366,Pre-Dissertation Research,Narendorf,Sarah C,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8298,18,27367,Doctoral Research,Louie,Stacey M,0,0,0,0,0,0,0,
+Spring 2024,MUSA,8243,13,27368,Doctoral Lecture Recital,Morgulis,Tali,0,0,0,0,0,0,0,
+Spring 2024,DANC,4398,2,27377,Independent Study,Chapman,Teresa Lynn,1,0,0,0,0,0,0,4.0
+Spring 2024,ENRG,4398,1,27379,Indep Stdy-Enrgy & Sustainblty,Jacobsen,Nicolas Fisher,1,0,0,0,0,0,0,4.0
+Spring 2024,PHIL,6398,4,27381,Special Problems,Mag Uidhir,Christopher Domh,1,0,0,0,0,0,0,4.0
+Spring 2024,PCEU,8498,1,27382,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7398,3,27383,Masters Research,Sun,Jiajia,0,0,0,0,0,2,0,
+Spring 2024,SOCW,8995,8,27384,Pre-Dissertation Research,Jennings,Sheara Williams,0,0,0,0,0,0,0,
+Spring 2024,HON,4396,2,27386,Senior Research Project,Deng,Liangzi,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,6,27391,Adv Special Problem Human Perf,Parikh,Pranav J,2,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6106,7,27392,Grad Large Ensemble,Koppel,Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,4397,5,27393,Selected Topics in Biology,Azevedo,Ricardo,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,3396,1,27394,Senior Research Project,Ott,William R,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7399,12,27395,Masters Thesis,Sager,William W,1,0,0,0,0,0,0,4.0
+Spring 2024,HIST,8677,7,27396,Reading for Comps Exams,Goldberg,Mark A,0,0,0,0,0,1,0,
+Spring 2024,ECE,8598,31,27397,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Spring 2024,PEP,7398,7,27399,Adv Special Problem Human Perf,Johnston,Craig Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,6399,12,27400,Masters Thesis,Alba,Kamran,0,0,0,0,0,1,0,
+Spring 2024,MECE,6399,13,27401,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8399,48,27402,Doctoral Dissertation,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,CIVE,8198,7,27404,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Spring 2024,MECE,7399,18,27405,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Spring 2024,MATH,8699,5,27407,Doctoral Dissertation,Nicol,Matthew J,1,0,0,0,0,0,0,4.0
+Spring 2024,FINA,8999,6,27413,Doctoral Dissertation,Kumar,Praveen,0,0,0,0,0,1,0,
+Spring 2024,HON,4396,3,27416,Senior Research Project,Xu,Shoujun,1,0,0,0,0,0,0,3.67
+Spring 2024,GEOL,6399,11,27417,Masters Thesis,Sun,Jiajia,0,0,0,0,0,1,0,
+Spring 2024,ARTS,7398,5,27419,Independent Graduate Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8198,9,27423,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Spring 2024,MARK,8397,1,27435,Selected Topics in Marketing,Ahearne,Michael,5,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,8,27436,Adv Special Problem Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Spring 2024,ECE,8498,33,27437,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,0,0,
+Spring 2024,ECE,8598,32,27438,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,0,0,
+Spring 2024,FINA,8396,3,27443,Research Practicum,Susmel,Raul,0,0,0,0,0,1,0,
+Spring 2024,MECE,7399,19,27444,Masters Thesis,Franchek,Matthew,0,0,0,0,0,1,0,
+Spring 2024,MUSA,8242,11,27445,Doctoral Recital III,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Spring 2024,COSC,4399,2,27447,Senior Honors Thesis,Shah,Shishir,0,0,0,0,0,0,0,
+Spring 2024,ACCT,8398,5,27448,Special Problems,Li,Bin,2,0,0,0,0,0,0,4.0
+Spring 2024,MECE,6399,15,27450,Masters Thesis,Huang,Yi-Chun,0,0,0,0,0,1,0,
+Spring 2024,COMM,4398,4,27455,Independent Study,Houk,Keith R,2,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8398,10,27456,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Spring 2024,MECE,8598,26,27457,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Spring 2024,CHEE,8699,2,27458,Doctoral Dissertation,Balakotaiah,Vemuri,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,4399,2,27460,Senior Honors Thesis,Sen,Mehmet,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,6698,8,27461,Special Problems,Fujita,Masaya,0,0,0,0,0,1,0,
+Spring 2024,CIVE,8398,20,27463,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Spring 2024,MECE,4398,6,27467,Independent Study,Love,Holley Carole,1,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8298,20,27468,Doctoral Research,Alba,Kamran,0,0,0,0,0,1,0,
+Spring 2024,MECE,8398,25,27469,Doctoral Research,Alba,Kamran,0,0,0,0,0,1,0,
+Spring 2024,CHEE,6397,3,27470,Selected Topics,Powell,Joseph Broun,8,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,4398,7,27474,Independent Study,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Spring 2024,GEOL,7399,13,27476,Masters Thesis,Zhou,Hua-Wei,1,0,0,0,0,0,0,4.0
+Spring 2024,OPTO,5198,6,27477,Spec Prob Phys Optics,Berntsen,David A,0,0,0,0,0,4,0,
+Spring 2024,GENB,7397,3,27478,Selected Topics,Webb,James R,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,8998,7,27479,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Spring 2024,FINA,8396,4,27481,Research Practicum,Yerramilli,Vijay,1,0,0,0,0,0,0,3.67
+Spring 2024,OPTO,5298,2,27483,Spec Prob Phys Optics,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8298,31,27484,Doctoral Research,Balan,Venkatesh,0,0,0,0,0,0,0,
+Spring 2024,OPTO,5198,7,27490,Spec Prob Phys Optics,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Spring 2024,HON,4396,4,27491,Senior Research Project,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,4398,1,27492,BME Independent Study,Du,Yuncheng,1,0,0,0,0,0,0,4.0
+Spring 2024,HLT,3325,4,27497,Medical Terminology,Burk,Kelly Ann,84,5,14,0,3,0,1,3.557
+Spring 2024,MECE,8398,60,27500,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,1,0,
+Spring 2024,MUSI,4198,20,27501,Research in Chamber Music,Yon,Kirsten A,3,0,0,0,0,0,1,4.0
+Spring 2024,PHLS,8396,5,27505,Doctoral Research,Gonzalez,Jorge E,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8191,2,27508,Special Field Projects,McKinney,Lonnie Lyle,0,0,0,0,0,0,0,
+Spring 2024,MUSA,8420,4,27512,Doctoral Applied Music,Morgulis,Tali,0,0,0,0,0,0,0,
+Spring 2024,SOC,6398,1,27514,Special Problems,Katz,Sheila,1,0,0,0,0,0,0,4.0
+Spring 2024,TLIM,3363,36,27516,Technical Communications,Tangeman,Anthony C,3,4,8,0,1,0,2,2.5
+Spring 2024,TLIM,3363,37,27517,Technical Communications,Piercy,Penelope Junker,7,8,1,1,0,0,1,3.196
+Spring 2024,PSYC,4398,8,27518,Independent Study,Reyes,Denise Lucia,0,0,0,0,0,1,0,
+Spring 2024,PHYS,4198,1,27524,Independent Study,Bering,Edgar A,0,0,0,0,0,1,0,
+Spring 2024,MECE,8999,4,27529,Doctoral Dissertation,Joshi,Shailendra Pramod,1,0,0,0,0,0,0,4.0
+Spring 2024,THEA,4398,1,27534,Independent Study,Coen,Elizabeth Manya,2,0,1,0,0,0,0,3.113
+Spring 2024,THEA,4398,2,27537,Independent Study,Niederer,Barbara,1,0,0,0,0,0,0,3.67
+Spring 2024,HIST,4398,1,27538,Independent Study,Al-Sowayel,Dina,0,1,0,0,0,0,0,3.0
+Spring 2024,COMM,3399,1,27539,Senior Honors Thesis,Lee,Jaesub,0,0,0,0,0,0,0,
+Spring 2024,PSYC,4198,2,27540,Independent Study,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,6298,2,27541,Special Problems,Boger Jr,Carl A,1,0,0,0,0,0,0,4.0
+Spring 2024,ARTS,4390,1,27543,Blaffer Museum Internship,Veneman,Katherine A,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,9,27544,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8699,9,27547,Doctoral Dissertation,Louis,Dave A,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6698,9,27548,Special Problems,Dryer,Stuart E,0,0,0,0,0,1,0,
+Spring 2024,BIOE,8398,30,27549,Doctoral Research,Nurminen,Lauri Oskari,0,0,0,0,0,1,0,
+Spring 2024,GEOL,6393,3,27550,Seismic Amplitude Interpretatn,Hilterman,Fred,0,1,0,0,0,0,0,3.33
+Spring 2024,BIOE,7399,7,27554,Masters Thesis,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Spring 2024,SCM,4398,1,27555,Independent Study,Anderson Fletcher,Elizabeth,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,10,27558,Adv Special Problem Human Perf,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Spring 2024,THEA,4398,3,27559,Independent Study,Webb,Matthew Clark,1,0,0,0,0,0,0,4.0
+Spring 2024,PHLS,8396,6,27560,Doctoral Research,Fan,Weihua,0,0,0,0,0,1,0,
+Spring 2024,MUSI,4298,2,27563,Special Problems in Pedagogy,Warren,Paul Alexander,1,0,0,0,0,0,0,4.0
+Spring 2024,PETR,6298,1,27564,Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Spring 2024,PETR,6498,1,27565,Research,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Spring 2024,ACCT,8699,3,27568,Doctoral Dissertation,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6358,2,27570,Directed Rsch in Neuropsyc,Woods,Steven Paul,0,0,0,0,0,1,0,
+Spring 2024,PEP,7398,11,27571,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6298,1,27574,Research,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,8399,20,27575,Doctoral Dissertation,May,Elebeoba E,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,6394,4,27578,Tpcs-Eco of Socl Issue,Verchenko,Olesia,3,7,0,0,0,0,0,3.333
+Spring 2024,ECON,6394,7,27581,Tpcs-Eco of Socl Issue,Besedina,Elena,1,4,0,0,0,0,0,3.398
+Spring 2024,SCM,8999,2,27583,Dissertation,Robinson Jr,Powell Ersell,0,0,0,0,0,0,0,
+Spring 2024,BIOL,4396,4,27585,Senior Research Project,Daane,Jacob,1,0,0,0,0,0,0,4.0
+Spring 2024,ECON,6394,8,27586,Tpcs-Eco of Socl Issue,Nivievskyi,Oleg,3,10,1,0,0,0,0,3.237
+Spring 2024,MUSI,6198,30,27591,Research,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,7398,12,27593,Adv Special Problem Human Perf,Ledoux,Tracey A,0,1,0,0,0,0,0,3.0
+Spring 2024,PEP,8350,2,27594,HHP Candidacy Project Research,Ledoux,Tracey A,0,0,0,0,0,0,0,
+Spring 2024,PEP,6198,1,27595,Special Problems in Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Spring 2024,PEP,6198,2,27596,Special Problems in Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Spring 2024,INDS,3398,1,27597,Independent Study,Kimbrough,Mark S,7,1,1,0,0,0,0,3.52
+Spring 2024,CUIN,8298,1,27598,Independent Study,McNeil,Sara G,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,4398,1,27599,Independent Study,Frankino,William A,3,0,0,0,0,0,0,4.0
+Spring 2024,MECE,8298,7,27600,Doctoral Research,Chen,Yi-Chao,0,0,0,0,0,1,0,
+Spring 2024,GEOL,6398,3,27601,Special Problems,Wellner,Julia S,3,0,0,0,0,0,0,3.89
+Spring 2024,PHLS,6397,2,27602,Selected Topics,Hurt,Kara Marie,1,0,0,0,0,0,0,4.0
+Spring 2024,EDS,6398,5,27604,Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Spring 2024,BIOL,6998,1,27608,Special Problems,Cirino,Patrick C,0,0,0,0,0,1,0,
+Spring 2024,ELCS,8399,6,27609,Doctoral Dissertation,Carales,Vincent D,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7698,1,27611,Masters Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Spring 2024,PEP,8999,5,27613,Doctoral Dissertation,Ledoux,Tracey A,0,0,0,0,0,1,0,
+Spring 2024,SUBS,6397,1,27614,Selected Topics,Hallai,Julian,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,6398,4,27615,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Spring 2024,GHL,4198,1,27616,Independent Study,Johnson,Tucker A,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,8898,7,27619,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Spring 2024,MUSI,6106,8,27620,Grad Large Ensemble,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Spring 2024,PHYS,8398,45,27621,Doctoral Research,Bittner,Eric R,0,0,0,0,0,1,0,
+Spring 2024,MUSI,4198,21,27622,Research in Chamber Music,Lo,Mann-Wen,3,1,0,0,0,0,0,3.75
+Spring 2024,MUSI,4198,22,27623,Research in Chamber Music,Suits,Brian J,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,23,27624,Research in Chamber Music,Cho,Eunghee,7,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,24,27625,Research in Chamber Music,Larson,Eric Amery,1,0,0,0,0,0,0,4.0
+Spring 2024,BCHS,6698,4,27626,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Spring 2024,COSC,4398,3,27627,Independent Study,Ordonez,Carlos,0,0,0,0,0,1,0,
+Spring 2024,ARTS,4398,6,27628,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6398,25,27630,Independent Studies,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7324,3,27648,Rock Physics,Castagna,John P,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSA,4189,14,27649,Senior Recital,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,6198,11,27650,Research in Chamber Music,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,25,27651,Research in Chamber Music,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Spring 2024,GHL,4132,2,27660,Bev Mgmt & Mktg Internship,Taylor,David C,0,0,0,0,1,0,0,0.0
+Spring 2024,ANTH,6399,8,27661,Masters Thesis,Chase,Arlen F,0,0,0,0,0,1,0,
+Spring 2024,ANTH,7399,8,27662,Masters Thesis,Chase,Arlen F,0,0,0,0,0,1,0,
+Spring 2024,COMD,8398,1,27663,Special Problems,Castilla-Earls,Anny,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,4398,5,27666,Independent Study,Uhrick,Jan,2,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,8299,1,27667,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7399,14,27672,Masters Thesis,Carlson,Brandee Nicole,1,0,0,0,0,0,0,4.0
+Spring 2024,POLS,4398,5,27673,Independent Study,Abbott Jr,Kenneth Wayne,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOL,4302,1,27675,Galapago! Rsch Lrng Abroad,Hanke,Marc H,1,0,0,0,0,0,0,4.0
+Spring 2024,MUSI,4198,2,27676,Independent Study,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Spring 2024,ENGL,4390,2,27678,Professional Internship,Zentz,Lauren R,0,0,0,0,0,1,0,
+Spring 2024,GHL,6298,3,27679,Special Problems,Back,KiJoon,0,0,0,0,1,0,0,0.0
+Spring 2024,PSYC,4398,9,27680,Independent Study,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Spring 2024,KIN,4390,2,27681,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Spring 2024,KIN,1304,6,27684,Public Hlt Issues in Phys/Obes,Park,Yoonjung,29,2,2,0,2,0,0,3.609
+Spring 2024,MUSI,4198,26,27686,Research in Chamber Music,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Spring 2024,CUIN,8397,10,27687,Selected Topics in C&I,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8198,3,27695,Independent Study,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Spring 2024,PSYC,4398,10,27696,Independent Study,Ng,Vincent,0,0,0,0,0,0,1,
+Spring 2024,PHCA,6297,2,27707,Selected Topics,Varkey,Divya A,1,0,0,0,0,0,0,4.0
+Spring 2024,HON,4398,50,27709,Independent Study,Williamson,Jonathan Lyle,0,0,0,0,0,0,0,
+Spring 2024,GEOL,6399,12,27710,Masters Thesis,Khan,Shuhab D,0,0,0,0,0,1,0,
+Spring 2024,PHLS,8397,1,27712,Selected Topics,Carmack,Chakema,1,0,0,0,0,0,0,4.0
+Spring 2024,ELCS,8195,1,27722,Dissertation in Practice,Johnson,Detra DeVerne,0,0,0,0,0,1,0,
+Spring 2024,GEOL,7398,4,27724,Masters Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Spring 2024,PSYC,6198,1,27725,Special Problems,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Spring 2024,PSYC,6298,2,27726,Special Problems,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,7399,9,27729,Masters Thesis,Larin,Kirill,1,0,0,0,0,0,0,4.0
+Spring 2024,LAW,5128,3,27732,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Spring 2024,LAW,5129,3,27733,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Spring 2024,LAW,5130,3,27734,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,1,0,
+Spring 2024,ENGI,4198,9,27744,Independent Study,Claydon,Frank J,0,0,0,0,0,1,0,
+Spring 2024,LAW,5198,3,27745,Special Rsch & Writing,Vetter,Greg R,1,0,0,0,0,0,0,4.0
+Spring 2024,COMM,4398,6,27746,Independent Study,Crowe,Craig Warren,1,0,0,0,0,0,0,4.0
+Spring 2024,HON,4396,60,27747,Senior Research Project,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Spring 2024,HDCS,4398,1,27748,Independent Study,Owens-Shepard,Toya,1,0,0,0,0,0,0,4.0
+Spring 2024,SCLT,4398,3,27750,Independent Study,Owens-Shepard,Toya,1,0,0,0,0,0,0,4.0
+Spring 2024,BIOE,6398,8,27766,Research,Larin,Kirill,0,0,0,0,0,1,0,
+Spring 2024,PCOL,8998,1,27767,Doctoral Research,Garey,Kevin W,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6198,1,27768,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2024,PCOL,6498,9,27769,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Spring 2024,GEOL,8399,8,27792,Doctoral Dissertation,Castagna,John P,1,0,0,0,0,0,0,4.0
+Spring 2024,BTEC,6396,32,27794,Masters Project in BTEC,Balan,Venkatesh,0,1,0,0,0,0,0,2.67

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2024-02 (Summer 2024).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2024-02 (Summer 2024).csv
@@ -1,0 +1,2069 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Summer 2024,MIS,6341,1,10003,Information Systems,Silva,Leiser O,14,0,0,0,0,0,0,4.0
+Summer 2024,BZAN,7320,1,10004,Bus Modeling For Comp Adv,Wiley,Briceon C,6,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5493,1,10005,Introduction to Community IPPE,Hatfield,Catherine L,75,26,1,1,0,0,0,3.699
+Summer 2024,PHAR,4280,1,10006,Med/Pt Safety & Informatics,Varkey,Divya A,99,6,0,0,0,0,0,3.943
+Summer 2024,BIOE,8398,2,10007,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Summer 2024,MARK,3336,1,10020,Introduction to Marketing,Zahn,William J,49,86,35,2,2,0,3,2.991
+Summer 2024,MARK,6398,1,10021,Research,Herman,Carl,1,0,0,0,0,0,0,4.0
+Summer 2024,LAW,5210,1,10035,Law Review,Sanders,Joseph,0,0,0,0,0,0,0,
+Summer 2024,LAW,5410,1,10039,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Summer 2024,LAW,6354,1,10043,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,1,0,
+Summer 2024,ECON,3332,1,10048,Intermediate Microeconomics,Troncoso,Pablo A,14,7,4,0,0,0,0,3.426
+Summer 2024,ECON,8399,1,10049,Doctoral Dissertation,Yi,Kei-Mu,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8699,3,10051,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,1,0,
+Summer 2024,SPAN,2311,1,10062,Intermediate Spanish I,Jouannet De La Jara,Sebastian Nicolas,7,10,3,1,1,0,0,2.91
+Summer 2024,SPAN,2311,3,10063,Intermediate Spanish I,del Castillo Garza,Alejandro,6,10,4,0,0,0,2,3.034
+Summer 2024,SPAN,2312,1,10064,Intermediate Spanish II,Scalzo,Dillon S,4,16,6,0,0,0,0,2.91
+Summer 2024,SPAN,2307,1,10065,Span for Heritage Learners I,Lopez Otero,Julio Cesar,11,2,2,1,2,0,0,3.074
+Summer 2024,SPAN,6398,4,10067,Special Problems,Gutierrez,Manuel J,0,0,0,0,0,0,0,
+Summer 2024,SPAN,7398,1,10069,Reading & Research,Gutierrez,Manuel J,0,0,0,0,0,1,0,
+Summer 2024,SPAN,8699,1,10071,Dissertation,Rivera Garza,Cristina,0,0,0,0,0,1,0,
+Summer 2024,SPAN,8699,2,10072,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,1,0,
+Summer 2024,ECON,2302,1,10074,Principles of Microeconomics,Hossain,Md Shahadath,51,87,9,0,0,0,0,3.263
+Summer 2024,BIOL,1106,1,10080,Biol for Science Majors I(Lab),Ibrahim,Abdalla Zanouny,12,5,1,0,0,0,0,3.629
+Summer 2024,BIOL,1106,2,10081,Biol for Science Majors I(Lab),Ibrahim,Abdalla Zanouny,9,2,0,0,0,0,1,3.848
+Summer 2024,BIOL,1106,3,10082,Biol for Science Majors I(Lab),Ibrahim,Abdalla Zanouny,12,1,2,0,0,0,0,3.579
+Summer 2024,BIOL,1306,1,10084,Biology for Science Majors I,Cheek,Ann Oliver,23,25,20,0,2,0,2,2.99
+Summer 2024,CHEM,1111,2,10087,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,10,0,0,0,0,0,3.18
+Summer 2024,CHEM,2123,1,10088,Organic Chemistry Lab I,Zaitsev,Vladimir G,4,9,8,0,0,0,0,2.841
+Summer 2024,CHEM,2123,3,10089,Organic Chemistry Lab I,Zaitsev,Vladimir G,6,7,4,2,0,0,1,2.877
+Summer 2024,MATH,1324,2,10090,Finite Math with Applications,Sosa,Moses,16,20,12,10,10,0,6,2.275
+Summer 2024,MATH,2413,3,10091,Calculus I,Sosa,Moses,12,20,14,8,10,0,6,2.168
+Summer 2024,MATH,4377,1,10094,Advanced Linear Algebra I,Labate,Demetrio,2,3,3,0,0,0,1,2.834
+Summer 2024,PHYS,1301,1,10142,College Physics I (lecture),Cardoso Barato,Andre,44,20,22,9,2,0,11,2.945
+Summer 2024,PHYS,8399,14,10184,Doctoral Dissertation,Das,Mini,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8399,24,10194,Doctoral Dissertation,Ordonez,Carlos,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8399,34,10201,Doctoral Dissertation,Timmins,Anthony Robert,1,0,0,0,0,0,0,4.0
+Summer 2024,PHYS,1101,1,10205,College Physics I (lab),Wood,Lowell T,0,9,7,0,0,0,0,2.624
+Summer 2024,PHYS,1101,2,10206,College Physics I (lab),Wood,Lowell T,3,9,5,0,0,0,0,2.863
+Summer 2024,SCM,3301,1,10212,SCM Fundamentals,Khumawala,Basheer M,97,60,8,1,2,0,4,3.464
+Summer 2024,HLT,3301,1,10213,Health Behavior Theories,Bennett,Kristin C,52,10,2,0,1,0,0,3.688
+Summer 2024,SPAN,1501,5,10261,Elementary Spanish I,Carrera Quiroga,Emilio Vicente,5,4,4,0,2,0,0,2.513
+Summer 2024,SPAN,1502,1,10263,Elementary Spanish II,Nieves Cabrera,Wendy,8,6,7,1,0,0,1,2.955
+Summer 2024,SPAN,1502,3,10265,Elementary Spanish II,Falahasl,Hamideh,10,4,3,0,2,0,2,3.035
+Summer 2024,ACCT,2301,3,10268,Prin of Financial Accounting,Sykes,Mary Reeves,16,11,4,1,0,0,2,3.426
+Summer 2024,ACCT,2302,2,10269,Prin of Managerial Accounting,Weber,Catherine K,8,8,6,3,1,0,1,2.794
+Summer 2024,ACCT,4396,1,10270,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,4,0,
+Summer 2024,ENTR,3312,1,10274,Corporate Entrepreneurship,Karonika,John R,32,2,0,0,0,0,7,3.902
+Summer 2024,ENTR,3312,2,10275,Corporate Entrepreneurship,Karonika,John R,29,6,0,0,0,0,6,3.81
+Summer 2024,ECON,4390,2,10299,Economics Internship,Saboury,Piruz,13,0,0,0,0,0,0,4.0
+Summer 2024,SPAN,2312,6,10302,Intermediate Spanish II,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,3,7,6,1,1,0,0,2.519
+Summer 2024,SPAN,2312,12,10303,Intermediate Spanish II,Jager Lopezllera,Valentina Kathe,5,11,5,2,1,0,0,2.722
+Summer 2024,SPAN,2308,1,10304,Span for Heritage Learners II,Hernandez,Yanina,9,9,0,1,0,0,1,3.299
+Summer 2024,SPAN,6398,9,10305,Special Problems,De Los Reyes Heredia,Jose Guillermo,2,0,0,0,0,0,0,4.0
+Summer 2024,SPAN,8699,4,10310,Dissertation,Kanellos,Nicolas,1,0,0,0,0,0,0,4.0
+Summer 2024,SPAN,8699,6,10312,Dissertation,Gutierrez,Manuel J,1,0,0,0,0,0,0,4.0
+Summer 2024,ENGL,3328,1,10313,Masterpieces of British Lit II,Wood,Barry Albert,18,10,3,0,0,0,1,3.399
+Summer 2024,BIOL,1107,1,10317,Biology for Science Majors II,Hanke,Marc H,16,2,1,0,0,0,0,3.685
+Summer 2024,BIOL,1107,2,10318,Biology for Science Majors II,Hanke,Marc H,15,2,0,0,0,0,0,3.844
+Summer 2024,BIOL,1307,1,10320,Biology for Science Majors II,Farmer,Lisa M,13,19,11,4,2,0,1,2.782
+Summer 2024,CHEM,6399,7,10342,Masters Thesis,Chiang,Naihao,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,6698,1,10360,Special Problems,Do,Loi H,0,0,0,0,0,4,0,
+Summer 2024,CHEM,6698,2,10361,Special Problems,Brgoch,Jakoah,0,0,0,0,0,3,0,
+Summer 2024,CHEM,6698,4,10362,Special Problems,Teets,Thomas,0,0,0,0,0,5,0,
+Summer 2024,CHEM,6698,5,10363,Special Problems,May,Jeremy A,0,0,0,0,0,4,0,
+Summer 2024,CHEM,6698,6,10364,Special Problems,Xu,Shoujun,0,0,0,0,0,1,0,
+Summer 2024,CHEM,6698,7,10365,Special Problems,Lee,T Randall,0,0,0,0,0,2,0,
+Summer 2024,CHEM,6698,10,10368,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,3,0,
+Summer 2024,CHEM,6698,11,10369,Special Problems,Baldelli,Steve,0,0,0,0,0,3,0,
+Summer 2024,CHEM,6698,13,10370,Special Problems,Zastrow,Melissa L,0,0,0,0,0,3,0,
+Summer 2024,CHEM,6698,15,10372,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Summer 2024,CHEM,6698,16,10373,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Summer 2024,CHEM,6698,18,10374,Special Problems,Comito,Robert Joseph,0,0,0,0,0,6,0,
+Summer 2024,CHEM,6698,19,10375,Special Problems,Carrow,Bradley,0,0,0,0,0,3,0,
+Summer 2024,CHEM,8698,1,10439,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,5,0,
+Summer 2024,CHEM,8698,2,10440,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,2,0,
+Summer 2024,CHEM,8698,4,10441,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,3,0,
+Summer 2024,CHEM,8698,5,10442,Doctoral Research,Lee,T Randall,0,0,0,0,0,5,0,
+Summer 2024,CHEM,8698,7,10444,Doctoral Research,May,Jeremy A,0,0,0,0,0,2,0,
+Summer 2024,CHEM,8698,9,10446,Doctoral Research,Teets,Thomas,0,0,0,0,0,1,0,
+Summer 2024,CHEM,8698,14,10450,Doctoral Research,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Summer 2024,CHEM,8698,15,10451,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,2,0,
+Summer 2024,CHEM,8698,16,10452,Doctoral Research,Harth,Eva M,0,0,0,0,0,4,0,
+Summer 2024,CHEM,8698,19,10454,Doctoral Research,Miljanic,Ognjen S,0,0,0,0,0,2,0,
+Summer 2024,CHEM,8699,5,10459,Doctoral Dissertation,Daugulis,Olafs,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8699,6,10460,Doctoral Dissertation,Lee,T Randall,1,0,0,0,0,1,0,4.0
+Summer 2024,CHEM,8699,7,10461,Doctoral Dissertation,Harth,Eva M,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8699,8,10462,Doctoral Dissertation,Teets,Thomas,2,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8699,9,10463,Doctoral Dissertation,Do,Loi H,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8699,10,10464,Doctoral Dissertation,Zastrow,Melissa L,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8699,11,10465,Doctoral Dissertation,May,Jeremy A,0,0,0,0,0,1,0,
+Summer 2024,MATH,2312,4,10473,Precalculus,May,Jennifer Ruhnow,20,10,14,8,8,0,18,2.378
+Summer 2024,MATH,2414,3,10474,Calculus II,May,Jennifer Ruhnow,6,12,5,4,1,0,5,2.666
+Summer 2024,MATH,3321,1,10477,Engineering Mathematics,Etgen,Garret J,11,7,8,5,10,0,4,2.065
+Summer 2024,MATH,4378,1,10478,Advanced Linear Algebra II,Kalantar,Mehrdad,11,0,0,0,0,0,1,3.91
+Summer 2024,PHYS,1302,1,10541,College Physics II (lecture),Curran,Seamus A,31,10,9,4,2,0,3,3.143
+Summer 2024,PHYS,1102,1,10543,College Physics II (lab),Wood,Lowell T,1,9,4,1,0,0,0,2.755
+Summer 2024,PHYS,1102,2,10544,College Physics II (lab),Wood,Lowell T,4,6,6,0,0,0,0,2.916
+Summer 2024,CHEM,1112,7,10545,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,10,3,0,0,0,1,3.021
+Summer 2024,MARK,3337,2,10548,Professional Selling,Suki,Yara D,50,6,0,1,2,0,0,3.656
+Summer 2024,AAS,2320,2,10551,Intro To African American Stdy,Williams III,El,20,9,0,1,1,0,0,3.473
+Summer 2024,CHEM,1112,8,10570,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,11,2,0,0,0,1,2.978
+Summer 2024,ARCH,6602,1,10572,Arch Design/Build Workshop,Peters,Patrick A,9,0,0,0,0,0,0,3.927
+Summer 2024,ACCT,5331,1,10575,Federal Income Tax,Fernandez,Ramon,1,1,0,0,1,0,0,2.333
+Summer 2024,ACCT,5335,1,10576,Financial Statement Auditing,Kuruvilla,Mohan,3,3,0,0,0,0,0,3.5
+Summer 2024,ACCT,5367,1,10577,Intermediate Accounting I,Kuruvilla,Mohan,6,2,1,0,0,0,0,3.592
+Summer 2024,HDFS,4394,1,10581,Internship in HDFS,Conston,Toya,8,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,6298,3,10586,Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2024,CHEE,6498,3,10600,Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2024,CHEE,7399,1,10603,Masters Thesis,Karim,Alamgir,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8198,2,10608,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8198,7,10613,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8198,8,10614,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8298,1,10618,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8298,2,10619,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,6,0,
+Summer 2024,CHEE,8298,4,10621,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8298,5,10622,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8398,1,10623,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8398,2,10624,Doctoral Research,Harold,Michael P,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8398,3,10625,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8398,5,10627,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8398,6,10628,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8398,8,10630,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8398,9,10631,Doctoral Research,Mountziaris,Triantafillos John,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8398,12,10634,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8399,1,10635,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8399,2,10636,Doctoral Dissertation,Zerze,Gul,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8399,3,10637,Doctoral Dissertation,Vekilov,Peter,2,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8399,4,10638,Doctoral Dissertation,Varadarajan,Navin,4,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8399,5,10639,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8399,7,10641,Doctoral Dissertation,Palmer,Jeremy,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8399,10,10644,Doctoral Dissertation,Mountziaris,Triantafillos John,2,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8399,11,10645,Doctoral Dissertation,Karim,Alamgir,6,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8399,12,10646,Doctoral Dissertation,Harold,Michael P,1,0,0,0,0,3,0,4.0
+Summer 2024,CHEE,8399,13,10647,Doctoral Dissertation,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8399,15,10649,Doctoral Dissertation,Conrad,Jacinta C,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8498,1,10650,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8498,2,10651,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,6,0,
+Summer 2024,CHEE,8498,4,10653,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8498,5,10654,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8598,1,10655,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8598,2,10656,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8699,1,10660,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,1,0,
+Summer 2024,ECE,6198,1,10664,Research,Chen,Ji,0,0,0,0,0,2,0,
+Summer 2024,ECE,6598,1,10669,Research,Pan,Miao,0,0,0,0,0,0,0,
+Summer 2024,ECE,8198,3,10672,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,
+Summer 2024,ECE,8298,2,10678,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Summer 2024,ECE,8498,2,10685,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Summer 2024,ECE,8598,3,10688,Doctoral Research,Han,Zhu,0,0,0,0,0,0,0,
+Summer 2024,INDE,8298,7,10695,Doctoral Research,Lin,Ying,0,0,0,0,0,2,0,
+Summer 2024,INDE,8398,1,10696,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,2,0,
+Summer 2024,INDE,8399,1,10697,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8398,13,10703,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,5,0,
+Summer 2024,CHEE,8399,16,10704,Doctoral Dissertation,Balakotaiah,Vemuri,1,0,0,0,0,0,0,4.0
+Summer 2024,GHL,6360,1,10705,Graduate Directed Practicum,Back,KiJoon,8,0,0,0,0,0,0,4.0
+Summer 2024,LAW,5398,1,10708,Special Research and Writing,Vetter,Greg R,1,0,0,0,0,0,0,4.0
+Summer 2024,COMD,7391,2,10710,Clinic in Speech Lang Disorder,Chapman,Amanda,2,0,0,0,0,0,0,3.835
+Summer 2024,COMD,7391,3,10711,Clinic in Speech Lang Disorder,Chapman,Amanda,0,2,0,0,0,0,0,3.33
+Summer 2024,COMD,7391,4,10712,Clinic in Speech Lang Disorder,Oicata de Torres,Nancy,2,0,0,0,0,0,0,3.67
+Summer 2024,COMD,7391,6,10713,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,2,0,0,0,0,0,0,3.835
+Summer 2024,COMD,7391,7,10714,Clinic in Speech Lang Disorder,Lebrun,Nathalie,1,1,0,0,0,0,0,3.5
+Summer 2024,COMD,7391,8,10715,Clinic in Speech Lang Disorder,Walker,Dionne A,2,0,0,0,0,0,0,3.67
+Summer 2024,COMD,7391,9,10716,Clinic in Speech Lang Disorder,Lebrun,Nathalie,2,0,0,0,0,0,0,3.835
+Summer 2024,COMM,4392,1,10718,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,22,0,
+Summer 2024,COMD,7391,10,10720,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,1,1,0,0,0,0,0,3.665
+Summer 2024,COMD,7391,12,10721,Clinic in Speech Lang Disorder,Ermgodts,Katherine Natalie,4,0,0,0,0,0,0,3.753
+Summer 2024,MATH,1325,1,10724,Calc for Bus & Social Sciences,Constante,Beatrice,24,36,16,0,6,0,14,2.886
+Summer 2024,MATH,2413,1,10725,Calculus I,Perepelitsa,Irina,26,36,46,16,38,0,18,1.943
+Summer 2024,MATH,2414,1,10727,Calculus II,Xhabli,Blerina,28,17,17,6,10,0,20,2.539
+Summer 2024,MATH,6298,3,10730,Special Problems,Timofeyev,Ilya,0,0,0,0,0,5,0,
+Summer 2024,MATH,6498,4,10741,Special Problems,Timofeyev,Ilya,0,0,0,0,0,5,0,
+Summer 2024,GEOL,1340,1,10747,Earth Systems,Lytwyn,Jennifer N,30,37,24,5,5,0,6,2.831
+Summer 2024,OPTO,6251,1,10748,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,21,0,
+Summer 2024,OPTO,7150,1,10749,Developmental Optometry,Chandler,Moriah Adine,87,7,0,0,1,0,0,3.884
+Summer 2024,OPTO,7493,1,10750,General Clinic IIIA,Herring,Ralph Jay,0,0,0,0,0,93,0,
+Summer 2024,OPTO,8338,1,10751,Recent Developments/Round,Wheat,Joe L,10,20,3,0,0,0,0,3.292
+Summer 2024,OPTO,8384,1,10752,Practice Management II,Davis,Mark K,22,11,0,0,0,0,0,3.607
+Summer 2024,OPTO,8696,1,10753,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,30,0,
+Summer 2024,OPTO,8990,1,10754,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,63,0,
+Summer 2024,OPTO,8991,1,10755,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,63,0,
+Summer 2024,PHOP,6160,1,10756,Gen Sem Visual Sciences,Porter,Jason,0,0,0,0,0,23,0,
+Summer 2024,PHOP,6372,1,10757,Experimental Quant in VS,Benoit,Julia S,10,7,1,0,0,0,0,3.5
+Summer 2024,PHAR,5642,1,10758,Emergency Medicine,Truong,Mabel,5,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5660,1,10760,Pharmaceutical Industry,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5664,1,10762,Legal & Regulatory Affairs,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5668,1,10763,Managed Care Pharmacy,Tolleson,Shane Russell,2,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5670,1,10764,Community Pharmaceutical Care,Tolleson,Shane Russell,17,0,1,0,0,0,0,3.889
+Summer 2024,PHAR,5674,1,10766,Nutritional Support,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5675,1,10767,Disease State Management,Tolleson,Shane Russell,10,5,0,0,0,0,0,3.667
+Summer 2024,PHAR,5678,1,10768,Transplant Therapeutics,Truong,Mabel,1,1,0,0,0,0,0,3.5
+Summer 2024,PHAR,5680,1,10770,Oncology,Truong,Mabel,0,1,0,0,0,0,0,3.0
+Summer 2024,PHAR,5685,1,10773,Critical Care,Truong,Mabel,4,4,0,0,0,0,0,3.5
+Summer 2024,PHAR,5690,1,10775,Internal Medicine,Truong,Mabel,17,4,1,0,0,0,0,3.727
+Summer 2024,PHAR,5690,2,10776,Internal Medicine,Sherer,Jeffrey T,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5691,1,10777,Drug Information,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5692,1,10778,Advanced Hospital Pharmacy,Truong,Mabel,18,6,0,0,0,0,0,3.75
+Summer 2024,PHAR,5693,1,10779,Advanced Community Pharmacy,Tolleson,Shane Russell,37,8,0,0,0,0,0,3.822
+Summer 2024,PHAR,5694,1,10780,Pediatrics,Truong,Mabel,6,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5695,1,10781,Geriatrics,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5663,2,10784,Pharmacy Management,Truong,Mabel,8,1,0,0,0,0,0,3.889
+Summer 2024,SOCW,7384,1,10785,SW Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,3,0,
+Summer 2024,SOCW,7391,1,10787,Social Work Practicum Elective,Gonzales,Shelley A,0,0,0,0,0,12,0,
+Summer 2024,MATH,1314,1,10789,College Algebra,Constante,Beatrice,4,9,8,7,19,0,19,1.439
+Summer 2024,SOCW,8399,1,10791,Dissertation,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Summer 2024,COMM,3353,1,10793,Information & Comm Tech I,Liu,Youmei,15,4,4,0,0,0,4,3.493
+Summer 2024,ACCT,5337,1,10799,Management Accounting,Serrato,Darlene Marie  Bohac,0,4,0,0,0,0,1,3.0
+Summer 2024,SOCW,7385,1,10801,SW Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,3,0,
+Summer 2024,COMM,3368,1,10803,Principles of Public Relations,Liu,Wenlin,17,6,6,0,0,0,0,3.379
+Summer 2024,ECON,3370,1,10804,Introduction To Econometrics,Zhivan,Natalia A,4,6,8,4,1,0,1,2.262
+Summer 2024,PHYS,1101,3,10805,College Physics I (lab),Wood,Lowell T,0,13,3,0,0,0,0,2.73
+Summer 2024,PHYS,1102,3,10806,College Physics II (lab),Wood,Lowell T,2,7,7,0,0,0,1,2.667
+Summer 2024,PHAR,5673,1,10825,Veterinary Pharmaceutical Care,Tolleson,Shane Russell,0,0,0,0,0,0,0,
+Summer 2024,INDE,8699,1,10836,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Summer 2024,KIN,4310,1,10877,Measurement Tech Human Perf,Thrasher,Timothy Adam,15,20,10,3,1,0,1,2.912
+Summer 2024,KIN,4345,1,10878,Econ and Finc Aspects of Sport,Lee,Dong Hun,26,6,3,0,0,0,0,3.591
+Summer 2024,KIN,4390,1,10879,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Summer 2024,KIN,4690,1,10880,Internship in Sport Admin 1,Walsh,David W,20,3,1,0,0,0,0,3.737
+Summer 2024,KIN,4691,1,10881,Internship in Sport Admin 2,Walsh,David W,16,2,1,0,0,0,0,3.755
+Summer 2024,KIN,4350,1,10882,Sport Marketing,Walsh,David W,18,53,12,2,0,0,3,2.969
+Summer 2024,NUTR,3334,1,10883,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,38,14,1,0,0,0,2,3.63
+Summer 2024,PEP,7393,1,10884,Internship & Practicum,Walsh,David W,1,0,0,1,0,0,0,2.5
+Summer 2024,COMM,2320,1,10885,Fundamentals Media Production,Crowe,Craig Warren,22,2,0,0,0,0,0,3.862
+Summer 2024,GHL,4343,1,10888,Financial Admin for Hosp.Ind.,Koh,Yoon,13,7,2,1,1,0,1,3.195
+Summer 2024,KIN,4340,1,10889,Sport Governance,Walsh,David W,13,15,5,0,0,0,0,3.202
+Summer 2024,GEOL,1303,1,10890,Physical Geology,Lytwyn,Jennifer N,42,34,26,15,5,0,8,2.773
+Summer 2024,ACCT,3367,1,10891,Intermediate Accounting I,Kuruvilla,Mohan,1,4,4,1,0,0,4,2.665
+Summer 2024,GOVT,2305,1,10892,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,23,40,8,0,2,0,1,3.146
+Summer 2024,HDFS,3350,1,10893,Observation and Assessment,Schroder,Kathleen Anne,19,6,1,1,0,0,0,3.605
+Summer 2024,NUTR,3336,1,10899,Nutritional Pathophysiology,Haubrick,Kevin,31,11,1,0,0,0,0,3.621
+Summer 2024,COMD,7381,1,10900,Medical SLP Seminar,Cizek,Laura S,27,0,0,0,0,0,0,4.0
+Summer 2024,SPAN,6398,2,10920,Special Problems,Cuesta,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2024,SPAN,1501,1,10921,Elementary Spanish I,Carrion Rivera,Lydiette,9,3,2,0,1,0,1,3.201
+Summer 2024,MATH,5389,1,10960,Survey of Mathematics,Etgen,Garret J,10,7,0,0,0,0,0,3.608
+Summer 2024,PHAR,5663,1,10961,Pharmacy Management,Tolleson,Shane Russell,4,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5683,1,10962,Cardiology,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,2101,1,10963,Anatomy & Physiology Lab I,Gill,Tejendra,4,9,7,0,0,0,1,2.817
+Summer 2024,BIOL,2101,2,10964,Anatomy & Physiology Lab I,Gill,Tejendra,3,12,4,0,3,0,1,2.5
+Summer 2024,BIOL,2101,3,10965,Anatomy & Physiology Lab I,Gill,Tejendra,1,9,10,2,1,0,0,2.319
+Summer 2024,BIOL,2101,4,10966,Anatomy & Physiology Lab I,Gill,Tejendra,2,13,4,2,0,0,0,2.699
+Summer 2024,GHL,4132,1,10968,Bev Mgmt & Mktg Internship,Taylor,David C,2,0,0,0,0,0,0,4.0
+Summer 2024,KIN,1304,1,10969,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,176,14,6,2,4,0,2,3.78
+Summer 2024,PEP,6309,1,10970,Policies & Govt of Sport Org.,Hawkins,Billy J,9,6,4,0,0,0,0,3.281
+Summer 2024,CHEE,8398,14,10971,Doctoral Research,Vekilov,Peter,0,0,0,0,0,2,0,
+Summer 2024,ELET,3405,1,10972,Microprocessor Architecture,Soneja,Chandrayee,5,5,0,0,0,0,1,3.533
+Summer 2024,ENGL,1302,2,10976,First Year Writing II,Rolater,Sara C,10,3,5,1,0,0,5,3.123
+Summer 2024,ENGL,1302,3,10977,First Year Writing II,Khalil,Rand Omar,19,4,2,0,0,0,0,3.68
+Summer 2024,MECT,3342,30,10978,Elements of Plant Design,El Nahas,Medhat A,2,9,7,0,0,0,1,2.741
+Summer 2024,FINA,3332,1,10981,Prin of Financial Management,Chisholm,Darla,23,29,26,6,1,0,5,2.742
+Summer 2024,PHAR,5675,2,10984,Disease State Management,Gee,Jodie Sue,3,0,0,0,0,0,0,4.0
+Summer 2024,MECE,3360,1,10993,Experimental Methods,Chen,Xuemei,7,3,6,1,0,0,2,2.922
+Summer 2024,CHEM,2125,3,10995,Organic Chemistry Lab II,Zaitsev,Vladimir G,9,7,1,0,0,0,1,3.432
+Summer 2024,CHEE,8398,15,11007,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8398,1,11018,Doctoral Research,Akay,Metin,0,0,0,0,0,0,0,
+Summer 2024,HDFS,4393,2,11019,Internship in HDFS,Conston,Toya,8,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,2319,1,11022,Intro to Social Psychology,Weinstein,Andrew Philip,28,4,4,0,1,0,2,3.523
+Summer 2024,BIOL,2301,1,11038,Anatomy & Physiology I (lect),Wayne,Chad M,8,21,20,1,3,0,6,2.547
+Summer 2024,BIOL,2102,1,11039,Anatomy & Physiology II (lab),Gill,Tejendra,1,8,2,2,1,0,0,2.452
+Summer 2024,BIOL,2102,2,11040,Anatomy & Physiology II (lab),Gill,Tejendra,3,4,4,1,1,0,2,2.513
+Summer 2024,BIOL,2102,3,11041,Anatomy & Physiology II (lab),Gill,Tejendra,2,12,2,3,1,0,1,2.633
+Summer 2024,BIOL,2102,4,11042,Anatomy & Physiology II (lab),Gill,Tejendra,2,11,5,1,1,0,0,2.616
+Summer 2024,BIOL,2302,1,11044,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,16,14,7,3,2,0,1,2.881
+Summer 2024,ACCT,2301,2,11045,Prin of Financial Accounting,Sykes,Mary Reeves,30,15,9,1,0,0,4,3.399
+Summer 2024,MIS,3360,1,11046,Systems Analysis and Design,Porra,Jaana,43,0,0,0,0,0,0,4.0
+Summer 2024,ACCT,7375,1,11049,Taxation of Business Entities,Mangano,Clifford A,11,4,0,0,0,0,1,3.755
+Summer 2024,CHEM,1111,9,11050,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,13,1,0,0,0,0,3.088
+Summer 2024,ENGL,1302,4,11055,First Year Writing II,Rolater,Sara C,8,5,3,2,2,0,3,2.701
+Summer 2024,PHAR,5644,1,11079,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,9,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,1111,14,11080,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,1,0,0,1,3.019
+Summer 2024,HRD,6396,1,11096,Internship in Human Res. Dev.,Shirmohammadi,Melika,6,0,0,0,0,0,0,4.0
+Summer 2024,HDCS,4375,1,11108,Strategies in Digital Retail,Kellough,James David,28,2,0,0,0,0,0,3.9
+Summer 2024,NUTR,4333,1,11110,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,2,8,0,0,0,0,0,3.002
+Summer 2024,NUTR,4347,1,11111,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,3,1,3,0,0,0,0,3.047
+Summer 2024,MARK,4362,1,11112,Applied Buyer Behavior,Noriega,Jaime L,17,21,7,0,0,0,0,3.222
+Summer 2024,ACCT,2302,1,11113,Prin of Managerial Accounting,Weber,Catherine K,20,14,6,3,0,0,4,3.217
+Summer 2024,MANA,6A25,1,11116,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,14,6,1,0,0,0,0,3.54
+Summer 2024,MIS,6A41,1,11117,Information Systems,Silva,Leiser O,46,0,0,0,0,0,0,3.986
+Summer 2024,KIN,4300,1,11118,Phys Activity Older Adults,Alastuey,Lisa L,8,13,5,0,0,0,0,3.141
+Summer 2024,KIN,3350,1,11119,Psych Aspects Sport Exercise,Ferrara,Morgan Paige,47,11,2,3,0,0,1,3.593
+Summer 2024,INTB,3355,1,11120,Global Environment of Business,Miljanic,Andra Olivia,81,21,7,1,2,0,2,3.53
+Summer 2024,LAW,5328,1,11121,Judicial Externship I,Archer,Anna M,0,0,0,0,0,7,0,
+Summer 2024,LAW,5328,2,11122,Judicial Externship I,Archer,Anna M,0,0,0,0,0,6,0,
+Summer 2024,LAW,5329,3,11124,Judicial Externship II,Archer,Anna M,0,0,0,0,0,1,0,
+Summer 2024,LAW,5400,2,11125,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,
+Summer 2024,LAW,5407,10,11126,Judicial Externship I,Archer,Anna M,0,0,0,0,0,3,0,
+Summer 2024,LAW,5415,3,11127,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,
+Summer 2024,LAW,6300,2,11128,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2024,LAW,6300,3,11129,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2024,LAW,6355,3,11131,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2024,LAW,5357,1,11132,Evidence,Gomez,Alissa R,5,11,1,0,0,4,0,3.196
+Summer 2024,CIS,4355,20,11133,Information Systems Operations,Peddoju,Suresh Kumar,16,7,4,0,1,0,1,3.321
+Summer 2024,KIN,3306,1,11134,Physiology-Human Performance,Park,Yoonjung,44,7,1,1,0,0,1,3.792
+Summer 2024,ECE,3331,1,11135,Program Appl in Elec Comp Engr,Hebert,Thomas James,4,9,6,1,0,0,1,2.8
+Summer 2024,ECE,3337,1,11136,Signals and Systems Analysis,Hebert,Thomas James,8,22,4,0,0,0,1,3.059
+Summer 2024,KIN,1352,3,11137,"Foundations of KIN, HLT, FIT",Alastuey,Lisa L,41,23,12,3,0,0,3,3.254
+Summer 2024,MANA,4396,1,11138,Management Internship,Carlin,Barbara A,0,0,0,0,0,11,0,
+Summer 2024,MARK,4396,1,11139,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,9,0,
+Summer 2024,MAS,3340,1,11140,Mexican Amer Urban Communities,Pino,Diana,8,2,0,0,0,0,0,3.767
+Summer 2024,MANA,4355,1,11141,Selection and Staffing,Phillips,James S,28,23,0,0,0,0,0,3.471
+Summer 2024,PHCA,8199,1,11151,Doctoral Dissertation Defense,Thornton,James D,1,0,0,0,0,0,0,4.0
+Summer 2024,MATH,1324,6,11153,Finite Math with Applications,Caglar,Atife,12,12,16,2,2,0,12,2.682
+Summer 2024,MATH,2312,5,11154,Precalculus,Almus,Melahat,12,4,12,8,18,0,24,1.581
+Summer 2024,CHEM,6698,20,11155,Special Problems,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Summer 2024,COMD,7383,2,11156,Pediatric SLP Seminar,Cizek,Laura S,20,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,6698,21,11157,Special Problems,Harth,Eva M,0,0,0,0,0,2,0,
+Summer 2024,CHEM,8698,32,11158,Doctoral Research,Baldelli,Steve,0,0,0,0,0,2,0,
+Summer 2024,MIS,6A41,2,11160,Information Systems,Silva,Leiser O,2,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,6698,23,11175,Special Problems,Chiang,Naihao,0,0,0,0,0,3,0,
+Summer 2024,MECE,3245,1,11180,Materials Science Laboratory,Hammami,Farah,27,9,1,0,0,0,1,3.667
+Summer 2024,HRD,4396,20,11231,Internship in HRD,Owens-Shepard,Toya,11,0,0,0,0,0,0,3.94
+Summer 2024,HRD,3340,1,11232,Principles of HRD,Hattier,Beth,21,2,0,0,1,0,0,3.723
+Summer 2024,HRD,4344,20,11233,Designing E-Learning,Bennett,LaTasha,10,3,0,0,0,0,0,3.642
+Summer 2024,GHL,2160,1,11236,Hospitality Internship,Shepherd,Ashley,10,1,0,0,0,0,0,3.909
+Summer 2024,MANA,6A25,2,11239,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,18,14,1,1,0,0,0,3.48
+Summer 2024,MANA,6A83,1,11240,Strategic Analysis,Chiu,Shih-chi,24,2,0,1,0,0,1,3.778
+Summer 2024,BIOL,2121,3,11247,Microbiol for Science Maj(lab),Knapp,Richard D,6,2,3,0,0,0,0,3.213
+Summer 2024,COMM,3353,2,11248,Information & Comm Tech I,Liu,Youmei,16,5,0,0,0,0,1,3.762
+Summer 2024,GENB,5303,1,11250,Prof Acct Communication,Newman,Michael Ray,4,1,0,0,0,0,0,3.866
+Summer 2024,GENB,7303,1,11251,Prof Accounting Communication,Newman,Michael Ray,17,3,0,0,0,0,0,3.883
+Summer 2024,GOVT,2305,4,11252,"US Govt: Congress,Pres & Crts",Cho,EunHye Grace,46,17,8,7,1,0,0,3.245
+Summer 2024,NUTR,4312,1,11253,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,9,3,1,1,0,0,0,3.358
+Summer 2024,NUTR,4334,1,11254,Community Nutrition,Svendsen-Sanchez,Ann Carol,25,40,10,0,0,0,0,3.209
+Summer 2024,SGNL,1302,1,11255,Elementary Sign Language II,Brittain,Terrell,3,9,3,0,0,0,0,3.0
+Summer 2024,MATH,1314,5,11257,College Algebra,Constante,Beatrice,8,2,3,7,1,0,2,2.444
+Summer 2024,MATH,1342,5,11258,Elementary Statistical Methods,Wang,Wenshuang,12,4,10,8,0,0,8,2.569
+Summer 2024,SCM,6A01,1,11259,SCM Concepts,Sahin,Funda,20,11,4,1,0,0,1,3.38
+Summer 2024,FINA,4320,1,11260,Investment Management,Doshi,Hitesh B,20,18,7,0,0,0,0,3.274
+Summer 2024,PHAR,5681,2,11261,Infectious Diseases,Truong,Mabel,6,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5645,1,11262,Pharmacy Informatics,Truong,Mabel,0,1,0,0,0,0,0,3.0
+Summer 2024,PHAR,5646,1,11263,Medication Safety,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Summer 2024,ATP,6191,1,11264,Clinical Experience I,Harrison,Layci,14,0,0,0,0,0,0,4.0
+Summer 2024,ATP,6301,1,11265,Anatomy,Harrison,Layci,8,6,0,0,0,0,0,3.571
+Summer 2024,ATP,6302,1,11266,Emergency Care,Knoblauch,Mark Alan,13,1,0,0,0,0,0,3.929
+Summer 2024,ATP,7194,1,11267,Clinical Experience IV,Knoblauch,Mark Alan,15,0,0,0,0,0,0,4.0
+Summer 2024,KIN,4190,1,11268,Sport Administration Seminar,Walsh,David W,18,3,1,0,1,0,0,3.609
+Summer 2024,ATP,7101,1,11269,"Head, Neck & Spine Eval Lab",Harrison,Layci,15,0,0,0,0,0,0,4.0
+Summer 2024,ATP,7301,1,11270,"Head, Neck & Spine Evaluation",Harrison,Layci,11,3,1,0,0,0,0,3.667
+Summer 2024,ATP,7302,1,11271,Gen Med/Pharm 2-Pathophysiolog,Knoblauch,Mark Alan,13,2,0,0,0,0,0,3.867
+Summer 2024,CUIN,7301,1,11272,CUIN Capstone Seminar,Brower,Samuel Richard,8,0,0,0,0,0,0,4.0
+Summer 2024,ENGL,1301,2,11273,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,9,2,1,1,0,0,1,3.36
+Summer 2024,CNST,3205,1,11274,Construction Safety Management,Hart,Lee J,29,5,0,0,0,0,0,3.853
+Summer 2024,ACCT,4331,1,11290,Federal Income Tax,Fernandez,Ramon,6,19,5,0,0,0,1,3.066
+Summer 2024,FINA,4396,1,11314,Finance Internship,Kumar,Praveen,0,0,0,0,0,37,0,
+Summer 2024,COMM,2311,1,11328,Writing for Print and Digital,Radcliffe Andre,Jennifer,18,6,0,0,1,0,0,3.56
+Summer 2024,DIGM,3354,30,11332,Visual Production,Snyder,Philip Charles,16,6,5,0,0,0,0,3.359
+Summer 2024,PETR,7399,1,11334,Masters Thesis,Soliman,Mohamed Yousef,1,0,0,0,0,0,0,4.0
+Summer 2024,DIGM,1350,30,11337,Graphics for Digital Media,Beyl,Charles Eugene,5,7,0,0,1,0,0,3.103
+Summer 2024,DIGM,2353,30,11338,Page Layout and Design,De Vega,Jaime M,8,5,0,0,2,0,1,3.089
+Summer 2024,HDFS,1300,1,11340,Dev of Contemporary Families,Jordan,Erica F,38,16,9,1,1,0,0,3.329
+Summer 2024,PSYC,3310,1,11343,Indstrl-Orgnztnl Psy,Thomas,Kalifa Nailah,37,15,2,2,1,0,1,3.526
+Summer 2024,PSYC,2316,1,11344,Psychology of Personality,Cifre,Anthony Ballachie,19,22,7,1,1,0,3,3.14
+Summer 2024,SOCW,7368,1,11346,Trauma Treatment for Children,Amtsberg,Donna K,25,0,0,0,0,0,0,4.0
+Summer 2024,GOVT,2306,4,11348,US and Texas Const/Politics,Abbott Jr,Kenneth Wayne,17,16,4,2,0,0,3,3.087
+Summer 2024,PSYC,2330,1,11349,Biological Psychology,Rech,Megan Elizabeth,20,9,5,1,1,0,1,3.214
+Summer 2024,MIS,4477,1,11350,Network & Security Infrastruct,Khan,Hina F,18,2,1,0,0,0,0,3.825
+Summer 2024,WGSS,2350,2,11352,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,24,2,0,0,0,0,1,3.91
+Summer 2024,PSYC,3339,1,11356,Intro To Clinical Psychology,Szafranski,Derek D,37,12,0,0,0,0,1,3.688
+Summer 2024,MECE,2334,1,11357,Thermodynamics,Love,Holley Carole,9,9,4,0,0,0,0,3.197
+Summer 2024,PSYC,7399,1,11358,Masters Thesis,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Summer 2024,NURS,3636,1,11359,Nur Process for Colabrtive Prc,Edwards-Maddox,Shermel Vinese,3,33,0,4,0,0,8,2.875
+Summer 2024,NURS,3337,1,11361,Rdg/Interpreting Sci Lit,Edwards-Maddox,Shermel Vinese,3,40,0,7,0,0,0,2.78
+Summer 2024,PSYC,8121,1,11362,Clinical Psychology Internship,Woods,Steven Paul,0,0,0,0,0,5,0,
+Summer 2024,PSYC,8399,1,11363,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Summer 2024,PSYC,8699,1,11364,Doctoral Dissertation,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6392,1,11365,Intervention Practicum,Vincent,John P,0,0,0,0,0,10,0,
+Summer 2024,PSYC,7399,3,11368,Masters Thesis,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Summer 2024,PSYC,8321,1,11371,Clinical Psyc Internship,Woods,Steven Paul,0,0,0,0,0,6,0,
+Summer 2024,PSYC,8390,1,11372,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,2,0,
+Summer 2024,PSYC,8399,3,11373,Doctoral Dissertation,Medina,Luis Daniel,0,0,0,0,0,2,0,
+Summer 2024,ELED,3320,1,11376,Survey Literature Child Adol,Tyson,Eleanore S,16,4,0,0,0,0,0,3.734
+Summer 2024,CHEM,6698,24,11378,Special Problems,Chen,Tai-Yen,0,0,0,0,0,2,0,
+Summer 2024,CHEM,6698,25,11379,Special Problems,Guloy,Arnold M,0,0,0,0,0,2,0,
+Summer 2024,PSYC,8399,5,11387,Doctoral Dissertation,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8698,20,11391,Doctoral Research,Xu,Shoujun,0,0,0,0,0,3,0,
+Summer 2024,PSYC,8399,6,11394,Doctoral Dissertation,Neighbors,Clayton T,0,0,0,0,0,0,0,
+Summer 2024,PSYC,8399,7,11402,Doctoral Dissertation,Babcock,Julia,1,0,0,0,0,1,0,4.0
+Summer 2024,ACCT,4331,2,11406,Federal Income Tax,Fernandez,Ramon,5,13,2,0,1,0,5,3.031
+Summer 2024,PSYC,8399,9,11411,Doctoral Dissertation,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Summer 2024,LAW,5602,1,11412,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,
+Summer 2024,PSYC,8399,10,11413,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6352,1,11414,Directed Rsch in I/O Psyc,Brummel,Bradley James,1,0,0,0,0,0,0,4.0
+Summer 2024,LAW,5500,1,11430,Government and Nonprofit Exter,Hancock,Amy Sladczyk,0,0,0,0,0,3,0,
+Summer 2024,PSYC,7390,1,11432,Clin Neuropsychology Practicum,Woods,Steven Paul,0,0,0,0,0,4,0,
+Summer 2024,CHEM,8698,33,11433,Doctoral Research,Carrow,Bradley,0,0,0,0,0,5,0,
+Summer 2024,CHEM,8698,34,11434,Doctoral Research,Wu,Judy,0,0,0,0,0,1,0,
+Summer 2024,PSYC,6352,2,11437,Directed Rsch in I/O Psyc,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Summer 2024,MATH,8698,2,11446,Doctoral Research,Labate,Demetrio,0,0,0,0,0,1,0,
+Summer 2024,CHEM,6698,26,11449,Special Problems,Bocarsly,Joshua David,0,0,0,0,0,3,0,
+Summer 2024,MIS,4378,1,11453,Admin of Computer-Based MIS,Porra,Jaana,39,1,0,0,0,0,0,3.967
+Summer 2024,CHEM,6698,27,11454,Special Problems,Cai,Chengzhi,0,0,0,0,0,3,0,
+Summer 2024,MATH,8698,4,11467,Doctoral Research,Josic,Kresimir,0,0,0,0,0,2,0,
+Summer 2024,MATH,8698,6,11470,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Summer 2024,HLT,4307,1,11472,Research and Eval in Health,Kamdar-Sharif,Amber,26,8,1,1,0,0,0,3.575
+Summer 2024,WGSS,4360,1,11491,Capstone Internship Course,Gregory,Elizabeth,2,0,0,0,0,0,0,4.0
+Summer 2024,ENGL,4390,1,11506,Professional Internship,Zentz,Lauren R,0,0,0,0,0,1,0,
+Summer 2024,PSYC,7393,1,11508,Field Practicum in Psychology,Woods,Steven Paul,0,0,0,0,0,13,0,
+Summer 2024,ENGL,1301,6,11514,First Year Writing I,O'Bryan,Ann Patricia,9,1,3,2,3,0,1,2.629
+Summer 2024,PSYC,6352,3,11519,Directed Rsch in I/O Psyc,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,2301,2,11525,Introduction to Psychology,Wu,Dongjie,21,10,3,1,1,0,0,3.26
+Summer 2024,PSYC,2317,2,11527,Intro to Psychology Statistics,Le,Giang Xuan,48,6,2,0,0,0,2,3.786
+Summer 2024,MATH,3325,1,11528,Transition to Advanced Math,Leger,Nicholas M,7,6,6,0,2,0,0,2.778
+Summer 2024,DIGM,3353,30,11532,Visual Communications Tech,Dozier,Devin K,43,8,10,1,3,0,0,3.344
+Summer 2024,LAW,5199,12,11533,Special Problems,Alderman,Richard M,0,0,0,0,0,1,0,
+Summer 2024,LAW,5385,1,11540,Introduction to the Laws of EU,Willis,Tasha L,6,5,1,0,0,0,1,3.389
+Summer 2024,LAW,5228,1,11541,Judicial Externship I,Archer,Anna M,0,0,0,0,0,7,0,
+Summer 2024,LAW,5228,2,11542,Judicial Externship I,Archer,Anna M,0,0,0,0,0,2,0,
+Summer 2024,LAW,5229,2,11544,Judicial Externship II,Archer,Anna M,0,0,0,0,0,2,0,
+Summer 2024,LAW,5203,1,11545,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,1,0,
+Summer 2024,LAW,5203,4,11546,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2024,LAW,5206,4,11547,Govt Nonprofit Extshp II,Hancock,Amy Sladczyk,0,0,0,0,0,2,0,
+Summer 2024,TMTH,3360,1,11548,Applied Technical Statistics,Thornton,Brandon Latroy,12,10,3,0,1,0,0,3.256
+Summer 2024,MANA,3335,1,11549,Intro Org Behavior and Mgmt,Currie,Daniel David,93,45,10,2,0,0,3,3.465
+Summer 2024,MANA,3335,2,11550,Intro Org Behavior and Mgmt,Currie,Daniel David,142,21,5,0,0,0,2,3.759
+Summer 2024,MANA,4336,1,11551,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,5,8,1,1,1,0,0,2.896
+Summer 2024,SOCW,7326,1,11552,Disparities in Health,Torres,Isabel,24,2,0,0,0,0,0,3.923
+Summer 2024,SOCW,7365,1,11553,Crisis Intervention,Battle,Jennifer Alene,2,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8191,1,11558,Special Field Projects,Davis,Bradley,9,0,0,0,0,0,0,4.0
+Summer 2024,PHIL,1361,1,11559,Philosophy and the Arts,Drapela,Nick Gerard,4,4,3,1,1,0,3,2.616
+Summer 2024,PHIL,1361,2,11560,Philosophy and the Arts,Drapela,Nick Gerard,5,9,5,1,0,0,2,2.933
+Summer 2024,ECE,2202,1,11561,Circuit Analysis II,Shattuck,David P,9,8,15,0,2,0,0,2.637
+Summer 2024,COSC,1437,301,11563,Introduction to Programming,Rincon Castro,Carlos Alberto,15,4,12,4,14,0,4,1.98
+Summer 2024,SOCW,8336,1,11564,Required Research Internship,Berger Cardoso,Jodi A,4,0,0,0,0,0,0,4.0
+Summer 2024,HDCS,1300,2,11565,Human Ecosystems & Tech Change,Gatterson,Beverly,42,3,1,0,1,0,3,3.717
+Summer 2024,GHL,6191,1,11566,Project Development,Haskell,Rebecca Erin,0,0,0,0,0,7,0,
+Summer 2024,ENTR,4394,1,11567,RED Labs Accelerator,Gonzalez,Liana,2,0,0,0,0,0,0,4.0
+Summer 2024,ENTR,7394,1,11568,RED Labs Accelerator,Gonzalez,Liana,1,0,0,0,0,0,0,4.0
+Summer 2024,MARK,7373,1,11569,Business to Business Marketing,Kamal,Saiyid Zafar,14,3,1,0,0,0,0,3.777
+Summer 2024,GOVT,2305,5,11572,"US Govt: Congress,Pres & Crts",Shor,Boris,8,8,7,3,3,0,0,2.494
+Summer 2024,PHLS,8351,1,11574,Hist & Philosophy of Psyc Syst,Reyna,Ronda,20,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,8357,1,11575,Clinical Interventions,de Dios,Marcel A,5,0,1,0,0,0,0,3.667
+Summer 2024,PHLS,8364,1,11576,"Prof Prac Psy: Eth,Law,& Iss",Reyna,Ronda,23,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,8393,2,11578,Doctoral Practicum in Psy,Racine,Madeline D,0,0,0,0,0,6,0,
+Summer 2024,HDFS,3320,1,11580,Careers in HDFS,Jordan,Erica F,16,3,0,0,0,0,0,3.79
+Summer 2024,MUSI,1117,1,11583,Aural Skills II,Garza,Paul Victor,11,12,0,0,0,0,0,3.407
+Summer 2024,MUSI,1312,1,11584,Music Theory II,Garza,Paul Victor,18,3,1,0,0,0,0,3.713
+Summer 2024,NUTR,2332,4,11585,Intro To Human Nutrition,Scott,Claudia W,18,11,4,2,0,0,2,3.248
+Summer 2024,MUSI,1182,1,11586,Group Piano II,Van Kekerix,Todd Evan,3,3,0,0,0,0,0,3.5
+Summer 2024,ECE,2201,1,11587,Circuit Analysis I,Shattuck,David P,13,9,5,7,2,0,10,2.703
+Summer 2024,GOVT,2306,50,11588,US and Texas Const/Politics,Belco,Michelle Helene,18,0,0,0,0,0,1,4.0
+Summer 2024,MECE,5388,1,11589,Intelligent Structural Systems,Song,Gangbing,11,31,3,0,0,0,3,3.148
+Summer 2024,MECE,3381,1,11590,Finite Elements for Mech Engr,Chen,Xuemei,5,8,8,2,2,0,0,2.414
+Summer 2024,GOVT,2305,2,11601,"US Govt: Congress,Pres & Crts",Littlepage,Kelley G,12,19,1,0,0,0,3,3.344
+Summer 2024,ENGL,3352,1,11602,19th Century American Fiction,Wood,Barry Albert,5,9,5,1,1,0,1,2.778
+Summer 2024,ELCS,6393,1,11603,Internship in Higher Education,Carales,Vincent D,7,0,0,0,0,0,0,3.906
+Summer 2024,PSYC,7392,2,11633,Psychology Practicum,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,2301,1,11641,Introduction to Psychology,Gehm,Kevan H,25,10,3,1,0,0,0,3.513
+Summer 2024,PHAR,5696,5,11645,Ambulatory Care - Primary Care,Tolleson,Shane Russell,1,0,0,0,0,0,0,4.0
+Summer 2024,KIN,3305,2,11650,Sport Sociology,Graham,Marilynn Hadassah,62,14,3,1,2,0,3,3.606
+Summer 2024,PSYC,8190,1,11659,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,1,0,
+Summer 2024,MATH,6315,1,11664,Masters Tutorial,Jun,Mikyoung,23,0,0,0,0,0,0,3.943
+Summer 2024,CHEM,1112,15,11681,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,11,2,0,0,0,0,3.13
+Summer 2024,PSYC,8399,15,11684,Doctoral Dissertation,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5695,2,11685,Geriatrics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5686,2,11686,Psychiatry,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Summer 2024,LAW,6300,11,11689,Govt Nonprofit Extshp I,Hancock,Amy Sladczyk,0,0,0,0,0,4,0,
+Summer 2024,ACCT,4396,2,11698,Accounting Internship,Newman,Michael Ray,0,0,0,0,0,1,0,
+Summer 2024,PSYC,4344,1,11707,Cultural Psychology,Murphy,Elijah Rayvon,47,4,2,1,0,0,1,3.809
+Summer 2024,PSYC,2316,2,11711,Psychology of Personality,Allman,Madeleine E,14,8,3,4,0,0,1,3.069
+Summer 2024,PSYC,3350,1,11713,Intro to Cognitive Psychology,Perkovich,Elizabeth Susan,39,12,2,0,4,0,1,3.386
+Summer 2024,MANA,4330,1,11714,Intro to Strategic HR Mgt,Babalola,Olusegun,23,8,0,0,0,0,2,3.646
+Summer 2024,SOCW,7303,1,11715,Child Abuse and Neglect,Berger Cardoso,Jodi A,23,3,0,0,0,0,0,3.885
+Summer 2024,COMM,4303,1,11716,Communication Law and Ethics,Bundage Juvane,Stephanie,52,5,0,1,0,0,0,3.714
+Summer 2024,COMM,4365,2,11717,Digital PR and Advertising,Choi,Ho Joon,21,4,0,0,0,0,1,3.8
+Summer 2024,MATH,3333,1,11720,Intermediate Analysis,Kalantar,Mehrdad,12,4,0,0,1,0,2,3.394
+Summer 2024,HRD,3351,1,11721,Instructional Design for HRD,Pereira-Leon,Maura Josefina,17,20,2,0,0,0,1,3.317
+Summer 2024,GHL,3341,1,11722,Hospitality Managerial Acct,Johnson,Tucker A,6,1,1,0,0,0,0,3.666
+Summer 2024,NUTR,4352,1,11723,Child and Adolescent Nutrition,Vollrath,Kirstin,28,22,13,2,0,0,1,3.139
+Summer 2024,KIN,4360,1,11724,Adaptive Athletics Management,Cottingham,Michael,17,0,0,0,0,0,0,3.981
+Summer 2024,PHYS,2325,1,11725,University Physics I (lecture),Bassler,Kevin E,8,18,2,1,1,0,3,3.011
+Summer 2024,PHYS,2326,1,11727,University Physics II(lecture),Varghese,Oomman K,8,4,5,1,1,0,7,2.791
+Summer 2024,ENGI,2304,3,11729,Technical Communications,Pushaw,Stephanie,14,5,0,0,1,0,2,3.517
+Summer 2024,POLS,3311,2,11730,Intro Compar Politics,Vardy,Ronald V,24,1,1,1,0,0,0,3.778
+Summer 2024,LAW,5303,1,11731,Criminal Law,Ten Cate,Irene,9,18,1,0,0,0,0,3.38
+Summer 2024,LAW,5378,1,11732,Statutory Interpretation & Rea,Bush,Darren,12,17,0,0,0,0,0,3.402
+Summer 2024,HIST,6380,1,11733,Public History Internship,Young,Nancy Beck,0,0,0,0,0,0,0,
+Summer 2024,SOCW,7371,1,11735,Trauma & SW,Sanchez,Chelsea Marie,25,0,1,0,0,0,1,3.923
+Summer 2024,SOCW,7378,1,11736,Integrated Behav Healthcare,Eisenbaum,Stephanie,23,6,0,0,0,0,0,3.793
+Summer 2024,PETR,8399,2,11740,Doctoral Dissertation,Dindoruk,Birol,1,0,0,0,0,0,0,4.0
+Summer 2024,PETR,8399,3,11741,Doctoral Dissertation,Myers,Michael Tolbert,1,0,0,0,0,0,0,4.0
+Summer 2024,PETR,8399,7,11744,Doctoral Dissertation,Wong,George K,0,0,0,0,0,1,0,
+Summer 2024,PETR,8399,8,11745,Doctoral Dissertation,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Summer 2024,PETR,8399,9,11746,Doctoral Dissertation,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Summer 2024,PETR,8399,10,11747,Doctoral Dissertation,Sakhaee Pour,Ahmad,1,0,0,0,0,0,0,3.67
+Summer 2024,PETR,8399,11,11748,Doctoral Dissertation,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Summer 2024,CHEM,1311,1,11751,Fundamentals of Chemistry,Czader,Arkadiusz,6,21,26,9,15,0,9,1.841
+Summer 2024,CHEM,1312,1,11752,Fundamentals of Chemistry 2,Czader,Arkadiusz,13,18,32,12,17,0,12,1.957
+Summer 2024,NURS,4216,1,11753,Perioperative Nursing,Quintana,Danielle,27,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,6115,1,11754,Clinical Integration,Gostovic,Anita Ticak,23,0,0,0,0,0,0,4.0
+Summer 2024,MIS,3370,1,11755,Info Systems Development Tools,Hossain,Nahid,11,5,3,8,2,0,4,2.517
+Summer 2024,ENGL,2306,1,11756,Intro To Poetry,Loan,Leisa Marie,24,1,0,0,0,0,0,3.881
+Summer 2024,PSYC,7399,6,11757,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Summer 2024,DRAM,1310,1,11758,Introduction to Theatre,Brincks,Alan,36,10,3,1,2,0,2,3.398
+Summer 2024,PSYC,8399,16,11759,Doctoral Dissertation,Alfano,Candice A,3,0,0,0,0,0,0,4.0
+Summer 2024,TECH,1301,1,11761,Intro to Data Analytics Tools,Thornton,Brandon Latroy,19,1,0,0,0,0,0,3.934
+Summer 2024,ENGL,1301,4,11763,First Year Writing I,Feizbakhsh Tavana,Zahra,12,1,0,0,0,0,0,3.872
+Summer 2024,ENGL,1302,7,11764,First Year Writing II,Pogue,Donovan A,11,6,1,0,3,0,2,3.063
+Summer 2024,CNST,3185,1,11821,Construction Experience,Lyon,Eva Yaneth,13,21,3,0,0,0,0,3.315
+Summer 2024,PHAR,5675,4,11824,Disease State Management,De La Cruz,Austin Isaac,2,1,0,0,0,0,0,3.667
+Summer 2024,PHAR,5675,5,11825,Disease State Management,Asias-Dinh,Bernadette De Leon,3,0,0,0,0,0,0,4.0
+Summer 2024,HRD,6354,20,11829,Facilitating Adult Group Proc.,Pereira-Leon,Maura Josefina,15,1,0,0,0,0,0,3.938
+Summer 2024,CHEM,1112,17,11830,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,1,1,0,0,0,3.118
+Summer 2024,MATH,8398,1,11837,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Summer 2024,PCOL,8399,2,11854,Doctoral Dissertation,Cuny,Gregory D,0,0,0,0,0,1,0,
+Summer 2024,CNST,3372,1,11864,Soil Mechanics & Foundations,Meyer,Joseph Ray,14,6,1,0,0,0,0,3.603
+Summer 2024,ACCT,4198,1,11870,Independent Study,Newman,Michael Ray,0,1,0,0,0,0,0,3.0
+Summer 2024,SPAN,3307,1,11871,Public Speaking in Spanish,Burgess,Miguel,25,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,1112,18,11872,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,11,3,0,0,0,1,3.043
+Summer 2024,SPEC,4353,1,11873,Assistive Technology,Goodrich,Elizabeth A,4,10,1,0,0,0,1,3.112
+Summer 2024,SPEC,6353,1,11874,Technology in Special Pops,Goodrich,Elizabeth A,3,1,0,0,0,0,0,3.585
+Summer 2024,SPEC,7391,1,11875,Collab Consulting & Coaching,Carp,Charlotte Lynn,23,0,0,0,0,0,0,3.914
+Summer 2024,MIS,4374,1,11876,Info Technology Project Mgmt,Campbell,Phillip James,26,13,2,0,1,0,0,3.445
+Summer 2024,SPEC,7341,1,11878,Assessment of Learning Diff,Hassett,Kristen Spring,10,0,0,0,0,0,0,4.0
+Summer 2024,SPEC,8360,1,11879,Instruct Probs in Special Pop,Rigby-Wills,Hope,8,0,0,0,0,0,0,4.0
+Summer 2024,MATH,5341,1,11882,Mathematical Modeling,He,Jiwen,19,0,0,0,0,0,0,4.0
+Summer 2024,ECON,6693,2,11883,Master's Research Project,Shpak,Solomiya,3,1,0,0,0,0,0,3.833
+Summer 2024,CNST,3155,1,11886,Const Materials & Testing,Meyer,Joseph Ray,18,8,1,0,0,0,0,3.642
+Summer 2024,CNST,3331,1,11887,Constructn Plan and Scheduling,Lyon,Eva Yaneth,7,20,3,0,0,0,0,3.144
+Summer 2024,CNST,3355,1,11888,Strength of Construction Mtrls,Hossain,Sk Amjad,13,7,1,0,0,0,0,3.571
+Summer 2024,SOCW,7320,1,11889,Empowerment,Rabo,Amber L,13,1,0,0,0,0,0,3.929
+Summer 2024,CNST,4302,1,11890,Construction Law and Ethics,Ducran,Denis George,5,12,4,1,2,0,0,2.722
+Summer 2024,HDFS,3300,1,11891,Educational Psychology,Conston,Toya,45,4,1,0,0,0,0,3.827
+Summer 2024,PSYC,4344,3,11892,Cultural Psychology,Jewell,Rebecca D,28,8,4,1,3,0,3,3.355
+Summer 2024,ELCS,8355,1,11893,Policy Pol & Gov of Education,Snodgrass Rangel,Virginia Walker,4,0,0,0,0,0,0,4.0
+Summer 2024,EDRS,8382,1,11894,Statistical Analyses in Eductn,Pettersson Cobb,Jennifer,10,5,0,0,0,0,1,3.711
+Summer 2024,NUTR,4346,1,11895,Research in Nutrition,Haubrick,Kevin,39,13,4,0,0,0,0,3.578
+Summer 2024,PHLS,6310,2,11896,Intro To Educ Research,Lee,Jungeun,13,1,1,0,0,0,0,3.8
+Summer 2024,MARK,7376,1,11897,Brand Management,Koch,Steven F,33,0,0,0,0,0,0,4.0
+Summer 2024,MANA,7351,1,11898,Mgt of  Global Organizations,Keller,Robert T,13,3,0,0,0,0,0,3.627
+Summer 2024,HRD,6358,30,11900,Global Human Resource Devel,Waight,Consuelo L,9,0,0,0,0,0,0,4.0
+Summer 2024,WCL,3366,2,11902,Latin American and Latino Film,Centeno,Daniel,15,11,3,0,0,0,1,3.346
+Summer 2024,NUTR,6301,1,11904,Clinic Aspects of Nutr Support,Ferrell,Carla Denise,16,3,0,0,0,0,0,3.755
+Summer 2024,SOCW,7373,1,11907,Human Sexuality & Sw,Gracely,Jill Marie,24,0,0,0,0,0,0,4.0
+Summer 2024,LAW,6217,1,11910,Negotia & Creative Prblm Slvng,Block,Nathan Matthew,4,8,1,0,0,1,0,3.307
+Summer 2024,LAW,5199,10,11911,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Summer 2024,LAW,5199,13,11913,Special Problems,Vetter,Greg R,0,0,0,0,0,2,0,
+Summer 2024,LAW,5299,17,11916,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Summer 2024,ACCT,5331,2,11917,Federal Income Tax,Fernandez,Ramon,1,2,2,0,0,0,0,2.932
+Summer 2024,GOVT,2306,2,11918,US and Texas Const/Politics,Cole,Jeffrey Bryan,34,20,10,1,3,0,2,3.172
+Summer 2024,GOVT,2305,3,11919,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,26,27,15,0,1,0,9,3.044
+Summer 2024,COMM,1302,1,11922,Intro To Comm Theory,Lee,Jaesub,3,5,3,1,0,0,1,2.668
+Summer 2024,COMM,3360,1,11923,Principles of Strategic Comm,Choi,Ho Joon,13,4,1,0,0,0,0,3.648
+Summer 2024,COMM,4355,1,11924,Organizational Comm,Liu,Wenlin,21,6,1,0,1,0,1,3.575
+Summer 2024,PSYC,2319,3,11925,Intro to Social Psychology,Browne,Lindsay J,5,9,1,0,2,0,1,2.882
+Summer 2024,DANC,2303,2,11926,Introduction to Dance,Bobet,Jacqueline A,28,10,6,2,4,0,2,3.08
+Summer 2024,NURS,4220,1,11927,Clinical Decision Making,Obey,Faye B,4,13,0,0,0,0,0,3.235
+Summer 2024,SPAN,3375,2,11928,US Hispanic Culture & Civiliza,Cuesta,Mabel,23,3,2,1,0,0,4,3.644
+Summer 2024,CNST,4341,20,11929,Project Controls,Bouhou,Nour-El Imane,17,19,4,0,0,0,0,3.342
+Summer 2024,SPAN,3308,1,11930,Written Com-Hisp Herit Learner,Leon,Maredil Josefina,22,6,0,0,0,0,0,3.703
+Summer 2024,NUTR,6311,1,11931,Capstone I,Haubrick,Kevin,13,9,0,0,0,0,0,3.636
+Summer 2024,WGSS,3322,1,11932,Intersectionalities,De Los Reyes Heredia,Jose Guillermo,25,1,0,1,1,0,2,3.703
+Summer 2024,WGSS,2360,2,11933,Introduction to LGBT Studies,Stone,Lauren Michelle,9,6,3,0,1,0,1,3.193
+Summer 2024,CIS,2334,20,11937,Information Systems Applicatns,Lendasse,Amaury,20,4,2,0,0,0,0,3.629
+Summer 2024,IRW,1300,1,11938,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,10,0,
+Summer 2024,IRW,1300,2,11939,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,1,0,
+Summer 2024,DIGM,4396,30,11940,Internship in Digital Media,Liao,Tony Chung-Li,8,2,0,0,0,0,0,3.833
+Summer 2024,MATH,6315,5,11941,Masters Tutorial,Morgan,Jeffrey,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6257,5,11958,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2024,CUIN,8310,1,11960,Laboratory of Practice,Hutchison,Laveria F,6,0,0,0,0,0,0,4.0
+Summer 2024,FINA,7361,1,11961,Risk Management,Hogan,Kenneth David,2,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5683,3,11974,Cardiology,Wang,Elisabeth,2,0,0,0,0,0,0,4.0
+Summer 2024,EDUC,2301,1,11979,Intro to Special Populations,Hassett,Kristen Spring,36,4,1,0,1,0,1,3.77
+Summer 2024,EDUC,2301,2,11980,Intro to Special Populations,Carp,Charlotte Lynn,13,3,1,0,0,0,0,3.686
+Summer 2024,SPEC,4367,1,11981,"Strategies for Collab, Coachin",Carp,Charlotte Lynn,19,6,2,0,0,0,0,3.544
+Summer 2024,ACCT,5332,1,11996,Taxation of Business Entities,Mangano,Clifford A,3,0,0,0,0,0,0,3.78
+Summer 2024,PHYS,1101,4,12002,College Physics I (lab),Wood,Lowell T,3,4,5,2,0,0,1,2.689
+Summer 2024,PHYS,1102,4,12003,College Physics II (lab),Wood,Lowell T,2,10,4,0,0,0,1,2.813
+Summer 2024,CUIN,8398,1,12006,Independent Study,Zhang,Jie,2,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6352,4,12008,Directed Rsch in I/O Psyc,Ng,Vincent,3,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,2317,4,12030,Intro to Psychology Statistics,Penheiro,Romeo Alex,22,17,4,3,0,0,4,3.268
+Summer 2024,ELCS,6310,1,12038,Strategic Engagement,Alex,Rachel Walker,20,1,5,0,0,0,1,3.577
+Summer 2024,POLS,8399,16,12039,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Summer 2024,COMM,2311,5,12042,Writing for Print and Digital,Radcliffe Andre,Jennifer,20,1,1,1,0,0,0,3.682
+Summer 2024,COMM,2356,1,12044,Business & Professional Comm,Uhrick,Jan,33,8,2,1,2,0,0,3.486
+Summer 2024,PSYC,2305,1,12047,Intro to Methods in Psychology,Myers,Annika Mariah,20,12,1,0,2,0,0,3.296
+Summer 2024,PSYC,2330,2,12049,Biological Psychology,Lopez,Mariana Selene,23,14,2,0,0,0,0,3.454
+Summer 2024,PSYC,2320,3,12050,Abnormal Psychology,Kim,Jinu,16,4,5,5,0,0,0,2.945
+Summer 2024,SPEC,6327,1,12051,Measurement Eval Research,Cole,Jana Belinda,25,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8371,1,12052,Legal Issues Sch District Levl,Goree,Tonya,1,1,0,0,0,0,0,3.665
+Summer 2024,CUIN,7375,1,12053,Capstone for Literacy Educ,Hale,Margaret Ann,3,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,2305,9,12054,Intro to Methods in Psychology,Hernandez Ortiz,Jessica G,21,16,1,0,2,0,0,3.441
+Summer 2024,PSYC,2305,11,12056,Intro to Methods in Psychology,Liu,Tingshu,23,12,1,0,2,0,2,3.421
+Summer 2024,PSYC,2319,2,12058,Intro to Social Psychology,Ravey,Eriksen,13,7,3,1,0,0,0,3.32
+Summer 2024,KIN,4315,1,12059,Motor Learning and Control,Layne,Charles S,10,37,10,0,1,0,0,2.931
+Summer 2024,KIN,4370,1,12060,Exercise Testing,Breslin,Whitney L,0,16,11,0,0,0,0,2.58
+Summer 2024,POLC,6391,1,12066,Public Policy Internship,Koelling,Peter,4,0,0,0,0,0,1,3.918
+Summer 2024,MANA,4338,1,12067,Performance Management Systems,Bozeman,Dennis,33,16,8,2,0,0,0,3.412
+Summer 2024,MANA,4348,1,12068,Global Leadership,Tabesh,Pooya,22,8,1,0,0,0,2,3.635
+Summer 2024,CIS,2348,20,12071,Info Systems Appl Development,Ratner,Edward,13,8,11,0,4,0,3,2.676
+Summer 2024,CIS,3347,20,12072,IS Infrastructure & Networking,Banerjee,Tania,24,3,0,0,0,0,1,3.889
+Summer 2024,COSC,3380,201,12073,Database Systems,Hilford,Victoria,43,33,15,0,1,0,1,3.236
+Summer 2024,COSC,4353,101,12074,Software Design,Singh,Raj Kumar,26,20,0,0,0,0,2,3.479
+Summer 2024,COSC,6353,101,12075,Software Design,Singh,Raj Kumar,7,0,1,0,0,0,0,3.626
+Summer 2024,ACCT,3377,1,12076,Cost Accounting,Serrato,Darlene Marie  Bohac,13,12,4,0,1,0,4,3.2
+Summer 2024,CHEM,2323,1,12077,Organic Chemistry I,Young,Crystal Ann,3,7,26,11,9,0,27,1.596
+Summer 2024,HDCS,1300,3,12079,Human Ecosystems & Tech Change,Mudd,Blake Stevens,22,2,1,1,0,0,1,3.68
+Summer 2024,HRD,6303,30,12081,Assessment & Evaluation in Hrd,Alston,Carmen M,8,0,0,0,0,0,0,3.876
+Summer 2024,MATH,6386,1,12082,Big Data Analytics,Shastri,Dvijesh J,18,6,0,0,0,0,0,3.64
+Summer 2024,CNST,4315,1,12083,Steel Construction,Chang,Chi Chung,16,13,0,0,0,0,0,3.518
+Summer 2024,FINA,4328,1,12084,Principles of Personal Finance,Coleman,Alfred G,11,7,1,0,1,0,0,3.334
+Summer 2024,TLIM,3345,30,12085,Human Resources in Technology,Mehring,Brian George,18,7,3,0,0,0,0,3.465
+Summer 2024,TLIM,3355,20,12086,Project Management Principles,Moore,George P,11,5,0,0,0,0,0,3.667
+Summer 2024,TLIM,3363,23,12087,Technical Communications,Tangeman,Anthony C,11,6,1,0,4,0,0,2.834
+Summer 2024,TLIM,3363,20,12088,Technical Communications,Piercy,Penelope Junker,14,5,2,1,0,0,1,3.395
+Summer 2024,TLIM,3363,21,12089,Technical Communications,Peterson,Kathryn Marie,18,1,0,0,0,0,0,3.861
+Summer 2024,TLIM,3363,34,12090,Technical Communications,Tangeman,Anthony C,14,10,5,0,0,0,0,3.39
+Summer 2024,TLIM,3363,22,12091,Technical Communications,Piercy,Penelope Junker,12,8,1,1,0,0,0,3.409
+Summer 2024,TLIM,4341,20,12093,Production & Service Operation,Chance,Michael Dean,12,10,4,0,1,0,0,3.173
+Summer 2024,TLIM,4341,30,12094,Production & Service Operation,O'Kelley,Donna K,17,5,0,0,0,0,1,3.653
+Summer 2024,TLIM,4342,21,12095,Quality Improvement Methods,Chance,Michael Dean,16,10,3,3,0,0,0,3.188
+Summer 2024,TLIM,4342,30,12096,Quality Improvement Methods,O'Kelley,Donna K,12,19,3,1,2,0,0,2.991
+Summer 2024,TLIM,4371,20,12097,Leading Change in the Wrkplace,Evans,Gerald S,13,2,0,0,0,0,0,3.713
+Summer 2024,TLIM,4372,20,12098,Proposal and Project Writing,Thomas,Jamie M,7,2,1,0,0,0,1,3.6
+Summer 2024,CHEM,1305,1,12099,Foundations of Chemistry,St Hill,Lydia Ruth,2,7,8,1,16,0,14,1.401
+Summer 2024,BIOL,1308,1,12100,Biology for Non-Science Majors,Gifford,Jenifer,8,8,5,1,0,0,1,3.045
+Summer 2024,PHAR,5206,1,12101,Pharmacy and Geriatrics,Fernandez,Julianna M,9,14,1,0,0,0,0,3.333
+Summer 2024,PHAR,5207,1,12102,Herbal Medicine,Ruan,Ke-He,8,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5217,1,12103,Pediatric Therapeutics,Martinez,Brigetta,40,4,0,0,0,0,0,3.909
+Summer 2024,PHAR,5457,1,12104,Institutional IPPE,Hatfield,Catherine L,82,25,0,0,0,0,0,3.766
+Summer 2024,FINA,7374,1,12105,Midstream Energy Finance,Braziel,David Russell,25,2,0,0,1,0,0,3.727
+Summer 2024,NUTR,6312,1,12110,Capstone II,Haubrick,Kevin,1,0,0,0,0,0,0,4.0
+Summer 2024,MUED,2342,1,12111,Music for Children,Chapa,Julissa Y,12,2,0,0,0,0,0,3.881
+Summer 2024,KIN,4302,1,12113,Fitness and Human Sexuality,Alastuey,Lisa L,16,13,5,1,0,0,1,3.182
+Summer 2024,FINA,7377,1,12114,Electric Power Markets,Gasca,Amparo Amy,19,0,0,0,0,0,0,3.913
+Summer 2024,FINA,4330,1,12115,Corporate Finance,Suleymanov,Masim,20,21,8,0,1,0,1,3.187
+Summer 2024,COSC,8398,101,12117,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,2,0,
+Summer 2024,COSC,8398,103,12119,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Summer 2024,COSC,8398,107,12123,Doctoral Research,Eick,Christoph F,0,0,0,0,0,1,0,
+Summer 2024,COSC,8398,124,12138,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Summer 2024,COSC,8398,128,12142,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Summer 2024,PHIL,1301,1,12176,Intro To Philosophy,Weisberg,Joshua,3,8,6,2,2,0,0,2.271
+Summer 2024,GEOL,3355,1,12179,Field Geology I,Robinson,Alexander C,3,6,1,0,0,0,0,3.332
+Summer 2024,GEOL,3360,1,12180,Field Geology II,Weber,John,5,3,0,0,0,0,0,3.625
+Summer 2024,COSC,4377,301,12181,Intro To Computer Networks,Long,Kevin B,47,45,16,0,2,0,2,3.227
+Summer 2024,COSC,3337,201,12182,Data Science I,Rizk,Nouhad J,15,11,16,2,4,0,4,2.611
+Summer 2024,COMM,3370,1,12183,History of Cinema,Houk,Keith R,35,0,1,0,0,0,1,3.889
+Summer 2024,ENGL,2305,1,12184,Intro To Fiction,Bose,Godhuly,19,2,0,0,0,0,2,3.858
+Summer 2024,COSC,3340,101,12186,Intro. to Automata and Comp.,Singh,Raj Kumar,78,29,4,0,1,0,0,3.578
+Summer 2024,ENGI,1331,3,12187,Computing for Engineers,Burleson,Daniel W,19,13,3,1,0,0,1,3.38
+Summer 2024,ENGI,2304,7,12188,Technical Communications,Wilson,Chad A,17,2,3,1,1,0,1,3.238
+Summer 2024,ENGI,2304,8,12189,Technical Communications,O'Bryan,Ann Patricia,13,4,0,0,0,0,0,3.687
+Summer 2024,MECE,3336,1,12190,Mechanics II,Hammami,Farah,15,16,4,1,2,0,1,3.088
+Summer 2024,MECE,3363,1,12191,Intro To Fluid Mechanics,Yang,Wenhua,9,7,2,0,0,0,0,3.407
+Summer 2024,BIOL,6355,1,12194,Introduction to Health Systems,Valier,Helen K,32,0,0,0,0,0,0,3.948
+Summer 2024,HIST,1301,1,12195,The U.S. to 1877,Clavin,Matthew J,6,12,4,3,5,0,0,2.345
+Summer 2024,ECON,3320,1,12197,Intro to Econ Data Analysis,Troncoso,Pablo A,10,9,10,1,0,0,2,2.955
+Summer 2024,OPTO,6115,2,12198,Clinical Integration,Gostovic,Anita Ticak,23,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,4303,1,12199,Biomaterials,Abidian,Mohammad Reza,2,0,0,0,0,0,1,4.0
+Summer 2024,BIOE,6303,1,12200,Biomaterials,Abidian,Mohammad Reza,11,0,0,0,0,0,0,3.94
+Summer 2024,WGSS,2350,1,12202,Intro To Women's Studies,Ford-McCartney,Devan Shontrell,27,1,1,1,0,0,0,3.778
+Summer 2024,WGSS,2360,1,12203,Introduction to LGBT Studies,Boffone,Trevor James,23,3,1,0,1,0,1,3.69
+Summer 2024,WGSS,3321,1,12204,Gender in Transnational Persp,Chatterjee,Shraddha,1,2,1,1,0,0,0,2.666
+Summer 2024,NUTR,2332,2,12205,Intro To Human Nutrition,Svendsen-Sanchez,Ann Carol,39,17,4,1,0,0,1,3.492
+Summer 2024,NUTR,2332,3,12206,Intro To Human Nutrition,Alastuey,Lisa L,23,23,7,5,2,0,2,2.967
+Summer 2024,PSYC,6393,3,12209,Clinical Research Practicum,Cirino,Paul,0,0,0,0,0,1,0,
+Summer 2024,PHOP,6257,6,12212,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6257,8,12214,Research Practicum B,Ostrin,Lisa,6,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6257,9,12215,Research Practicum B,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,8698,35,12216,Doctoral Research,Chiang,Naihao,0,0,0,0,0,1,0,
+Summer 2024,PHOP,6257,10,12217,Research Practicum B,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,6698,28,12222,Special Problems,Yang,Ding-Shyue,0,0,0,0,0,3,0,
+Summer 2024,CHEM,6698,29,12223,Special Problems,Lubchenko,Vassiliy,0,0,0,0,0,1,0,
+Summer 2024,ATP,6303,1,12225,Gen Med/Pharm 1 -System & Eval,Knoblauch,Mark Alan,11,3,0,0,0,0,0,3.786
+Summer 2024,ENGL,1302,11,12229,First Year Writing II,Salome,Melanie Rebecca,6,12,1,0,1,0,2,3.084
+Summer 2024,ENGL,1302,12,12230,First Year Writing II,Downey,Carlton M,20,0,0,0,1,0,3,3.794
+Summer 2024,ENGL,1302,13,12231,First Year Writing II,Downey,Carlton M,10,1,2,0,1,0,1,3.357
+Summer 2024,ENGL,2315,1,12234,Literature and Film,Pegoda,Andrew Joseph,4,4,8,0,0,0,6,2.771
+Summer 2024,PHOP,8399,5,12239,Doctoral Dissertation,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2024,FINA,3332,2,12241,Prin of Financial Management,Chisholm,Darla,20,12,6,0,1,0,3,3.189
+Summer 2024,PHOP,8598,1,12244,Doctoral Research,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Summer 2024,HIST,8699,6,12249,Doctoral Dissertation,Goldberg,Mark A,2,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8598,4,12256,Doctoral Research,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8598,5,12257,Doctoral Research,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8298,1,12262,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2024,PHYS,1101,5,12264,College Physics I (lab),Wood,Lowell T,1,12,2,0,0,0,0,2.999
+Summer 2024,SCM,4311,1,12268,Project Management,Wayhan,Victor Brian,54,65,16,2,1,0,3,3.22
+Summer 2024,PHOP,6267,1,12269,Research Practicum A,Porter,Jason,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6467,1,12271,Research Practicuum A,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6567,3,12273,Research Practicum A,Yoon,Geunyoung,2,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6567,4,12274,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6567,7,12278,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6267,3,12281,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8498,1,12282,Doctoral Research,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6365,2,12286,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,0,0,
+Summer 2024,PHOP,6367,1,12293,Research Practicum A,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6336,3,12294,Directed Rsch in Social Psyc,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Summer 2024,COSC,8698,122,12297,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,3,0,
+Summer 2024,COSC,8698,106,12299,Doctoral Research,Deng,Zhigang,0,0,0,0,0,4,0,
+Summer 2024,HLT,3301,2,12300,Health Behavior Theories,Bennett,Kristin C,46,5,4,0,1,0,2,3.62
+Summer 2024,COSC,8698,128,12302,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,2,0,
+Summer 2024,HLT,3325,1,12304,Medical Terminology,Bloom,Joel A,93,3,1,0,0,0,1,3.921
+Summer 2024,HLT,3325,2,12305,Medical Terminology,Bloom,Joel A,87,4,1,0,0,0,1,3.913
+Summer 2024,HLT,3325,3,12306,Medical Terminology,Burk,Kelly Ann,94,2,0,0,0,0,1,3.948
+Summer 2024,HLT,1353,2,12307,Personal Health,Rafique,Kiran Sajid,56,33,5,1,0,0,1,3.488
+Summer 2024,SPAN,1501,3,12308,Elementary Spanish I,Borroto Lopez,Cecilia De La Caridad,3,8,2,1,0,0,1,2.881
+Summer 2024,SPAN,2311,4,12310,Intermediate Spanish I,Miranda Moreno,Sujaila Abigail,4,6,9,0,0,0,2,2.633
+Summer 2024,MATH,6308,1,12311,Advanced Linear Algebra I,Labate,Demetrio,3,0,0,0,0,0,0,4.0
+Summer 2024,MATH,8698,15,12315,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Summer 2024,MATH,8698,16,12316,Doctoral Research,Mang,Andreas,0,0,0,0,0,2,0,
+Summer 2024,ENGL,8399,5,12320,Doctoral Dissertation,Butler,Paul G,0,0,0,0,0,1,0,
+Summer 2024,MATH,8698,10,12322,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,3,0,
+Summer 2024,MATH,8698,12,12323,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Summer 2024,COSC,8698,102,12326,Doctoral Research,Chen,Guoning,0,0,0,0,0,4,0,
+Summer 2024,HDFS,2314,3,12328,Human Dev and Interventions,Schoger,Kimberly,42,7,0,0,1,0,0,3.734
+Summer 2024,COSC,8698,127,12330,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,2,0,
+Summer 2024,PHOP,6267,4,12333,Research Practicum A,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Summer 2024,COSC,8698,114,12335,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,2,0,
+Summer 2024,PEP,8399,2,12336,Doctoral Dissertation,O'Connor,Daniel Patrick,1,0,0,0,0,0,0,4.0
+Summer 2024,ENGL,8698,1,12341,Graduate Research,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Summer 2024,COSC,8698,112,12342,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,2,0,
+Summer 2024,COSC,8698,113,12347,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Summer 2024,COSC,8698,107,12348,Doctoral Research,Eick,Christoph F,0,0,0,0,0,1,0,
+Summer 2024,COMD,7391,11,12350,Clinic in Speech Lang Disorder,Bolling,Kenyetta,2,0,0,0,0,0,0,3.67
+Summer 2024,COMD,7391,16,12351,Clinic in Speech Lang Disorder,Cizek,Laura S,3,1,0,0,0,0,0,3.75
+Summer 2024,COMD,7391,17,12352,Clinic in Speech Lang Disorder,Andrade,Michelle Lee,1,1,0,0,0,0,0,3.5
+Summer 2024,COMD,7391,18,12353,Clinic in Speech Lang Disorder,Chapman,Amanda,2,0,0,0,0,0,0,3.835
+Summer 2024,COMD,7391,19,12354,Clinic in Speech Lang Disorder,Townsend,Alayna,2,0,0,0,0,0,0,3.67
+Summer 2024,COMD,7391,1,12356,Clinic in Speech Lang Disorder,Walker,Dionne A,2,0,0,0,0,0,0,3.67
+Summer 2024,COSC,8698,120,12359,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Summer 2024,COSC,8698,125,12360,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Summer 2024,COSC,8698,109,12364,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Summer 2024,ECON,8699,5,12367,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,2,0,
+Summer 2024,COSC,8698,117,12369,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,2,0,
+Summer 2024,COSC,8698,129,12371,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,3,0,
+Summer 2024,COMM,1303,1,12373,Writing for Communicators,Lyn,Robyn,24,5,3,0,0,0,0,3.636
+Summer 2024,INDE,8198,1,12374,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Summer 2024,INDE,8198,4,12377,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Summer 2024,INDE,8298,1,12379,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,2,0,
+Summer 2024,INDE,8498,1,12390,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,2,0,
+Summer 2024,INDE,8498,4,12393,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Summer 2024,INDE,8598,4,12396,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Summer 2024,INDE,8598,6,12398,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,1,0,
+Summer 2024,COMD,7391,21,12406,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,0,1,0,0,0,0,0,3.33
+Summer 2024,WGSS,2350,3,12407,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,22,3,2,0,0,0,1,3.753
+Summer 2024,PHOP,6167,3,12411,Research Practicum A,Patel,Nimesh Bhikhu,0,0,0,0,0,1,0,
+Summer 2024,MANA,4347,1,12413,Ethics and Corp Soc Respon.,Salaiz,Ashley,56,4,0,0,0,0,0,3.928
+Summer 2024,CIVE,8198,1,12415,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,1,12417,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8699,1,12418,Doctoral Dissertation,Vipulanandan,Cumaraswamy,1,0,0,0,0,0,0,4.0
+Summer 2024,WGSS,2350,4,12421,Intro To Women's Studies,Martinez,Itzel Areli,18,4,1,0,2,0,0,3.361
+Summer 2024,ENTR,3310,4,12422,Entrepreneurship,Ortega,Carlos Alberto,81,13,2,1,0,0,0,3.746
+Summer 2024,ENGL,1302,14,12423,First Year Writing II,Islam,Muhammad Nurul,15,0,0,0,3,0,0,3.205
+Summer 2024,PSYC,6365,6,12424,Dir Rsch in Dev Cog Beh Neuro,Leasure,Jennifer Leigh,1,0,0,0,0,0,0,4.0
+Summer 2024,INDE,8198,7,12425,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Summer 2024,CUIN,8399,1,12427,Doctoral Dissertation,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Summer 2024,COMM,2327,1,12432,Introduction to Screen Writing,Vaughan,Thomas Michael,16,1,2,1,1,0,2,3.397
+Summer 2024,COMM,3317,2,12433,Multimedia Journalism,Roth,Geoffrey,12,3,1,0,0,0,1,3.688
+Summer 2024,COMM,3328,1,12434,Intro to Sports Production,Crowe,Craig Warren,9,5,1,0,0,0,0,3.511
+Summer 2024,COMM,3300,1,12435,Health Communication,Yamasaki,Jill S,46,11,2,0,0,0,0,3.712
+Summer 2024,COMM,3369,2,12436,Strategic Comm. Writing,Belton,Stephanie,22,0,0,0,2,0,1,3.557
+Summer 2024,MATH,2305,1,12439,Discrete Mathematics,Papadakis,Emanuel Ioannis,51,1,1,0,1,0,0,3.858
+Summer 2024,BIOL,6352,1,12442,Molecular Mech Disease,Lin,Chin-Yo,26,5,0,0,0,0,0,3.743
+Summer 2024,GHL,4352,1,12443,Hosp Organizational Behavior,Doudna,Simone P,10,1,0,0,1,0,0,3.583
+Summer 2024,GHL,4360,1,12444,Professional Development,Kenyan,Erin Oeser,33,2,0,0,0,0,1,3.886
+Summer 2024,LAW,6220,1,12445,Trademark Prosecution,Hunt,Lee Burton,3,8,1,0,0,0,0,3.222
+Summer 2024,CUIN,4375,1,12450,Classroom Management,Thompson,Alan M,15,3,0,0,0,0,0,3.852
+Summer 2024,ELCS,6330,2,12452,Finance & School-Based Budgtng,Horner,Glenda Sue,16,0,0,0,0,0,0,4.0
+Summer 2024,SPEC,6367,1,12453,Special Education for Leaders,Rigby-Wills,Hope,22,5,1,0,1,0,0,3.621
+Summer 2024,DIGM,1376,30,12456,User Experience (UX)Principles,Rodwell,Elizabeth Ann,47,12,5,0,5,0,0,3.334
+Summer 2024,DIGM,3152,30,12457,Graphic Comm Output Lab,Dawson,Michael John,6,0,0,0,0,0,0,4.0
+Summer 2024,TLIM,3360,30,12459,Law & Ethics-Tech & Innovation,Feriante,Chris,81,16,0,0,0,0,1,3.791
+Summer 2024,TLIM,3340,20,12460,Org Leadership & Supervision,Evans,Gerald S,52,1,1,0,0,0,1,3.926
+Summer 2024,ELCS,8330,1,12461,Statistical Analyses,Pettersson Cobb,Jennifer,0,0,0,0,1,0,0,0.0
+Summer 2024,SPEC,8365,1,12462,Admin-Supv Special Educ,Malechuk,Brian Edward,9,0,0,0,0,0,0,4.0
+Summer 2024,BCIS,1305,1,12466,Business Computer Applications,Felvegi,Emese,47,11,7,1,1,0,1,3.527
+Summer 2024,BUSI,3300,1,12467,Intro to Personal Finance,Harvey,Danny,47,2,0,0,0,0,1,3.912
+Summer 2024,BUSI,3300,3,12468,Intro to Personal Finance,Munchbach,Jim,36,5,3,1,3,0,2,3.417
+Summer 2024,KIN,3304,1,12469,Human Structure & Phys Perform,Breslin,Whitney L,6,5,10,5,1,0,1,2.346
+Summer 2024,BUSI,2305,1,12471,Business Statistics,Wiley,Briceon C,18,12,14,16,6,0,6,2.153
+Summer 2024,MANA,4336,2,12473,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,8,6,1,0,0,0,0,3.401
+Summer 2024,MANA,4346,1,12474,Leadership Development,Evans,Klavdia Markelova,38,0,0,0,0,0,0,4.0
+Summer 2024,MANA,4353,1,12475,Mgmt Training and Career Devel,Bozeman,Dennis,34,18,6,0,1,0,0,3.485
+Summer 2024,ECON,3334,1,12476,Intermediate Macroeconomics,Peru Durayalage,Dhanushka Arunasiri,7,8,7,2,1,0,8,2.667
+Summer 2024,MANA,4355,2,12477,Selection and Staffing,Bozeman,Dennis,14,9,4,0,0,0,0,3.468
+Summer 2024,PSYC,3339,2,12478,Intro To Clinical Psychology,Szafranski,Derek D,38,8,2,2,0,0,0,3.607
+Summer 2024,MANA,6A32,2,12480,Organizational Behavior & Mgt,Krylova,Ksenia O,11,4,0,0,0,0,0,3.667
+Summer 2024,FINA,7364,1,12482,Intl Bus & Political Risk Mgt,Miljanic,Andra Olivia,11,4,0,0,0,0,0,3.821
+Summer 2024,BUSI,1301,1,12484,Business Principles,Thompson,Joseph Lee,85,3,1,2,2,0,2,3.792
+Summer 2024,BIOE,4349,1,12486,Biomedical Microdevices,Majd,Sheereen,6,1,0,0,0,0,0,3.81
+Summer 2024,BIOE,6349,1,12487,Biomedical Microdevices,Majd,Sheereen,6,1,0,0,0,0,0,3.763
+Summer 2024,ACCT,3367,2,12489,Intermediate Accounting I,Kuruvilla,Mohan,1,2,2,1,1,0,5,2.19
+Summer 2024,CIS,2336,20,12490,Web Application Development,Lindner,Peggy,5,8,5,1,1,0,2,2.717
+Summer 2024,WGSS,2350,5,12491,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,21,0,1,0,1,0,4,3.725
+Summer 2024,WGSS,2350,6,12492,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,21,3,2,0,2,0,1,3.476
+Summer 2024,ACCT,4335,1,12493,Financial Statement Auditing,Kuruvilla,Mohan,3,3,1,0,1,0,1,2.958
+Summer 2024,AAS,2330,1,12494,Black Liberation Theology,Johnson,Alexander Emmitt Maurice,2,3,2,0,2,0,1,2.407
+Summer 2024,HDCS,1300,1,12495,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,36,6,3,1,1,0,1,3.575
+Summer 2024,HDCS,4302,1,12496,Apparel Analysis,Gatterson,Beverly,21,8,3,0,1,0,0,3.465
+Summer 2024,MANA,7340,1,12498,Management of High Tech Org.,Keller,Robert T,28,2,0,0,0,0,0,3.834
+Summer 2024,ENGI,1331,4,12499,Computing for Engineers,Burleson,Daniel W,23,10,3,0,0,0,0,3.574
+Summer 2024,FINA,7361,2,12501,Risk Management,Hogan,Kenneth David,19,0,0,0,0,0,0,4.0
+Summer 2024,NURS,3634,1,12504,Clinical Nursing Practice II,Edwards-Maddox,Shermel Vinese,21,15,0,4,0,0,8,3.325
+Summer 2024,NURS,4218,1,12505,Emergency Nursing,Edwards-Maddox,Shermel Vinese,20,2,0,1,0,0,0,3.783
+Summer 2024,PHLS,6335,1,12507,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,8,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,6335,2,12508,Intro To Grp Couns Thry,Whitaker,Rachael Gwin,10,0,0,0,0,0,0,4.0
+Summer 2024,MECE,6387,1,12509,Intelligent Structural Systems,Song,Gangbing,3,6,0,0,0,0,3,3.407
+Summer 2024,TLIM,3330,30,12510,Innovation Principles,Feriante,Chris,17,17,8,0,0,0,6,3.277
+Summer 2024,HLT,4302,1,12512,Hlt Aspect Human Sexuality,Drenner,Kelli Linn,17,9,2,0,0,0,0,3.5
+Summer 2024,INDE,6336,1,12513,Reliability Engineering,Keedy,Elias,4,4,0,0,0,0,0,3.624
+Summer 2024,TLIM,3371,20,12514,Budgeting and Financial Princ,Burns,Maria,13,0,2,0,0,0,0,3.667
+Summer 2024,BUSI,4350,1,12515,Business Law and Ethics,Williams,John M,164,12,0,2,0,0,1,3.843
+Summer 2024,BUSI,4350,3,12517,Business Law and Ethics,Williams,John M,27,3,0,0,0,0,0,3.911
+Summer 2024,BUSI,4396,1,12518,Business Internship,Wortzel,Zachary,0,0,0,0,0,71,0,
+Summer 2024,IEEM,6360,1,12519,Data Analytics for Engr. Mgt,Hu,Minxiang,29,5,0,0,0,0,2,3.863
+Summer 2024,ARCH,6303,3,12521,Visual Studies III,Olwi,Asmaa,8,1,0,0,0,0,0,3.852
+Summer 2024,BUSI,4350,5,12524,Business Law and Ethics,Williams,John M,119,10,2,0,0,0,2,3.838
+Summer 2024,CHEE,6398,1,12541,Research,Karim,Alamgir,0,0,0,0,0,1,0,
+Summer 2024,INDE,8398,7,12549,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Summer 2024,BUSI,4396,2,12565,Business Internship,Wortzel,Zachary,0,0,0,0,0,7,0,
+Summer 2024,GEOL,7399,1,12590,Masters Thesis,Khan,Shuhab D,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8298,2,12592,Doctoral Research,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,7301,2,12596,Capstone Project,Khan,Shuhab D,0,0,0,0,0,0,0,
+Summer 2024,MANA,4385,1,12598,Intro to Strategic Management,Tabesh,Pooya,17,2,1,0,0,0,0,3.817
+Summer 2024,ACCT,2301,4,12600,Prin of Financial Accounting,Newman,Michael Ray,2,2,0,0,0,0,0,3.5
+Summer 2024,ACCT,2302,3,12601,Prin of Managerial Accounting,Newman,Michael Ray,7,2,0,0,0,0,1,3.778
+Summer 2024,ACCT,3368,1,12604,Intermediate Accounting II,Ramaswamy,Vinita,9,11,6,0,1,0,3,3.086
+Summer 2024,ACCT,5368,1,12605,Intermediate Accounting II,Ramaswamy,Vinita,2,1,1,0,0,0,0,3.333
+Summer 2024,ACCT,3371,1,12606,Accounting Information Systems,Seijas,Nuria S,28,17,2,2,0,0,2,3.469
+Summer 2024,ACCT,5371,1,12607,Accounting Information Systems,Seijas,Nuria S,2,3,0,0,0,0,0,3.532
+Summer 2024,ACCT,4330,1,12608,Advanced Accounting,Ramaswamy,Vinita,0,1,1,0,0,0,0,2.5
+Summer 2024,ACCT,5330,1,12609,Advanced Accounting,Ramaswamy,Vinita,1,2,1,0,0,0,0,3.165
+Summer 2024,ACCT,7330,1,12610,Advanced Accounting,Ramaswamy,Vinita,8,10,1,0,0,0,0,3.421
+Summer 2024,ACCT,4335,2,12611,Financial Statement Auditing,Kuruvilla,Mohan,7,8,8,4,0,0,0,2.703
+Summer 2024,ACCT,5301,1,12612,Financial and Managerial Acct,Kuruvilla,Mohan,4,1,1,0,2,0,1,2.46
+Summer 2024,CUIN,1103,11,12613,Educator Dispositions,Culpepper,Shea Mosley,1,0,0,0,0,0,0,4.0
+Summer 2024,BUSI,4305,1,12615,Business Ethics for Accountant,Newman,Michael Ray,3,0,0,0,0,0,0,4.0
+Summer 2024,GENB,5304,2,12616,Business Ethics for Accountant,Newman,Michael Ray,3,0,0,0,0,0,0,4.0
+Summer 2024,GENB,7304,2,12617,Bus Ethics for Accountants,Newman,Michael Ray,17,0,0,0,0,0,0,4.0
+Summer 2024,BUSI,4396,3,12618,Business Internship,Newman,Michael Ray,0,0,0,0,0,20,1,
+Summer 2024,EDUC,3101,11,12619,Practicum for Preservice Tchrs,Siller Escudero,Patricia,1,0,0,0,0,0,0,4.0
+Summer 2024,TLIM,3350,30,12620,Emergency Management Principle,Freedkin,Aaron Samuel,35,10,1,0,0,0,1,3.703
+Summer 2024,ECON,2301,1,12623,Principles of Macroeconomics,Maden,Bitaran Jang,17,28,13,3,5,0,3,2.742
+Summer 2024,AAS,2320,3,12624,Intro To African American Stdy,Thompson,Kevin Bernard,24,5,1,0,1,0,2,3.635
+Summer 2024,CNST,3265,1,12625,Construction Layout & Site Dvp,Lupher,Jacob John,14,7,0,0,1,0,2,3.5
+Summer 2024,MARK,4332,1,12628,Social Media Marketing,Noriega,Jaime L,37,9,2,1,0,0,0,3.62
+Summer 2024,SPEC,6350,1,12630,Nature/Needs of Students w/GT,Carp,Charlotte Lynn,1,0,0,0,0,0,0,4.0
+Summer 2024,GHL,4350,1,12633,Strategy&Innovation Hosp Ind,Morosan,Cristian,2,4,1,0,3,0,1,2.266
+Summer 2024,GHL,7337,1,12634,Human Resources in Hospitality,Madera,Juan Manuel,5,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,7327,1,12635,Counseling Children,Hurt,Kara Marie,10,1,0,0,0,0,0,3.909
+Summer 2024,ENGI,2304,10,12637,Technical Communications,Downey,Carlton M,18,1,0,0,0,0,0,3.93
+Summer 2024,ENGI,2304,11,12638,Technical Communications,Ettelson,Jennifer Jane,14,6,0,0,0,0,0,3.717
+Summer 2024,COMM,4357,1,12639,Intercultural Communication,Liu,Wenlin,21,2,0,0,0,0,0,3.827
+Summer 2024,ENGI,2304,12,12640,Technical Communications,Ettelson,Jennifer Jane,13,4,1,1,0,0,0,3.509
+Summer 2024,ENGI,2304,13,12641,Technical Communications,Smith-Irving,Brandi,13,7,3,1,0,0,0,3.333
+Summer 2024,ENGI,2304,14,12642,Technical Communications,Smith-Irving,Brandi,12,9,0,1,0,0,0,3.5
+Summer 2024,ENGI,2304,15,12643,Technical Communications,Khalil,Rand Omar,20,4,0,0,0,0,0,3.806
+Summer 2024,CHEE,3369,1,12646,Chemical Engr Transport Proc,Zerze,Hasan,8,1,3,0,0,0,7,3.362
+Summer 2024,INDE,3333,1,12649,Engineering Economy I,Diaz Martinez,Neil Orlando,10,14,4,0,0,0,0,3.238
+Summer 2024,INDE,4372,1,12656,Operation Control,Hu,Minxiang,7,1,0,0,0,0,0,3.834
+Summer 2024,INDE,6332,1,12657,Egr Project Mgt,Rypien,David V,19,4,0,0,0,0,1,3.855
+Summer 2024,IEEM,6335,1,12658,Engr Mgmt of Organizations,Hu,Minxiang,28,0,0,0,0,0,0,3.953
+Summer 2024,ELCS,6330,3,12659,Finance & School-Based Budgtng,Lewis-Skinner,Dametra N,22,3,4,0,0,0,0,3.552
+Summer 2024,EDRS,8382,2,12660,Statistical Analyses in Eductn,Pettersson Cobb,Jennifer,11,3,0,0,0,0,0,3.668
+Summer 2024,SOC,3390,1,12661,Sociology of Gender,Adams,Jennifer Lauren,34,8,2,2,0,0,1,3.63
+Summer 2024,BIOL,4340,1,12662,Research Methods,Ekeoba,Jacqueline Njideka,12,1,0,0,0,0,0,3.872
+Summer 2024,PHYS,4340,1,12663,Research Methods,Ekeoba,Jacqueline Njideka,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,4340,1,12664,Research Methods,Ekeoba,Jacqueline Njideka,2,0,0,0,0,0,0,4.0
+Summer 2024,KIN,3306,2,12670,Physiology-Human Performance,Breslin,Whitney L,35,15,1,2,0,0,1,3.504
+Summer 2024,CIS,2337,20,12673,Fund of Information Security,Peddoju,Suresh Kumar,1,10,8,0,2,0,3,2.318
+Summer 2024,HRD,6355,30,12674,Designing OD Interventions,Hausmann,Robert Carl,9,0,0,0,0,0,0,4.0
+Summer 2024,COSC,2436,201,12675,Programming and Data Structure,Rizk,Nouhad J,17,16,4,1,7,0,2,2.792
+Summer 2024,ACCT,5367,2,12677,Intermediate Accounting I,Kuruvilla,Mohan,2,0,0,0,0,0,0,4.0
+Summer 2024,MUED,2342,3,12678,Music for Children,Edwards,Zachary B,14,2,0,0,0,0,0,3.813
+Summer 2024,COSC,3360,301,12683,Operating Systems,Rincon Castro,Carlos Alberto,5,11,14,3,5,0,5,2.193
+Summer 2024,PHYS,2325,3,12684,University Physics I (lecture),Chen,Shuo,85,122,57,5,2,0,0,3.008
+Summer 2024,NURS,4322,1,12686,Policy &Ethics in Prof Nursing,Smith,Deborah Ann,34,14,0,0,0,0,0,3.708
+Summer 2024,NURS,6335,1,12688,Mgmt of Hlth Disrdrs in Adults,Tahmasbi,Sherin,2,1,0,0,0,0,0,3.667
+Summer 2024,NURS,6336,1,12689,Mgmt of Hlth Disordrs Clinical,Varghese,Simi,0,0,0,0,0,3,0,
+Summer 2024,FINA,4323,1,12690,Investment & Mutual Fund Mgt,Caire,Matthew,14,1,0,0,0,0,0,3.911
+Summer 2024,DRAM,1310,15,12694,Introduction to Theatre,Egging,Jon Leo,38,5,3,1,1,0,0,3.604
+Summer 2024,PSYC,2317,3,12697,Intro to Psychology Statistics,Nguyen,My Viet Ha,28,10,7,3,9,0,2,2.795
+Summer 2024,PSYC,2320,1,12698,Abnormal Psychology,Ridgely,Natalie,18,11,4,1,0,0,4,3.324
+Summer 2024,ENGL,2307,1,12700,Intro To Drama,Presswood,Phillip Hilliard,24,0,0,0,0,0,0,3.986
+Summer 2024,ENGL,2315,2,12701,Literature and Film,Sicinski,Michael J,14,5,1,0,2,0,2,3.258
+Summer 2024,ECE,2100,1,12706,Circuit Analysis Laboratory,Trombetta,Leonard P,14,9,6,0,0,0,0,3.253
+Summer 2024,PHED,1306,1,12707,Emergency Care & First Aid,Brown,Korey J,16,2,1,0,0,0,0,3.772
+Summer 2024,COMD,4489,1,12708,Clinical Procedures,Ermgodts,Katherine Natalie,12,0,0,0,0,0,0,4.0
+Summer 2024,COSC,4351,201,12713,Fundamentals of Software Engr,Hilford,Victoria,9,8,4,0,0,0,0,3.207
+Summer 2024,NUTR,4351,1,12714,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,30,13,1,0,0,0,0,3.592
+Summer 2024,PHYS,2125,2,12715,University Physics Lab I,Maric,Sladjana,45,54,20,2,0,0,0,3.078
+Summer 2024,CHEE,8399,18,12721,Doctoral Dissertation,Cirino,Patrick C,1,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,6230,1,12723,Contact Lens Pathology,Bergmanson,Jan Pg,0,0,0,0,0,33,0,
+Summer 2024,CHEE,8398,16,12728,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8398,17,12729,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8398,20,12732,Doctoral Research,Karim,Alamgir,0,0,0,0,0,5,0,
+Summer 2024,COSC,3320,101,12734,Algorithms and Data Structures,Hourani,Khalid Maen,15,15,9,0,2,0,3,3.072
+Summer 2024,CHEE,8298,7,12738,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8298,8,12739,Doctoral Research,Harold,Michael P,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8298,10,12741,Doctoral Research,Karim,Alamgir,0,0,0,0,0,9,0,
+Summer 2024,CHEE,8298,11,12742,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8298,13,12744,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8298,14,12745,Doctoral Research,Orman,Mehmet,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8298,15,12746,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8298,16,12747,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,11,0,
+Summer 2024,CHEE,8298,17,12748,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8298,18,12749,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8298,19,12750,Doctoral Research,Vekilov,Peter,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8298,20,12751,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8298,21,12752,Doctoral Research,Zerze,Gul,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8498,6,12753,Doctoral Research,Economou,Demetre J,0,0,0,0,0,0,0,
+Summer 2024,CHEE,8498,7,12754,Doctoral Research,Grabow,Lars C,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8498,8,12755,Doctoral Research,Harold,Michael P,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8498,10,12757,Doctoral Research,Karim,Alamgir,0,0,0,0,0,9,0,
+Summer 2024,CHEE,8498,11,12758,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8498,13,12760,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8498,14,12761,Doctoral Research,Orman,Mehmet,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8498,15,12762,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8498,16,12763,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,11,0,
+Summer 2024,CHEE,8498,17,12764,Doctoral Research,Robertson,Megan L,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8498,18,12765,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Summer 2024,CHEE,8498,19,12766,Doctoral Research,Vekilov,Peter,0,0,0,0,0,4,0,
+Summer 2024,CHEE,8498,21,12768,Doctoral Research,Zerze,Gul,0,0,0,0,0,3,0,
+Summer 2024,MANA,4341,1,12769,Leading Organizational Change,Evans,Klavdia Markelova,31,2,0,0,1,0,0,3.794
+Summer 2024,BCHS,8698,2,12771,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2024,PHOP,7399,6,12774,Masters Thesis,Twa,Michael D,0,0,0,0,0,0,1,
+Summer 2024,GEOL,8698,2,12775,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,2,0,
+Summer 2024,KIN,4391,1,12777,Internship in PE,Betts,Randi Jill,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,8199,1,12778,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8198,2,12779,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8198,4,12781,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8598,2,12782,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,4,12786,Doctoral Research,Shaffer,Devin,0,0,0,0,0,2,0,
+Summer 2024,GEOL,8698,4,12787,Doctoral Research,Wang,Guoquan,0,0,0,0,0,0,0,
+Summer 2024,CIVE,8198,5,12788,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8198,6,12789,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8198,7,12790,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8198,8,12791,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8198,9,12792,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8198,10,12793,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8198,11,12794,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8198,12,12795,Doctoral Research,Li,Hongyi,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8198,14,12797,Doctoral Research,Momen,Mostafa,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8198,19,12802,Doctoral Research,Milillo,Pietro,0,0,0,0,0,5,0,
+Summer 2024,CIVE,8198,20,12803,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,6,12805,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,7,12806,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,8,12807,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,9,12808,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8598,10,12809,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8598,11,12810,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8598,12,12811,Doctoral Research,Lee,Hyongki,0,0,0,0,0,4,0,
+Summer 2024,CIVE,8598,13,12812,Doctoral Research,Li,Hongyi,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8598,15,12814,Doctoral Research,Momen,Mostafa,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8598,19,12818,Doctoral Research,Milillo,Pietro,0,0,0,0,0,5,0,
+Summer 2024,CIVE,8598,20,12819,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8398,3,12825,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8398,4,12826,Doctoral Research,Abidian,Mohammad Reza,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8398,5,12827,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,3,0,
+Summer 2024,BIOE,8398,6,12828,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8398,9,12831,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,2,0,
+Summer 2024,BIOE,8398,10,12832,Doctoral Research,Larin,Kirill,0,0,0,0,0,9,0,
+Summer 2024,BIOE,8398,13,12835,Doctoral Research,Roh,Jinsook,0,0,0,0,0,2,0,
+Summer 2024,BIOE,8398,15,12837,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8398,16,12838,Doctoral Research,Wu,Tianfu,0,0,0,0,0,3,0,
+Summer 2024,BIOE,8398,19,12841,Doctoral Research,Das,Mini,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8399,1,12845,Doctoral Dissertation,Akay,Metin,0,0,0,0,0,0,0,
+Summer 2024,CIVE,8198,21,12849,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,4,0,
+Summer 2024,BIOE,8399,6,12852,Doctoral Dissertation,Gifford,Howard,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8598,21,12853,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,4,0,
+Summer 2024,BIOE,8399,8,12855,Doctoral Dissertation,Larin,Kirill,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8399,10,12857,Doctoral Dissertation,May,Elebeoba E,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8399,11,12858,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8399,13,12860,Doctoral Dissertation,Shevkoplyas,Sergey,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8399,14,12861,Doctoral Dissertation,Wu,Tianfu,1,0,0,0,0,1,0,4.0
+Summer 2024,BIOE,8298,1,12865,Doctoral Research,Akay,Metin,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8198,1,12867,Doctoral Research,Akay,Metin,0,0,0,0,0,0,0,
+Summer 2024,PSYC,3339,4,12881,Intro To Clinical Psychology,Healy,Nathaniel Andrew,14,16,4,0,3,0,3,3.018
+Summer 2024,BIOE,8399,16,12882,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8398,22,12883,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,ARTS,4398,2,12888,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8198,5,12889,Doctoral Research,Larin,Kirill,0,0,0,0,0,8,0,
+Summer 2024,BIOE,8298,5,12890,Doctoral Research,Larin,Kirill,0,0,0,0,0,7,0,
+Summer 2024,OPTO,7495,1,12893,General Clinic IIIc,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8398,23,12895,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8198,7,12897,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,3,0,
+Summer 2024,BIOE,8298,7,12898,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,3,0,
+Summer 2024,PETR,8398,2,12902,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Summer 2024,PETR,8398,3,12903,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,1,0,
+Summer 2024,PETR,8398,7,12906,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Summer 2024,PETR,8398,8,12907,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,0,0,
+Summer 2024,PETR,8398,10,12909,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Summer 2024,PETR,8598,3,12912,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,3,0,
+Summer 2024,MANA,8399,2,12915,Doctoral Dissertation,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,5250,1,12917,Seminar Scientific Investigatn,Frishman,Laura J,3,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8198,8,12918,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,2,0,
+Summer 2024,BIOE,8298,8,12919,Doctoral Research,Ince,Nuri Firat,0,0,0,0,0,2,0,
+Summer 2024,MECE,8498,1,12923,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Summer 2024,MECE,8298,1,12925,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Summer 2024,MECE,8699,2,12928,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Summer 2024,MECE,8498,3,12929,Doctoral Research,Yang,Di,0,0,0,0,0,2,0,
+Summer 2024,MECE,8298,3,12930,Doctoral Research,Yang,Di,0,0,0,0,0,2,0,
+Summer 2024,MECE,8398,27,12932,Doctoral Research,Chen,Zheng,0,0,0,0,0,2,0,
+Summer 2024,MECE,8298,4,12933,Doctoral Research,Floryan,Daniel,0,0,0,0,0,3,0,
+Summer 2024,MECE,8498,4,12934,Doctoral Research,Floryan,Daniel,0,0,0,0,0,3,0,
+Summer 2024,MECE,8399,20,12937,Doctoral Dissertation,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Summer 2024,MECE,8498,7,12942,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,
+Summer 2024,MECE,8298,7,12943,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,6,0,
+Summer 2024,MECE,8699,3,12950,Doctoral Dissertation,Selvamanickam,Venkat,0,0,0,0,0,1,0,
+Summer 2024,PETR,8398,11,12962,Doctoral Research,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Summer 2024,PETR,8598,6,12964,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,0,0,
+Summer 2024,PETR,8598,8,12966,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Summer 2024,PETR,8198,5,12972,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,0,0,
+Summer 2024,PETR,8198,7,12974,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Summer 2024,PETR,8198,9,12976,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,3,0,
+Summer 2024,PETR,8198,11,12978,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,3,0,
+Summer 2024,PETR,8598,11,12981,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,3,0,
+Summer 2024,DRAM,1310,10,12985,Introduction to Theatre,Hinkel,Heidi Anne,45,3,1,0,0,0,0,3.864
+Summer 2024,DRAM,1310,11,12986,Introduction to Theatre,Hinkel,Heidi Anne,44,4,0,0,0,0,1,3.896
+Summer 2024,MECE,8498,12,12996,Doctoral Research,Franchek,Matthew,0,0,0,0,0,1,0,
+Summer 2024,MECE,8298,12,12997,Doctoral Research,Franchek,Matthew,0,0,0,0,0,1,0,
+Summer 2024,BIOL,8698,4,12998,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,2,0,
+Summer 2024,MECE,8298,13,12999,Doctoral Research,Sun,Li,0,0,0,0,0,2,0,
+Summer 2024,MECE,8498,13,13001,Doctoral Research,Sun,Li,0,0,0,0,0,2,0,
+Summer 2024,MECE,8398,9,13004,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,
+Summer 2024,PHLS,8199,3,13009,Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2024,PHOP,6157,6,13015,Research Practicum B,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8298,3,13022,Doctoral Research,Yao,Yan,0,0,0,0,0,6,0,
+Summer 2024,ECE,8498,3,13023,Doctoral Research,Yao,Yan,0,0,0,0,0,6,0,
+Summer 2024,ECE,8498,5,13025,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,4,13026,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,5,13027,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,4,0,
+Summer 2024,ECE,8298,6,13028,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,8,13030,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Summer 2024,ECE,8298,9,13031,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,10,13032,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Summer 2024,ECE,8298,13,13036,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,3,0,
+Summer 2024,ECE,8298,14,13037,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,
+Summer 2024,ECE,8498,6,13046,Doctoral Research,Bao,Jiming,0,0,0,0,0,2,0,
+Summer 2024,ECE,8498,7,13047,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,5,0,
+Summer 2024,ECE,8498,8,13048,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Summer 2024,ECE,8498,9,13049,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Summer 2024,ECE,8498,10,13050,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,11,13051,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,12,13052,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,4,0,
+Summer 2024,ECE,8398,6,13056,Doctoral Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Summer 2024,PHOP,8398,3,13065,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,8399,19,13067,Doctoral Dissertation,Vujanovic,Anka Anna,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8698,7,13075,Doctoral Research,Feng,Qin,0,0,0,0,0,1,0,
+Summer 2024,GEOL,8698,7,13076,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,1,0,
+Summer 2024,MANA,4396,2,13077,Management Internship,Carlin,Barbara A,0,0,0,0,0,2,0,
+Summer 2024,ECE,8298,15,13079,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,5,0,
+Summer 2024,ECE,8498,15,13080,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,5,0,
+Summer 2024,ECE,6398,3,13081,Research,Chen,Ji,0,0,0,0,0,2,0,
+Summer 2024,PSYC,7399,8,13082,Masters Thesis,Cirino,Paul,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,16,13083,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,17,13084,Doctoral Research,Chen,Ji,0,0,0,0,0,9,0,
+Summer 2024,ECE,8298,18,13086,Doctoral Research,Becker,Aaron T,0,0,0,0,0,2,0,
+Summer 2024,ECE,8298,19,13087,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,20,13088,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Summer 2024,ECE,8298,21,13089,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Summer 2024,ECE,8498,16,13090,Doctoral Research,Becker,Aaron T,0,0,0,0,0,2,0,
+Summer 2024,ECE,8498,17,13091,Doctoral Research,Chen,Ji,0,0,0,0,0,9,0,
+Summer 2024,ECE,8498,18,13092,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,19,13095,Doctoral Research,Fu,Xin,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,20,13097,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,21,13098,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Summer 2024,PHLS,8199,4,13100,Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Summer 2024,ECE,6298,1,13101,Research,Chen,Ji,0,0,0,0,0,2,0,
+Summer 2024,ECE,6298,2,13102,Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Summer 2024,ECE,6198,2,13103,Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Summer 2024,ECE,6398,4,13104,Research,Shih,Wei-Chuan,0,0,0,0,0,0,0,
+Summer 2024,ECE,8699,2,13111,Doctoral Dissertation,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Summer 2024,ECE,8298,22,13114,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,23,13115,Doctoral Research,Chen,Jiefu,0,0,0,0,0,0,0,
+Summer 2024,ECE,8498,22,13116,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,23,13117,Doctoral Research,Chen,Jiefu,0,0,0,0,0,0,0,
+Summer 2024,ECE,8398,12,13121,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Summer 2024,BIOL,8698,8,13125,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Summer 2024,FINA,6398,1,13131,Research,Bean,Gregory S,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,8698,5,13133,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,2,0,
+Summer 2024,BIOL,8698,9,13134,Doctoral Research,Peng,Weiyi,0,0,0,0,0,2,0,
+Summer 2024,BIOL,8698,10,13135,Doctoral Research,Meisel,Richard P,0,0,0,0,0,1,0,
+Summer 2024,PSYC,6352,5,13136,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,3,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6398,12,13142,Independent Studies,Kosten,Therese A,0,0,0,0,0,0,0,
+Summer 2024,BCHS,8698,6,13146,Doctoral Research,Willson,Richard,0,0,0,0,0,2,0,
+Summer 2024,MECE,8498,17,13147,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Summer 2024,MECE,8298,17,13148,Doctoral Research,Chen,Zheng,0,0,0,0,0,1,0,
+Summer 2024,PHOP,8199,3,13150,Doctoral Dissertation,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8298,24,13153,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Summer 2024,ECE,8498,24,13154,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Summer 2024,OPTO,8992,1,13155,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,3,0,
+Summer 2024,OPTO,8993,1,13156,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,4,0,
+Summer 2024,PSYC,7399,10,13158,Masters Thesis,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,8698,8,13160,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,2,0,
+Summer 2024,ECE,8298,25,13164,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,25,13165,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Summer 2024,ECE,8699,4,13167,Doctoral Dissertation,Pan,Miao,0,0,0,0,0,2,0,
+Summer 2024,ECE,6198,4,13168,Research,Pan,Miao,0,0,0,0,0,0,0,
+Summer 2024,ANTH,6398,1,13171,Special Problems,Routon,Erin Danielle,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8698,12,13173,Doctoral Research,Sater,Amy,0,0,0,0,0,1,0,
+Summer 2024,PSYC,8399,21,13175,Doctoral Dissertation,Reyes,Denise Lucia,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,8698,9,13178,Doctoral Research,Castagna,John P,0,0,0,0,0,5,0,
+Summer 2024,GEOL,8698,10,13179,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,12,0,
+Summer 2024,GEOL,8698,11,13187,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,5,0,
+Summer 2024,PSYC,3350,2,13192,Intro to Cognitive Psychology,Griep,Christina Diaz,23,28,5,1,0,0,1,3.304
+Summer 2024,GEOL,8698,12,13193,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Summer 2024,COMD,7192,1,13196,Advanced Practicum,Eckert,Janet F,0,1,0,0,0,0,0,3.0
+Summer 2024,GEOL,8698,13,13202,Doctoral Research,Mann,Paul,0,0,0,0,0,2,0,
+Summer 2024,PEP,8699,1,13215,Doctoral Dissertation,Park,Yoonjung,0,0,0,0,0,1,0,
+Summer 2024,PSYC,6365,7,13218,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,2,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8298,10,13219,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Summer 2024,BIOE,8198,11,13220,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Summer 2024,MECE,8498,21,13237,Doctoral Research,Song,Gangbing,0,0,0,0,0,3,0,
+Summer 2024,MECE,8298,22,13241,Doctoral Research,Song,Gangbing,0,0,0,0,0,3,0,
+Summer 2024,BCHS,8698,9,13242,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Summer 2024,BIOL,8698,13,13243,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,2,0,
+Summer 2024,MECE,8399,9,13259,Doctoral Dissertation,Franchek,Matthew,2,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,8199,5,13262,Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Summer 2024,COMD,7391,6,13266,Clinic in Speech Lang Disorder,Trevino,Alexandra Hanson,1,0,0,0,0,0,0,3.67
+Summer 2024,BIOE,8298,11,13269,Doctoral Research,Das,Mini,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8198,12,13270,Doctoral Research,Das,Mini,0,0,0,0,0,0,0,
+Summer 2024,ECE,8198,9,13272,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Summer 2024,ECE,8598,7,13273,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Summer 2024,PHLS,8199,7,13277,Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8298,12,13282,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8198,13,13283,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6298,6,13285,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6498,6,13286,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8198,22,13302,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8598,22,13303,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,3,0,
+Summer 2024,PCEU,6698,1,13310,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,3,0,
+Summer 2024,ANTH,6399,1,13316,Masters Thesis,Ghazali,Marwa,2,0,0,0,0,0,0,4.0
+Summer 2024,ANTH,7399,1,13317,Masters Thesis,Ghazali,Marwa,1,0,0,0,0,0,0,4.0
+Summer 2024,PHLA,6260,1,13321,Healthcare Finance,Varkey,Divya A,5,1,0,1,0,0,0,3.429
+Summer 2024,PHLA,6220,1,13322,Leadership Concepts II,Varkey,Divya A,6,0,0,0,0,0,0,4.0
+Summer 2024,PHLA,7199,1,13323,Masters Thesis,Varkey,Divya A,0,0,0,0,0,7,0,
+Summer 2024,MECE,8399,11,13327,Doctoral Dissertation,Liu,Dong,0,0,0,0,0,1,0,
+Summer 2024,PSYC,8399,22,13328,Doctoral Dissertation,Sharp,Carla,0,0,0,0,0,2,0,
+Summer 2024,BIOE,8198,14,13331,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8298,13,13332,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Summer 2024,CUIN,8398,2,13334,Independent Study,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Summer 2024,CUIN,8399,5,13339,Doctoral Dissertation,Alarcon,Jeannette Driscoll,0,0,0,0,0,1,0,
+Summer 2024,MECE,8398,10,13340,Doctoral Research,Song,Gangbing,0,0,0,0,0,3,0,
+Summer 2024,PSYC,7399,14,13341,Masters Thesis,Leasure,Jennifer Leigh,2,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,6498,4,13352,Special Problems,Widger,William R,0,0,0,0,0,5,0,
+Summer 2024,BIOE,8298,15,13356,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Summer 2024,FINA,4396,2,13375,Finance Internship,Kumar,Praveen,0,0,0,0,0,8,0,
+Summer 2024,PEP,8199,1,13378,Doctoral Dissertation,Ledoux,Tracey A,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,3369,2,13384,Chemical Engr Transport Proc,Zerze,Hasan,2,0,0,0,0,0,0,3.835
+Summer 2024,GEOL,1103,1,13388,Physical Geology Lab,Hauptvogel,Daniel William,10,1,0,0,0,0,0,3.759
+Summer 2024,BZAN,7320,2,13389,Bus Modeling For Comp Adv,Wiley,Briceon C,14,0,0,0,0,0,0,4.0
+Summer 2024,ECON,2302,2,13392,Principles of Microeconomics,Melendez Lugo,Joel,28,52,48,8,5,0,4,2.622
+Summer 2024,LAW,6230,1,13393,Current Crisis Middle East,Foteh,Samir Jabra,0,2,0,0,0,0,0,3.33
+Summer 2024,LAW,7335,1,13394,WRS: Animal Law,Morath,Sarah,5,5,0,0,0,0,0,3.401
+Summer 2024,LAW,5117,1,13396,Advocacy Board TWO,Lawrence,Jim E,0,0,0,0,0,2,0,
+Summer 2024,LAW,5125,1,13399,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,2,0,
+Summer 2024,LAW,5125,2,13400,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2024,LAW,5128,1,13401,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,14,0,
+Summer 2024,LAW,5128,2,13402,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,2,0,
+Summer 2024,LAW,5130,1,13403,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,5,0,
+Summer 2024,LAW,5130,2,13404,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,3,0,
+Summer 2024,LAW,5129,1,13405,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,4,0,
+Summer 2024,LAW,5129,2,13406,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Summer 2024,CUIN,3302,5,13410,Social Education,Thomas,Dustine J,22,0,0,0,0,0,0,3.985
+Summer 2024,CUIN,8310,5,13417,Laboratory of Practice,Thomas,Dustine J,5,0,0,0,0,0,0,4.0
+Summer 2024,MANA,4358,1,13421,Compensation and Benefits,Zamanipour,Tina,30,6,0,0,0,0,3,3.833
+Summer 2024,SCM,4362,1,13422,Demand and Supply Integration,Dillibe,Onyinye,22,11,6,1,0,0,0,3.367
+Summer 2024,BIOL,2120,3,13426,Microbiology for Non-Science,Knapp,Richard D,3,0,2,0,0,0,1,3.332
+Summer 2024,SOCW,7313,1,13427,Global SW: Women & Human Right,Strohl,Katyayani Rao,26,0,0,0,0,0,1,4.0
+Summer 2024,SOCW,7361,1,13428,Clinical SW Practice w Elders,Miyawaki,Christina E,16,1,0,0,0,0,0,3.941
+Summer 2024,ACCT,7370,1,13432,Adv Fin Statement Auditing,Seltz,Joe D,8,13,1,0,1,0,0,3.231
+Summer 2024,ACCT,3366,1,13436,Financial Reporting Frameworks,Serrato,Darlene Marie  Bohac,0,3,8,0,0,0,4,2.273
+Summer 2024,ACCT,3366,2,13437,Financial Reporting Frameworks,Serrato,Darlene Marie  Bohac,5,16,16,3,1,0,5,2.512
+Summer 2024,ACCT,3377,2,13438,Cost Accounting,Serrato,Darlene Marie  Bohac,4,4,3,0,0,0,2,3.181
+Summer 2024,SCLT,4396,30,13445,Internship in Supply Chain,Kidd,Margaret A,3,0,0,0,0,0,0,4.0
+Summer 2024,ELED,4315,11,13446,Mathematics in Elem School II,Shelton,Laura,9,0,0,0,0,0,0,4.0
+Summer 2024,CNST,2360,1,13450,Communication in Construction,Sheppard,Travis,34,7,1,0,0,0,2,3.786
+Summer 2024,FORE,6395,1,13462,Master's Project in Foresight,Hines,Andrew Lewis,3,0,0,0,0,0,0,4.0
+Summer 2024,HRD,3310,1,13463,Talent Management,Greer,Tomika,12,4,1,1,0,0,0,3.5
+Summer 2024,PSYC,2305,3,13464,Intro to Methods in Psychology,Kennedy,Caitlin Grace,5,6,5,3,5,0,1,2.07
+Summer 2024,PSYC,2307,1,13466,Psychology of Adolescence,Anderson,Jill Annette,18,15,1,1,2,0,0,3.208
+Summer 2024,MATH,1342,1,13482,Elementary Statistical Methods,Wang,Wenshuang,42,70,32,36,26,0,10,2.33
+Summer 2024,PSYC,4344,2,13483,Cultural Psychology,Kilani,Mohamed Hechmi,19,11,4,0,3,0,2,3.1
+Summer 2024,PSYC,2317,5,13484,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,19,16,9,3,3,0,3,2.834
+Summer 2024,PSYC,3339,3,13485,Intro To Clinical Psychology,Szafranski,Derek D,42,3,2,0,0,0,3,3.83
+Summer 2024,MATH,3338,2,13486,Probability,Papadakis,Emanuel Ioannis,17,1,1,0,1,0,2,3.65
+Summer 2024,COMM,2311,7,13487,Writing for Print and Digital,Crixell,Charles A,5,7,1,0,0,0,0,3.232
+Summer 2024,COMM,3311,3,13489,Editing Print & Digital Media,Crixell,Charles A,11,5,0,0,0,0,0,3.688
+Summer 2024,COMM,3381,1,13490,Short Film Practicum,Houk,Keith R,0,0,0,0,0,21,0,
+Summer 2024,LAW,6321,1,13496,Professional Responsibility,Knake,Renee N,14,25,0,0,0,0,0,3.444
+Summer 2024,CNST,4331,1,13499,Construction Management II,Menendez,Daniel,6,0,0,0,0,0,1,3.835
+Summer 2024,MARK,4389,2,13500,Marketing Strategy & Planning,Lish,Alan D,22,14,0,0,0,0,0,3.538
+Summer 2024,GHL,2343,1,13502,Hospitality Cost Controls,Haskell,Rebecca Erin,15,2,0,0,0,0,0,3.785
+Summer 2024,GHL,3352,1,13504,Human Resource Management,Madera,Juan Manuel,11,0,0,0,0,0,0,3.97
+Summer 2024,PHIL,3388,1,13507,Hist of 20Th Cent Phi,Weisberg,Joshua,4,9,3,0,2,0,3,2.759
+Summer 2024,COMM,4384,1,13509,Strategic Comm Applications,Williams,Uniqua Janae,13,5,0,0,0,0,0,3.759
+Summer 2024,NUTR,2332,5,13510,Intro To Human Nutrition,Hughes,Lindsay,10,7,1,1,2,0,0,3.048
+Summer 2024,GHL,6364,1,13512,Hosp. Managerial Accounting,Johnson,Tucker A,4,2,0,0,0,0,0,3.557
+Summer 2024,GHL,7361,1,13514,Hospitality Marketing Analysis,Taylor,David C,5,1,0,0,0,0,0,3.888
+Summer 2024,BIOL,4320,1,13516,Molecular Biology,Scott,Sean-Patrick,7,9,4,0,0,0,0,3.051
+Summer 2024,PSYC,3331,1,13517,Psychology of Gender,Jaramillo,Kristen,46,9,3,1,1,0,0,3.617
+Summer 2024,FREN,2311,1,13519,Intermediate French I,Giacchetti,Claudine A,4,4,1,0,0,0,0,3.333
+Summer 2024,FREN,2312,1,13520,Intermediate French II,Giacchetti,Claudine A,5,3,1,0,0,0,0,3.444
+Summer 2024,FREN,3312,1,13521,Oral Communication,Giacchetti,Claudine A,2,2,1,0,0,0,0,3.398
+Summer 2024,FREN,3316,1,13522,Survey of French Culture/Civ,Giacchetti,Claudine A,4,0,1,0,0,0,0,3.468
+Summer 2024,SOCW,7361,2,13525,Clinical SW Practice w Elders,Miyawaki,Christina E,9,0,0,0,0,0,0,4.0
+Summer 2024,GERM,3381,1,13527,German Cinema,Kleinheider,Julia D,9,8,0,0,2,0,2,3.071
+Summer 2024,COMM,1307,6,13528,Media and Society,Olson,Beth M,11,22,9,4,0,0,0,2.884
+Summer 2024,COMM,1307,7,13529,Media and Society,Olson,Beth M,4,10,7,1,1,0,2,2.652
+Summer 2024,COMM,3349,1,13530,Nonverbal Communication,Lee,Jaesub,18,8,1,2,0,0,0,3.426
+Summer 2024,ARAB,3377,1,13535,"Energy, Society & Middle East",El-Badawi,Emran,4,5,0,0,0,0,0,3.408
+Summer 2024,HISP,2374,1,13539,Spanish American Culture & Civ,De Los Reyes Heredia,Jose Guillermo,21,3,2,0,2,0,1,3.405
+Summer 2024,ARTS,3374,1,13543,Computer Imaging,Chen,Shang-Yee Mark,8,2,0,0,1,0,1,3.365
+Summer 2024,ENGL,3347,1,13549,Classics of Adolescent Lit,Wood,Barry Albert,4,8,4,0,0,0,1,2.979
+Summer 2024,HLT,3306,1,13552,Environmental Health,Behjat,Amirmohsen,1,4,3,2,2,0,2,2.055
+Summer 2024,SOCI,1301,5,13559,Introduction To Sociology,Dorsey,Patricia Lynne,7,8,2,0,0,0,0,3.275
+Summer 2024,INDE,3330,1,13560,Financial and Cost Management,Wiggins,Nathanial David,13,1,0,0,0,0,1,3.929
+Summer 2024,INDE,2333,1,13561,Engineering Statistics I,Diaz Martinez,Neil Orlando,10,13,6,1,1,0,1,2.925
+Summer 2024,OPTO,6115,3,13562,Clinical Integration,Gostovic,Anita Ticak,24,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,6115,4,13563,Clinical Integration,Gostovic,Anita Ticak,24,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,2305,5,13565,Intro to Methods in Psychology,Anderson,Jill Annette,10,7,0,0,0,0,1,3.549
+Summer 2024,HIST,1302,1,13568,The U.S. Since 1877,Clavin,Matthew J,11,9,3,1,1,0,2,3.12
+Summer 2024,HIST,1302,2,13569,The U.S. Since 1877,Johnson,Michele R,115,51,40,13,27,0,13,2.895
+Summer 2024,ENGL,4322,1,13572,Grammar & Usage,Zentz,Lauren R,17,6,5,0,1,0,0,3.276
+Summer 2024,NURS,6366,1,13574,FNP Capstone Clinical,Tahmasbi,Sherin,1,0,0,0,0,0,0,4.0
+Summer 2024,DRAM,1310,4,13576,Introduction to Theatre,Brincks,Alan,36,5,3,3,0,0,1,3.532
+Summer 2024,MIS,3371,1,13577,Transaction Processing Sys I,Messinger,Jacob Nelson,26,17,4,0,0,0,0,3.461
+Summer 2024,BIOE,4309,1,13578,Neural Technology Interfaces,Abidian,Mohammad Reza,2,0,0,0,0,0,0,4.0
+Summer 2024,ARTS,3384,1,13587,Sound Art,Meza,Abinadi,19,1,0,3,2,0,1,3.28
+Summer 2024,ENGI,2304,1,13590,Technical Communications,Salvo,Deborah C,19,5,0,0,0,0,0,3.778
+Summer 2024,ENGI,2304,2,13591,Technical Communications,Contos,Ashlie Meghan,11,10,1,0,1,0,0,3.304
+Summer 2024,ENGI,2304,4,13592,Technical Communications,Downey,Carlton M,16,1,0,0,0,0,0,3.941
+Summer 2024,COMD,7391,7,13593,Clinic in Speech Lang Disorder,Devore,Danielle R,1,0,0,0,0,0,1,3.67
+Summer 2024,TLIM,4396,30,13609,Internship in TLIM,Burns,Maria,2,0,0,0,0,0,0,4.0
+Summer 2024,MARK,4379,2,13611,Personal Branding,Richards,Sean Wesley,18,2,0,0,0,0,0,3.818
+Summer 2024,MATH,8699,3,13615,Doctoral Dissertation,Labate,Demetrio,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,8698,17,13618,Doctoral Research,Jiang,Xun,0,0,0,0,0,2,0,
+Summer 2024,TECH,3365,1,13622,Appl of Discrete Mthds in Tech,Thornton,Brandon Latroy,12,2,0,0,0,0,1,3.881
+Summer 2024,BCHS,8698,10,13630,Doctoral Research,Wang,Yuhong,0,0,0,0,0,3,0,
+Summer 2024,BTIS,3300,1,13632,Intro to Homeland Security,Burns,Maria,11,1,0,0,0,0,0,3.834
+Summer 2024,BIOL,8698,17,13656,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,2,0,
+Summer 2024,PEP,8350,1,13660,HHP Candidacy Project Research,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Summer 2024,POLC,4390,2,13661,Public Policy Internship,Pinto,Pablo M,5,0,0,0,0,0,0,4.0
+Summer 2024,TLIM,3363,35,13663,Technical Communications,Bracken II,William Terry,14,3,1,0,2,0,0,3.301
+Summer 2024,ECE,8399,12,13667,Doctoral Dissertation,Li,Xingpeng,1,0,0,0,0,0,0,4.0
+Summer 2024,COMD,7391,4,13672,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,3,1,0,0,0,0,0,3.585
+Summer 2024,COMD,7391,5,13673,Clinic in Speech Lang Disorder,Devore,Danielle R,1,1,0,0,0,0,0,3.5
+Summer 2024,BIOL,8698,18,13680,Doctoral Research,Liu,Xinli,0,0,0,0,0,1,0,
+Summer 2024,DRAM,1310,12,13682,Introduction to Theatre,Hinkel,Heidi Anne,40,4,0,0,0,0,0,3.887
+Summer 2024,FINA,7323,2,13685,Applied Equity Fund Management,George,Thomas J,13,0,0,0,0,0,0,4.0
+Summer 2024,MARK,3337,1,13690,Professional Selling,Suki,Yara D,42,11,0,2,0,0,0,3.643
+Summer 2024,PSYC,6393,4,13700,Clinical Research Practicum,Williams,Michael W,1,0,0,0,0,0,0,4.0
+Summer 2024,COSC,8698,132,13707,Doctoral Research,Yan,Feng,0,0,0,0,0,3,0,
+Summer 2024,ENTR,6398,1,13709,Research,Gonzalez,Liana,3,1,0,0,0,0,0,3.833
+Summer 2024,GEOL,8698,18,13710,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Summer 2024,PCEU,6398,1,13715,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,6398,4,13717,Special Problems,McConnell,Bradley K,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6398,5,13718,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6398,7,13728,Special Problems,Zhang,Yang,0,0,0,0,0,1,0,
+Summer 2024,MATH,8399,8,13730,Doctoral Dissertation,Azencott,Robert Guy,1,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,8398,2,13731,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Summer 2024,PSYC,6399,4,13734,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Summer 2024,MATH,8399,6,13735,Doctoral Dissertation,Labate,Demetrio,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8399,13,13747,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,0,0,
+Summer 2024,PHOP,8199,4,13748,Doctoral Dissertation,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Summer 2024,PCEU,6398,2,13753,Special Problems,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2024,PCEU,8398,1,13754,Doctoral Research,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,8399,25,13765,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,3,0,
+Summer 2024,GEOL,8698,21,13770,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6398,8,13773,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Summer 2024,PHLS,8396,2,13786,Doctoral Research,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2024,BIOE,6309,1,13794,Neural Interfaces,Abidian,Mohammad Reza,2,0,0,0,0,0,0,4.0
+Summer 2024,MECE,6399,1,13795,Masters Thesis,Ryou,Jae-Hyun,0,0,0,0,0,0,0,
+Summer 2024,SOC,7399,2,13805,Masters Thesis,Katz,Sheila,1,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8355,3,13810,Policy Pol & Gov of Education,Snodgrass Rangel,Virginia Walker,3,2,0,0,0,0,0,3.732
+Summer 2024,CUIN,8398,3,13812,Independent Study,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,6231,1,13814,Grad Biochem Lab Rotation II,Widger,William R,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8699,8,13822,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8399,3,13827,Doctoral Dissertation,Wang,Keh-Han,0,0,0,0,0,1,0,
+Summer 2024,ECE,7399,7,13830,Masters Thesis,Mayerich,David Matthew,0,0,0,0,0,1,0,
+Summer 2024,ECE,8399,14,13831,Doctoral Dissertation,Fu,Xin,3,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8399,15,13834,Doctoral Dissertation,Han,Zhu,1,0,0,0,0,1,0,4.0
+Summer 2024,BIOE,8398,28,13838,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Summer 2024,PHCA,6398,4,13846,Special Problems,Chen,Hua,1,0,0,0,0,0,0,4.0
+Summer 2024,COMD,7391,8,13847,Clinic in Speech Lang Disorder,Jacobson,Shannon,1,1,0,0,0,0,0,3.5
+Summer 2024,PHLS,8199,8,13854,Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Summer 2024,PSYC,8399,26,13858,Doctoral Dissertation,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,7399,20,13859,Masters Thesis,Viana,Andres G,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,6392,2,13871,Intervention Practicum,Vincent,John P,0,0,0,0,0,2,0,
+Summer 2024,COMM,4392,2,13872,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,2,0,
+Summer 2024,ARTS,4398,20,13880,Independent Study,Parazette,Aaron,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,6693,1,14067,Master's Research Project,Zhivan,Natalia A,3,2,0,0,0,0,0,3.732
+Summer 2024,DRAM,1310,8,14068,Introduction to Theatre,Young,Courtney Leigh,29,5,0,0,0,0,0,3.814
+Summer 2024,ECE,3340,1,14069,Numerical Methods for ECE,Mayerich,David Matthew,41,13,2,0,0,0,0,3.632
+Summer 2024,ENGI,2304,3,14070,Technical Communications,Contos,Ashlie Meghan,17,4,1,1,0,0,0,3.566
+Summer 2024,ACCT,2301,1,14072,Prin of Financial Accounting,Newman,Michael Ray,2,5,0,0,0,0,0,3.427
+Summer 2024,MANA,7397,1,14073,Selected Topics in Management,Witt,Lawrence A,7,0,0,0,0,0,0,4.0
+Summer 2024,GENB,7397,1,14074,Selected Topics,Carlin,Barbara A,13,1,0,0,0,0,0,3.952
+Summer 2024,GENB,7397,2,14075,Selected Topics,Carlin,Barbara A,6,0,0,0,0,0,0,4.0
+Summer 2024,NUTR,6117,1,14076,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,7,0,
+Summer 2024,NUTR,6218,1,14077,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,9,0,
+Summer 2024,FREN,4396,1,14084,Sel Topics-Fren-lang & culture,Giacchetti,Claudine A,0,1,0,0,0,0,0,2.67
+Summer 2024,SPAN,1502,5,14161,Elementary Spanish II,Javierre Londono,Juliana,7,10,5,1,0,0,1,2.971
+Summer 2024,ENGL,3301,1,14163,Intro To Literary Studies,Murray,Christopher Brean,14,4,0,0,0,0,0,3.759
+Summer 2024,ENGL,4315,1,14164,Sociolinguistics,Zentz,Lauren R,14,6,6,1,1,0,1,3.166
+Summer 2024,ENGL,3330,1,14165,Beg Creative Writing-Fiction,Budhwar,Kartika,11,0,1,0,0,0,0,3.751
+Summer 2024,ENGL,3331,1,14166,Beg Creative Writing-Poetry,O'Connor,Bevin,8,0,0,0,0,0,1,4.0
+Summer 2024,ENGL,4383,1,14167,Poetic Forms,Williams,Adele E,14,0,0,0,0,0,0,3.953
+Summer 2024,KIN,3301,1,14173,Design/Eval Phys Activity Prog,Betts,Charles Raphael,39,10,1,1,2,0,1,3.591
+Summer 2024,CUIN,6375,1,14791,Classroom Mgt,Alarcon,Jeannette Driscoll,5,2,1,0,0,0,0,3.541
+Summer 2024,ELED,6335,1,14793,Tchg Math in Elem Grade,Cutler,Carrie Sybil,8,0,0,0,0,0,0,4.0
+Summer 2024,MANA,6A32,1,14834,Organizational Behavior & Mgt,Witt,Lawrence A,12,0,0,0,0,0,0,3.973
+Summer 2024,MANA,4385,2,14836,Intro to Strategic Management,Tabesh,Pooya,9,2,1,0,1,0,0,3.359
+Summer 2024,MANA,4350,2,14838,International Management,Pathak,Seemantini Madhukar,19,2,1,0,0,0,1,3.758
+Summer 2024,MANA,4397,2,14840,Selected Topics in Mana,Salaiz,Ashley,27,4,1,0,0,0,1,3.813
+Summer 2024,MANA,7397,2,14841,Selected Topics in Management,Abbott,Jeanna L,34,0,0,0,0,0,0,4.0
+Summer 2024,MANA,7397,3,14842,Selected Topics in Management,Miljanic,Andra Olivia,9,3,0,0,0,0,0,3.778
+Summer 2024,MANA,7397,4,14843,Selected Topics in Management,Vera,Dusya M,34,1,0,0,0,0,0,3.953
+Summer 2024,INDE,4315,1,14867,Supply Chain Design Management,Diaz Martinez,Neil Orlando,6,6,0,0,0,0,1,3.445
+Summer 2024,INDE,6333,1,14869,Probability Stat For Engineers,Wiggins,Nathanial David,14,1,0,0,0,0,1,3.911
+Summer 2024,INDE,6334,1,14870,Predictive Data Analytics,Lin,Ying,13,4,0,0,0,0,1,3.804
+Summer 2024,INDE,7390,1,14872,Supply Chain Management,Diaz Martinez,Neil Orlando,1,0,0,0,0,0,0,3.67
+Summer 2024,MATH,1332,2,14873,Contemporary Mathematics,Hafeez,Shahinda,4,7,3,1,1,0,1,2.771
+Summer 2024,MATH,1351,2,14874,Intro to Geometric Reasoning,Watkins,Katie Nicole,10,20,18,26,16,0,24,1.771
+Summer 2024,MATH,2318,1,14877,Linear Algebra,He,Jiwen,5,6,3,2,2,0,4,2.556
+Summer 2024,MATH,2318,2,14878,Linear Algebra,Perepelitsa,Mikhail Antolyevic,6,10,2,2,1,0,1,2.826
+Summer 2024,MATH,3339,4,14879,Statistics for the Sciences,Wang,Wenshuang,57,30,4,0,7,0,6,3.333
+Summer 2024,ELED,4320,1,14882,Social Studies Ele Sch,Carr,Bianca Shaunte,10,0,0,0,1,0,0,3.636
+Summer 2024,SOCW,7320,2,14884,Empowerment,Rabo,Amber L,12,0,0,0,0,0,0,4.0
+Summer 2024,SOCW,7365,2,14885,Crisis Intervention,Battle,Jennifer Alene,23,1,0,0,0,0,0,3.958
+Summer 2024,PHYS,8698,1,14886,Doctoral Research,Cardoso Barato,Andre,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,2,14887,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,3,0,
+Summer 2024,PHYS,8698,3,14888,Doctoral Research,Bellwied,Rene,0,0,0,0,0,4,0,
+Summer 2024,PHYS,8698,5,14890,Doctoral Research,Chen,Shuo,0,0,0,0,0,2,0,
+Summer 2024,PHYS,8698,6,14891,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,3,0,
+Summer 2024,PHYS,8698,7,14892,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,3,0,
+Summer 2024,PHYS,8698,8,14893,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,10,14895,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,11,14896,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,5,0,
+Summer 2024,PHYS,8698,12,14897,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,13,14898,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,3,0,
+Summer 2024,PHYS,8698,15,14900,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,3,0,
+Summer 2024,PHYS,8698,16,14901,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,19,14904,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,20,14905,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,21,14906,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,23,14908,Doctoral Research,Ratti,Claudia,0,0,0,0,0,5,0,
+Summer 2024,PHYS,8698,24,14909,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,4,0,
+Summer 2024,PHYS,8698,25,14910,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,2,0,
+Summer 2024,PHYS,8698,28,14913,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,3,0,
+Summer 2024,PHYS,8698,29,14914,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,30,14915,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,33,14918,Doctoral Research,Bittner,Eric R,0,0,0,0,0,4,0,
+Summer 2024,PHYS,8698,34,14919,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,35,14920,Doctoral Research,Vovchenko,Volodymyr,0,0,0,0,0,1,0,
+Summer 2024,SOCW,7373,2,14921,Human Sexuality & Sw,Gracely,Jill Marie,3,0,0,0,0,0,0,4.0
+Summer 2024,SOCW,6193,1,14922,SW Generalist Practicum 1,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Summer 2024,SOCW,6194,1,14923,SW Generalist Practicum 2,Gonzales,Shelley A,0,0,0,0,0,13,0,
+Summer 2024,SOCW,7397,1,14924,Selected Topics in Social Work,Dettlaff,Alan J,22,0,0,0,0,0,0,4.0
+Summer 2024,SOCW,7397,2,14925,Selected Topics in Social Work,Dettlaff,Alan J,12,0,0,0,0,0,0,4.0
+Summer 2024,ARCH,1500,1,14926,Design Studio I,Wienert,Ross George,6,6,0,0,0,0,0,3.445
+Summer 2024,ARCH,1501,1,14928,Arc/Int Arc Design Studio II,Wienert,Ross George,7,6,0,0,0,0,0,3.437
+Summer 2024,ARCH,3397,1,14932,Selected Topics,Diehl,Tom,1,11,0,0,0,0,0,3.221
+Summer 2024,ARCH,3397,2,14933,Selected Topics,Diehl,Tom,4,5,3,0,0,0,0,3.056
+Summer 2024,PSYC,2301,3,14950,Introduction to Psychology,Henderson,Perla R,21,3,1,0,0,0,1,3.721
+Summer 2024,PSYC,2301,4,14951,Introduction to Psychology,Silva,Karina,16,16,3,1,0,0,1,3.287
+Summer 2024,PSYC,2330,3,14955,Biological Psychology,Jackson,Lillian Reed,27,12,0,0,0,0,0,3.616
+Summer 2024,PSYC,3331,2,14958,Psychology of Gender,Pathak,Neha,21,32,2,0,2,0,2,3.321
+Summer 2024,SOCW,7397,3,14960,Selected Topics in Social Work,Flores,Vanessa Marie,12,3,1,0,0,0,0,3.688
+Summer 2024,SOCW,7397,4,14961,Selected Topics in Social Work,Flores,Vanessa Marie,10,2,0,0,0,0,0,3.833
+Summer 2024,PSYC,4344,4,14962,Cultural Psychology,Martinez,Anjelica M,26,7,0,1,1,0,1,3.515
+Summer 2024,PSYC,3338,1,14963,Psychology of Older Adults,Mustafa,Andrea Iman,51,3,3,0,1,0,2,3.77
+Summer 2024,PSYC,4363,1,14964,Abnormal Child Psych,Bautista,Ashley,37,13,3,1,4,0,2,3.265
+Summer 2024,PSYC,4363,3,14966,Abnormal Child Psych,Li,Xinge,51,8,1,0,0,0,0,3.756
+Summer 2024,PSYC,4363,4,14967,Abnormal Child Psych,Mattuck,Shira Regina,10,26,16,1,1,0,1,2.754
+Summer 2024,ARCH,6397,1,14969,Sel Tpcs-Arc/Urbn Desgn,Diehl,Tom,0,1,0,0,1,0,0,1.5
+Summer 2024,ARCH,6397,2,14970,Sel Tpcs-Arc/Urbn Desgn,Diehl,Tom,1,0,0,0,1,0,0,2.0
+Summer 2024,ARCH,3397,3,14972,Selected Topics,Lander,Lawrence Farnham,10,1,0,0,1,0,0,3.611
+Summer 2024,GOVT,2306,1,14978,US and Texas Const/Politics,Cole,Jeffrey Bryan,38,27,7,3,2,0,3,3.247
+Summer 2024,POLS,3312,1,14979,"Arguments, Data, Politics",Justus,Billy,13,11,3,0,2,0,1,3.183
+Summer 2024,POLS,3313,1,14980,Intro Internatl Relatns,Vardy,Ronald V,36,2,2,2,0,0,2,3.699
+Summer 2024,GHL,3336,1,14981,Beverage Management,Taylor,David C,14,9,5,0,0,0,1,3.392
+Summer 2024,GHL,4353,1,14982,Leadership in Hospitality Ind,Guchait,Priyanko,7,1,4,2,3,0,1,2.412
+Summer 2024,GHL,4397,1,14983,Selected Topics Hosp Mgt,Legendre,Jungyoung Shin,22,3,1,0,0,0,0,3.795
+Summer 2024,GHL,6197,1,14984,Selected Topics,Reynolds,Dennis Edward,1,0,0,0,0,0,0,4.0
+Summer 2024,GHL,6343,1,14985,Beverage Management,Taylor,David C,5,0,0,0,0,0,0,4.0
+Summer 2024,GHL,6397,1,14986,Selected Topics,Legendre,Jungyoung Shin,5,0,0,0,0,0,0,3.868
+Summer 2024,GHL,6197,2,14987,Selected Topics,Padilla,Magdalena Manzano,6,0,0,0,0,0,0,3.945
+Summer 2024,HISP,2387,1,14990,LatinAm: History Through Film,Arboleda,Paola,16,4,2,1,1,0,3,3.334
+Summer 2024,MANA,4397,3,14991,Selected Topics in Mana,Hwang,Hyunseok,7,0,1,0,0,0,0,3.75
+Summer 2024,MANA,7347,1,14992,Environm & Social Governance,Chiu,Shih-chi,33,0,0,0,1,0,0,3.873
+Summer 2024,SOCW,7185,1,14993,SW Clinical Practicum 2,Gonzales,Shelley A,0,0,0,0,0,28,0,
+Summer 2024,SOCW,7189,1,14994,Social Work Macro Practicum 2,Gonzales,Shelley A,0,0,0,0,0,11,0,
+Summer 2024,SOCW,7397,5,14995,Selected Topics in Social Work,Webb,Ann E,14,1,0,0,0,0,0,3.933
+Summer 2024,SOCW,7397,6,14996,Selected Topics in Social Work,Webb,Ann E,12,0,0,0,0,0,1,4.0
+Summer 2024,SOCW,7397,7,14997,Selected Topics in Social Work,Amtsberg,Donna K,6,0,0,0,0,0,0,4.0
+Summer 2024,SOCW,7397,8,14998,Selected Topics in Social Work,Amtsberg,Donna K,14,0,1,0,0,0,0,3.867
+Summer 2024,SOCW,7397,9,14999,Selected Topics in Social Work,Mendoza,Yvonne Anette,16,2,0,0,0,0,0,3.889
+Summer 2024,SOCW,7397,10,15000,Selected Topics in Social Work,Mendoza,Yvonne Anette,13,0,0,0,0,0,0,4.0
+Summer 2024,ENGL,1301,3,15001,First Year Writing I,Murray,Christopher Brean,13,4,0,0,1,0,1,3.537
+Summer 2024,MIS,3376,1,15002,Busn Appls Database Mgmt I,Grimes,George M,17,16,8,2,1,0,0,3.045
+Summer 2024,MIS,4397,1,15003,Selected Topics in MIS,Messinger,Jacob Nelson,2,1,0,0,0,0,0,3.447
+Summer 2024,MIS,4397,2,15004,Selected Topics in MIS,Lewis,Michael Joseph,3,2,0,0,0,0,1,3.6
+Summer 2024,MIS,7397,1,15005,Selected Topics in MIS,Campbell,Phillip James,5,2,0,0,0,0,0,3.667
+Summer 2024,MIS,7397,2,15006,Selected Topics in MIS,Khan,Hina F,5,0,0,0,0,0,0,4.0
+Summer 2024,COMD,6399,1,15007,Masters Thesis,Mills,Monique T,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEM,2325,1,15026,Organic Chemistry II,Young,Crystal Ann,1,4,10,5,4,0,10,1.708
+Summer 2024,ACCT,3367,3,15028,Intermediate Accounting I,Kilic,Emre,11,15,5,2,1,0,1,2.951
+Summer 2024,ENTR,3310,3,15029,Entrepreneurship,Wilbur,Stephen,42,40,11,2,0,0,1,3.295
+Summer 2024,ENTR,4397,1,15033,Sel Topics in Entrepreneurship,McCormick,Kelly,23,15,1,1,0,0,0,3.475
+Summer 2024,ENTR,4397,3,15035,Sel Topics in Entrepreneurship,Ortega,Carlos Alberto,26,1,1,0,0,0,0,3.881
+Summer 2024,ENTR,7397,1,15036,Sel Topics in Entrepreneurship,McCormick,Kelly,9,1,0,0,0,0,0,3.9
+Summer 2024,ACCT,3371,2,15042,Accounting Information Systems,Seijas,Nuria S,8,8,4,0,1,0,0,3.079
+Summer 2024,POLC,3314,1,15046,Leadership and Public Policy,Witt,Lawrence A,16,0,0,0,1,0,0,3.765
+Summer 2024,POLC,2312,1,15047,Intro to Econ Policy Analysis,Wong,Man Chiu,4,7,2,1,0,0,2,2.929
+Summer 2024,MARK,3338,1,15049,Intro to Marketing Analytics,Praveen,FNU,3,0,0,0,0,0,0,3.89
+Summer 2024,MARK,3365,1,15053,Intro to Digital Marketing,Zahn,William J,24,13,6,0,0,0,2,3.357
+Summer 2024,ACCT,4331,3,15056,Federal Income Tax,Fernandez,Ramon,5,21,11,0,1,0,2,2.885
+Summer 2024,MARK,7399,1,15059,MS Marketing Prof Project,Koch,Steven F,4,1,0,0,0,0,0,3.866
+Summer 2024,SCLT,3385,30,15062,Transport Economics and Policy,Henson,Alfred Bernard,15,7,2,0,0,0,0,3.528
+Summer 2024,ACCT,5331,3,15069,Federal Income Tax,Fernandez,Ramon,1,2,0,0,0,0,1,3.443
+Summer 2024,SCLT,4387,20,15070,Financial Evaluation For SCM,Reyes,Jorge,9,4,4,0,0,0,0,3.352
+Summer 2024,SCLT,3381,30,15073,Industrial and Consumer Sales,Cassler,Daniel,6,0,0,0,0,0,0,3.945
+Summer 2024,SCLT,4312,20,15074,Inventory & Materials Handling,Kennedy,Elizabeth Heyn,28,0,0,0,0,0,0,3.988
+Summer 2024,ACCT,5372,2,15081,Intro-Data Analytics in ACCT,Erdem,Ozer,4,0,0,0,0,0,0,3.918
+Summer 2024,ACCT,7320,1,15082,Intro to Data Analytics-Acct,Erdem,Ozer,3,0,0,0,0,0,0,3.89
+Summer 2024,ACCT,7320,2,15083,Intro to Data Analytics-Acct,Erdem,Ozer,22,6,0,0,0,0,0,3.798
+Summer 2024,ACCT,7360,1,15084,Partnership Taxation,King,Sheldon,11,8,0,0,0,0,0,3.596
+Summer 2024,CNST,3365,20,15087,Cost Estimating Capital Projec,Glumac,Carmel,4,9,2,0,0,0,0,3.265
+Summer 2024,CNST,4345,1,15088,Reinforced Concrete Structures,Chang,Chi Chung,13,15,0,0,0,0,1,3.5
+Summer 2024,SCLT,6316,20,15093,Global Supply Chain Logistics,Wang,Kailai,4,0,0,0,0,0,1,4.0
+Summer 2024,HLT,2320,3,15098,Introduction to Public Health,Proctor,Robin Ann,82,3,6,1,0,0,0,3.79
+Summer 2024,HLT,3304,1,15099,Child and Adolescent Health,Drenner,Kelli Linn,21,17,9,2,3,0,1,2.993
+Summer 2024,HLT,3380,3,15100,Culture and Health,Fedor Amador,Theresa Marie,49,4,1,0,1,0,0,3.746
+Summer 2024,HLT,3380,4,15101,Culture and Health,Fedor Amador,Theresa Marie,25,9,1,0,0,0,0,3.629
+Summer 2024,HLT,3381,3,15102,Hlt Promotn & Disease Preventn,Markowitz,Eliz,70,9,4,0,0,0,1,3.708
+Summer 2024,ECON,3357,1,15108,Data Mgmt with Econ Appl,Peru Durayalage,Dhanushka Arunasiri,20,12,1,1,3,0,0,3.145
+Summer 2024,FINA,7397,1,15112,Selected Topics in Finance,Levy,Clayton V,4,2,0,0,0,0,0,3.722
+Summer 2024,FINA,7A97,1,15113,Selected Topics in Finance,Caire,Matthew,11,0,0,0,0,0,0,4.0
+Summer 2024,FINA,7327,1,15243,Entrepreneurial Finance,Stewart,Marcus,4,0,0,0,0,0,0,3.835
+Summer 2024,MATH,1324,1,15252,Finite Math with Applications,Hong,Yuqi,14,16,14,22,40,0,32,1.372
+Summer 2024,MANA,4346,2,15261,Leadership Development,Evans,Klavdia Markelova,24,0,0,0,0,0,0,3.986
+Summer 2024,MANA,4347,2,15262,Ethics and Corp Soc Respon.,Salaiz,Ashley,50,7,1,0,0,0,0,3.856
+Summer 2024,GENB,8397,1,15263,Selected Topics Gen Bus Admin,Patrick-Ralhan,Vanessa M,25,1,0,0,0,0,0,3.949
+Summer 2024,MATH,2415,1,15264,Calculus III,Pan,Tsorng-Whay,20,10,4,0,2,0,1,3.278
+Summer 2024,PSYC,2330,4,15267,Biological Psychology,Beltran-Najera,Ilex,16,20,2,2,1,0,1,3.251
+Summer 2024,PHLS,8193,5,15268,Internship in Psychology,Arbona,Consuelo,0,0,0,0,0,9,0,
+Summer 2024,MATH,4389,2,15269,Survey of Undergraduate Math,Etgen,Garret J,3,2,7,0,0,0,0,2.722
+Summer 2024,PHLS,8393,3,15270,Doctoral Practicum in Psy,de Dios,Marcel A,0,0,0,0,0,3,0,
+Summer 2024,FORE,6395,40,15271,Master's Project in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Summer 2024,FORE,6397,40,15275,Selected Topics in Foresight,Rush,Julie,5,0,0,0,0,0,0,4.0
+Summer 2024,FORE,6397,20,15276,Selected Topics in Foresight,Rush,Julie,10,0,0,0,0,0,0,4.0
+Summer 2024,INDE,6363,1,15294,Statistical Process Control,Keedy,Elias,5,4,0,0,0,0,0,3.629
+Summer 2024,CUIN,7356,1,15310,Issues in Distance Education,Dogan,Bulent,22,0,0,0,0,0,0,3.985
+Summer 2024,CUIN,7356,2,15311,Issues in Distance Education,Dogan,Bulent,21,1,0,0,0,0,0,3.97
+Summer 2024,HLT,4397,1,15312,Selected Topics in Health,Nguyen,An,7,9,1,0,1,0,0,3.057
+Summer 2024,CUIN,7376,1,15313,New Tools Create Online Matls,Dogan,Bulent,22,0,0,0,1,0,0,3.812
+Summer 2024,CUIN,7376,2,15314,New Tools Create Online Matls,Vyas,Anita,21,0,0,0,0,0,0,3.984
+Summer 2024,AAMS,4397,1,15315,Selected Topics in AAMS,Nguyen,An,1,2,0,0,0,0,0,3.223
+Summer 2024,ENGI,1100,1,15316,Introduction To Engineering,Burleson,Daniel W,14,4,1,0,0,0,0,3.702
+Summer 2024,HLT,4320,1,15317,Admin of Health Services,Markowitz,Eliz,18,7,3,2,0,0,4,3.301
+Summer 2024,HLT,3300,1,15318,Social Health and Wellness,Ripperger-Suhler,Ken,68,20,3,0,0,0,1,3.653
+Summer 2024,PHLS,8366,2,15320,"Assmt Child/Adol Aff, Beh, Per",Kahn,David Andrew,6,0,0,0,0,0,0,4.0
+Summer 2024,MECE,3338,1,15322,Dynamic & Control of Mech Syst,Chang,Christiana,2,3,2,0,2,0,1,2.26
+Summer 2024,HDCS,3304,1,15327,Visual Merchandising,Stewart,Barbara L,9,3,5,0,2,0,0,2.791
+Summer 2024,HDCS,4303,1,15329,Merchandising Systems,Johnson,Olivia,3,5,3,2,3,0,1,2.188
+Summer 2024,HDCS,4393,1,15330,Internship in RCS,Mudd,Blake Stevens,20,1,0,0,0,0,0,3.921
+Summer 2024,CUIN,4332,11,15335,Literacy Assess Rdg Writing,Christensen,Caroline,8,2,0,0,0,0,0,3.8
+Summer 2024,HRD,4350,20,15339,Org Dev & Consulting,Clancy,James Patrick,12,1,3,0,0,0,0,3.521
+Summer 2024,HRD,4352,20,15341,Facilitation Strategies,Hampton,Elaine Denae,17,0,0,0,0,0,0,4.0
+Summer 2024,HLT,1353,5,15354,Personal Health,Rafique,Kiran Sajid,62,28,2,1,1,0,3,3.497
+Summer 2024,SCLT,2362,20,15355,Intro To Logistics Technology,Kidd,Margaret A,4,13,3,0,0,0,0,2.984
+Summer 2024,SCLT,2380,20,15357,Distribution Channels,Kidd,Margaret A,17,12,0,1,0,0,0,3.401
+Summer 2024,HLT,2320,4,15358,Introduction to Public Health,Proctor,Robin Ann,52,4,3,2,0,0,0,3.705
+Summer 2024,SCLT,3384,30,15361,Logistics Tech and Processes,Blount,James,20,14,1,0,0,0,0,3.543
+Summer 2024,SCLT,3387,20,15362,Procurement,Velarde,Jose Manuel,3,16,6,1,1,0,1,2.777
+Summer 2024,SCLT,3389,30,15363,Transportation Law,Blount,James,16,11,0,0,1,0,0,3.394
+Summer 2024,SCLT,4375,20,15364,Global Supply Chain,Velarde,Jose Manuel,8,10,3,1,1,0,0,2.885
+Summer 2024,SCLT,4389,20,15366,Practicum in Supply Chain,Kidd,Margaret A,17,0,1,1,0,0,0,3.719
+Summer 2024,SOCI,1301,1,15381,Introduction To Sociology,Dorsey,Patricia Lynne,24,8,2,1,1,0,2,3.417
+Summer 2024,SOC,3311,1,15382,Sociology of Law,Nelson,Steven M,20,18,6,1,0,0,2,3.193
+Summer 2024,SOC,3344,2,15384,Sociology of Aging,Davis,Mary A,30,13,0,0,3,0,1,3.478
+Summer 2024,SOC,3312,1,15385,Sociology of Deviance,Nelson,Steven M,5,3,0,1,0,0,0,3.37
+Summer 2024,SOC,3349,1,15386,Sociology of Culture,Adams,Jennifer Lauren,28,12,5,1,1,0,0,3.376
+Summer 2024,GEOL,1302,1,15388,Intro To Global Climate Change,Griggs,Philip Travis,59,5,0,1,0,0,0,3.821
+Summer 2024,LAW,5397,1,15389,Selected Topics,Willis,Tasha L,0,3,0,0,0,0,0,3.33
+Summer 2024,LAW,5416,1,15395,Civil Justice Clinic I,Krasny,Frederick A,1,3,0,0,0,0,0,3.415
+Summer 2024,LAW,5224,1,15396,Civil Justice Clinic II,Marquez,Ryan Michael,0,0,0,0,0,1,0,
+Summer 2024,ENGL,3351,1,15399,Am Lit Since 1865,Ehlers,Sarah E,20,3,1,0,1,0,0,3.627
+Summer 2024,LAW,7339,1,15407,WRC: Draftg for Firm Attorneys,Swift,Kenneth Richard,6,6,0,0,0,0,0,3.39
+Summer 2024,SAER,8388,1,15408,Sem-Res Ed Ldshp Pol St,Hernandez,Belkis Pamela,10,0,0,1,2,0,0,3.103
+Summer 2024,LAW,7311,1,15409,"WRS:Gender, Power & Leadership",Knake,Renee N,6,3,0,1,0,1,0,3.4
+Summer 2024,ELCS,8332,1,15410,Student Dev in Post Sec. Inst,Messa,Emily Alice,16,1,0,0,0,0,0,3.902
+Summer 2024,ELCS,8350,2,15412,Resource Management,Mayers,Onica L,4,1,0,0,0,0,0,3.734
+Summer 2024,ELCS,8371,2,15413,Legal Issues Sch District Levl,Goree,Tonya,5,0,0,0,0,0,0,4.0
+Summer 2024,LAW,5300,1,15414,Criminal Defense Clinic,Locascio,Erik Matthew,1,0,0,0,0,0,0,3.67
+Summer 2024,COSC,4393,301,15418,Digital Image Processing,Mantini,Pranav,19,7,1,1,1,0,0,3.369
+Summer 2024,COSC,6380,301,15419,Digital Image Processing,Mantini,Pranav,6,1,0,0,1,0,0,3.293
+Summer 2024,EDS,6397,2,15432,Selected Topics,Nwosu,Lucy,8,0,0,0,0,0,0,4.0
+Summer 2024,ECE,3355,1,15434,Electronics,Meh Chu,Chu,8,5,0,0,0,0,0,3.641
+Summer 2024,ECE,3155,1,15435,Electronics Laboratory,Meh Chu,Chu,9,0,0,0,0,0,0,4.0
+Summer 2024,ECE,3441,1,15436,Digital Logic Design,Sheth,Bhavin R,7,0,1,1,1,0,1,3.1
+Summer 2024,LAW,5355,1,15447,Oil and Gas,Wells,Douglas,2,2,0,0,0,1,0,3.583
+Summer 2024,SPEC,7395,1,15451,Diagnostician Practicum II,Hassett,Kristen Spring,0,0,0,0,0,2,0,
+Summer 2024,MIS,3371,2,15453,Transaction Processing Sys I,Messinger,Jacob Nelson,6,3,0,0,0,0,0,3.703
+Summer 2024,MIS,4397,3,15454,Selected Topics in MIS,Messinger,Jacob Nelson,3,1,0,0,0,0,0,3.668
+Summer 2024,HRD,3346,1,15469,Performance Assessment & Eval,Norman,Joanna,17,3,0,0,0,0,1,3.735
+Summer 2024,LAW,5200,1,15470,Depositions,Daw,Willie,7,9,0,0,0,0,1,3.376
+Summer 2024,SOCW,7184,1,15472,SW Clinical Practicum 1,Gonzales,Shelley A,0,0,0,0,0,17,0,
+Summer 2024,SOCW,7188,1,15473,Social Work Macro Practicum 1,Gonzales,Shelley A,0,0,0,0,0,5,0,
+Summer 2024,COMM,3303,1,15474,Health Literacy,Xiao,Zhiwen,17,1,0,0,0,0,0,3.944
+Summer 2024,COMM,4331,1,15475,Persuasion,Huang,Yan,16,4,1,1,0,0,0,3.576
+Summer 2024,COMM,4378,1,15476,Social Impact of Info Tech,Ashley,Laura B,14,2,0,0,0,0,0,3.875
+Summer 2024,HIST,1301,1,15480,The U.S. to 1877,Johnson,Michele R,80,40,30,17,22,0,12,2.735
+Summer 2024,HIST,2368,1,15484,Intro to African Studies,Klieman,Kairn,17,9,3,1,0,0,2,3.301
+Summer 2024,GEOL,1102,2,15509,Intro to Climate Change Lab,Griggs,Philip Travis,6,2,0,0,0,0,0,3.668
+Summer 2024,GEOL,1103,2,15510,Physical Geology Lab,Hauptvogel,Daniel William,4,4,1,0,0,0,0,3.407
+Summer 2024,IDNS,2197,1,15511,Top-Natrl Sci & Mth,Pattison,Donna,0,0,0,0,0,50,0,
+Summer 2024,HON,3303,1,16370,Mental Health & Society,Reynolds,Aaron E,19,0,0,0,0,0,1,3.948
+Summer 2024,BIOL,1106,5,16414,Biol for Science Majors I(Lab),Ibrahim,Abdalla Zanouny,9,4,3,0,0,0,0,3.334
+Summer 2024,BIOL,1107,5,16417,Biology for Science Majors II,Hanke,Marc H,5,2,0,0,0,0,0,3.761
+Summer 2024,ECON,6691,1,16419,Master's Internship,Thornton,Rebecca Achee,3,0,0,0,0,0,0,3.89
+Summer 2024,ECON,4390,1,16420,Economics Internship,Troncoso,Pablo A,6,1,0,0,0,0,1,3.904
+Summer 2024,ELCS,8395,1,16433,Dissertation in practice,Davis,Bradley,0,0,0,0,0,3,0,
+Summer 2024,ELCS,8395,2,16434,Dissertation in practice,Butcher,Keith,1,0,0,0,0,1,0,4.0
+Summer 2024,ELCS,8395,4,16436,Dissertation in practice,Snodgrass Rangel,Virginia Walker,0,0,0,0,0,4,0,
+Summer 2024,ELCS,8695,1,16440,Dissertation in Practice,Davis,Bradley,0,0,0,0,0,1,0,
+Summer 2024,BIOL,2321,1,16448,Microbiology for Science Major,Medrano,Ana I,7,8,6,0,1,0,2,2.849
+Summer 2024,LAW,5297,3,16455,Selected Topics,Jones,Karen Lynn,4,8,0,0,0,1,0,3.388
+Summer 2024,PSYC,3310,2,16458,Indstrl-Orgnztnl Psy,Schoolfield,Lucy,52,1,2,1,1,0,1,3.801
+Summer 2024,LAW,6335,1,16459,Entertainment Law Clinic,Barks,Justen S,1,0,0,0,0,0,0,4.0
+Summer 2024,INDE,4364,1,16483,Big Data and Analytics,Lin,Ying,1,0,0,1,0,0,1,2.335
+Summer 2024,HDFS,1300,3,16484,Dev of Contemporary Families,Jordan,Erica F,25,6,2,0,0,0,0,3.677
+Summer 2024,HDFS,2314,5,16486,Human Dev and Interventions,Kamdar-Sharif,Amber,43,10,2,0,0,0,0,3.727
+Summer 2024,HDFS,3300,3,16488,Educational Psychology,Conston,Toya,40,4,0,0,1,0,2,3.786
+Summer 2024,HDFS,4316,3,16490,Dynamics of Family Relations,Kamdar-Sharif,Amber,11,0,1,1,0,0,0,3.59
+Summer 2024,HDFS,4316,4,16491,Dynamics of Family Relations,Schroder,Kathleen Anne,15,10,2,1,3,0,2,3.086
+Summer 2024,HDFS,4317,1,16492,Intro to Early Child Dev,Storch,Jill Frenchman,10,5,2,1,1,0,1,3.158
+Summer 2024,HLT,4307,3,16494,Research and Eval in Health,Kamdar-Sharif,Amber,22,8,1,1,0,0,2,3.563
+Summer 2024,HLT,4310,3,16495,Program Planning for Hlt Prof,Haq,Arooba A,21,11,1,1,0,0,0,3.432
+Summer 2024,HLT,4310,4,16496,Program Planning for Hlt Prof,Haq,Arooba A,20,15,0,0,0,0,0,3.402
+Summer 2024,ARCH,4328,1,16594,Technology 6 Practice of ARCH,Taylor,Rives,1,0,0,0,0,0,0,4.0
+Summer 2024,ARCH,6360,1,16595,Practice of Arch,Taylor,Rives,7,0,0,0,0,0,0,4.0
+Summer 2024,ARCH,2350,1,16598,Hist of the Built Environmt I,Ramaswamy,Deepa,8,13,2,2,1,0,3,2.885
+Summer 2024,MECE,5397,2,16601,Selected Topics,Franchek,Matthew,22,14,7,1,0,0,3,3.228
+Summer 2024,PHIL,1305,1,16602,Intro To Ethics,Aiman,Edwin E,20,14,0,0,0,0,0,3.52
+Summer 2024,NUTR,6319,1,16603,Supervised Practice,Haubrick,Kevin,0,0,0,0,0,1,0,
+Summer 2024,MECE,6397,2,16607,Selected Topics,Franchek,Matthew,14,3,1,0,0,0,0,3.667
+Summer 2024,MECE,6397,4,16608,Selected Topics,Marotta,Egidio,14,0,0,0,0,0,0,4.0
+Summer 2024,MECE,5397,3,16609,Selected Topics,Marotta,Egidio,1,0,0,0,0,0,0,4.0
+Summer 2024,HDCS,4375,2,16612,Strategies in Digital Retail,Kellough,James David,21,2,0,0,1,0,0,3.736
+Summer 2024,FINA,4323,2,16613,Investment & Mutual Fund Mgt,Caire,Matthew,13,0,0,0,0,0,0,3.975
+Summer 2024,FINA,4397,1,16617,Selected Topics in Finance,Stewart,Marcus,9,8,0,1,0,0,1,3.407
+Summer 2024,FINA,4397,2,16618,Selected Topics in Finance,Kapatos,Nick Gus,12,13,1,0,0,0,0,3.41
+Summer 2024,FINA,4397,3,16619,Selected Topics in Finance,Kapatos,Nick Gus,15,12,0,0,0,0,0,3.494
+Summer 2024,ENGL,4300,1,16620,Intro-Study of Language,Zentz,Lauren R,13,10,3,1,0,0,1,3.235
+Summer 2024,CNST,6370,1,16621,Quality Mgmt & Six Sigma in CM,Gao,Lu,14,0,0,0,0,0,0,4.0
+Summer 2024,MATH,4322,1,16622,Data Science and Machine Learn,Poliak,Cathy Dawn,40,9,0,0,1,0,3,3.7
+Summer 2024,CHEE,2331,1,16623,Chemical Processes,Cirino,Patrick C,4,0,1,3,0,0,6,2.584
+Summer 2024,CHEE,2332,1,16624,Chem Engr Thermodyn I,Fleischer,Miguel T,2,5,3,2,1,0,4,2.283
+Summer 2024,CHEE,3321,1,16626,Analytical Methods Chem Engr,Malamataris,Nikolaos,9,1,5,2,0,0,2,2.981
+Summer 2024,CHEE,3321,2,16627,Analytical Methods Chem Engr,Malamataris,Nikolaos,0,0,0,0,0,0,1,
+Summer 2024,CHEE,3367,1,16630,Process Modeling and Control,Kaspar,Michael,3,4,1,0,0,0,1,3.209
+Summer 2024,CHEE,3367,2,16631,Process Modeling and Control,Kaspar,Michael,1,1,1,0,0,0,1,2.89
+Summer 2024,CHEE,6397,1,16634,Selected Topics,Kaushik,Krishna R,3,2,0,0,0,0,0,3.534
+Summer 2024,CHEE,5370,1,16635,Sustain Environ Mitigation,Kaushik,Krishna R,1,1,0,0,0,0,0,3.665
+Summer 2024,MANA,3335,5,16637,Intro Org Behavior and Mgmt,Babalola,Olusegun,28,4,1,1,1,0,1,3.6
+Summer 2024,CIS,3330,30,16638,Info Systems in Organizations,Detillier,Bret James,3,12,3,0,0,0,0,2.982
+Summer 2024,CIS,3368,20,16639,Adv Info Systems Development,Peddoju,Suresh Kumar,32,3,0,1,2,0,2,3.579
+Summer 2024,CIS,4365,20,16641,Database Management,Hu,Renjie,15,14,0,0,0,0,1,3.449
+Summer 2024,CIS,6355,20,16643,Cybersecurity Tools,Conklin,William A,7,0,0,0,0,0,0,3.906
+Summer 2024,TLIM,4350,30,16644,Occup Safety & Envir Health,Freedkin,Aaron Samuel,18,13,3,0,2,0,2,3.213
+Summer 2024,DIGM,3152,31,16645,Graphic Comm Output Lab,Dawson,Michael John,4,0,0,0,2,0,0,2.667
+Summer 2024,PUBL,6325,1,16646,Capstone Problem Project,Koelling,Peter,0,0,0,0,0,0,0,
+Summer 2024,PUBL,6321,1,16647,Seminar in Urban Politics,Thurmond,James H,8,2,0,0,0,0,0,3.767
+Summer 2024,DIGM,1300,30,16648,Introduction to Digital Media,Liao,Pamara F,9,6,5,1,0,0,1,3.19
+Summer 2024,DIGM,2376,30,16649,UX Principles 2,Rodwell,Elizabeth Ann,16,7,0,0,1,0,0,3.487
+Summer 2024,DIGM,3252,30,16650,Graphic Communication Output,Dawson,Michael John,8,6,0,0,0,0,0,3.454
+Summer 2024,DIGM,4372,30,16651,DIGM Production Management,Hargrove,Mark Stephen,9,3,1,0,0,0,1,3.615
+Summer 2024,GEOL,6358,1,16661,Terrigenous Depositional Systm,Dupre,William Roark,3,4,0,0,0,0,1,3.287
+Summer 2024,GEOL,6363,1,16662,Carbonate Sedimentalogy,Dravis,Jeffrey James,2,5,0,0,0,0,1,3.191
+Summer 2024,GEOL,6372,1,16664,Petroleum Geochemistry,Van Nieuwenhuise,Donald S,5,2,0,0,0,0,1,3.761
+Summer 2024,GEOL,7323,1,16665,Borehole Geophysics,Stewart,Robert R,4,0,0,0,0,0,0,3.753
+Summer 2024,GEOL,7330,1,16666,Potntl Fld Mtds-Geophys,Bird,Dale E,1,1,0,0,0,0,0,3.5
+Summer 2024,PHYS,1304,1,16667,Solar System,Renshaw,Andrew,17,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,4363,5,16684,Abnormal Child Psych,Salentine,Cassidy,26,18,10,2,1,0,1,3.146
+Summer 2024,PSYC,3350,3,16685,Intro to Cognitive Psychology,Racioppo,Keith,29,27,1,0,2,0,0,3.378
+Summer 2024,PSYC,2307,2,16692,Psychology of Adolescence,Anderson,Jill Annette,21,12,1,0,0,0,1,3.501
+Summer 2024,PSYC,2319,4,16695,Intro to Social Psychology,Anderson,Jill Annette,24,12,1,0,0,0,2,3.577
+Summer 2024,PSYC,2319,5,16696,Intro to Social Psychology,Anderson,Jill Annette,19,13,2,0,3,0,1,3.145
+Summer 2024,HDFS,3318,2,16712,Human Ecol of Adult Developmt,Schoger,Kimberly,35,5,0,1,0,0,1,3.749
+Summer 2024,ARLD,6398,1,16726,Special Prob in Arts Leadrshp,Fernando,Fleurette S,0,0,0,0,0,0,0,
+Summer 2024,ARLD,6691,1,16727,Internship in Arts Organizatn,Fernando,Fleurette S,0,0,0,0,0,0,0,
+Summer 2024,PCEU,8698,2,16730,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Summer 2024,COMM,3361,1,16732,Advertising Copywriting,Tinnel,Jason Wayne,2,7,2,1,0,0,2,2.806
+Summer 2024,COMM,4360,1,16733,Media Planning & Placement,Jin,Eunjoo,3,7,5,0,0,0,1,2.933
+Summer 2024,COMM,2331,1,16738,Relational Communication,Uhrick,Jan,9,2,0,0,0,0,0,3.818
+Summer 2024,COMM,3376,1,16740,Media Effects,Olson,Beth M,18,9,5,0,1,0,0,3.283
+Summer 2024,DIGM,3374,30,16746,Video Production 2,Molina,Carlos,16,0,0,0,0,0,0,3.938
+Summer 2024,ECE,5397,1,16749,Selected Topics,Nguyen,Hien V,7,1,0,0,0,0,3,3.793
+Summer 2024,ECE,6397,1,16750,Selected Topics,Nguyen,Hien V,4,0,0,0,0,0,1,3.918
+Summer 2024,GEOL,7323,2,16759,Borehole Geophysics,Stewart,Robert R,1,0,0,0,0,0,0,3.67
+Summer 2024,GEOL,7330,2,16762,Potntl Fld Mtds-Geophys,Bird,Dale E,1,0,0,0,0,0,0,3.67
+Summer 2024,CUIN,7312,1,16770,Curr Design in Bilingual Ed,Burgess,Miguel,11,0,0,0,0,0,2,4.0
+Summer 2024,CUIN,1350,3,16781,Mathematics for Teachers 1,Burris,Justin T,13,1,2,0,0,0,0,3.564
+Summer 2024,ECE,5380,2,16782,Pwr Electrncs & Electrc Drives,Krishnamoorthy,Harish Sarma,7,2,0,0,0,0,0,3.741
+Summer 2024,MUSI,1307,2,16796,Listening to Classical Music,Vansteenburg,Jessica N,42,7,2,2,1,0,3,3.568
+Summer 2024,MUSI,2302,1,16797,Listening to Jazz,Hubley,Robert L,52,5,1,1,1,0,3,3.64
+Summer 2024,MUSI,3301,2,16799,Listening To World Music,Vansteenburg,Jessica N,40,7,4,0,0,0,0,3.674
+Summer 2024,IART,7370,1,16800,Interdisciplinary Fieldwork,Meza,Abinadi,10,0,0,0,0,0,0,4.0
+Summer 2024,DRAM,1310,3,16801,Introduction to Theatre,Young,Courtney Leigh,50,2,1,0,1,0,1,3.827
+Summer 2024,DRAM,1310,6,16802,Introduction to Theatre,Young,Courtney Leigh,43,8,2,0,0,0,0,3.73
+Summer 2024,DRAM,1310,7,16803,Introduction to Theatre,Young,Courtney Leigh,51,3,1,0,0,0,0,3.849
+Summer 2024,HLT,4392,3,16820,Field Work in Community Health,Proctor,Robin Ann,39,3,2,1,0,0,3,3.741
+Summer 2024,PHLS,7301,1,16822,Practicum,Hurt,Kara Marie,0,0,0,0,0,8,1,
+Summer 2024,PHLS,7301,2,16823,Practicum,Lee,Jungeun,0,0,0,0,0,9,0,
+Summer 2024,PHLS,6398,3,16824,Special Problems,Whitaker,Rachael Gwin,11,0,0,0,0,0,0,4.0
+Summer 2024,DRAM,1310,13,16825,Introduction to Theatre,Hinkel,Heidi Anne,40,3,1,0,1,0,0,3.756
+Summer 2024,DRAM,1310,14,16826,Introduction to Theatre,Hinkel,Heidi Anne,28,8,0,2,2,0,1,3.384
+Summer 2024,DANC,2303,1,16828,Introduction to Dance,Bobet,Jacqueline A,16,10,4,2,6,0,4,2.65
+Summer 2024,COMM,3331,1,16830,Communication in the Family,Uhrick,Jan,4,0,0,0,0,0,1,4.0
+Summer 2024,MANA,4354,1,16832,EEO Commission Internship,Williams,John M,0,0,0,0,0,6,0,
+Summer 2024,CUIN,4398,1,16833,Independent Study,Hale,Margaret Ann,1,0,0,0,0,0,0,4.0
+Summer 2024,BTEC,3317,30,16836,Biotech Regulatory Environment,Flavier,Albert B,1,8,6,0,0,0,0,2.733
+Summer 2024,BTEC,3321,30,16837,Good Manufacturing Practices,Aghoghovbia-Pugh,Alero,0,2,4,1,2,0,1,1.63
+Summer 2024,BTEC,3200,30,16839,Biotech Research Methods,Hosseinzadeh,Hemen,4,4,0,0,0,0,0,3.418
+Summer 2024,STAT,3331,1,16840,Statistical Anal Bus Appl I,Johnson,Norman A,14,10,9,9,0,0,6,2.635
+Summer 2024,MECT,3367,30,16841,Quality Control Technology,Afrin,Samia,7,6,0,0,0,0,0,3.462
+Summer 2024,MECT,3330,30,16842,Advanced Engineering Graphics,Basaran,Burak,18,13,3,0,0,0,0,3.441
+Summer 2024,MECT,4188,20,16844,Ethics in Engineering Tech,Bose,Anima B,14,7,1,1,0,0,0,3.378
+Summer 2024,ARLD,3300,1,16845,Intro to Arts Administration,Wilson,Paula Michelle,6,5,3,0,0,0,0,3.238
+Summer 2024,NURS,4297,1,16846,Special Topic in Nursing,Phan,Huong Thi,12,0,0,0,0,0,0,4.0
+Summer 2024,NURS,4520,1,16848,Concept Integ Patient Care Mgt,Smith,Deborah Ann,1,0,0,0,0,0,0,4.0
+Summer 2024,NURS,6230,1,16849,Diagnostic Tests & Procedures,Kleinhans,Alicia Diane,2,2,0,0,0,0,0,3.5
+Summer 2024,NURS,6320,1,16850,Healthcare Informatics,Smith,Deborah Ann,9,0,0,0,0,0,0,4.0
+Summer 2024,NURS,8336,1,16851,Advanced Synthesis Practicum,Joseph,Beena Roby,0,0,0,0,0,1,0,
+Summer 2024,COMD,2376,1,16857,Anatomy for Communication,Blake,Margaret T,6,8,3,0,0,0,0,3.118
+Summer 2024,ARCH,5502,1,16863,Arch Design Studio-Traveling,Diehl,Tom,5,7,0,0,0,0,0,3.389
+Summer 2024,ARCH,7602,1,16865,ArchDesign Studio Abroad,Diehl,Tom,1,0,0,0,1,0,0,1.835
+Summer 2024,GOVT,2306,5,16869,US and Texas Const/Politics,Weng,Ting-wei,15,7,4,5,2,0,3,2.838
+Summer 2024,GOVT,2306,6,16870,US and Texas Const/Politics,Khayat,Racha,34,29,5,3,3,0,2,3.176
+Summer 2024,MECT,3365,30,16887,Computer-Aided Design I,El Nahas,Medhat A,4,10,3,0,0,0,0,3.078
+Summer 2024,CIS,3320,30,16888,Information Visualization,Ratner,Edward,32,14,3,1,2,0,5,3.309
+Summer 2024,CHEE,6397,2,16890,Selected Topics,Kaushik,Krishna R,8,5,0,0,0,0,0,3.514
+Summer 2024,ENGL,7335,1,16893,Sociolinguistics,Zentz,Lauren R,2,0,0,0,0,0,1,4.0
+Summer 2024,MECE,7399,5,16908,Masters Thesis,Huang,Yi-Chun,0,0,0,0,0,1,0,
+Summer 2024,MAS,3340,1,16915,Mexican Amer Urban Communities,Pino,Diana,2,7,1,0,0,0,2,3.166
+Summer 2024,SOCI,1301,3,16916,Introduction To Sociology,Cooper,Chelsey Wells,43,2,2,0,0,0,0,3.851
+Summer 2024,SOC,3400,1,16917,Intro To Social Statistics,Hwang,Hyunseok,5,4,1,0,2,0,5,2.723
+Summer 2024,ANTH,3381,1,16929,Global Hinduism,Borkataky-Varma,Sravana,12,7,3,0,1,0,2,3.132
+Summer 2024,PHLS,8193,6,16939,Internship in Psychology,Smith,Bradley,0,0,0,0,0,8,0,
+Summer 2024,PHLS,7193,2,16940,Internship and Practicum,Smith,Bradley,1,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,3434,1,16942,Fluid Mech and Hydraulic Engr,Saladi,Krishna Rishi Vijay,0,2,5,0,0,0,0,2.286
+Summer 2024,CIVE,5397,1,16944,Selected Topics,Vipulanandan,Cumaraswamy,8,0,0,0,0,0,0,3.959
+Summer 2024,CIVE,7397,1,16945,Selected Topics,Vipulanandan,Cumaraswamy,5,0,0,0,0,0,1,4.0
+Summer 2024,CIVE,4332,1,16946,Hydrology,Saladi,Krishna Rishi Vijay,1,1,4,0,0,0,1,2.39
+Summer 2024,CIVE,7340,1,16949,Earthquake Engineering,Mo,Larry Yi-Lung,22,0,0,0,0,0,0,3.94
+Summer 2024,CIVE,4363,1,16950,Concrete Design,Belarbi,Abdeldjelil,2,2,1,0,0,0,0,3.2
+Summer 2024,CIVE,3337,1,16951,Structural Analysis,Herman,Reagan,3,3,5,2,1,0,2,2.239
+Summer 2024,CIVE,4337,1,16952,Transportation Engineering,Phatak,Tejasree Mohan,0,4,0,1,0,0,0,2.468
+Summer 2024,ENGR,2301,1,16953,Mechanics I (Statics),Krakowiak,Konrad,5,5,4,3,2,0,2,2.421
+Summer 2024,PHAR,5297,1,16954,Selected Topics in Pharmacy,Rosario,Natalie,10,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5297,2,16955,Selected Topics in Pharmacy,Rosario,Natalie,13,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5297,3,16956,Selected Topics in Pharmacy,Asias-Dinh,Bernadette De Leon,40,3,0,0,0,0,0,3.93
+Summer 2024,BIOL,8698,19,16963,Doctoral Research,Zhang,Shaun Xiaoliu,0,0,0,0,0,2,0,
+Summer 2024,BIOL,6698,1,16965,Special Problems,Albecker,Molly A,0,0,0,0,0,2,0,
+Summer 2024,BIOL,6698,2,16966,Special Problems,Daane,Jacob,0,0,0,0,0,3,0,
+Summer 2024,COMM,1303,2,16967,Writing for Communicators,Lyn,Robyn,10,2,0,0,1,0,1,3.564
+Summer 2024,BCHS,8698,13,16968,Doctoral Research,Liu,Yu,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,3,16969,Special Problems,Stuckert,Adam,0,0,0,0,0,2,0,
+Summer 2024,COSC,1336,201,16974,Computer Science & Program,Yun,Changhoon,8,5,5,4,3,0,4,2.44
+Summer 2024,COSC,4370,101,16978,Interactive Computer Graphics,Biediger,Daniel Edward,48,29,6,1,1,0,6,3.459
+Summer 2024,MATH,8698,17,16980,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Summer 2024,PHLS,7398,1,16981,Candidacy Research,Allan,Blake A,0,0,0,0,0,1,0,
+Summer 2024,PHLS,8399,2,16983,Doctoral Dissertation,Allan,Blake A,0,0,0,0,0,1,0,
+Summer 2024,HIST,2313,3,16989,Global Civilization to 1500,Johnson,Michele R,9,7,8,3,1,0,2,2.844
+Summer 2024,CIVE,8198,23,16991,Doctoral Research,Xie,Surui,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8598,23,16992,Doctoral Research,Xie,Surui,0,0,0,0,0,3,0,
+Summer 2024,ECE,8399,16,16993,Doctoral Dissertation,Litvinov,Dmitri,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8398,16,16994,Doctoral Research,Litvinov,Dmitri,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8298,22,16995,Doctoral Research,Wen,Mingjian,0,0,0,0,0,0,0,
+Summer 2024,CHEE,8298,23,16996,Doctoral Research,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,0,0,
+Summer 2024,CHEE,8498,22,16997,Doctoral Research,Wen,Mingjian,0,0,0,0,0,0,0,
+Summer 2024,CHEE,8498,23,16998,Doctoral Research,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,0,0,
+Summer 2024,NURS,4212,1,17000,Informatics in Health Care,Edwards-Maddox,Shermel Vinese,8,0,0,0,0,0,0,4.0
+Summer 2024,LASS,3150,1,17001,CLASS Internship,Wingard,Jennifer L,0,0,0,0,0,1,0,
+Summer 2024,MATH,6698,1,17003,Special Problems,Haynes,Alan K,0,0,0,0,0,12,0,
+Summer 2024,MATH,6698,1,17004,Special Problems,Haynes,Alan K,0,0,0,0,0,9,0,
+Summer 2024,MATH,8699,4,17006,Doctoral Dissertation,Timofeyev,Ilya,1,0,0,0,0,0,0,3.67
+Summer 2024,MECE,8698,1,17009,Doctoral Research,Chen,Tian,0,0,0,0,0,3,0,
+Summer 2024,MIS,7378,1,17011,Info.Tech Management & Control,Porra,Jaana,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,6698,4,17012,Special Problems,Chung,Sanghyuk,0,0,0,0,0,2,0,
+Summer 2024,BIOL,6698,5,17013,Special Problems,Lekven,Arne,0,0,0,0,0,1,0,
+Summer 2024,BCHS,6698,1,17014,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,3,0,
+Summer 2024,ACCT,4198,2,17015,Independent Study,Newman,Michael Ray,5,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8698,20,17016,Doctoral Research,Graur,Dan,0,0,0,0,0,1,0,
+Summer 2024,THEA,6280,2,17017,The teaching of Acting,Ferrarone,Jessica,10,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6281,2,17018,The teaching of Voice,Wetzel,Molly Elizabeth,10,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6284,2,17019,Program Management,Allen,Robert Scott,12,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6285,2,17020,Field Work New York,Ferrarone,Jessica,28,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,8398,1,17021,Special Problems,Fan,Weihua,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8298,24,17022,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Summer 2024,CHEE,8498,24,17024,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Summer 2024,THEA,6287,2,17027,Acting Styles,Bronfenbrenner,Skye,6,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6381,2,17028,Scenic Des for H.S. Director,Krouskop,Mark,10,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6382,2,17029,Dramaturgy for H.S. Director,Wernig,Amy Steele,10,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6383,2,17030,Light/Cost Des for HS Director,Giannelli,Christina Rose,6,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6384,2,17031,Directing,Cook,Rena R,6,0,0,0,0,0,1,4.0
+Summer 2024,THEA,6386,2,17032,Drama in Context,Miller,Destyne,12,0,0,0,0,0,0,4.0
+Summer 2024,THEA,6396,2,17033,Selected Topics Theatre,Hickman,Margo Louise,12,0,0,0,0,0,0,3.973
+Summer 2024,PHYS,8698,36,17038,Doctoral Research,Chen,Xiaojia,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8698,37,17039,Doctoral Research,Mondaini,Rubem,0,0,0,0,0,2,0,
+Summer 2024,PSYC,4398,1,17043,Independent Study,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Summer 2024,ELET,3425,3,17045,Embedded Systems,Moges,Mequanint A,2,3,0,0,0,0,0,3.334
+Summer 2024,SOCW,7191,1,17048,SW Practicum Elective I,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Summer 2024,ECE,8699,5,17049,Doctoral Dissertation,Becker,Aaron T,1,0,0,0,0,0,0,4.0
+Summer 2024,TLIM,4390,30,17050,Current Issues Ldshp & Innov,Mehring,Brian George,11,4,1,0,1,0,1,3.354
+Summer 2024,PHLS,8699,1,17051,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,0,0,
+Summer 2024,CNST,6370,40,17053,Quality Mgmt & Six Sigma in CM,Gao,Lu,2,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8699,1,17059,Doctoral Dissertation,Feng,Qin,2,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8699,2,17060,Doctoral Dissertation,Amaral Antunes,Dinler,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8698,21,17062,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,6,17063,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Summer 2024,ECE,6298,6,17067,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Summer 2024,ECE,6498,2,17068,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Summer 2024,MATH,8698,13,17069,Doctoral Research,Mang,Andreas,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8699,1,17074,Doctoral Dissertation,Bellwied,Rene,1,0,0,0,0,0,0,4.0
+Summer 2024,PHYS,8699,2,17075,Doctoral Dissertation,Morrison,Gregory C,1,0,0,0,0,0,0,4.0
+Summer 2024,PHYS,8699,4,17077,Doctoral Dissertation,Hosur,Pavan R,0,1,0,0,0,0,0,3.0
+Summer 2024,MATH,8698,14,17081,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Summer 2024,MATH,8698,13,17082,Doctoral Research,Wu,Yingying,0,0,0,0,0,1,0,
+Summer 2024,MATH,8399,8,17083,Doctoral Dissertation,Kalantar,Mehrdad,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8298,27,17085,Doctoral Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,28,17086,Doctoral Research,Fan,Lei,0,0,0,0,0,1,0,
+Summer 2024,ECE,8498,27,17087,Doctoral Research,Fan,Lei,0,0,0,0,0,1,0,
+Summer 2024,PCEU,8398,2,17088,Doctoral Research,Tam,Vincent H,0,0,0,0,0,1,0,
+Summer 2024,BIOL,8699,3,17089,Doctoral Dissertation,Rodrigues,Debora Frigi,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,6698,7,17090,Special Problems,Yi,Ping,0,0,0,0,0,3,0,
+Summer 2024,BIOL,6698,8,17092,Special Problems,Nunez,Martin A,0,0,0,0,0,2,0,
+Summer 2024,BCHS,6698,2,17094,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,9,17095,Special Problems,Pennings,Steven C,0,0,0,0,0,3,0,
+Summer 2024,CIVE,8398,4,17096,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Summer 2024,MATH,8699,6,17097,Doctoral Dissertation,Cappanera,Loic,1,0,0,0,0,0,0,4.0
+Summer 2024,PCEU,8398,3,17099,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Summer 2024,ECE,6298,7,17101,Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Summer 2024,ECE,8699,6,17102,Doctoral Dissertation,Yao,Yan,0,0,0,0,0,1,0,
+Summer 2024,GEOL,3355,3,17103,Field Geology I,Kalakay,Thomas J,2,3,0,0,0,0,0,3.532
+Summer 2024,GEOL,3360,3,17104,Field Geology II,Lindline,Jennifer,4,2,1,0,0,0,0,3.334
+Summer 2024,POLS,4398,1,17105,Independent Study,Archer,Allison Michelle Nam,1,0,0,0,0,0,0,4.0
+Summer 2024,COMM,4398,1,17106,Independent Study,Uhrick,Jan,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8198,10,17107,Doctoral Research,Fu,Xin,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,29,17108,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,3,0,
+Summer 2024,ECE,8498,28,17109,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,3,0,
+Summer 2024,ECE,8699,7,17110,Doctoral Dissertation,Robles Hernandez,Francisco C,0,0,0,0,0,2,0,
+Summer 2024,BCHS,6698,3,17113,Special Problems,Widger,William R,0,0,0,0,0,2,0,
+Summer 2024,ELCS,8398,1,17114,Independent Study,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8695,8,17115,Dissertation in Practice,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Summer 2024,COSC,4398,101,17116,Independent Study,Yun,Changhoon,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,11,17118,Special Problems,Vicens,Quentin,0,0,0,0,0,1,0,
+Summer 2024,CHEM,1111,1,17119,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,7,1,1,0,0,0,3.119
+Summer 2024,BIOL,6698,12,17120,Special Problems,Feng,Qin,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,13,17121,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Summer 2024,BCHS,6698,5,17123,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,14,17129,Special Problems,Khan,Abdul Latif,0,0,0,0,0,2,0,
+Summer 2024,BIOL,6698,15,17130,Special Problems,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Summer 2024,OPTO,5198,1,17131,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,1,0,
+Summer 2024,OPTO,5198,2,17132,Spec Prob Phys Optics,Porter,Jason,0,0,0,0,0,45,0,
+Summer 2024,OPTO,5198,3,17133,Spec Prob Phys Optics,Berntsen,David A,0,0,0,0,0,39,0,
+Summer 2024,BIOE,6309,2,17135,Neural Interfaces,Abidian,Mohammad Reza,8,0,0,0,0,0,0,4.0
+Summer 2024,MATH,8698,17,17137,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,1,0,
+Summer 2024,MATH,8698,18,17138,Doctoral Research,Charon,Nicolas,0,0,0,0,0,1,0,
+Summer 2024,MATH,6698,3,17140,Special Problems,Cappanera,Loic,0,0,0,0,0,2,0,
+Summer 2024,BCHS,6698,6,17141,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Summer 2024,OPTO,5298,1,17143,Spec Prob Phys Optics,Logan,Anna-Kaye M,0,0,0,0,0,19,0,
+Summer 2024,MECE,8398,2,17144,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,3,0,
+Summer 2024,ARTS,2311,2,17145,"Color, Materials and Methods",Williams,Celeste,11,1,1,0,0,0,0,3.642
+Summer 2024,PHOP,6357,6,17151,Research Practicum B,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,6698,16,17152,Special Problems,Mohan,Chandra,0,0,0,0,0,1,0,
+Summer 2024,CIS,3343,20,17155,Info Systems Analysis & Design,Miertschin,Susan L,17,15,2,0,1,0,0,3.296
+Summer 2024,MATH,6698,3,17157,Special Problems,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Summer 2024,OPTO,5298,2,17159,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,27,0,
+Summer 2024,PHOP,6257,16,17160,Research Practicum B,Ferreira,Tarsis Gesteira,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8299,3,17161,Doctoral Dissertation,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8298,3,17162,Doctoral Research,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8198,2,17163,Doctoral Research,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8499,1,17164,Doctoral Dissertation,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8298,4,17165,Doctoral Research,Yoon,Geunyoung,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8399,8,17166,Doctoral Dissertation,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6467,7,17167,Research Practicuum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6198,12,17168,Spec Prob-Physio Optics,Matynia,Anna,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8199,5,17169,Doctoral Dissertation,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6257,17,17170,Research Practicum B,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8199,6,17171,Doctoral Dissertation,Patel,Nimesh Bhikhu,2,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8299,4,17172,Doctoral Dissertation,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,7398,2,17173,Candidacy Research,Smith,Nathan G,0,0,0,0,0,0,0,
+Summer 2024,PHOP,6357,7,17177,Research Practicum B,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6267,7,17178,Research Practicum A,Burns,Alan R,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6357,8,17179,Research Practicum B,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,8498,6,17180,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Summer 2024,PHOP,6567,10,17181,Research Practicum A,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,3400,1,17183,Intro To Mechanics,Agrawal,Ashutosh,5,15,4,0,0,0,0,2.945
+Summer 2024,MATH,8698,21,17189,Doctoral Research,Ott,William R,0,0,0,0,0,2,0,
+Summer 2024,OPTO,5298,3,17190,Spec Prob Phys Optics,Martinez,Muriel L,0,0,0,0,0,11,0,
+Summer 2024,PCOL,6298,7,17195,Special Problems,Darabi,Radbod,1,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,6498,7,17196,Special Problems,Darabi,Radbod,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,8698,3,17200,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,5,0,
+Summer 2024,PCOL,8398,3,17202,Doctoral Research,Hussain,Tahir,0,0,0,0,0,1,0,
+Summer 2024,BCHS,8698,14,17203,Doctoral Research,Briggs,James M,0,0,0,0,0,1,0,
+Summer 2024,MECE,8398,3,17205,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,
+Summer 2024,PEP,8699,3,17206,Doctoral Dissertation,Lee,Dong Hun,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5297,4,17207,Selected Topics in Pharmacy,Garey,Kevin W,3,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5297,5,17208,Selected Topics in Pharmacy,Eubank,Taryn Ashley,2,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,6398,9,17209,Special Problems,Cuny,Gregory D,0,0,0,0,0,2,0,
+Summer 2024,BIOL,6698,17,17211,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Summer 2024,ELCS,8397,1,17212,Sem Top Ed Ldshp&Cul St,Barnes,Yolanda Michelle,17,3,0,0,0,0,0,3.834
+Summer 2024,BCHS,6698,7,17213,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6398,10,17214,Special Problems,Das,Joydip,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,8698,15,17215,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Summer 2024,RELS,3381,1,17218,Global Hinduism,Borkataky-Varma,Sravana,1,1,3,0,0,0,1,2.468
+Summer 2024,MARK,7A97,1,17220,Selected Topics in Marketing,Kelly,Robert J,5,0,0,0,0,0,0,4.0
+Summer 2024,MARK,7A97,2,17221,Selected Topics in Marketing,Kelly,Robert J,5,0,0,0,0,0,0,4.0
+Summer 2024,SPAN,2311,5,17222,Intermediate Spanish I,Ruffino,Gustavo,6,3,5,0,1,0,0,2.801
+Summer 2024,MECE,8698,4,17223,Doctoral Research,Chen,Yi-Chao,0,0,0,0,0,1,0,
+Summer 2024,GEOL,8698,24,17227,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Summer 2024,ARTS,4398,1,17228,Independent Study,Kittelson,Paul A,1,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8398,5,17229,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Summer 2024,ECON,6394,1,17232,Tpcs-Eco of Socl Issue,Besedina,Elena,8,4,0,0,0,0,0,3.612
+Summer 2024,ECON,6394,2,17233,Tpcs-Eco of Socl Issue,Obrizan,Maksym,2,2,0,0,0,0,0,3.583
+Summer 2024,ECON,6394,3,17234,Tpcs-Eco of Socl Issue,Nivievskyi,Oleg,0,3,0,0,0,0,0,3.22
+Summer 2024,ECON,6691,2,17235,Master's Internship,Verchenko,Olesia,13,0,0,0,0,0,0,3.746
+Summer 2024,ECE,8198,11,17246,Doctoral Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Summer 2024,ECE,8298,30,17247,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,3,0,
+Summer 2024,ECE,8498,29,17248,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,3,0,
+Summer 2024,PHAR,5297,6,17249,Selected Topics in Pharmacy,Liu,Xinli,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,6498,5,17250,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Summer 2024,BCHS,6231,2,17251,Grad Biochem Lab Rotation II,Widger,William R,5,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8699,2,17258,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,1,0,
+Summer 2024,MATH,6315,7,17259,Masters Tutorial,Etgen,Garret J,1,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,5198,4,17263,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8699,3,17267,Doctoral Dissertation,Louie,Stacey M,0,0,0,0,0,1,0,
+Summer 2024,BCHS,8699,2,17268,Doctoral Dissertation,Briggs,James M,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,8699,3,17269,Doctoral Dissertation,Gustafsson,Jan-Ake,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,8699,4,17270,Doctoral Dissertation,Lin,Chin-Yo,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,8699,7,17274,Doctoral Dissertation,Zhao,Bo,0,0,0,0,0,1,0,
+Summer 2024,DIGM,3152,32,17276,Graphic Comm Output Lab,Dawson,Michael John,3,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8398,7,17282,Doctoral Research,Momen,Mostafa,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8399,6,17283,Doctoral Dissertation,Momen,Mostafa,0,0,0,0,0,2,0,
+Summer 2024,GEOL,8698,25,17285,Doctoral Research,Li,Aibing,0,0,0,0,0,2,0,
+Summer 2024,CIVE,4337,2,17286,Transportation Engineering,Phatak,Tejasree Mohan,14,15,9,1,0,0,0,3.128
+Summer 2024,INDE,2333,3,17287,Engineering Statistics I,Wang,Yaping,19,16,15,2,1,0,0,2.887
+Summer 2024,INDE,2333,4,17288,Engineering Statistics I,Wang,Yaping,54,31,15,5,2,0,0,3.233
+Summer 2024,BIOL,8698,22,17289,Doctoral Research,Yi,Ping,0,0,0,0,0,1,0,
+Summer 2024,PSYC,6399,6,17290,Masters Thesis,Viana,Andres G,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,3360,5,17291,Experimental Methods,Yang,Wenhua,11,24,7,0,0,0,0,3.04
+Summer 2024,PCOL,8398,4,17293,Doctoral Research,Statsyuk,Alexander V,0,0,0,0,0,0,0,
+Summer 2024,BIOL,6698,18,17301,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,19,17302,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,2,0,
+Summer 2024,PSYC,6399,7,17303,Masters Thesis,Venta,Amanda Cristina,0,0,0,0,0,1,0,
+Summer 2024,PHOP,6167,8,17304,Research Practicum A,Frishman,Laura J,1,0,0,0,0,0,0,4.0
+Summer 2024,PCEU,8298,1,17305,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Summer 2024,PCEU,8199,1,17306,Dissertation,Chow,Diana Shu-Lian,0,0,0,0,0,0,0,
+Summer 2024,CUIN,8690,1,17307,Dissertation in Practice,Hutchison,Laveria F,4,0,0,0,0,1,0,4.0
+Summer 2024,CUIN,8390,1,17308,Dissertation in Practice,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Summer 2024,BCHS,8699,5,17309,Doctoral Dissertation,Bawa-Khalfe,Tasneem,2,0,0,0,0,0,0,4.0
+Summer 2024,MATH,8399,10,17310,Doctoral Dissertation,Mamonov,Alexander V,1,0,0,0,0,0,0,4.0
+Summer 2024,ECE,6198,7,17311,Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Summer 2024,ELCS,8399,1,17313,Doctoral Dissertation,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8399,2,17317,Doctoral Dissertation,Liu,Elaine Meichen,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8399,3,17318,Doctoral Dissertation,Cubas Norando,German,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8399,4,17319,Doctoral Dissertation,Juhn,Chinhui,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8699,7,17320,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,1,0,
+Summer 2024,ECON,8399,5,17322,Doctoral Dissertation,Sorensen,Bent E,1,0,0,0,0,0,0,4.0
+Summer 2024,ENTR,4397,4,17325,Sel Topics in Entrepreneurship,McCormick,Kelly,18,6,1,0,2,0,1,3.346
+Summer 2024,CIS,6355,40,17328,Cybersecurity Tools,Conklin,William A,7,0,0,0,0,0,1,4.0
+Summer 2024,BIOL,6698,20,17331,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Summer 2024,HIST,6393,1,17334,Rdgs Seminar in US History,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Summer 2024,HIST,6357,1,17335,19Th Cent US Historiography,Clavin,Matthew J,1,0,0,0,0,0,0,4.0
+Summer 2024,ECON,8699,9,17336,Doctoral Dissertation,Liu,Elaine Meichen,0,0,0,0,0,1,0,
+Summer 2024,ELCS,8397,2,17338,Sem Top Ed Ldshp&Cul St,Barnes,Yolanda Michelle,10,5,0,0,0,0,0,3.689
+Summer 2024,GHL,3160,1,17342,Hospitality Practicum II,Kenyan,Erin Oeser,1,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,4398,1,17343,Independent Study,Henderson,Jerrod A,3,0,0,0,0,0,0,4.0
+Summer 2024,ECE,8399,17,17347,Doctoral Dissertation,Nguyen,Hien V,1,0,0,0,0,0,0,4.0
+Summer 2024,FINA,8396,1,17356,Research Practicum,Jacobs,Kris,1,0,0,0,0,0,0,4.0
+Summer 2024,MARK,8396,1,17358,Research Practicum,Ahearne,Michael,0,0,0,0,0,0,0,
+Summer 2024,MANA,8699,1,17359,Doctoral Dissertation,Ruggs,Enrica N,2,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,8399,13,17360,Doctoral Dissertation,Rappenglueck,Bernhard,1,0,0,0,0,0,0,4.0
+Summer 2024,MATH,6315,8,17363,Masters Tutorial,Ji,Shanyu,1,0,0,0,0,0,0,3.67
+Summer 2024,COMD,7391,23,17364,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,1,1,0,0,0,0,0,3.5
+Summer 2024,PCOL,8698,5,17366,Doctoral Research,Boini,Krishna M,0,0,0,0,0,2,0,
+Summer 2024,CIVE,8699,4,17371,Doctoral Dissertation,Li,Hongyi,2,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8399,7,17372,Doctoral Dissertation,Shaffer,Devin,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8699,5,17373,Doctoral Dissertation,Momen,Mostafa,0,0,0,0,0,1,0,
+Summer 2024,COMM,4398,2,17377,Independent Study,Vaughan,Thomas Michael,1,0,0,0,0,0,0,4.0
+Summer 2024,CUIN,7301,2,17379,CUIN Capstone Seminar,Hale,Margaret Ann,0,0,0,0,0,13,0,
+Summer 2024,PCOL,6398,11,17380,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6298,8,17381,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6498,8,17382,Special Problems,Udugamasooriya,Damith Gomika,0,0,0,0,0,1,0,
+Summer 2024,POLS,8699,1,17383,Doctoral Dissertation,Zhu,Ling,1,0,0,0,0,0,0,4.0
+Summer 2024,POLS,8699,2,17384,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,1,0,
+Summer 2024,POLS,8699,3,17385,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Summer 2024,PSYC,4398,2,17386,Independent Study,Zvolensky,Michael J,2,0,0,0,0,0,0,4.0
+Summer 2024,POLS,8699,4,17387,Doctoral Dissertation,Kennedy,Ryan P,0,0,0,0,0,1,0,
+Summer 2024,POLS,8699,5,17388,Doctoral Dissertation,Bagashka,Tanya G,0,0,0,0,0,0,0,
+Summer 2024,POLS,8699,6,17389,Doctoral Dissertation,Badas,Alex,0,0,0,0,0,1,0,
+Summer 2024,FINA,8398,1,17390,Special Problems,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Summer 2024,ARTS,4398,3,17391,Independent Study,Hecker,Rachel G,1,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,6398,12,17392,Special Problems,Garey,Kevin W,2,0,0,0,0,0,0,4.0
+Summer 2024,MARK,8398,1,17393,Special Problems,Ahearne,Michael,0,0,0,0,0,0,0,
+Summer 2024,MARK,8699,1,17394,Doctoral Dissertation,Ahearne,Michael,0,0,0,0,0,0,0,
+Summer 2024,MIS,7397,3,17395,Selected Topics in MIS,Lewis,Michael Joseph,1,0,0,0,0,0,0,4.0
+Summer 2024,FINA,8396,2,17396,Research Practicum,Susmel,Raul,0,0,0,0,0,3,0,
+Summer 2024,MECE,8698,5,17397,Doctoral Research,Cescon,Marzia,0,0,0,0,0,3,0,
+Summer 2024,PCOL,6498,9,17398,Special Problems,Zhang,Yang,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6298,9,17399,Special Problems,Zhang,Yang,0,0,0,0,0,1,0,
+Summer 2024,MECE,6198,1,17400,Research,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2024,HLT,4310,5,17401,Program Planning for Hlt Prof,Haq,Arooba A,8,8,2,0,0,0,0,3.278
+Summer 2024,PHLS,7398,3,17403,Candidacy Research,Carmack,Chakema,1,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,5298,4,17404,Spec Prob Phys Optics,Lambreghts,Kimberly,0,0,0,0,0,1,0,
+Summer 2024,PCOL,6298,10,17405,Special Problems,Wu,Mingfu,1,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,6498,10,17406,Special Problems,Wu,Mingfu,1,0,0,0,0,0,0,4.0
+Summer 2024,PHCA,6398,5,17408,Special Problems,Varisco,Tyler J,2,0,0,0,0,0,0,4.0
+Summer 2024,OPTO,5198,5,17409,Spec Prob Phys Optics,Dempsey,Robert L,0,0,0,0,0,2,0,
+Summer 2024,MARK,8396,2,17412,Research Practicum,Hess,James D,0,0,0,0,0,0,0,
+Summer 2024,CIVE,8699,6,17415,Doctoral Dissertation,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Summer 2024,CIVE,8699,7,17416,Doctoral Dissertation,Li,Hongyi,1,0,0,0,0,0,0,4.0
+Summer 2024,FINA,8398,2,17417,Special Problems,Hitzemann,Steffen,1,0,0,0,0,0,0,4.0
+Summer 2024,MIS,8399,1,17418,Doctoral Dissertation in MIS,Aron,Ravi,0,0,0,0,0,1,0,
+Summer 2024,MIS,8398,1,17419,Special Problems in MIS,Chin,Wynne W,0,0,0,0,0,0,0,
+Summer 2024,FINA,8396,3,17427,Research Practicum,Yerramilli,Vijay,1,0,0,0,0,0,0,3.67
+Summer 2024,CUIN,8393,1,17428,Adv Internship & Prac,Li,Miao,1,0,0,0,0,0,0,4.0
+Summer 2024,COSC,8699,126,17434,Doctoral Dissertation,Solorio Martinez,Thamar Ivette,0,1,0,0,0,0,0,3.33
+Summer 2024,ARCH,3398,1,17435,Independent Study,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8398,8,17437,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,2,0,
+Summer 2024,POLS,4398,2,17451,Independent Study,Cross,Renee Danielle,3,0,0,0,0,0,0,3.89
+Summer 2024,SCM,8396,1,17453,Research Practicum,Li,Meng,1,0,0,0,0,0,0,4.0
+Summer 2024,SCM,8396,2,17454,Research Practicum,Hosseinabadi Farahani,Mehdi,1,0,0,0,0,0,0,4.0
+Summer 2024,PETR,8699,2,17461,Doctoral Dissertation,Sakhaee Pour,Ahmad,1,1,0,0,0,0,0,3.5
+Summer 2024,PETR,8699,3,17463,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,0,0,
+Summer 2024,POLC,4398,1,17464,Independent Study,Cross,Renee Danielle,3,1,0,0,0,0,0,3.833
+Summer 2024,PHAR,5297,7,17468,Selected Topics in Pharmacy,Trivedi,Meghana,0,0,0,0,0,1,0,
+Summer 2024,POLC,6391,2,17470,Public Policy Internship,Pinto,Pablo M,4,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,8698,23,17472,Doctoral Research,Daane,Jacob,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,21,17473,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Summer 2024,COMD,8398,1,17474,Special Problems,Bunta,Ferenc,1,0,0,0,0,0,0,4.0
+Summer 2024,COMD,8398,2,17475,Special Problems,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Summer 2024,COMD,8391,1,17476,COMD Research,Thiessen,Amber L,0,0,0,0,0,0,0,
+Summer 2024,INDS,3398,2,17483,Independent Study,Wells,Adam C,2,0,0,0,0,0,0,4.0
+Summer 2024,CHEE,8398,23,17484,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,3,0,
+Summer 2024,CHEE,8298,25,17485,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,3,0,
+Summer 2024,ENGI,2304,1,17486,Technical Communications,Estrada,Carl,11,6,2,0,1,0,1,3.267
+Summer 2024,MECE,7399,6,17487,Masters Thesis,Ardebili,Haleh,1,0,0,0,0,0,0,4.0
+Summer 2024,SCM,8396,3,17488,Research Practicum,Aron,Ravi,1,0,0,0,0,0,0,4.0
+Summer 2024,SCM,8699,1,17490,Dissertation,Li,Meng,1,0,0,0,0,0,0,4.0
+Summer 2024,FINA,7397,3,17491,Selected Topics in Finance,Levy,Clayton V,3,0,0,0,0,0,0,3.78
+Summer 2024,INDE,6363,2,17494,Statistical Process Control,Keedy,Elias,1,0,0,0,0,0,0,3.67
+Summer 2024,GEOL,8398,10,17495,Doctoral Research,Capuano,Regina M,0,0,0,0,0,1,0,
+Summer 2024,BCHS,6698,9,17496,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2024,MECE,6399,2,17497,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Summer 2024,PCOL,8399,4,17499,Doctoral Dissertation,Ruan,Ke-He,0,0,0,0,0,1,0,
+Summer 2024,PSYC,6398,15,17500,Independent Studies,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Summer 2024,GHL,4198,1,17501,Independent Study,Haskell,Rebecca Erin,1,0,0,0,0,0,0,4.0
+Summer 2024,ACCT,8699,1,17502,Doctoral Dissertation,Crawford,Steven,1,0,0,0,0,0,0,4.0
+Summer 2024,ACCT,8699,2,17503,Doctoral Dissertation,Lobo,Gerald,0,0,0,0,0,2,0,
+Summer 2024,ACCT,8699,4,17505,Doctoral Dissertation,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Summer 2024,POLC,4498,1,17508,Independent Study,Cross,Renee Danielle,2,0,0,0,0,0,0,4.0
+Summer 2024,POLC,4598,1,17509,Independent Study,Cross,Renee Danielle,2,0,0,0,0,0,0,4.0
+Summer 2024,PHCA,8398,1,17511,Doctoral Dissertation Research,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Summer 2024,PCEU,6398,4,17512,Special Problems,Hu,Ming,0,0,0,0,0,1,0,
+Summer 2024,BCHS,8698,16,17513,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Summer 2024,MECE,8398,12,17514,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2024,SOCW,7398,1,17515,Independent Study in SW,Helms,Kristen,1,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8699,8,17516,Doctoral Dissertation,Rodrigues,Debora Frigi,2,0,0,0,0,0,0,4.0
+Summer 2024,PHCA,8398,3,17520,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Summer 2024,CUIN,8390,2,17523,Dissertation in Practice,Hale,Margaret Ann,1,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8395,9,17524,Dissertation in practice,Hale,Margaret Ann,1,0,0,0,0,0,0,4.0
+Summer 2024,INDE,2333,2,17525,Engineering Statistics I,Wiggins,Nathanial David,16,8,0,0,0,0,0,3.557
+Summer 2024,ENTR,4397,6,17526,Sel Topics in Entrepreneurship,McCormick,Kelly,8,2,0,0,0,0,1,3.734
+Summer 2024,MIS,8399,2,17528,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Summer 2024,INDE,8198,8,17537,Doctoral Research,Xiang,Yisha,0,0,0,0,0,4,0,
+Summer 2024,INDE,8598,8,17541,Doctoral Research,Xiang,Yisha,0,0,0,0,0,4,0,
+Summer 2024,MANA,8699,2,17543,Doctoral Dissertation,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Summer 2024,HON,3396,1,17549,Senior Research Project,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8695,9,17552,Dissertation in Practice,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Summer 2024,PCOL,8698,6,17553,Doctoral Research,McConnell,Bradley K,0,0,0,0,0,1,0,
+Summer 2024,GEOL,8699,5,17554,Doctoral Dissertation,Choi,Yunsoo,1,0,0,0,0,0,0,4.0
+Summer 2024,MIS,7397,4,17556,Selected Topics in MIS,Lewis,Michael Joseph,1,0,0,0,0,0,0,4.0
+Summer 2024,PHLS,7398,4,17557,Candidacy Research,Arbona,Consuelo,0,0,0,0,0,1,0,
+Summer 2024,CORE,1101,1,17561,College Success,Haywood,Dy'Rius La'Ron,13,3,0,0,0,0,0,3.813
+Summer 2024,BCHS,8698,17,17563,Doctoral Research,Sen,Mehmet,0,0,0,0,0,1,0,
+Summer 2024,BCHS,8698,18,17564,Doctoral Research,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Summer 2024,PHAR,5297,8,17573,Selected Topics in Pharmacy,Sansgiry,Sujit Sharad,0,0,0,0,0,23,0,
+Summer 2024,MATH,8698,20,17580,Doctoral Research,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Summer 2024,ARTS,4398,4,17581,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Summer 2024,FINA,4360,2,17582,International Financial Mgmt,Susmel,Raul,1,1,1,0,0,0,0,3.11
+Summer 2024,COMD,7190,1,17584,Graduate Seminar in Speech-L,Cizek,Laura S,0,0,0,0,0,0,0,
+Summer 2024,MUSI,7399,1,17585,Masters Thesis,Lee,Ji Yeon,0,0,0,0,0,0,1,
+Summer 2024,BIOL,6698,22,17588,Special Problems,Cirino,Patrick C,0,0,0,0,0,1,0,
+Summer 2024,BIOL,8698,24,17589,Doctoral Research,Liu,Xinli,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,23,17590,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Summer 2024,PEP,7398,1,17591,Adv Special Problem Human Perf,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Summer 2024,PEP,7398,2,17592,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8399,18,17595,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Summer 2024,ELET,6325,1,17597,Practicum in Engineering Tech,Yuan,Xiaojing,0,0,0,0,0,0,0,
+Summer 2024,INDE,6332,2,17598,Egr Project Mgt,Rypien,David V,2,0,0,0,0,0,0,4.0
+Summer 2024,MARK,8396,3,17599,Research Practicum,Patrick-Ralhan,Vanessa M,1,0,0,0,0,0,0,4.0
+Summer 2024,MIS,8399,3,17601,Doctoral Dissertation in MIS,Silva,Leiser O,1,0,0,0,0,0,0,4.0
+Summer 2024,CIVE,8398,9,17602,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Summer 2024,FINA,8399,2,17603,Doctoral Dissertation,George,Thomas J,0,0,0,0,0,1,0,
+Summer 2024,PCEU,6698,3,17605,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,24,17607,Special Problems,O'Brien,John,0,0,0,0,0,1,0,
+Summer 2024,BIOL,6698,25,17608,Special Problems,O'Brien,John,0,0,0,0,0,1,0,
+Summer 2024,PSYC,4398,4,17613,Independent Study,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,8698,27,17616,Doctoral Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Summer 2024,ARCH,6398,1,17625,Special Problems,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Summer 2024,PHCA,6398,6,17626,Special Problems,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,7399,7,17628,Masters Thesis,Wang,Su Su,0,0,0,0,0,0,0,
+Summer 2024,EDS,6398,2,17632,Research,Lendasse,Amaury,0,0,0,0,0,1,0,
+Summer 2024,FINA,8398,3,17633,Special Problems,Susmel,Raul,1,0,0,0,0,0,0,4.0
+Summer 2024,CNST,6396,1,17636,Master's Project,Gao,Lu,1,0,0,0,0,0,0,4.0
+Summer 2024,CIS,4398,30,17637,Independent Study,Lindner,Peggy,0,0,1,0,0,0,0,2.0
+Summer 2024,MECE,6397,5,17638,Selected Topics,Marotta,Egidio,8,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,6380,1,17639,Educational Planning & Policy,McKinney,Lonnie Lyle,0,1,0,0,0,0,0,3.0
+Summer 2024,PHAR,5297,9,17657,Selected Topics in Pharmacy,Nguyen,Kimberly A,0,0,0,0,0,1,0,
+Summer 2024,COMM,4398,3,17661,Independent Study,Crowe,Craig Warren,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5297,10,17664,Selected Topics in Pharmacy,Ononogbu,Onyebuchi J,1,0,0,0,0,0,0,4.0
+Summer 2024,HIST,3314,1,17666,Lib vs. Conserv: FDR to Presen,Young,Nancy Beck,9,10,1,0,1,0,0,3.207
+Summer 2024,BCHS,6698,10,17668,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Summer 2024,PSYC,4398,5,17672,Independent Study,Alfano,Candice A,1,0,0,0,0,0,0,3.67
+Summer 2024,ENTR,3310,5,17674,Entrepreneurship,Ortega,Carlos Alberto,84,13,1,1,0,0,0,3.742
+Summer 2024,PSYC,6398,16,17677,Independent Studies,Naumova,Oxana,1,0,0,0,0,0,0,4.0
+Summer 2024,ELCS,8198,2,17679,Independent Study,Horn,Catherine Lynn,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8699,4,17680,Doctoral Dissertation,Akay,Metin,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,7399,8,17681,Masters Thesis,Grigoriadis,Karolos,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,6398,1,17683,Special Problems,Flynn III,James Howard,0,0,0,0,0,1,0,
+Summer 2024,PCEU,8698,3,17686,Doctoral Research,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8298,21,17687,Doctoral Research,Nurminen,Lauri Oskari,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8498,1,17688,Doctoral Research,Nurminen,Lauri Oskari,0,0,0,0,0,1,0,
+Summer 2024,PCOL,8698,7,17689,Doctoral Research,Wu,Mingfu,1,0,0,0,0,0,0,4.0
+Summer 2024,CUIN,7398,1,17691,Independent Study,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Summer 2024,COSC,8399,101,17692,Doctoral Dissertation,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Summer 2024,SOCW,7367,1,17696,Social Policy Analysis,Pang,Melanie Espinosa,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,6368,1,17697,Mechanical Design Proj,Cescon,Marzia,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,6399,2,17698,Masters Thesis,Merchant,Fatima Aziz,1,0,0,0,0,0,0,3.67
+Summer 2024,PSYC,6393,5,17699,Clinical Research Practicum,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8198,22,17701,Doctoral Research,Akay,Yasemin M,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8298,22,17702,Doctoral Research,Akay,Yasemin M,0,0,0,0,0,0,0,
+Summer 2024,BIOE,8398,30,17703,Doctoral Research,Akay,Yasemin M,0,0,0,0,0,0,0,
+Summer 2024,CHEE,8398,24,17704,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,1,0,
+Summer 2024,PHYS,8399,50,17705,Doctoral Dissertation,Bittner,Eric R,1,0,0,0,0,0,0,4.0
+Summer 2024,GEOL,8398,11,17706,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8198,23,17708,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Summer 2024,BIOE,8298,23,17709,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Summer 2024,COMM,2356,2,17711,Business & Professional Comm,Uhrick,Jan,7,1,0,0,0,0,2,3.751
+Summer 2024,COMM,3374,1,17712,Strategic Social Media,Choi,Ho Joon,9,2,0,0,1,0,1,3.473
+Summer 2024,SOCI,1301,6,17713,Introduction To Sociology,Cooper,Chelsey Wells,20,4,1,0,1,0,0,3.59
+Summer 2024,ARTS,4398,40,17717,Independent Study,Molina,Lorena Guadalupe,1,0,0,0,0,0,0,4.0
+Summer 2024,PHAR,5672,2,17718,Clinical Pharmaceutical Resch,Jo,Jinhee,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOE,8699,5,17719,Doctoral Dissertation,Shevkoplyas,Sergey,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,8398,13,17728,Doctoral Research,Alba,Kamran,0,0,0,0,0,1,0,
+Summer 2024,PSYC,2317,6,17729,Intro to Psychology Statistics,Saiyed,Amna Shabbir,5,8,1,0,0,0,0,3.309
+Summer 2024,ECON,4390,3,17730,Economics Internship,Troncoso,Pablo A,3,0,0,0,0,0,0,3.78
+Summer 2024,MUSI,8296,1,17735,Doctoral Essay,Snyder,John L,1,0,0,0,0,0,0,4.0
+Summer 2024,COMM,4398,4,17745,Independent Study,Olson,Beth M,2,0,0,0,0,0,0,4.0
+Summer 2024,COSC,8399,417,17746,Doctoral Dissertation,Merchant,Fatima Aziz,1,0,0,0,0,0,0,4.0
+Summer 2024,PCEU,8698,1,17751,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Summer 2024,COMD,6398,1,17762,Special Problems,Cizek,Laura S,0,0,0,0,0,0,0,
+Summer 2024,BUSI,4396,4,17766,Business Internship,Newman,Michael Ray,0,0,0,0,0,1,0,
+Summer 2024,COSC,8399,425,17768,Doctoral Dissertation,Shi,Weidong,0,0,0,0,0,1,0,
+Summer 2024,MECE,8698,6,17774,Doctoral Research,Xu,Ben,0,0,0,0,0,4,0,
+Summer 2024,ELCS,8399,2,17776,Doctoral Dissertation,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Summer 2024,MECE,8698,7,17779,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Summer 2024,MUED,6398,2,17780,Research in Music Education,Derges,Julie D,2,0,0,0,0,0,0,4.0
+Summer 2024,PHYS,8399,51,17784,Doctoral Dissertation,Stokes,Donna,0,0,0,0,0,0,0,
+Summer 2024,GEOL,4398,1,17785,Independent Study,Zheng,Yingcai,1,0,0,0,0,0,0,4.0
+Summer 2024,PEP,7398,3,17786,Adv Special Problem Human Perf,Layne,Charles S,2,0,0,0,0,0,0,4.0
+Summer 2024,MARK,6398,2,17790,Research,Herman,Carl,5,0,0,0,0,0,0,4.0
+Summer 2024,PHCA,6398,1,17792,Special Problems,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Summer 2024,BIOL,4398,1,17807,Independent Study,Briggs,James M,1,0,0,0,0,0,0,4.0
+Summer 2024,PSYC,8121,2,17808,Clinical Psychology Internship,Woods,Steven Paul,0,0,0,0,0,1,0,
+Summer 2024,BIOL,4398,2,17810,Independent Study,Frankino,William A,2,0,0,0,0,0,0,4.0
+Summer 2024,LAW,5297,4,17821,Selected Topics,Barks,Justen S,1,0,0,0,0,0,0,4.0

--- a/documents/edu.uh.grade_distribution/Grade Distribution 2024-03 (Fall 2024).csv
+++ b/documents/edu.uh.grade_distribution/Grade Distribution 2024-03 (Fall 2024).csv
@@ -1,0 +1,7033 @@
+TERM,SUBJECT,CATALOG NBR,CLASS SECTION,CLASS NUMBER,COURSE DESCR,INSTR LAST NAME,INSTR FIRST NAME,A,B,C,D,F,SATISFACTORY,TOTAL DROPPED,AVG GPA
+Fall 2024,PHYS,2325,1,10002,University Physics I (lecture),Timmins,Anthony Robert,58,49,54,11,4,0,19,2.813
+Fall 2024,GENB,7A97,1,10004,Selected Topics,Haseley,Ken A.,9,0,0,0,0,0,0,4.0
+Fall 2024,GENB,7A97,2,10005,Selected Topics,Haseley,Ken A.,7,1,1,0,0,0,0,3.667
+Fall 2024,GENB,7A97,3,10006,Selected Topics,Williams,John M,9,0,0,0,0,0,0,3.89
+Fall 2024,GENB,7A97,4,10007,Selected Topics,Williams,John M,8,1,0,0,0,0,0,3.889
+Fall 2024,SCM,6301,1,10008,Supply Chain Mgt Foundations,Hosseinabadi Farahani,Mehdi,12,1,0,0,0,0,0,3.822
+Fall 2024,SCM,6301,2,10009,Supply Chain Mgt Foundations,Smith,Gordon D,4,2,0,0,0,0,0,3.722
+Fall 2024,MANA,6A25,1,10010,Ethical Leadrshp & Crit Reason,Krylova,Ksenia O,9,0,0,0,0,0,0,4.0
+Fall 2024,MANA,6332,1,10011,Organiztnl Behavior & Mangemnt,Werner,Steve,8,1,0,0,0,0,0,3.889
+Fall 2024,BZAN,6310,5,10012,Quant Analysis for Busn Dec,Johnson,Norman A,5,4,0,0,0,0,0,3.482
+Fall 2024,BZAN,6310,6,10013,Quant Analysis for Busn Dec,Johnson,Norman A,5,2,2,0,0,0,0,3.223
+Fall 2024,MANA,6383,1,10014,Strategic Managment,Carlin,Barbara A,4,2,0,0,0,0,0,3.667
+Fall 2024,COMM,6399,1,10015,Masters Thesis,Yamasaki,Jill S,3,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8323,1,10017,Research Methods III,Scott Jr,Edward Douglas,9,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,1301,4,10020,Intro To Philosophy,Haaga,Curtis W,21,15,8,3,0,0,1,3.17
+Fall 2024,PHIL,1305,1,10021,Intro To Ethics,Aiman,Edwin E,60,33,8,0,5,0,6,3.33
+Fall 2024,PHIL,1361,1,10022,Philosophy and the Arts,Drapela,Nick Gerard,8,21,6,1,3,0,11,2.702
+Fall 2024,ARCH,1500,1,10023,Design Studio I,Wells,Adam C,10,4,2,0,0,0,0,3.397
+Fall 2024,ARCH,1500,3,10025,Design Studio I,Murray,Cara,2,10,3,0,0,0,1,3.021
+Fall 2024,ARCH,1500,5,10027,Design Studio I,McEuen,Aaron Ross,6,7,2,0,0,0,0,3.289
+Fall 2024,ARCH,1500,9,10031,Design Studio I,Price,Desirae,3,11,0,0,0,0,0,3.144
+Fall 2024,ARCH,1500,11,10033,Design Studio I,Woodfill,Celeste Ponce,2,7,3,0,0,0,2,2.807
+Fall 2024,ARCH,1500,13,10035,Design Studio I,Olwi,Asmaa,5,6,3,0,0,0,0,3.166
+Fall 2024,ARCH,2350,1,10037,Hist of the Built Environmt I,Ramaswamy,Deepa,71,87,12,6,2,0,2,3.173
+Fall 2024,ARCH,2500,1,10044,Arc/Int Arc Design Studio III,Gonzales,Michael A,14,2,4,0,0,0,0,3.302
+Fall 2024,ARCH,2500,5,10046,Arc/Int Arc Design Studio III,Murray,Cara,6,10,1,0,0,0,1,3.178
+Fall 2024,ARCH,2500,11,10048,Arc/Int Arc Design Studio III,Wienert,Ross George,11,7,0,0,0,0,0,3.519
+Fall 2024,ARCH,5500,3,10051,Architecture Design Studio IX,Longoria,Rafael R,5,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6340,1,10055,Architectural History Survey I,Ramaswamy,Deepa,5,5,2,2,0,0,0,2.976
+Fall 2024,ARCH,7600,1,10057,Architecture Design Studio V,Race,Bruce Alan,2,1,0,0,0,0,0,3.337
+Fall 2024,INDS,2340,1,10059,Visual Communication,Jamjoom,Zain Ahmed,2,11,1,0,1,0,1,2.889
+Fall 2024,INDS,2355,1,10061,Design History I,Westich,Stephen,6,18,5,1,0,0,1,2.912
+Fall 2024,INDS,3500,1,10062,Industrial Design Studio V,Feng,Jeff Feng,3,11,0,0,0,0,0,3.261
+Fall 2024,ACCT,2301,1,10067,Prin of Financial Accounting,Sykes,Mary Reeves,33,11,7,3,0,0,4,3.45
+Fall 2024,ACCT,2301,2,10068,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,19,62,29,26,12,0,20,2.431
+Fall 2024,ACCT,3377,1,10070,Cost Accounting,Lin,Haijin,19,24,11,0,2,0,3,2.989
+Fall 2024,ACCT,3377,2,10071,Cost Accounting,Lin,Haijin,26,19,12,0,1,0,0,3.184
+Fall 2024,ACCT,3368,1,10072,Intermediate Accounting II,Muslu,Volkan,3,9,14,0,1,0,0,2.408
+Fall 2024,ACCT,4335,1,10073,Financial Statement Auditing,Zhao,Yuping,30,42,2,1,0,0,0,3.355
+Fall 2024,ACCT,4375,1,10074,Internal Audit Entity Environ,Brant Jr,Robert Edward,3,13,3,1,0,0,1,2.999
+Fall 2024,ACCT,6331,1,10076,Financial Accounting,Ramaswamy,Vinita,31,7,2,0,0,0,0,3.75
+Fall 2024,ACCT,6331,2,10077,Financial Accounting,Ramaswamy,Vinita,21,12,5,0,2,0,0,3.316
+Fall 2024,ACCT,6331,4,10078,Financial Accounting,Zhu,Limin,6,13,6,0,2,0,0,2.802
+Fall 2024,ACCT,7330,1,10079,Advanced Accounting,Larson,Chad R,7,6,0,1,1,0,0,3.089
+Fall 2024,ACCT,7330,2,10080,Advanced Accounting,Larson,Chad R,11,15,2,0,1,0,1,3.173
+Fall 2024,ACCT,7340,1,10081,Financial Statement Analysis,Lu,Tong,32,2,0,0,0,0,0,3.893
+Fall 2024,ACCT,7375,1,10082,Taxation of Business Entities,Mangano,Clifford A,11,12,0,0,1,0,0,3.347
+Fall 2024,ACCT,8699,1,10083,Doctoral Dissertation,Lobo,Gerald,0,0,0,0,0,1,0,
+Fall 2024,ACCT,8999,1,10084,Doctoral Dissertation,Lu,Tong,0,0,0,0,0,1,0,
+Fall 2024,ENTR,3310,1,10085,Entrepreneurship,Ortega,Carlos Alberto,143,38,5,2,1,0,8,3.606
+Fall 2024,ENTR,3310,2,10086,Entrepreneurship,Wilbur,Stephen,167,94,10,5,3,0,1,3.478
+Fall 2024,ENTR,3312,1,10087,Corporate Entrepreneurship,Karonika,John R,33,9,3,0,0,0,4,3.645
+Fall 2024,ENTR,3312,2,10088,Corporate Entrepreneurship,Karonika,John R,32,10,1,0,0,0,4,3.652
+Fall 2024,ENTR,3312,3,10089,Corporate Entrepreneurship,Lish,Alan D,10,60,26,1,3,0,0,2.737
+Fall 2024,FINA,3332,3,10090,Prin of Financial Management,Chisholm,Darla,23,47,37,39,10,0,40,2.195
+Fall 2024,FINA,4354,1,10091,Risk Management,Kapatos,Nick Gus,16,16,17,6,0,0,2,2.776
+Fall 2024,FINA,4355,1,10092,International Risk Management,Kapatos,Nick Gus,13,35,9,1,0,0,4,3.069
+Fall 2024,FINA,4357,1,10093,Commercial Liability,Kapatos,Nick Gus,10,13,2,1,0,0,1,3.18
+Fall 2024,FINA,6387,2,10094,Managerial Analysis,Basu,Swati,19,7,1,0,0,0,0,3.63
+Fall 2024,FINA,8398,1,10096,Special Problems,George,Thomas J,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,8999,1,10099,Doctoral Dissertation,Kumar,Praveen,0,0,0,0,0,1,0,
+Fall 2024,BUSI,4396,1,10100,Business Internship,Wortzel,Zachary,0,0,0,0,0,22,0,
+Fall 2024,MANA,3335,1,10102,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,189,48,9,1,1,0,1,3.671
+Fall 2024,MANA,3335,4,10103,Intro Org Behavior and Mgmt,Currie,Daniel David,130,83,24,6,2,0,4,3.354
+Fall 2024,MANA,4330,1,10104,Intro to Strategic HR Mgt,Phillips,James S,136,56,7,0,1,0,3,3.554
+Fall 2024,MANA,6398,1,10106,Research,Sebastijanovic,Marina,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,8999,1,10108,Doctoral Dissertation,Ruggs,Enrica N,1,0,0,0,0,0,0,4.0
+Fall 2024,MARK,4389,2,10110,Marketing Strategy & Planning,Koch,Steven F,30,0,0,0,0,0,0,3.945
+Fall 2024,MARK,4389,3,10111,Marketing Strategy & Planning,Randazzo,Gary W,24,7,0,0,0,0,0,3.774
+Fall 2024,MARK,4389,4,10112,Marketing Strategy & Planning,Blair,Edward A,32,0,0,0,0,0,0,3.948
+Fall 2024,MARK,4373,1,10113,Advanced Professional Selling,Bremer,Justin,18,10,0,0,0,0,0,3.596
+Fall 2024,MARK,4374,1,10114,Sales Management,Webb,James R,32,1,0,0,0,0,0,3.96
+Fall 2024,MARK,4374,2,10115,Sales Management,Webb,James R,26,2,0,0,0,0,1,3.929
+Fall 2024,MARK,4375,1,10116,Key Account Selling,Webb,James R,15,4,0,0,0,0,0,3.755
+Fall 2024,MARK,7374,1,10117,New Product Development,Kamal,Saiyid Zafar,11,3,0,0,0,0,0,3.809
+Fall 2024,ACCT,4330,1,10122,Advanced Accounting,Larson,Chad R,0,0,0,0,0,0,1,
+Fall 2024,ACCT,4330,2,10123,Advanced Accounting,Larson,Chad R,8,4,1,0,0,0,1,3.513
+Fall 2024,ENTR,3312,4,10124,Corporate Entrepreneurship,Lish,Alan D,19,40,28,4,4,0,3,2.646
+Fall 2024,ACCT,7370,1,10125,Adv Fin Statement Auditing,Zhao,Yuping,17,6,0,0,0,0,0,3.797
+Fall 2024,ENTR,7336,1,10139,Entrepreneurship Overview,Wilbur,Stephen,13,6,1,0,0,0,0,3.534
+Fall 2024,STAT,3331,1,10141,Statistical Anal Bus Appl I,Wiley,Briceon C,131,105,81,41,7,0,29,2.811
+Fall 2024,SCM,3301,1,10142,SCM Fundamentals,Miller,Bradley D,385,133,21,2,1,0,3,3.62
+Fall 2024,BCIS,1305,1,10143,Business Computer Applications,Felvegi,Emese,26,0,0,0,0,0,0,4.0
+Fall 2024,BCIS,1305,2,10144,Business Computer Applications,Felvegi,Emese,180,37,15,3,3,0,8,3.618
+Fall 2024,MIS,3370,1,10145,Info Systems Development Tools,Schultz,Kimberley Rash,14,25,9,7,2,0,6,2.737
+Fall 2024,MIS,3371,1,10146,Transaction Processing Sys I,Messinger,Jacob Nelson,146,50,2,0,2,0,1,3.639
+Fall 2024,FINA,4370,1,10148,Energy Trading,Smith III,Edwin A,10,2,2,0,0,0,1,3.454
+Fall 2024,FINA,4371,1,10149,Energy Value Chain,Slaughter,Andrew Jeremy,5,8,0,0,1,0,0,3.143
+Fall 2024,MARK,4373,2,10150,Advanced Professional Selling,Pingel,John W,28,1,0,0,0,0,0,3.954
+Fall 2024,ARED,6365,1,10158,Integrative Art Teaching,Chung,Sheng Kuan,4,0,0,0,0,0,0,3.918
+Fall 2024,CUIN,3310,1,10159,Bilingual Education,Leon,Maredil Josefina,12,2,1,0,0,0,1,3.711
+Fall 2024,CUIN,4375,2,10160,Classroom Management,Castillo,Bernadette Marie,22,2,0,0,1,0,0,3.681
+Fall 2024,CUIN,7336,1,10161,Popular Culture in Education,Brower,Samuel Richard,8,0,0,0,0,0,0,4.0
+Fall 2024,EDUC,4314,1,10163,Clinical Teaching 1-Secondary,Culpepper,Shea Mosley,20,4,1,0,0,0,1,3.668
+Fall 2024,EDUC,4315,1,10164,Clinical Teaching 2-Secondary,Thompson,Amber M,14,1,0,0,0,0,0,3.845
+Fall 2024,EDUC,4316,1,10165,Clinical Teaching Elem Art,Culpepper,Shea Mosley,7,0,0,0,0,0,0,3.953
+Fall 2024,EDUC,4317,1,10166,Clinical Teaching Sec Art,Thompson,Amber M,4,0,0,0,0,0,0,3.918
+Fall 2024,EDUC,4318,1,10167,Student Tch Music Elem,McGinnis,Emily Jane,10,0,0,0,0,0,0,4.0
+Fall 2024,EDUC,4319,1,10168,Student Tch Music Sec,McGinnis,Emily Jane,10,0,0,0,0,0,0,4.0
+Fall 2024,EDUC,4325,1,10169,Clinical Teaching 2-Middle Sch,Thompson,Amber M,17,3,0,0,0,0,0,3.817
+Fall 2024,PHLS,6325,1,10170,Theories of Counseling,Lee,Jungeun,10,2,0,0,0,0,0,3.888
+Fall 2024,HDFS,1300,1,10172,Dev of Contemporary Families,Jordan,Erica F,95,39,8,2,5,0,4,3.441
+Fall 2024,HDFS,1300,7,10178,Dev of Contemporary Families,Jordan,Erica F,116,32,5,4,2,0,3,3.587
+Fall 2024,HDFS,4393,1,10182,Internship in HDFS,Conston,Toya,35,1,1,0,0,0,0,3.883
+Fall 2024,HLT,1353,1,10183,Personal Health,Rafique,Kiran Sajid,52,53,7,3,2,0,2,3.203
+Fall 2024,HDFS,4394,1,10188,Internship in HDFS,Conston,Toya,34,3,0,0,0,0,0,3.928
+Fall 2024,PHLS,6345,1,10189,Atypical Growth & Behavior,Hurt,Kara Marie,7,1,0,0,0,0,0,3.916
+Fall 2024,CUIN,4336,1,10190,Popular Culture in Education,Brower,Samuel Richard,10,2,0,0,0,0,0,3.888
+Fall 2024,HLT,3381,1,10191,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,83,0,1,0,0,0,1,3.953
+Fall 2024,PHLS,8319,1,10192,Infer Stats in Psych/Educ Res,Fan,Weihua,16,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,6111,1,10193,Grad Bioengineering Seminar,Larin,Kirill,0,0,0,0,0,58,0,
+Fall 2024,CHEE,2332,1,10194,Chem Engr Thermodyn I,Palmer,Jeremy,22,2,0,0,0,0,1,3.834
+Fall 2024,CHEE,3300,1,10195,Materials Science & Engr I,Donnelly,Vincent M,6,7,4,1,0,0,1,3.018
+Fall 2024,CHEE,3333,1,10196,Chem Engr Thermodyn II,Zerze,Gul,20,24,4,0,1,0,2,3.171
+Fall 2024,CHEE,3334,1,10197,Stat/Num Tchqs for Chem Engrs,Zerze,Hasan,4,19,18,1,1,0,5,2.566
+Fall 2024,CHEE,3363,1,10198,Fluid Mechanics for Chem Engrs,Wen,Mingjian,16,25,7,0,4,0,1,2.86
+Fall 2024,CHEE,4321,1,10199,Chemical Engineering Design I,Abdelrahman,Omar Abdelrahman Ali,30,33,5,0,0,0,0,3.28
+Fall 2024,CHEE,4361,1,10200,Chemical Engineering Practices,Cirino,Patrick C,33,7,0,0,0,0,0,3.817
+Fall 2024,CHEE,4367,1,10203,Chemical Reaction Engineering,Bollini,Praveen P,34,33,2,0,0,0,1,3.449
+Fall 2024,CHEE,6111,1,10204,Graduate Seminar,Mountziaris,Triantafillos John,0,0,0,0,0,78,0,
+Fall 2024,CHEE,8198,1,10205,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8298,1,10210,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8298,2,10211,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8298,4,10213,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8298,9,10218,Doctoral Research,Karim,Alamgir,0,0,0,0,0,6,0,
+Fall 2024,CHEE,8298,12,10221,Doctoral Research,Nikolaou,Michael,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,1,10222,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8398,2,10223,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,7,10228,Doctoral Research,Grabow,Lars C,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,9,10230,Doctoral Research,Karim,Alamgir,0,0,0,0,0,6,0,
+Fall 2024,CHEE,8398,13,10234,Doctoral Research,Orman,Mehmet,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8399,1,10235,Doctoral Dissertation,Balakotaiah,Vemuri,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8399,2,10236,Doctoral Dissertation,Bollini,Praveen P,5,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8399,4,10238,Doctoral Dissertation,Conrad,Jacinta C,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8399,5,10239,Doctoral Dissertation,Donnelly,Vincent M,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8399,7,10241,Doctoral Dissertation,Grabow,Lars C,0,0,0,0,0,5,0,
+Fall 2024,CHEE,8399,8,10242,Doctoral Dissertation,Harold,Michael P,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8399,9,10243,Doctoral Dissertation,Karim,Alamgir,8,0,0,0,0,3,0,3.959
+Fall 2024,CHEE,8399,10,10244,Doctoral Dissertation,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8399,11,10245,Doctoral Dissertation,Mountziaris,Triantafillos John,2,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8498,9,10254,Doctoral Research,Karim,Alamgir,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8598,1,10259,Doctoral Research,Balakotaiah,Vemuri,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8598,2,10260,Doctoral Research,Bollini,Praveen P,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8598,4,10262,Doctoral Research,Conrad,Jacinta C,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8598,5,10263,Doctoral Research,Donnelly,Vincent M,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8598,7,10265,Doctoral Research,Grabow,Lars C,0,0,0,0,0,4,0,
+Fall 2024,CHEE,8598,8,10266,Doctoral Research,Harold,Michael P,0,0,0,0,0,4,0,
+Fall 2024,CIVE,3339,1,10268,Geotechnical Engineering,Vipulanandan,Cumaraswamy,25,20,1,0,0,0,1,3.507
+Fall 2024,CIVE,8298,1,10272,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8398,1,10273,Doctoral Research,Li,Hongyi,0,0,0,0,0,5,0,
+Fall 2024,CIVE,8498,1,10275,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8999,1,10277,Doctoral Dissertation,Shaffer,Devin,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,3441,1,10285,Digital Logic Design,Sheth,Bhavin R,43,11,6,1,5,0,4,3.293
+Fall 2024,ECE,3436,1,10287,Microprocessor Systems,De La Rosa-Pohl,Diana,41,1,0,0,0,0,0,3.913
+Fall 2024,ECE,5317,1,10289,Microwave Engineering,Islam,Md Zahidul,4,0,0,0,0,0,0,3.753
+Fall 2024,ECE,6111,2,10290,Graduate Research Seminar,Li,Xingpeng,0,0,0,0,0,0,0,
+Fall 2024,ECE,6198,2,10294,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2024,ECE,6198,8,10300,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2024,ECE,6198,14,10306,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2024,ECE,6198,24,10316,Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Fall 2024,ECE,6198,25,10317,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2024,ECE,6298,2,10322,Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2024,ECE,6298,8,10328,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2024,ECE,6298,14,10334,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2024,ECE,6298,24,10344,Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Fall 2024,ECE,6298,25,10345,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2024,ECE,6351,1,10349,Microwave Engineering,Islam,Md Zahidul,9,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6398,4,10353,Research,Chen,Ji,0,0,0,0,0,1,0,
+Fall 2024,ECE,6398,6,10355,Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2024,ECE,6398,7,10356,Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Fall 2024,ECE,6398,8,10357,Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2024,ECE,6398,10,10359,Research,Fu,Xin,0,0,0,0,0,2,0,
+Fall 2024,ECE,6398,11,10360,Research,Han,Zhu,0,0,0,0,0,1,0,
+Fall 2024,ECE,6398,14,10363,Research,Li,Xingpeng,0,0,0,0,0,1,0,
+Fall 2024,ECE,6398,24,10373,Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Fall 2024,ECE,6398,25,10374,Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2024,ECE,6399,7,10384,Masters Thesis,Chen,Yuhua,0,0,0,0,0,2,0,
+Fall 2024,ECE,6399,11,10387,Masters Thesis,Fu,Xin,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6399,24,10400,Masters Thesis,Shan,Xiaonan,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,7399,2,10407,Masters Thesis,Chen,Yuhua,1,0,0,0,0,1,0,4.0
+Fall 2024,ECE,7399,3,10408,Masters Thesis,Krishnamoorthy,Harish Sarma,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8198,2,10412,Doctoral Research,Becker,Aaron T,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,4,10414,Doctoral Research,Chen,Ji,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,7,10417,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,11,10421,Doctoral Research,Han,Zhu,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,13,10423,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,18,10428,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,20,10430,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,21,10431,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,22,10432,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,25,10435,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2024,ECE,8198,27,10437,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,28,10438,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,29,10439,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,1,10440,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,2,10441,Doctoral Research,Becker,Aaron T,0,0,0,0,0,3,0,
+Fall 2024,ECE,8298,3,10442,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,4,10443,Doctoral Research,Chen,Ji,0,0,0,0,0,3,0,
+Fall 2024,ECE,8298,5,10444,Doctoral Research,Chen,Jiefu,0,0,0,0,0,4,0,
+Fall 2024,ECE,8298,6,10445,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,7,10446,Doctoral Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,8,10447,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,10,10449,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,11,10450,Doctoral Research,Han,Zhu,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,12,10451,Doctoral Research,Jackson,David R,0,0,0,0,0,3,0,
+Fall 2024,ECE,8298,13,10452,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,14,10453,Doctoral Research,Li,Xingpeng,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,16,10455,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,17,10456,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,21,10460,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,22,10461,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,23,10462,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,24,10463,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,26,10465,Doctoral Research,Yao,Yan,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,27,10466,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,28,10467,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,4,0,
+Fall 2024,ECE,8398,4,10471,Doctoral Research,Chen,Ji,0,0,0,0,0,6,0,
+Fall 2024,ECE,8398,5,10472,Doctoral Research,Chen,Jiefu,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,7,10474,Doctoral Research,Chen,Yuhua,0,0,0,0,0,3,0,
+Fall 2024,ECE,8398,9,10476,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2024,ECE,8398,10,10477,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Fall 2024,ECE,8398,11,10478,Doctoral Research,Fu,Xin,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,12,10479,Doctoral Research,Han,Zhu,0,0,0,0,0,4,0,
+Fall 2024,ECE,8398,13,10480,Doctoral Research,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,14,10481,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,3,0,
+Fall 2024,ECE,8398,15,10482,Doctoral Research,Li,Xingpeng,0,0,0,0,0,4,0,
+Fall 2024,ECE,8398,18,10485,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,19,10486,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,21,10487,Doctoral Research,Pan,Miao,0,0,0,0,0,4,0,
+Fall 2024,ECE,8398,25,10490,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,2,0,
+Fall 2024,ECE,8398,26,10491,Doctoral Research,Reddy,Rohith Krishna,0,0,0,0,0,2,0,
+Fall 2024,ECE,8398,28,10493,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Fall 2024,ECE,8398,29,10494,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8399,7,10504,Doctoral Dissertation,Chen,Yuhua,0,0,0,0,0,1,0,
+Fall 2024,ECE,8399,11,10507,Doctoral Dissertation,Fu,Xin,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,13,10509,Doctoral Dissertation,Jackson,David R,0,0,0,0,0,1,0,
+Fall 2024,ECE,8399,14,10510,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,1,0,0,0,0,1,0,4.0
+Fall 2024,ECE,8399,17,10513,Doctoral Dissertation,Mayerich,David Matthew,0,0,0,0,0,2,0,
+Fall 2024,ECE,8399,18,10514,Doctoral Dissertation,Nguyen,Hien V,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,19,10515,Doctoral Dissertation,Pan,Miao,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,21,10517,Doctoral Dissertation,Prasad,Saurabh,0,0,0,0,0,0,0,
+Fall 2024,ECE,8399,23,10519,Doctoral Dissertation,Reddy,Rohith Krishna,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,25,10520,Doctoral Dissertation,Roysam,Badrinath,0,0,0,0,0,1,0,
+Fall 2024,ECE,8399,26,10521,Doctoral Dissertation,Shan,Xiaonan,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,27,10522,Doctoral Dissertation,Shih,Wei-Chuan,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,29,10524,Doctoral Dissertation,Yao,Yan,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8399,30,10525,Doctoral Dissertation,Shireen,Wajiha,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8498,1,10527,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,2,10528,Doctoral Research,Becker,Aaron T,0,0,0,0,0,2,0,
+Fall 2024,ECE,8498,3,10529,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,4,10530,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Fall 2024,ECE,8498,5,10531,Doctoral Research,Chen,Jiefu,0,0,0,0,0,6,0,
+Fall 2024,ECE,8498,6,10532,Doctoral Research,Chen,Jinghong,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,7,10533,Doctoral Research,Chen,Yuhua,0,0,0,0,0,2,0,
+Fall 2024,ECE,8498,8,10534,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,3,0,
+Fall 2024,ECE,8498,10,10536,Doctoral Research,Fu,Xin,0,0,0,0,0,2,0,
+Fall 2024,ECE,8498,11,10537,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Fall 2024,ECE,8498,12,10538,Doctoral Research,Jackson,David R,0,0,0,0,0,3,0,
+Fall 2024,ECE,8498,13,10539,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,5,0,
+Fall 2024,ECE,8498,14,10540,Doctoral Research,Li,Xingpeng,0,0,0,0,0,5,0,
+Fall 2024,ECE,8498,16,10542,Doctoral Research,Mayerich,David Matthew,0,0,0,0,0,3,0,
+Fall 2024,ECE,8498,17,10543,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,3,0,
+Fall 2024,ECE,8498,18,10544,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,21,10547,Doctoral Research,Roysam,Badrinath,0,0,0,0,0,2,0,
+Fall 2024,ECE,8498,24,10550,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,3,0,
+Fall 2024,ECE,8498,25,10551,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,27,10553,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,28,10554,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Fall 2024,ECE,8498,29,10555,Doctoral Research,Le,Hung Quang,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,1,10556,Doctoral Research,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,3,10558,Doctoral Research,Brankovic,Stanko R,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,4,10559,Doctoral Research,Chen,Ji,0,0,0,0,0,2,0,
+Fall 2024,ECE,8598,5,10560,Doctoral Research,Chen,Jiefu,0,0,0,0,0,2,0,
+Fall 2024,ECE,8598,7,10562,Doctoral Research,Chen,Yuhua,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,8,10563,Doctoral Research,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,11,10566,Doctoral Research,Han,Zhu,0,0,0,0,0,3,0,
+Fall 2024,ECE,8598,13,10568,Doctoral Research,Krishnamoorthy,Harish Sarma,0,0,0,0,0,2,0,
+Fall 2024,ECE,8598,14,10569,Doctoral Research,Shireen,Wajiha,0,0,0,0,0,2,0,
+Fall 2024,ECE,8598,15,10570,Doctoral Research,Li,Xingpeng,0,0,0,0,0,3,0,
+Fall 2024,ECE,8598,18,10573,Doctoral Research,Nguyen,Hien V,0,0,0,0,0,2,0,
+Fall 2024,ECE,8598,19,10574,Doctoral Research,Pan,Miao,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,21,10576,Doctoral Research,Prasad,Saurabh,0,0,0,0,0,2,0,
+Fall 2024,ECE,8598,22,10577,Doctoral Research,Rajashekara,Kaushik,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,25,10580,Doctoral Research,Shan,Xiaonan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,26,10581,Doctoral Research,Shih,Wei-Chuan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,28,10583,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,29,10584,Doctoral Research,Malki,Heidar A,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,30,10585,Doctoral Research,Le,Hung Quang,0,0,0,0,0,1,0,
+Fall 2024,ECE,8699,3,10588,Doctoral Dissertation,Brankovic,Stanko R,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8699,4,10589,Doctoral Dissertation,Chen,Ji,0,0,0,0,0,4,0,
+Fall 2024,ECE,8699,7,10592,Doctoral Dissertation,Chen,Yuhua,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8699,8,10593,Doctoral Dissertation,Contreras-Vidal,Jose Luis,0,0,0,0,0,1,0,
+Fall 2024,ECE,8699,13,10598,Doctoral Dissertation,Krishnamoorthy,Harish Sarma,0,0,0,0,0,1,0,
+Fall 2024,ECE,8699,14,10599,Doctoral Dissertation,Li,Xingpeng,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8699,15,10600,Doctoral Dissertation,Litvinov,Dmitri,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8699,21,10606,Doctoral Dissertation,Rajashekara,Kaushik,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8699,22,10607,Doctoral Dissertation,Reddy,Rohith Krishna,0,0,0,0,0,1,0,
+Fall 2024,INDE,3330,1,10616,Financial and Cost Management,Wiggins,Nathanial David,55,5,0,0,0,0,1,3.867
+Fall 2024,INDE,3333,1,10617,Engineering Economy I,Schulze,Lawrence John Henry,7,1,0,0,0,0,0,3.71
+Fall 2024,INDE,3364,1,10618,Engineering Statistics II,Wang,Yaping,13,19,5,1,1,0,2,3.052
+Fall 2024,INDE,3382,1,10619,Stochastic Models,Xiang,Yisha,7,20,15,3,0,0,2,2.586
+Fall 2024,INDE,4111,1,10620,Industrial Engineering Seminar,Peng,Jiming Ouyang,18,4,2,0,0,0,1,3.653
+Fall 2024,INDE,6111,1,10621,Graduate Seminar,Peng,Jiming Ouyang,0,0,0,0,0,51,0,
+Fall 2024,INDE,6372,1,10622,Advanced Linear Optimization,Peng,Jiming Ouyang,4,6,13,2,0,0,0,2.493
+Fall 2024,INDE,8298,1,10627,Doctoral Research,Xiang,Yisha,0,0,0,0,0,2,0,
+Fall 2024,INDE,8298,3,10629,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,3,0,
+Fall 2024,INDE,8398,1,10630,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2024,INDE,8398,2,10631,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Fall 2024,INDE,8398,3,10632,Doctoral Research,Peng,Jiming Ouyang,0,0,0,0,0,1,0,
+Fall 2024,INDE,8399,5,10636,Doctoral Dissertation,Lin,Ying,1,0,0,0,0,0,0,4.0
+Fall 2024,INDE,8498,1,10638,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2024,INDE,8598,1,10639,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2024,INDE,8699,1,10640,Doctoral Dissertation,Lim,Gino Jinho,0,0,0,0,0,3,0,
+Fall 2024,MECE,2334,1,10644,Thermodynamics,Malamataris,Nikolaos,25,5,6,4,1,0,3,3.155
+Fall 2024,MECE,2361,1,10645,Intro Mechanical Design,Chang,Christiana,19,45,27,7,0,0,0,2.786
+Fall 2024,MECE,3245,1,10647,Materials Science Laboratory,Chen,Xuemei,17,22,8,3,0,0,2,3.034
+Fall 2024,MECE,3360,1,10649,Experimental Methods,Chen,Xuemei,18,35,15,1,0,0,3,3.029
+Fall 2024,MECE,4371,1,10652,Thermal-Fluids Laboratory,Love,Holley Carole,56,0,0,0,0,0,0,3.906
+Fall 2024,MECE,4372,1,10655,Mechs-Cntrls-Vibrtn Lab,Song,Gangbing,7,24,4,0,0,0,0,3.02
+Fall 2024,MECE,8111,1,10658,Graduate Seminar,Grigoriadis,Karolos,0,0,0,0,0,55,0,
+Fall 2024,MECE,6384,1,10659,Methods of Applied Math I,Chen,Yi-Chao,8,9,7,1,1,0,0,2.795
+Fall 2024,CHEE,8298,13,10660,Doctoral Research,Orman,Mehmet,0,0,0,0,0,3,0,
+Fall 2024,INDE,6383,1,10663,Engr Design and Prototyping,Kamrani,Ali K,5,0,7,0,1,0,0,2.463
+Fall 2024,CHEE,8399,13,10666,Doctoral Dissertation,Orman,Mehmet,5,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8498,15,10667,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8598,9,10668,Doctoral Research,Karim,Alamgir,0,0,0,0,0,6,0,
+Fall 2024,PETR,6350,1,10669,Natural Gas Engineering,Farouq-Ali,Syed,12,2,0,0,0,0,0,3.81
+Fall 2024,GHL,1337,1,10671,Intro To Hospitality Industry,Doudna,Simone P,46,6,3,1,2,0,1,3.569
+Fall 2024,GHL,1337,2,10672,Intro To Hospitality Industry,Doudna,Simone P,32,7,7,1,2,0,0,3.354
+Fall 2024,GHL,1345,1,10673,"Safety, Sanitation in Hosp Ind",Sirsat,Sujata Ashok,14,31,11,1,4,0,1,2.711
+Fall 2024,GHL,2365,1,10674,Tourism,Draper,Jason A,18,17,3,0,2,0,0,3.209
+Fall 2024,GHL,3336,1,10676,Beverage Management,Rinck,Kristen Ann,19,4,2,2,0,0,0,3.469
+Fall 2024,GHL,2343,1,10677,Hospitality Cost Controls,Hight,Stephen Kyle,12,6,1,0,0,0,0,3.457
+Fall 2024,GHL,2343,2,10678,Hospitality Cost Controls,Haskell,Rebecca Erin,13,10,4,2,2,0,0,2.915
+Fall 2024,GHL,3345,1,10679,Wine Appreciation,Taylor,David C,21,8,2,1,1,0,0,3.404
+Fall 2024,GHL,3352,1,10681,Human Resource Management,Guchait,Priyanko,11,5,2,2,0,0,5,3.25
+Fall 2024,GHL,3361,1,10682,Hospitality Marketing,Suh,Taehyun,16,2,0,0,0,0,0,3.834
+Fall 2024,GHL,3361,2,10683,Hospitality Marketing,Park,Yunna,29,1,1,3,1,0,0,3.524
+Fall 2024,GHL,4343,1,10684,Financial Admin for Hosp.Ind.,Johnson,Tucker A,21,13,3,0,0,0,0,3.478
+Fall 2024,GHL,4353,1,10685,Leadership in Hospitality Ind,Barth,Stephen C,11,4,1,0,0,0,0,3.563
+Fall 2024,GHL,4353,2,10686,Leadership in Hospitality Ind,Maneethai,Dustin,29,15,2,0,1,0,1,3.433
+Fall 2024,GHL,6345,1,10687,Wine Appreciation,Taylor,David C,3,2,0,1,0,0,0,3.277
+Fall 2024,GHL,6360,1,10689,Graduate Directed Practicum,Back,KiJoon,8,0,0,0,0,0,0,4.0
+Fall 2024,GHL,3358,2,10695,Hospitality Industry Law,Abbott,Jeanna L,19,2,3,1,0,0,1,3.56
+Fall 2024,GHL,2350,1,10696,Mgmt Principles in Hospitality,Hingoraney,Mahima Manish,11,1,1,0,0,0,0,3.668
+Fall 2024,LAW,5103,1,10699,Health Law Journal,Fowler,Leah Robbins,0,0,0,0,0,2,0,
+Fall 2024,LAW,5104,1,10700,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,2,0,
+Fall 2024,LAW,5110,1,10701,Law Review,Sanders,Joseph,0,0,0,0,0,2,0,
+Fall 2024,LAW,5147,1,10702,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,4,1,
+Fall 2024,LAW,5151,1,10703,Tax Research,Dykes,Christopher,3,0,0,0,0,1,0,3.89
+Fall 2024,LAW,5198,1,10704,Special Rsch & Writing,Vetter,Greg R,4,0,0,0,0,0,0,3.835
+Fall 2024,LAW,5210,1,10705,Law Review,Sanders,Joseph,0,0,0,0,0,1,0,
+Fall 2024,LAW,5247,2,10706,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,4,0,
+Fall 2024,LAW,5288,1,10707,Tax Ethics,Arabi Katbi,Eman Patricia,0,1,0,0,0,0,0,3.33
+Fall 2024,LAW,5298,1,10709,Special Rsch & Writing,Vetter,Greg R,1,1,0,0,0,0,0,3.5
+Fall 2024,LAW,5319,1,10710,Intro To American Law,Kalu,Vivian O,25,15,5,0,0,0,0,3.422
+Fall 2024,LAW,5322,1,10711,Pretrial Litigation,Gibson,Traci A,5,8,0,0,0,9,0,3.385
+Fall 2024,LAW,5328,1,10712,Judicial Externship I,Powers,William,0,0,0,0,0,5,0,
+Fall 2024,LAW,5355,1,10713,Oil and Gas,Mason,Jasper,9,28,0,0,0,0,1,3.404
+Fall 2024,LAW,5381,1,10714,Legal Negotiation,Abbott,Jeanna L,24,20,0,0,0,4,0,3.395
+Fall 2024,LAW,5386,1,10715,Trial Advocacy,Baldassano,Steven L,9,16,1,0,0,9,0,3.346
+Fall 2024,LAW,5406,2,10718,Civil Procedure,Salib,Peter,32,51,0,0,0,0,0,3.401
+Fall 2024,LAW,5406,3,10719,Civil Procedure,Ragazzo,Robert A,32,45,3,0,0,0,0,3.375
+Fall 2024,LAW,5409,6,10720,Contracts,Guggenberger,Nikolas,13,29,0,0,0,0,0,3.302
+Fall 2024,LAW,5418,2,10722,Torts,Duncan,Meredith J,22,54,2,0,0,0,0,3.358
+Fall 2024,LAW,5459,1,10723,Federal Income Tax,Wilson,John Marshall,11,13,1,0,0,12,0,3.4
+Fall 2024,LAW,6209,1,10724,Health Law Journal,Fowler,Leah Robbins,0,0,0,0,0,10,0,
+Fall 2024,LAW,6211,1,10725,Houston Buiness/Tax Journal,Wells,Douglas,0,0,0,0,0,9,0,
+Fall 2024,LAW,6300,1,10726,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,10,0,
+Fall 2024,LAW,6318,1,10728,Houston Business/Tax Journal,Wells,Douglas,0,0,0,0,0,8,0,
+Fall 2024,LAW,6354,1,10729,Houston Journal of Int'l Law,Trujillo,Elizabeth I,0,0,0,0,0,10,0,
+Fall 2024,LAW,6356,1,10730,Law Review,Sanders,Joseph,0,0,0,0,0,16,0,
+Fall 2024,LAW,6358,1,10731,Health Law Journal,Fowler,Leah Robbins,0,0,0,0,0,7,0,
+Fall 2024,LAW,5406,5,10732,Civil Procedure,Lanham,Andrew James,30,48,0,0,0,0,0,3.402
+Fall 2024,LAW,5329,1,10733,Judicial Externship II,Powers,William,0,0,0,0,0,1,0,
+Fall 2024,LAW,5301,1,10734,Immigration Clinic II,Alimohammad,Rehan Shams,1,0,0,0,0,0,0,3.67
+Fall 2024,AAS,2320,1,10736,Intro To African American Stdy,Smith,Marlon Antoine,24,11,3,1,0,0,0,3.377
+Fall 2024,AFSC,1201,1,10737,Foundations of the USAF I,Koontz,Savanah,15,2,2,1,0,0,3,3.484
+Fall 2024,AFSC,1201,2,10738,Foundations of the USAF I,Koontz,Savanah,1,2,0,0,0,0,0,3.333
+Fall 2024,AFSC,2201,1,10740,Evolution of Air Power I,Bolarinwa,Feyisade,27,0,0,0,1,0,0,3.822
+Fall 2024,AFSC,2201,2,10741,Evolution of Air Power I,Bolarinwa,Feyisade,0,0,0,0,0,0,1,
+Fall 2024,ANTH,6300,1,10744,Anthropological Theory,Sen,Debarati,6,0,0,0,0,0,0,3.945
+Fall 2024,ANTH,6399,3,10747,Masters Thesis,Ghazali,Marwa,0,0,0,0,0,5,0,
+Fall 2024,ARAB,2311,1,10750,Intermediate Arabic I,Sayyid,Huda,15,1,1,0,0,0,0,3.804
+Fall 2024,ARTS,1316,1,10751,Fundamentals of Drawing,Mellor,Jade Elizabeth,10,7,1,1,0,0,1,3.351
+Fall 2024,ARTS,1316,3,10752,Fundamentals of Drawing,Coulter,Crystal Lennette,17,2,0,0,0,0,1,3.877
+Fall 2024,ARTS,1316,4,10753,Fundamentals of Drawing,Griffin,Alvin Garrett,17,2,1,0,0,0,0,3.767
+Fall 2024,ARTS,2316,1,10755,Fundamentals of Painting,Bender,Hannah,14,3,1,0,0,0,2,3.704
+Fall 2024,ARTS,2316,2,10756,Fundamentals of Painting,Herndon,Ashley Anika,12,5,2,0,1,0,0,3.251
+Fall 2024,ARTS,6380,1,10757,Seminar,Anderson-Staley,Keliy,16,0,0,0,0,0,0,3.979
+Fall 2024,ARTS,1304,1,10758,Art Hist II(15th C to Present),Zalman,Sandra,40,94,47,8,5,0,8,2.745
+Fall 2024,ARTH,4383,1,10759,Contemporary Painting,Barrera,Debra,23,7,2,0,2,0,1,3.325
+Fall 2024,CHIN,1501,1,10760,Elementary Chinese I,Zhang,Jing,15,2,2,1,0,0,1,3.517
+Fall 2024,CHIN,1501,3,10762,Elementary Chinese I,Zhang,Jing,7,2,0,0,0,0,0,3.778
+Fall 2024,CHIN,2311,1,10764,Intermediate Chinese I,Zhang,Jing,18,7,3,1,1,0,1,3.322
+Fall 2024,CHIN,3301,1,10765,Advanced Mandarin Chinese I,Zhang,Jing,10,2,0,0,0,0,2,3.806
+Fall 2024,SGNL,1301,1,10766,Elementary Sign Language I,Brittain,Robyn Michelle,2,12,2,2,1,0,1,2.597
+Fall 2024,COMD,2338,1,10768,Phonetics,Schaff,Carrie Allyson,15,8,3,0,1,0,3,3.284
+Fall 2024,COMD,6328,1,10769,Acquired Cognitive Disorders,Thiessen,Amber L,28,19,2,0,0,0,0,3.483
+Fall 2024,COMD,6387,1,10770,Voice Disorders,Joshi,Ashwini,27,23,0,0,0,0,0,3.527
+Fall 2024,COMD,7322,1,10771,Speech Sound Disorders,Cizek,Laura S,20,5,0,0,0,0,0,3.708
+Fall 2024,COMD,7391,2,10772,Clinic in Speech Lang Disorder,Devore,Danielle R,2,1,0,0,0,0,0,3.557
+Fall 2024,COMD,7391,3,10773,Clinic in Speech Lang Disorder,Guerra,Teresa Evangelina,3,0,0,0,0,0,0,3.67
+Fall 2024,COMD,7391,4,10774,Clinic in Speech Lang Disorder,Townsend,Alayna,0,3,0,0,0,0,0,3.22
+Fall 2024,COMD,7391,5,10775,Clinic in Speech Lang Disorder,Townsend,Alayna,1,0,0,0,0,0,0,3.67
+Fall 2024,COMD,7391,6,10776,Clinic in Speech Lang Disorder,Devore,Danielle R,2,0,0,0,0,0,0,3.835
+Fall 2024,COMD,7391,7,10777,Clinic in Speech Lang Disorder,Trevino,Alexandra Hanson,1,1,0,0,0,0,0,3.665
+Fall 2024,COMD,7392,1,10778,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,4,1,0,0,0,0,0,3.8
+Fall 2024,COMD,7392,2,10779,Adv Pract Sp & Lang Dis,Cadavid,Kelsey Lee,3,1,1,0,0,0,0,3.466
+Fall 2024,COMD,7392,3,10780,Adv Pract Sp & Lang Dis,Walker,Dionne A,3,2,0,0,0,0,0,3.666
+Fall 2024,SPCH,1318,1,10781,Interpersonal Communication,Uhrick,Jan,14,14,1,1,0,0,1,3.367
+Fall 2024,COMM,2300,1,10782,Communication Research Methods,Lyn,Robyn,20,1,0,1,0,0,4,3.818
+Fall 2024,COMM,4331,1,10784,Persuasion,Huang,Yan,24,5,1,0,0,0,0,3.679
+Fall 2024,COMM,6370,1,10785,Public Relations Management,Ni,Lan,16,2,0,0,0,0,2,3.669
+Fall 2024,DANC,1300,1,10786,Dance as a Fine Art,Prokop,Travis Cooper,10,1,2,0,0,0,2,3.59
+Fall 2024,DANC,2305,1,10787,Dance Composition I,Prokop,Travis Cooper,17,4,0,0,0,0,0,3.825
+Fall 2024,DANC,2303,1,10788,Introduction to Dance,Bobet,Jacqueline A,56,14,4,0,12,0,12,3.148
+Fall 2024,DANC,4302,1,10790,Advanced Technique and Theory,Estrada,Maria Gabriela,9,1,0,0,0,0,0,3.9
+Fall 2024,ECON,2302,1,10791,Principles of Microeconomics,Hossain,Md Shahadath,239,178,69,3,4,0,13,3.274
+Fall 2024,ECON,3371,1,10793,Economics of Money & Banking,Peru Durayalage,Dhanushka Arunasiri,17,36,22,0,2,0,4,2.849
+Fall 2024,ECON,3370,1,10795,Introduction To Econometrics,Peru Durayalage,Dhanushka Arunasiri,10,7,10,4,4,0,4,2.372
+Fall 2024,ECON,8399,1,10797,Doctoral Dissertation,Chin,Aimee,0,0,0,0,0,2,0,
+Fall 2024,ENGL,1301,1,10798,First Year Writing I,Julian,Jennifer La'Vonne,16,2,0,0,0,0,0,3.834
+Fall 2024,ENGL,1301,2,10799,First Year Writing I,Julian,Jennifer La'Vonne,16,1,1,1,0,0,0,3.649
+Fall 2024,ENGL,1301,3,10800,First Year Writing I,O'Bryan,Ann Patricia,15,1,2,0,1,0,0,3.492
+Fall 2024,ENGL,1301,4,10801,First Year Writing I,O'Bryan,Ann Patricia,7,6,3,0,1,0,1,3.02
+Fall 2024,ENGL,1301,5,10802,First Year Writing I,Colchado,Lea,6,6,2,2,1,0,2,2.785
+Fall 2024,ENGL,1301,6,10803,First Year Writing I,Colchado,Lea,11,3,0,3,2,0,0,2.861
+Fall 2024,ENGL,1301,7,10804,First Year Writing I,Downey,Carlton M,19,4,2,0,0,0,0,3.614
+Fall 2024,ENGL,1301,8,10805,First Year Writing I,Mandia,Christopher Peter,14,11,0,0,0,0,0,3.534
+Fall 2024,ENGL,1301,9,10806,First Year Writing I,Rolater,Sara C,13,4,3,0,3,0,2,3.0
+Fall 2024,ENGL,1301,10,10807,First Year Writing I,Rolater,Sara C,8,4,2,5,5,0,1,2.167
+Fall 2024,ENGL,1301,11,10808,First Year Writing I,Bradley,Jari,12,2,0,2,2,0,1,2.964
+Fall 2024,ENGL,1301,12,10809,First Year Writing I,Kunasek,Caleb,9,4,2,0,4,0,0,2.737
+Fall 2024,ENGL,1301,15,10810,First Year Writing I,Garcia,Serena Mari,10,10,0,2,1,0,1,3.102
+Fall 2024,ENGL,1301,16,10811,First Year Writing I,Campese,Kathleen Ann,17,6,0,0,2,0,0,3.282
+Fall 2024,ENGL,1301,18,10812,First Year Writing I,Islam,Muhammad Nurul,10,3,1,1,2,0,2,3.02
+Fall 2024,ENGL,1301,19,10813,First Year Writing I,Pogue,Donovan A,18,0,1,1,3,0,2,3.247
+Fall 2024,ENGL,1301,28,10814,First Year Writing I,Yates,Kaitlyn,10,9,4,0,1,0,1,3.056
+Fall 2024,ENGL,1301,42,10815,First Year Writing I,Niu,Catherine,11,5,1,0,1,0,0,3.316
+Fall 2024,ENGL,1301,48,10816,First Year Writing I,Niu,Catherine,9,6,2,0,1,0,0,3.149
+Fall 2024,ENGL,1301,50,10817,First Year Writing I,Lee,Eunjeong,9,11,3,0,1,0,1,3.111
+Fall 2024,ENGL,1301,54,10818,First Year Writing I,Ganter,Blaine,6,10,4,1,0,0,3,2.969
+Fall 2024,ENGL,1301,61,10819,First Year Writing I,Koulen,Marisa Theresa,12,2,1,1,3,0,0,2.965
+Fall 2024,ENGL,1301,63,10820,First Year Writing I,Downey,Carlton M,16,7,2,0,0,0,0,3.573
+Fall 2024,ENGL,1301,70,10821,First Year Writing I,Weitman,Mathew,15,2,0,0,1,0,0,3.667
+Fall 2024,ENGL,1301,73,10822,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,6,6,2,1,3,0,1,2.648
+Fall 2024,ENGL,1302,2,10823,First Year Writing II,Wolff,Alexander Lazarus,6,6,2,0,1,0,3,3.023
+Fall 2024,ENGL,1302,4,10824,First Year Writing II,Sicinski,Michael J,21,6,0,0,0,0,0,3.717
+Fall 2024,ENGL,1302,10,10825,First Year Writing II,Cowan,Joshua Jared,8,7,0,0,2,0,7,2.982
+Fall 2024,ENGL,1302,13,10826,First Year Writing II,Mengesha,Abigail Mulatu,7,8,3,0,0,0,1,3.167
+Fall 2024,ENGL,1302,16,10827,First Year Writing II,Stewart-Steele,Heather Marie,9,2,1,1,3,0,7,2.771
+Fall 2024,ENGL,1302,19,10828,First Year Writing II,Stewart-Steele,Heather Marie,13,6,2,0,0,0,3,3.54
+Fall 2024,ENGL,1302,34,10829,First Year Writing II,Brinkley,Paola Garcia,11,2,1,1,3,0,1,2.944
+Fall 2024,ENGL,1370,1,10830,Composition II-Honors,Barnes,Michael,4,4,0,0,0,0,0,3.541
+Fall 2024,ENGL,1370,2,10831,Composition II-Honors,Barnes,Michael,2,1,0,0,0,0,0,3.557
+Fall 2024,ENGL,2305,3,10832,Intro To Fiction,Guajardo,Paul,9,18,1,0,0,0,1,3.203
+Fall 2024,ENGL,2307,1,10833,Intro To Drama,Lee,Nathanael D,8,14,3,1,1,0,3,2.902
+Fall 2024,ENGL,3330,1,10834,Beg Creative Writing-Fiction,Prufer,Kevin D,9,7,3,0,0,0,1,3.298
+Fall 2024,ENGL,4390,1,10835,Professional Internship,Zentz,Lauren R,0,0,0,0,0,4,0,
+Fall 2024,FREN,1501,1,10836,Elementary French I,Gnanwo Hounfodji,Raymond,6,6,3,2,0,0,4,2.844
+Fall 2024,FREN,1502,1,10838,Elementary French II,Green,Viola V,3,5,1,0,2,0,1,2.606
+Fall 2024,FREN,2311,1,10840,Intermediate French I,Chalhoub,Rania Maria,8,5,2,0,1,0,0,3.126
+Fall 2024,FREN,2312,1,10841,Intermediate French II,Vredenburgh,Amanda Jane,3,4,2,0,0,0,0,3.038
+Fall 2024,GERM,2311,1,10842,Intermediate German I,Kleinheider,Julia D,5,11,4,0,0,0,0,3.05
+Fall 2024,GERM,3333,1,10843,Ger Conversatn&Composit,Kleinheider,Julia D,0,3,1,0,0,0,0,2.915
+Fall 2024,HIST,1301,1,10844,The U.S. to 1877,Clavin,Matthew J,10,36,32,9,13,0,9,2.131
+Fall 2024,HIST,8699,1,10846,Doctoral Dissertation,Bhattacharya,Nandini Saradindu,0,0,0,0,0,1,0,
+Fall 2024,HIST,8699,2,10847,Doctoral Dissertation,Goldberg,Mark A,0,0,0,0,0,1,0,
+Fall 2024,HIST,8999,8,10849,Doctoral Dissertation,Golubev,Alexey Valeryevich,0,0,0,0,0,0,0,
+Fall 2024,HON,2301,1,10851,The Human Situation: Antiquity,Barnes,Michael,191,67,10,1,2,0,1,3.56
+Fall 2024,HON,2301,2,10852,The Human Situation: Antiquity,Ferguson,Jamie H,174,89,0,0,3,0,5,3.572
+Fall 2024,ITAL,2311,2,10853,Intermediate Italian I,Ercolani,Monica,8,4,1,0,1,0,1,3.286
+Fall 2024,LATI,2311,1,10855,Intermediate Latin I,Armstrong,Richard H,6,5,1,0,0,0,0,3.389
+Fall 2024,MAS,2340,1,10856,Intro Mexican American Studies,Rodriguez,Andre,9,6,1,0,1,0,0,3.236
+Fall 2024,MSCI,1125,1,10857,Phys Readiness Training,Bradford,Todd F,7,7,1,0,0,0,3,3.334
+Fall 2024,MSCI,1210,1,10858,Introduction to the Army,Bradford,Todd F,5,1,0,0,0,0,0,3.833
+Fall 2024,MSCI,2210,1,10860,Leadership & Decision Making,Thomas,Roland,7,4,0,0,0,0,3,3.636
+Fall 2024,MSCI,2210,2,10861,Leadership & Decision Making,Thomas,Roland,1,1,0,0,0,0,0,3.5
+Fall 2024,MSCI,3310,1,10863,Training Management & WFF,Bradford,Todd F,8,2,0,0,0,0,0,3.8
+Fall 2024,MSCI,3310,2,10864,Training Management & WFF,Bradford,Todd F,1,1,0,0,0,0,0,3.5
+Fall 2024,MSCI,4310,1,10866,The Army Officer,Bradford,Todd F,15,2,0,0,0,0,1,3.882
+Fall 2024,MUED,4305,1,10868,General Music/Elem & Sec Schls,Derges,Julie D,11,5,4,0,0,0,0,3.334
+Fall 2024,MUSA,1300,1,10869,Applied Voice,Averyt,Zachary Benjamin,1,1,0,0,0,0,1,3.5
+Fall 2024,MUSA,1300,2,10870,Applied Voice,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1310,2,10871,Applied Piano,Morgulis,Tali,1,0,1,0,0,0,0,3.165
+Fall 2024,MUSA,1320,2,10872,Applied Violin,Lo,Mann-Wen,3,0,0,0,0,0,0,3.78
+Fall 2024,MUSA,1326,1,10874,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1330,1,10875,Applied Flute,Russell,Peggy,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1334,2,10877,Applied Clarinet,Rowell,Chester D,3,0,1,0,0,0,0,3.418
+Fall 2024,MUSA,1336,1,10878,Applied Bassoon,Wagner,Elise L,6,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1342,2,10879,Applied French Horn,Reed,Gavin Davis,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1344,1,10880,Applied Trombone,Kauk,Brian Keith,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1346,1,10881,Applied Tuba,Barton,Mark,4,0,0,0,0,0,0,3.918
+Fall 2024,MUSA,1348,1,10882,Applied Euphonium,Fenske,Kevin,4,0,0,0,0,0,0,3.835
+Fall 2024,MUSA,2300,1,10883,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2300,2,10884,Applied Voice,Ceres,Emily Margaret,2,0,0,0,0,0,0,3.835
+Fall 2024,MUSA,2300,3,10885,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,3.89
+Fall 2024,MUSA,2320,1,10887,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2326,1,10888,Applied Double Bass,Larson,Eric Amery,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2330,1,10889,Applied Flute,Russell,Peggy,4,1,0,0,0,0,0,3.8
+Fall 2024,MUSA,2330,2,10890,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2334,1,10891,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2336,1,10892,Applied Bassoon,Wagner,Elise L,2,1,0,0,0,0,0,3.667
+Fall 2024,MUSA,2342,2,10893,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,3.835
+Fall 2024,MUSA,2344,1,10894,Applied Trombone,Kauk,Brian Keith,6,0,0,0,0,0,1,4.0
+Fall 2024,MUSA,2346,1,10895,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2348,1,10896,Applied Euphonium,Fenske,Kevin,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3400,1,10897,Applied Voice,Averyt,Zachary Benjamin,1,1,0,0,0,0,0,3.665
+Fall 2024,MUSA,3400,2,10898,Applied Voice,Clayton Vasquez,Cynthia L,2,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,3400,5,10899,Applied Voice,Jones,Timothy J,4,0,0,0,0,0,0,3.918
+Fall 2024,MUSA,3400,6,10900,Applied Voice,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3434,2,10901,Applied Clarinet,Rowell,Chester D,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3436,1,10902,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3442,2,10903,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3448,1,10904,Applied Euphonium,Fenske,Kevin,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4400,2,10905,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,3.89
+Fall 2024,MUSA,4402,1,10906,Applied Composition,Maroney,Marcus K,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,4430,2,10909,Applied Flute,Martin,Tyler Craig,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4434,2,10910,Applied Clarinet,Rowell,Chester D,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4436,1,10911,Applied Bassoon,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4442,2,10912,Applied French Horn,Reed,Gavin Davis,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4444,1,10913,Applied Trombone,Kauk,Brian Keith,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4446,1,10914,Applied Tuba,Barton,Mark,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4448,1,10915,Applied Euphonium,Fenske,Kevin,4,0,0,0,0,0,0,3.918
+Fall 2024,MUSI,1100,1,10917,Marching Band,Kubos,Cameron Kade,222,0,0,0,0,0,3,4.0
+Fall 2024,MUSI,1102,1,10918,Wind Ensemble,Bertman,David Garry,69,1,0,0,0,0,0,3.99
+Fall 2024,MUSI,1102,2,10919,Wind Ensemble,Bertman,David Garry,73,0,0,0,0,0,1,4.0
+Fall 2024,MUSI,1110,1,10920,Jazz Orchestra,Marmolejo,Noe J,18,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,1120,1,10922,University Chorus,Basili,Franco,11,2,0,0,0,0,1,3.821
+Fall 2024,MUSI,1121,1,10923,Concert Chorus,Koppel,Alexander,27,3,0,0,0,0,1,3.867
+Fall 2024,MUSI,1140,1,10924,Orchestra,Krager,Franz A,54,5,1,0,0,0,0,3.856
+Fall 2024,MUSI,1181,2,10926,Group Piano I,Van Kekerix,Todd Evan,8,3,0,0,0,0,0,3.727
+Fall 2024,MUSI,1116,1,10927,Aural Skills I,Guez,Jonathan Charles,8,8,2,0,0,0,1,3.333
+Fall 2024,MUSI,1311,1,10928,Music Theory I,Guez,Jonathan Charles,7,8,4,0,0,0,0,3.141
+Fall 2024,MUSI,1160,1,10929,Italian and English Diction,Suits,Brian J,2,11,3,0,0,0,0,2.979
+Fall 2024,MUSI,2181,1,10930,Group Piano III,Van Kekerix,Todd Evan,7,2,2,0,0,0,0,3.515
+Fall 2024,MUSI,2181,2,10931,Group Piano III,Van Kekerix,Todd Evan,6,6,0,0,0,0,0,3.473
+Fall 2024,MUSI,2116,1,10932,Aural Skills III,Snyder,John L,5,8,6,0,2,0,2,2.635
+Fall 2024,MUSI,2210,1,10933,Theory III,Snyder,John L,5,9,4,0,1,0,3,2.825
+Fall 2024,MUED,2320,1,10934,Computers for Musicians,Zajicek,Daniel James,9,6,1,0,0,0,0,3.397
+Fall 2024,MUED,2320,2,10935,Computers for Musicians,Zajicek,Daniel James,3,5,4,0,0,0,3,2.889
+Fall 2024,MUSI,2361,1,10936,Music and Culture,Rakonjac,Damjan,46,22,17,2,7,0,2,3.043
+Fall 2024,MUED,3100,1,10937,Woodwinds,Bell,Priscilla Garrett,14,3,1,0,0,0,0,3.722
+Fall 2024,MUED,3101,1,10938,Woodwinds,Bell,Priscilla Garrett,8,1,1,0,0,0,0,3.601
+Fall 2024,MUED,3104,1,10939,Strings,Meitz,Penelope J,10,6,2,0,0,0,0,3.279
+Fall 2024,MUSI,3215,1,10940,Introduction To Large Forms,Snyder,John L,3,2,2,0,1,0,1,2.874
+Fall 2024,MUSI,3215,2,10941,Introduction To Large Forms,Garza,Paul Victor,9,3,4,1,4,0,1,2.556
+Fall 2024,MUSI,3215,3,10942,Introduction To Large Forms,Garza,Paul Victor,12,3,4,0,0,0,0,3.352
+Fall 2024,MUSI,1307,1,10943,Listening to Classical Music,Smerud,Aidan J,83,27,10,1,4,0,8,3.472
+Fall 2024,MUSI,1307,2,10944,Listening to Classical Music,Smerud,Aidan J,108,13,5,4,7,0,11,3.531
+Fall 2024,MUSI,3301,1,10945,Listening To World Music,Hubley,Robert L,55,11,1,1,1,0,3,3.653
+Fall 2024,MUSI,3363,1,10946,History of Music II,Rakonjac,Damjan,44,16,9,1,5,0,1,3.205
+Fall 2024,MUSI,4102,1,10947,Acting for Opera,Belcher,Kathleen,9,2,0,0,0,0,0,3.848
+Fall 2024,MUSI,4120,1,10948,Percussion Ensemble,Wilkins,Blake M,15,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4220,1,10949,Choral Conducting I,DeSpain,Kaitlin Elizabeth,18,4,1,0,1,0,1,3.583
+Fall 2024,MUSI,4230,1,10950,Instrumental Conducting I,Bertman,David Garry,23,0,2,0,0,0,0,3.827
+Fall 2024,MUED,4344,1,10951,MS/JS/HS Inst Admin&Ens Tech,Meals,Cory Dewitt,18,6,0,0,0,0,0,3.75
+Fall 2024,MUSI,6104,1,10952,New Music Ensemble,Smith,Robert Thomas,9,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,8300,1,10953,Doct Research Seminar,Pollack,Howard J,3,3,0,0,0,0,0,3.39
+Fall 2024,POLS,4390,1,10954,Government Internship,Cross,Renee Danielle,21,2,0,0,0,0,0,3.913
+Fall 2024,PSYC,2305,1,10955,Intro to Methods in Psychology,Foss,Donald J,12,12,4,2,7,0,8,2.532
+Fall 2024,PSYC,4344,1,10957,Cultural Psychology,Beltran-Najera,Ilex,52,16,7,2,2,0,0,3.497
+Fall 2024,PSYC,3310,2,10958,Indstrl-Orgnztnl Psy,Ng,Vincent,28,7,7,0,1,0,1,3.449
+Fall 2024,PSYC,2316,1,10959,Psychology of Personality,Inman,Tonya N,53,25,8,1,3,0,3,3.385
+Fall 2024,PSYC,2330,1,10960,Biological Psychology,Leasure,Jennifer Leigh,17,9,9,7,4,0,4,2.602
+Fall 2024,PSYC,6317,1,10961,Psychopathology I,Garey,Lorra Lynn,12,0,0,0,0,0,0,3.973
+Fall 2024,SOCI,1301,3,10962,Introduction To Sociology,Nelson,Steven M,32,16,5,2,4,0,2,3.17
+Fall 2024,SOCI,1301,1,10963,Introduction To Sociology,Nelson,Steven M,34,16,6,2,0,0,2,3.385
+Fall 2024,SOCI,1301,5,10964,Introduction To Sociology,Dorsey,Patricia Lynne,15,25,15,4,2,0,0,2.738
+Fall 2024,SOC,3400,1,10965,Intro To Social Statistics,Hwang,Hyunseok,18,8,1,0,0,0,1,3.593
+Fall 2024,SOC,6300,1,10968,Sem-Sociological Theory,Lee,Shayne,12,0,0,0,0,0,0,4.0
+Fall 2024,SOC,6304,1,10969,Social Statistics,Anderson,Kathryn,5,4,2,0,0,0,1,3.123
+Fall 2024,SPAN,1501,1,10972,Elementary Spanish I,Jager Lopezllera,Valentina Kathe,8,5,4,2,3,0,4,2.621
+Fall 2024,SPAN,1501,7,10974,Elementary Spanish I,Molina Vargas,Oscar Ivan,7,6,3,1,1,0,2,2.853
+Fall 2024,SPAN,1501,9,10976,Elementary Spanish I,Naderi,Cina Oscar,15,5,3,1,0,0,0,3.32
+Fall 2024,SPAN,1501,11,10978,Elementary Spanish I,Rodriguez Mora,Camilo Andres,6,11,2,2,0,0,3,2.969
+Fall 2024,SPAN,1501,13,10980,Elementary Spanish I,Guimaraes Cardozo,Luiz Paulo,8,10,5,1,0,0,0,2.987
+Fall 2024,SPAN,1502,5,10982,Elementary Spanish II,Borroto Lopez,Cecilia De La Caridad,5,9,5,0,0,0,3,2.913
+Fall 2024,SPAN,1502,11,10984,Elementary Spanish II,Carrera Quiroga,Emilio Vicente,7,10,7,1,1,0,3,2.77
+Fall 2024,SPAN,1502,15,10986,Elementary Spanish II,Scalzo,Dillon S,20,4,0,0,1,0,1,3.627
+Fall 2024,SPAN,2311,4,10988,Intermediate Spanish I,Javierre Londono,Juliana,8,9,5,1,0,0,1,2.972
+Fall 2024,SPAN,2311,7,10989,Intermediate Spanish I,Nieves Cabrera,Wendy,6,9,9,0,1,0,1,2.76
+Fall 2024,SPAN,2312,1,10990,Intermediate Spanish II,Pueyo Castan,Josefa,1,12,9,1,3,0,0,2.32
+Fall 2024,SPAN,2312,2,10991,Intermediate Spanish II,Falahasl,Hamideh,5,13,5,1,0,0,2,2.848
+Fall 2024,SPAN,2307,1,10992,Span for Heritage Learners I,Ruiz,Eugenia Maria,8,6,5,0,0,0,2,3.106
+Fall 2024,SPAN,2308,2,10993,Span for Heritage Learners II,Martinez,Raquel,16,8,4,0,1,0,0,3.299
+Fall 2024,SPAN,3302,1,10994,Adv Span for Non-Heritage,Cuesta,Mabel,13,3,3,0,0,0,1,3.492
+Fall 2024,SPAN,3307,3,10995,Public Speaking in Spanish,Ventura,Gabriela Baeza,17,6,1,0,0,0,0,3.543
+Fall 2024,SPAN,3308,2,10996,Written Com-Hisp Herit Learner,Hasbun,Rodrigo,11,7,1,0,0,0,0,3.439
+Fall 2024,SPAN,3384,2,10997,Intro To Hispanic Literature,Gutierrez,Pedro Revuelta,6,3,0,0,0,0,2,3.63
+Fall 2024,SPAN,6398,8,10999,Special Problems,Sisk,Christina L,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,6398,9,11000,Special Problems,Tejada,Roberto Jose,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,6398,10,11001,Special Problems,Solino,Maria Elena,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,7398,6,11002,Reading & Research,Gutierrez,Manuel J,0,0,0,0,0,2,0,
+Fall 2024,SPAN,8399,1,11004,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Fall 2024,SPAN,8399,2,11005,Dissertation,Gutierrez,Manuel J,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,8399,3,11006,Dissertation,Rivera Garza,Cristina,0,0,0,0,0,2,0,
+Fall 2024,SPAN,8399,4,11007,Dissertation,Kanellos,Nicolas,0,0,0,0,0,1,0,
+Fall 2024,SPAN,8399,6,11008,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,1,0,
+Fall 2024,SPAN,8699,1,11009,Dissertation,De Los Reyes Heredia,Jose Guillermo,0,0,0,0,0,1,0,
+Fall 2024,SPAN,8699,2,11010,Dissertation,Rivera Garza,Cristina,0,0,0,0,0,5,0,
+Fall 2024,SPAN,8699,5,11012,Dissertation,Kanellos,Nicolas,0,0,0,0,0,1,0,
+Fall 2024,THEA,1332,1,11013,Fundamentals of Theatre,Bush,Rachel R,13,9,5,0,0,0,2,3.296
+Fall 2024,DRAM,1330,1,11014,Scenic Technology,Vlahos,Kalliope,18,2,1,0,0,0,1,3.81
+Fall 2024,THEA,2373,1,11016,Costume Technology,Niederer,Barbara,8,5,2,0,0,0,0,3.444
+Fall 2024,THEA,3335,1,11018,History of the Theatre I,Coen,Elizabeth Manya,18,10,4,0,0,0,2,3.427
+Fall 2024,THEA,6201,1,11019,Graduate Acting I,Young,John M,3,5,0,0,0,0,0,3.251
+Fall 2024,VIET,2301,1,11020,Intermediate Vietnamese I,Dang,Thong Q,12,0,0,0,0,0,0,3.945
+Fall 2024,WGSS,2350,3,11021,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,28,1,0,0,0,0,1,3.92
+Fall 2024,MUSI,8106,2,11022,Doctoral Large Ensemble,Marmolejo,Noe J,2,0,0,0,0,0,0,4.0
+Fall 2024,COMM,3361,1,11023,Advertising Copywriting,Tinnel,Jason Wayne,5,14,5,1,2,0,3,2.581
+Fall 2024,SPAN,3305,1,11025,Spanish Grammar Review,Gellon,Sofia,6,8,5,1,0,0,0,2.901
+Fall 2024,VIET,1501,1,11026,Elementary Vietnamese I,Dang,Thong Q,27,2,0,0,0,0,0,3.908
+Fall 2024,PSYC,2305,3,11028,Intro to Methods in Psychology,Foss,Donald J,16,11,9,1,4,0,4,2.861
+Fall 2024,ENGL,1301,101,11030,First Year Writing I,Rolater,Sara C,13,7,1,1,1,0,1,3.247
+Fall 2024,ENGL,1301,103,11031,First Year Writing I,Lopez,Reese D,12,4,2,0,0,0,1,3.446
+Fall 2024,ENGL,1301,109,11048,First Year Writing I,Fretwell,Leah M,12,3,1,0,2,0,1,3.259
+Fall 2024,ARTS,2316,3,11075,Fundamentals of Painting,Siddiq,Sajeela,12,5,0,0,0,0,1,3.667
+Fall 2024,MUSI,2181,3,11080,Group Piano III,Van Kekerix,Todd Evan,12,2,0,0,0,0,0,3.692
+Fall 2024,MUSI,3303,1,11081,Pop Music of Americas Sn 1840,Garza,Paul Victor,55,13,3,6,0,0,2,3.498
+Fall 2024,GERM,1501,1,11083,Beginning German I,Bandmann,Tanya,6,4,3,3,0,0,5,2.854
+Fall 2024,GERM,1501,3,11085,Beginning German I,Bandmann,Tanya,6,3,3,1,1,0,2,2.834
+Fall 2024,FREN,1502,3,11087,Elementary French II,Green,Viola V,1,4,3,0,0,0,3,2.791
+Fall 2024,CHIN,1501,5,11089,Elementary Chinese I,Wang,Wei,6,3,2,1,0,0,4,3.084
+Fall 2024,AFSC,4301,3,11092,National Security Affairs I,Curiel,Ernesto F,5,0,0,0,0,0,0,3.868
+Fall 2024,SOC,6399,1,11093,Masters Thesis,Langa,Neema Michael,1,0,0,0,0,0,0,4.0
+Fall 2024,POLS,6380,1,11094,Quantitative Methods I,Ollerenshaw,Trent,7,3,0,0,0,0,0,3.634
+Fall 2024,CHIN,3360,1,11095,A Look Into Modern China,McArthur,Charles M,18,10,4,1,0,0,2,3.274
+Fall 2024,WGSS,2350,4,11096,Intro To Women's Studies,Martinez,Itzel Areli,29,0,1,0,0,0,0,3.911
+Fall 2024,THEA,7303,1,11098,Graduate Acting III,Young,John M,0,6,1,0,0,0,0,2.621
+Fall 2024,THEA,7213,1,11099,Graduate Movement III,Noble,Adam S,7,0,0,0,0,0,0,3.67
+Fall 2024,ENGL,1302,42,11100,First Year Writing II,Sicinski,Michael J,17,5,1,0,2,0,0,3.321
+Fall 2024,ENGL,1302,43,11101,First Year Writing II,Campese,Kathleen Ann,18,6,0,0,1,0,0,3.547
+Fall 2024,ENGL,1302,44,11102,First Year Writing II,Bellomy,Charlotte Seychelles,17,1,0,0,1,0,0,3.598
+Fall 2024,ENGL,1301,111,11103,First Year Writing I,Khalil,Rand Omar,12,4,2,0,0,0,0,3.537
+Fall 2024,DANC,3310,1,11104,Dance History I,Estrada,Maria Gabriela,30,4,4,0,0,0,2,3.667
+Fall 2024,THEA,7223,1,11105,Graduate Voice/Speech III,Majkowski,Vivian,7,0,0,0,0,0,0,3.953
+Fall 2024,MUSI,2188,1,11106,Keybd Skills & Collab Technqs,Hester,Timothy E,6,0,0,0,0,0,0,4.0
+Fall 2024,WCL,2352,2,11107,World Cinema,Nguyen,Duy,15,17,4,0,2,0,2,3.062
+Fall 2024,ENGL,1302,46,11122,First Year Writing II,Hunt,Ke'ara Shadae,5,5,3,1,1,0,4,2.844
+Fall 2024,SOCI,1301,11,11124,Introduction To Sociology,Davis,Mary A,37,10,3,3,0,0,1,3.497
+Fall 2024,ENGL,1301,120,11125,First Year Writing I,Murray,Christopher Brean,16,3,3,1,1,0,0,3.32
+Fall 2024,ENGL,1301,121,11126,First Year Writing I,Murray,Christopher Brean,14,5,1,1,0,0,4,3.54
+Fall 2024,SGNL,1301,3,11127,Elementary Sign Language I,Brittain,Robyn Michelle,1,7,6,0,1,0,5,2.445
+Fall 2024,ENGL,1301,122,11128,First Year Writing I,Murray,Christopher Brean,17,6,1,0,0,0,1,3.612
+Fall 2024,ENGL,1301,123,11129,First Year Writing I,Pachuca,Adrian,4,9,4,0,2,0,0,2.736
+Fall 2024,MUSI,4120,2,11130,Percussion Ensemble,Warren,Paul Alexander,13,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,124,11131,First Year Writing I,Kunasek,Caleb,9,4,2,0,3,0,1,2.834
+Fall 2024,ENGL,1301,125,11132,First Year Writing I,Bass,Kasey Dawn,17,1,1,0,3,0,2,3.273
+Fall 2024,BCHS,3304,1,11139,General Biochemistry I,Amaral Antunes,Dinler,74,36,15,0,1,0,2,3.505
+Fall 2024,BCHS,3304,2,11140,General Biochemistry I,Vicens,Quentin,29,54,17,1,0,0,23,3.106
+Fall 2024,BCHS,3305,1,11141,General Biochemistry II,Yi,Ping,29,19,6,0,0,0,2,3.383
+Fall 2024,BCHS,4306,1,11142,Nucleic Acids,Gunaratne,Preethi H,20,20,4,2,0,0,4,3.203
+Fall 2024,BCHS,4313,1,11143,Cell Biochemistry,Rea,Michael A,1,6,6,0,0,0,1,2.615
+Fall 2024,BCHS,6113,1,11144,Graduate Biochemistry Seminar,Fujita,Masaya,0,0,0,0,0,26,0,
+Fall 2024,BCHS,6298,1,11145,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6398,1,11146,Special Problems,Widger,William R,0,0,0,0,0,4,0,
+Fall 2024,BIOL,2101,1,11153,Anatomy & Physiology Lab I,Gill,Tejendra,9,10,3,0,1,0,1,3.116
+Fall 2024,BIOL,2101,2,11154,Anatomy & Physiology Lab I,Gill,Tejendra,5,11,4,1,1,0,2,2.773
+Fall 2024,BIOL,2101,3,11155,Anatomy & Physiology Lab I,Gill,Tejendra,1,7,10,1,1,0,3,2.251
+Fall 2024,BIOL,2101,4,11156,Anatomy & Physiology Lab I,Gill,Tejendra,8,9,5,1,0,0,1,2.972
+Fall 2024,BIOL,2101,5,11157,Anatomy & Physiology Lab I,Gill,Tejendra,3,10,8,1,1,0,1,2.522
+Fall 2024,BIOL,2101,6,11158,Anatomy & Physiology Lab I,Gill,Tejendra,5,13,2,1,2,0,1,2.869
+Fall 2024,BIOL,2101,7,11159,Anatomy & Physiology Lab I,Gill,Tejendra,2,12,6,1,1,0,2,2.591
+Fall 2024,BIOL,2101,8,11160,Anatomy & Physiology Lab I,Gill,Tejendra,5,7,6,4,1,0,1,2.45
+Fall 2024,BIOL,2101,9,11161,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,7,1,0,0,1,2.74
+Fall 2024,BIOL,2120,1,11162,Microbiology for Non-Science,Knapp,Richard D,11,7,4,2,0,0,0,3.194
+Fall 2024,BIOL,2120,2,11163,Microbiology for Non-Science,Knapp,Richard D,7,12,4,0,1,0,0,3.041
+Fall 2024,BIOL,1106,1,11164,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,2,0,0,0,0,3.598
+Fall 2024,BIOL,1106,2,11165,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,0,1,0,0,1,3.623
+Fall 2024,BIOL,1106,3,11166,Biol for Science Majors I(Lab),Medrano,Ana I,17,5,1,0,0,0,0,3.681
+Fall 2024,BIOL,1106,4,11167,Biol for Science Majors I(Lab),Medrano,Ana I,11,11,1,1,0,0,0,3.361
+Fall 2024,BIOL,1106,6,11168,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,2,0,0,0,1,3.591
+Fall 2024,BIOL,1106,7,11169,Biol for Science Majors I(Lab),Medrano,Ana I,14,5,1,0,0,0,4,3.667
+Fall 2024,BIOL,1106,8,11170,Biol for Science Majors I(Lab),Medrano,Ana I,21,1,1,0,0,0,1,3.855
+Fall 2024,BIOL,1106,9,11171,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,1,0,0,0,1,3.739
+Fall 2024,BIOL,1106,10,11172,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,3,0,1,0,0,3.361
+Fall 2024,BIOL,1106,11,11173,Biol for Science Majors I(Lab),Medrano,Ana I,18,2,2,2,0,0,0,3.473
+Fall 2024,BIOL,1106,12,11174,Biol for Science Majors I(Lab),Medrano,Ana I,18,3,1,0,0,0,1,3.728
+Fall 2024,BIOL,1106,13,11175,Biol for Science Majors I(Lab),Medrano,Ana I,18,1,0,0,0,0,3,3.895
+Fall 2024,BIOL,1106,14,11176,Biol for Science Majors I(Lab),Medrano,Ana I,20,2,1,0,0,0,0,3.812
+Fall 2024,BIOL,1106,15,11177,Biol for Science Majors I(Lab),Medrano,Ana I,13,8,0,0,2,0,1,3.276
+Fall 2024,BIOL,1106,16,11178,Biol for Science Majors I(Lab),Medrano,Ana I,13,7,1,3,0,0,0,3.236
+Fall 2024,BIOL,1106,17,11179,Biol for Science Majors I(Lab),Medrano,Ana I,10,7,4,2,0,0,0,3.058
+Fall 2024,BIOL,1106,18,11180,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,1,0,0,0,2,3.604
+Fall 2024,BIOL,1106,19,11181,Biol for Science Majors I(Lab),Medrano,Ana I,13,4,3,0,1,0,2,3.349
+Fall 2024,BIOL,1106,20,11182,Biol for Science Majors I(Lab),Medrano,Ana I,12,7,2,1,0,0,2,3.364
+Fall 2024,BIOL,1106,21,11183,Biol for Science Majors I(Lab),Medrano,Ana I,15,6,0,0,1,0,2,3.5
+Fall 2024,BIOL,1106,22,11184,Biol for Science Majors I(Lab),Medrano,Ana I,12,11,0,0,0,0,1,3.536
+Fall 2024,BIOL,1308,1,11185,Biology for Non-Science Majors,Ibrahim,Abdalla Zanouny,57,59,18,5,4,0,9,3.1
+Fall 2024,BIOL,2301,1,11186,Anatomy & Physiology I (lect),Wayne,Chad M,50,128,110,55,19,0,112,2.349
+Fall 2024,BIOL,2320,1,11187,Microbiology for Non-Science,Knapp,Richard D,83,117,73,31,8,0,18,2.736
+Fall 2024,BIOL,1306,1,11188,Biology for Science Majors I,Farmer,Lisa M,85,83,60,24,5,0,22,2.841
+Fall 2024,BIOL,1306,2,11189,Biology for Science Majors I,Cheek,Ann Oliver,76,65,67,31,14,0,28,2.696
+Fall 2024,BIOL,1306,3,11190,Biology for Science Majors I,Cheek,Ann Oliver,23,40,21,17,18,0,21,2.322
+Fall 2024,BIOL,1306,4,11191,Biology for Science Majors I,Gifford,Jenifer,73,67,62,20,18,0,13,2.645
+Fall 2024,BIOL,3306,1,11192,Evolutionary Biology,Azevedo,Ricardo,32,33,24,1,2,0,10,2.993
+Fall 2024,BIOL,3324,1,11193,Human Physiology,Wayne,Chad M,17,28,36,0,1,0,16,2.76
+Fall 2024,BIOL,3341,1,11194,Human Genetics,Feng,Qin,98,73,21,1,1,0,0,3.354
+Fall 2024,BIOL,4320,1,11196,Molecular Biology,Chung,Sanghyuk,14,11,3,2,0,0,4,3.211
+Fall 2024,BIOL,6110,1,11197,Biology Seminar,Zhang,Shaun Xiaoliu,0,0,0,0,0,26,0,
+Fall 2024,BIOL,7167,1,11201,Population Biology Seminar,Azevedo,Ricardo,0,0,0,0,0,11,0,
+Fall 2024,BIOL,8598,1,11205,Doctoral Research,Sater,Amy,0,0,0,0,0,1,0,
+Fall 2024,CHEM,1105,1,11206,Foundations of Chem Lab,Zaitsev,Vladimir G,7,9,1,0,0,0,1,3.372
+Fall 2024,CHEM,1105,2,11207,Foundations of Chem Lab,Zaitsev,Vladimir G,6,5,2,0,0,0,3,3.232
+Fall 2024,CHEM,1111,1,11208,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,8,3,0,1,0,4,2.644
+Fall 2024,CHEM,1111,2,11209,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,0,1,1,0,2,2.908
+Fall 2024,CHEM,1111,5,11210,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,6,4,0,0,0,0,3.176
+Fall 2024,CHEM,1111,4,11211,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,2,0,1,0,1,2.961
+Fall 2024,CHEM,1111,9,11212,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,1,1,0,0,0,3.203
+Fall 2024,CHEM,1111,12,11213,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,2,0,0,0,0,3.196
+Fall 2024,CHEM,1111,7,11214,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,15,1,0,1,0,2,2.833
+Fall 2024,CHEM,1111,10,11215,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,10,2,0,0,0,2,3.222
+Fall 2024,CHEM,1111,11,11216,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,0,0,0,3,3.125
+Fall 2024,CHEM,1111,13,11217,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,0,0,0,0,3,3.166
+Fall 2024,CHEM,1111,14,11218,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,2,0,0,0,1,3.119
+Fall 2024,CHEM,1111,15,11219,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,14,1,0,0,0,0,3.093
+Fall 2024,CHEM,1111,16,11220,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,8,4,0,1,0,1,2.871
+Fall 2024,CHEM,1111,17,11221,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,15,1,0,0,0,2,3.039
+Fall 2024,CHEM,1111,19,11222,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,17,0,0,1,0,0,2.999
+Fall 2024,CHEM,1111,20,11223,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,0,0,0,2,3.125
+Fall 2024,CHEM,1111,22,11224,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,15,2,0,0,0,1,3.017
+Fall 2024,CHEM,1111,23,11225,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,2,2,0,0,0,2.929
+Fall 2024,CHEM,1111,25,11226,Fundamentals of Chm Lab,Zaitsev,Vladimir G,0,16,0,0,0,0,2,2.979
+Fall 2024,CHEM,1111,26,11227,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,11,1,0,0,0,2,3.204
+Fall 2024,CHEM,1111,28,11228,Fundamentals of Chm Lab,Zaitsev,Vladimir G,7,11,1,0,0,0,0,3.281
+Fall 2024,CHEM,1111,29,11229,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,1,0,0,0,3.017
+Fall 2024,CHEM,1111,31,11230,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,3,0,0,0,2,3.078
+Fall 2024,CHEM,1111,32,11231,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,10,0,1,0,0,2,3.167
+Fall 2024,CHEM,1111,34,11232,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,2,1,0,0,1,3.0
+Fall 2024,CHEM,1111,35,11233,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,14,0,0,0,0,1,3.204
+Fall 2024,CHEM,1111,37,11234,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,4,0,0,0,1,2.895
+Fall 2024,CHEM,1111,40,11235,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,16,1,0,0,0,1,3.105
+Fall 2024,CHEM,1111,41,11236,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,3,0,0,0,1,3.0
+Fall 2024,CHEM,1111,43,11237,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,3,1,0,0,2,2.965
+Fall 2024,CHEM,1111,44,11238,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,9,2,1,1,0,0,2.982
+Fall 2024,CHEM,1111,46,11239,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,11,1,1,0,0,0,3.056
+Fall 2024,CHEM,1112,1,11240,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,11,2,0,0,0,5,3.044
+Fall 2024,CHEM,1112,2,11241,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,5,0,0,0,1,2.947
+Fall 2024,CHEM,1112,3,11242,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,3,0,0,0,6,2.953
+Fall 2024,CHEM,1112,5,11243,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,2,0,0,0,2,3.098
+Fall 2024,CHEM,1112,6,11244,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,11,2,0,0,0,2,3.104
+Fall 2024,CHEM,1112,7,11245,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,2,0,0,0,0,3.166
+Fall 2024,CHEM,1112,8,11246,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,0,1,0,1,2.902
+Fall 2024,CHEM,1112,9,11247,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,10,3,0,0,0,5,2.977
+Fall 2024,CHEM,1112,10,11248,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,1,0,0,0,3,3.118
+Fall 2024,CHEM,1112,12,11249,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,14,0,0,0,0,1,3.3
+Fall 2024,CHEM,1112,13,11250,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,14,0,0,0,0,1,3.277
+Fall 2024,CHEM,1305,1,11251,Foundations of Chemistry,Czernuszewicz,Roman S,23,53,69,13,30,0,63,2.105
+Fall 2024,CHEM,1311,1,11252,Fundamentals of Chemistry,Larsen,Russell Gene,97,118,166,31,33,0,92,2.451
+Fall 2024,CHEM,1311,2,11253,Fundamentals of Chemistry,Carrasquillo M,Edwin,45,45,44,18,16,0,45,2.506
+Fall 2024,CHEM,1312,1,11254,Fundamentals of Chemistry 2,Larsen,Russell Gene,53,81,96,24,31,0,82,2.285
+Fall 2024,CHEM,3133,1,11255,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,4,10,1,0,0,0,0,3.244
+Fall 2024,CHEM,3133,2,11256,Inorganic Chemistry Lab I,Zaitsev,Vladimir G,3,4,1,0,0,0,0,3.168
+Fall 2024,CHEM,3119,1,11257,Anlytical Chemistry Lab,Czader,Arkadiusz,4,2,2,0,0,0,1,3.209
+Fall 2024,CHEM,3119,2,11258,Anlytical Chemistry Lab,Czader,Arkadiusz,4,8,0,0,0,0,0,3.416
+Fall 2024,CHEM,2123,1,11259,Organic Chemistry Lab I,Bean,Mary B,1,12,7,1,0,0,0,2.525
+Fall 2024,CHEM,2123,2,11260,Organic Chemistry Lab I,Bean,Mary B,5,9,7,2,0,0,0,2.682
+Fall 2024,CHEM,2123,3,11261,Organic Chemistry Lab I,Bean,Mary B,5,12,3,0,0,0,2,2.952
+Fall 2024,CHEM,2123,4,11262,Organic Chemistry Lab I,Bean,Mary B,3,9,5,1,1,0,3,2.614
+Fall 2024,CHEM,2123,5,11263,Organic Chemistry Lab I,Bean,Mary B,3,10,7,0,0,0,1,2.784
+Fall 2024,CHEM,2123,6,11264,Organic Chemistry Lab I,Bean,Mary B,3,8,13,0,0,0,0,2.528
+Fall 2024,CHEM,2123,7,11265,Organic Chemistry Lab I,Bean,Mary B,1,10,7,1,0,0,2,2.544
+Fall 2024,CHEM,2123,8,11266,Organic Chemistry Lab I,Bean,Mary B,2,12,6,1,0,0,3,2.636
+Fall 2024,CHEM,2123,9,11267,Organic Chemistry Lab I,Bean,Mary B,5,9,6,2,0,0,1,2.758
+Fall 2024,CHEM,2123,10,11268,Organic Chemistry Lab I,Bean,Mary B,5,8,9,2,0,0,0,2.584
+Fall 2024,CHEM,2123,11,11269,Organic Chemistry Lab I,Bean,Mary B,3,14,6,0,0,0,0,2.855
+Fall 2024,CHEM,2123,12,11270,Organic Chemistry Lab I,Bean,Mary B,3,11,5,1,0,0,2,2.668
+Fall 2024,CHEM,2123,17,11271,Organic Chemistry Lab I,Bean,Mary B,2,8,10,1,0,0,2,2.445
+Fall 2024,CHEM,2123,14,11272,Organic Chemistry Lab I,Bean,Mary B,4,4,6,2,0,0,3,2.543
+Fall 2024,CHEM,2123,15,11273,Organic Chemistry Lab I,Bean,Mary B,0,14,9,0,0,0,0,2.594
+Fall 2024,CHEM,2123,16,11274,Organic Chemistry Lab I,Bean,Mary B,3,9,9,2,0,0,0,2.508
+Fall 2024,CHEM,2123,21,11275,Organic Chemistry Lab I,Bean,Mary B,5,4,14,0,0,0,0,2.637
+Fall 2024,CHEM,2123,18,11276,Organic Chemistry Lab I,Bean,Mary B,2,8,12,0,0,0,0,2.47
+Fall 2024,CHEM,2123,19,11277,Organic Chemistry Lab I,Bean,Mary B,3,10,6,2,0,0,1,2.635
+Fall 2024,CHEM,2123,20,11278,Organic Chemistry Lab I,Bean,Mary B,2,12,9,1,0,0,0,2.639
+Fall 2024,CHEM,2123,25,11279,Organic Chemistry Lab I,Bean,Mary B,4,8,3,3,0,0,4,2.649
+Fall 2024,CHEM,2123,22,11280,Organic Chemistry Lab I,Bean,Mary B,5,8,7,1,0,0,3,2.731
+Fall 2024,CHEM,2123,24,11281,Organic Chemistry Lab I,Bean,Mary B,4,9,6,2,0,0,1,2.604
+Fall 2024,CHEM,2125,2,11282,Organic Chemistry Lab II,Bean,Mary B,3,6,11,1,0,0,1,2.477
+Fall 2024,CHEM,2125,3,11283,Organic Chemistry Lab II,Bean,Mary B,3,5,9,2,0,0,1,2.508
+Fall 2024,CHEM,2125,4,11284,Organic Chemistry Lab II,Bean,Mary B,3,7,8,3,0,0,0,2.492
+Fall 2024,CHEM,2125,7,11285,Organic Chemistry Lab II,Bean,Mary B,7,4,8,0,1,0,2,2.784
+Fall 2024,CHEM,2125,6,11286,Organic Chemistry Lab II,Bean,Mary B,3,6,8,2,0,0,0,2.526
+Fall 2024,CHEM,2323,1,11287,Organic Chemistry I,Bean,Mary B,63,71,81,16,13,0,59,2.612
+Fall 2024,CHEM,2323,3,11288,Organic Chemistry I,Miljanic,Ognjen S,22,36,31,35,36,0,87,1.798
+Fall 2024,CHEM,2323,4,11289,Organic Chemistry I,Do,Loi H,7,11,2,1,0,0,3,3.174
+Fall 2024,CHEM,2323,2,11290,Organic Chemistry I,Bean,Mary B,65,62,80,19,29,0,49,2.441
+Fall 2024,CHEM,2325,1,11291,Organic Chemistry II,Comito,Robert Joseph,5,7,12,5,8,0,18,1.865
+Fall 2024,CHEM,3369,1,11292,Analytical Chemistry 1,Czader,Arkadiusz,5,8,12,2,2,0,0,2.448
+Fall 2024,CHEM,4229,1,11293,Instrmntl Mthd-Anly Lab,Czader,Arkadiusz,5,18,1,0,0,0,0,3.084
+Fall 2024,CHEM,4272,1,11294,Physical Chemistry Lab II,Czader,Arkadiusz,2,11,1,1,0,0,0,2.955
+Fall 2024,CHEM,4369,1,11295,Analytical Chemistry 2,Chiang,Naihao,3,19,5,1,0,0,0,2.857
+Fall 2024,CHEM,4372,1,11296,Physical Chemistry II,Xu,Shoujun,9,7,6,1,1,0,1,2.889
+Fall 2024,CHEM,4373,1,11297,Survey of Physical Chemistry,Lubchenko,Vassiliy,18,28,19,0,1,0,1,2.899
+Fall 2024,CHEM,6111,1,11298,Graduate Colloquium,Chiang,Naihao,0,0,0,0,0,44,0,
+Fall 2024,CHEM,6112,1,11299,Graduate Seminar,Do,Loi H,0,0,0,0,0,23,0,
+Fall 2024,CHEM,6112,2,11300,Graduate Seminar,Chiang,Naihao,0,0,0,0,0,10,0,
+Fall 2024,CHEM,6112,3,11301,Graduate Seminar,Brgoch,Jakoah,0,0,0,0,0,11,0,
+Fall 2024,CHEM,6115,3,11302,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,5,0,
+Fall 2024,CHEM,6115,1,11303,Sem in Chm Lab Instruct,Zaitsev,Vladimir G,0,0,0,0,0,18,0,
+Fall 2024,CHEM,6198,5,11307,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6198,6,11308,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6198,8,11310,Special Problems,Carrow,Bradley,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6198,9,11311,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6198,10,11312,Special Problems,Teets,Thomas,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6198,11,11313,Special Problems,Bocarsly,Joshua David,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6198,13,11314,Special Problems,Chen,Tai-Yen,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6198,14,11315,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6198,15,11316,Special Problems,Chiang,Naihao,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6198,16,11317,Special Problems,Cai,Chengzhi,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6198,18,11318,Special Problems,Comito,Robert Joseph,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6313,1,11320,Thermodynamcs & Kinects,Cho,Yeongsu,10,7,1,0,0,0,0,3.317
+Fall 2024,CHEM,6352,1,11321,Orgnc React & Synthesis,May,Jeremy A,2,13,1,0,0,0,0,3.021
+Fall 2024,CHEM,6374,1,11322,Physical Inorganic Chem I,Teets,Thomas,5,4,0,0,0,0,0,3.446
+Fall 2024,CHEM,6398,7,11323,Special Problems,Comito,Robert Joseph,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6398,19,11328,Special Problems,Harth,Eva M,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,2,11330,Special Problems,Harth,Eva M,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,4,11331,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6698,6,11333,Special Problems,Xu,Shoujun,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,7,11334,Special Problems,Gilbertson,Scott R,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,8,11335,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,10,11336,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,11,11337,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6698,13,11338,Special Problems,Zastrow,Melissa L,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6698,15,11339,Special Problems,Yang,Ding-Shyue,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6698,16,11340,Special Problems,Baldelli,Steve,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6698,19,11341,Special Problems,Teets,Thomas,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6998,1,11342,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6998,2,11343,Special Problems,Teets,Thomas,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6998,4,11344,Special Problems,Do,Loi H,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6998,5,11345,Special Problems,May,Jeremy A,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6998,6,11346,Special Problems,Comito,Robert Joseph,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6998,7,11347,Special Problems,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6998,8,11348,Special Problems,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Fall 2024,CHEM,6998,10,11350,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6998,18,11356,Special Problems,Carrow,Bradley,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6998,19,11357,Special Problems,Miljanic,Ognjen S,0,0,0,0,0,2,0,
+Fall 2024,CHEM,8399,1,11359,Doctoral Dissertation,Lee,T Randall,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,8998,2,11386,Doctoral Research,Harth,Eva M,0,0,0,0,0,4,0,
+Fall 2024,CHEM,8998,4,11387,Doctoral Research,Teets,Thomas,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8998,5,11388,Doctoral Research,Lee,T Randall,0,0,0,0,0,4,0,
+Fall 2024,CHEM,8998,8,11391,Doctoral Research,Comito,Robert Joseph,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8998,10,11392,Doctoral Research,Zastrow,Melissa L,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8998,14,11395,Doctoral Research,Chiang,Naihao,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8998,15,11396,Doctoral Research,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8998,19,11398,Doctoral Research,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Fall 2024,CHEM,8999,1,11399,Doctoral Dissertation,Gilbertson,Scott R,0,0,0,0,0,2,0,
+Fall 2024,CHEM,8999,13,11404,Doctoral Dissertation,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2024,COSC,6110,1,11407,Graduate Colloquium,Leiss,Ernst L,0,0,0,0,0,1,0,
+Fall 2024,GEOL,1103,1,11408,Physical Geology Lab,Hauptvogel,Daniel William,11,0,4,0,0,0,1,3.467
+Fall 2024,GEOL,1103,2,11409,Physical Geology Lab,Hauptvogel,Daniel William,14,3,4,0,1,0,1,3.348
+Fall 2024,GEOL,1103,4,11410,Physical Geology Lab,Hauptvogel,Daniel William,18,3,0,0,0,0,0,3.857
+Fall 2024,GEOL,1103,5,11411,Physical Geology Lab,Hauptvogel,Daniel William,10,8,2,0,1,0,0,3.207
+Fall 2024,GEOL,1340,1,11413,Earth Systems,Lytwyn,Jennifer N,13,17,4,2,0,0,3,3.13
+Fall 2024,MATH,1314,1,11414,College Algebra,Caglar,Atife,98,57,60,28,29,0,22,2.576
+Fall 2024,MATH,1314,5,11416,College Algebra,Chern,Haley Nicole,46,26,62,33,59,0,43,1.774
+Fall 2024,MATH,1332,2,11417,Contemporary Mathematics,Kim,Jae Youn,50,78,28,10,18,0,12,2.68
+Fall 2024,MATH,2312,2,11419,Precalculus,Kartheiser,Abigail Louise,104,62,50,20,36,0,40,2.628
+Fall 2024,MATH,2312,3,11420,Precalculus,Perepelitsa,Irina,186,114,82,40,40,0,66,2.789
+Fall 2024,MATH,2312,5,11421,Precalculus,Almus,Melahat,170,134,82,38,22,0,82,2.857
+Fall 2024,MATH,2312,7,11422,Precalculus,May,Jennifer Ruhnow,204,120,70,38,60,0,46,2.729
+Fall 2024,MATH,2413,1,11423,Calculus I,Perepelitsa,Irina,196,92,48,42,52,0,46,2.783
+Fall 2024,MATH,2413,11,11427,Calculus I,Almus,Melahat,312,88,50,24,30,0,28,3.262
+Fall 2024,MATH,2413,21,11434,Calculus I,Perepelitsa,Irina,242,96,66,44,40,0,48,2.911
+Fall 2024,MATH,2413,31,11439,Calculus I,Sosa,Moses,192,90,78,36,36,0,82,2.841
+Fall 2024,MATH,2413,41,11442,Calculus I,May,Jennifer Ruhnow,128,74,56,26,52,0,48,2.603
+Fall 2024,MATH,2414,11,11447,Calculus II,Xhabli,Blerina,139,69,53,26,24,0,25,2.879
+Fall 2024,MATH,2414,21,11450,Calculus II,Xhabli,Blerina,82,65,42,26,37,0,45,2.499
+Fall 2024,MATH,1342,1,11452,Elementary Statistical Methods,Kim,Jae Youn,128,148,96,36,32,0,32,2.62
+Fall 2024,MATH,1342,2,11453,Elementary Statistical Methods,Kim,Jae Youn,112,104,88,34,48,0,48,2.455
+Fall 2024,MATH,1342,4,11454,Elementary Statistical Methods,Kartheiser,Abigail Louise,64,78,70,54,58,0,64,2.058
+Fall 2024,MATH,1342,5,11455,Elementary Statistical Methods,Ryan,John M,112,98,100,44,44,0,44,2.383
+Fall 2024,MATH,2415,1,11456,Calculus III,West,James David,61,54,38,23,27,0,27,2.475
+Fall 2024,MATH,2415,11,11459,Calculus III,Pan,Tsorng-Whay,70,50,44,12,11,0,10,2.801
+Fall 2024,MATH,3303,1,11463,Elts Algebra & Numb Thy,Gibson,Rebecca Ann,35,6,4,1,0,0,0,3.595
+Fall 2024,MATH,3321,2,11464,Engineering Mathematics,Etgen,Garret J,60,52,36,34,32,0,30,2.332
+Fall 2024,MATH,3331,1,11466,Intermediate Diff Equations,Sanders,Richard,16,14,12,4,1,0,3,2.837
+Fall 2024,MATH,3363,1,11467,Introduction To PDE,Morgan,Jeffrey,19,23,6,4,1,0,5,3.013
+Fall 2024,MATH,3364,1,11468,Intro Complex Analysis,Onofrei,Daniel T,14,8,3,2,0,0,11,3.174
+Fall 2024,MATH,4320,1,11469,Intro To Stochastic Processes,Ott,William R,16,12,1,0,2,0,0,3.216
+Fall 2024,MATH,6302,1,11470,Modern Algebra,Haynes,Alan K,12,0,0,1,0,0,2,3.718
+Fall 2024,MATH,6315,1,11471,Masters Tutorial,Jun,Mikyoung,4,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6315,2,11472,Masters Tutorial,Zhong,Ming,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6315,8,11478,Masters Tutorial,Ott,William R,2,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6315,9,11479,Masters Tutorial,Haynes,Alan K,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6320,1,11497,Func Real Variable,Bodmann,Bernhard G,8,2,2,0,0,0,3,3.418
+Fall 2024,MATH,6342,1,11498,Topology,Climenhaga,Vaughn,3,5,0,0,0,0,0,3.293
+Fall 2024,MATH,6366,1,11499,Optimization Theory,Charon,Nicolas,21,6,0,0,0,0,3,3.753
+Fall 2024,MATH,6370,1,11500,Numerical Analysis,Quaini,Annalisa,17,7,0,1,0,0,4,3.574
+Fall 2024,MATH,6398,6,11504,Special Problems,Mang,Andreas,0,0,0,0,0,2,0,
+Fall 2024,MATH,6398,8,11506,Special Problems,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Fall 2024,MATH,6398,10,11508,Special Problems,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Fall 2024,MATH,6398,13,11511,Special Problems,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,3,11525,Doctoral Research,Mang,Andreas,0,0,0,0,0,2,0,
+Fall 2024,MATH,8398,4,11526,Doctoral Research,Azencott,Robert Guy,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,5,11527,Doctoral Research,Blecher,David P,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,6,11528,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,8,11529,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,11,11532,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,15,11536,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,16,11537,Doctoral Research,Ru,Min,0,0,0,0,0,2,0,
+Fall 2024,MATH,8398,17,11538,Doctoral Research,Cappanera,Loic,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,22,11543,Doctoral Research,Labate,Demetrio,0,0,0,0,0,4,0,
+Fall 2024,MATH,8699,7,11548,Doctoral Dissertation,Kalantar,Mehrdad,1,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,1301,1,11549,College Physics I (lecture),Portillo Vazquez,Israel,5,15,26,8,3,0,13,2.181
+Fall 2024,PHYS,1302,1,11550,College Physics II (lecture),Portillo Vazquez,Israel,39,29,20,19,8,0,7,2.626
+Fall 2024,PHYS,1304,1,11551,Solar System,Li,Liming,181,115,10,1,1,0,3,3.475
+Fall 2024,PHYS,1303,1,11552,Stars and Galaxies,Bellwied,Rene,24,43,18,2,2,0,11,2.918
+Fall 2024,PHYS,2326,3,11554,University Physics II(lecture),Forrest,Rebecca L,15,26,84,11,4,0,9,2.208
+Fall 2024,PHYS,8398,3,11563,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8398,6,11566,Doctoral Research,Cherdack,Daniel David,0,0,0,0,0,4,0,
+Fall 2024,PHYS,8398,8,11568,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8398,12,11572,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8398,18,11576,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8398,23,11581,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8398,24,11582,Doctoral Research,Ordonez,Carlos,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8398,27,11584,Doctoral Research,Ratti,Claudia,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8398,32,11588,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8399,4,11593,Doctoral Dissertation,Bering,Edgar A,1,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,8399,6,11595,Doctoral Dissertation,Cherdack,Daniel David,1,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,8399,12,11600,Doctoral Dissertation,Das,Mini,1,1,0,0,0,0,0,3.665
+Fall 2024,PHYS,8399,21,11606,Doctoral Dissertation,Koerner,Lisa Whitehead,0,0,0,0,0,1,0,
+Fall 2024,ENGL,2306,1,11625,Intro To Poetry,Yates,Kaitlyn,15,5,1,0,3,0,1,3.195
+Fall 2024,HIST,1301,2,11628,The U.S. to 1877,Hopkins,Kelly Y,109,84,57,24,20,0,6,2.778
+Fall 2024,PHYS,1102,1,11655,College Physics II (lab),Wood,Lowell T,4,6,11,0,0,0,3,2.651
+Fall 2024,PHYS,1101,1,11656,College Physics I (lab),Wood,Lowell T,5,10,6,0,1,0,1,2.728
+Fall 2024,PHYS,1101,2,11657,College Physics I (lab),Wood,Lowell T,4,4,7,0,0,0,1,2.69
+Fall 2024,PHYS,1101,3,11658,College Physics I (lab),Wood,Lowell T,1,14,8,0,0,0,1,2.782
+Fall 2024,PHYS,1101,4,11659,College Physics I (lab),Wood,Lowell T,0,9,3,0,1,0,1,2.64
+Fall 2024,PHYS,1101,5,11660,College Physics I (lab),Wood,Lowell T,2,12,4,1,1,0,2,2.634
+Fall 2024,PHYS,1101,6,11661,College Physics I (lab),Wood,Lowell T,0,7,0,0,1,0,3,2.708
+Fall 2024,PHYS,1101,7,11662,College Physics I (lab),Wood,Lowell T,1,9,9,1,0,0,3,2.583
+Fall 2024,PHYS,1101,8,11663,College Physics I (lab),Wood,Lowell T,0,10,3,1,0,0,2,2.619
+Fall 2024,PHYS,1101,9,11664,College Physics I (lab),Wood,Lowell T,3,7,11,0,0,0,1,2.619
+Fall 2024,PHYS,1101,10,11665,College Physics I (lab),Wood,Lowell T,5,3,8,0,0,0,0,2.771
+Fall 2024,PHYS,1102,2,11666,College Physics II (lab),Wood,Lowell T,3,11,7,1,1,0,0,2.594
+Fall 2024,PHYS,1102,3,11667,College Physics II (lab),Wood,Lowell T,2,6,10,0,0,0,2,2.702
+Fall 2024,PHYS,1102,4,11668,College Physics II (lab),Wood,Lowell T,0,11,7,0,0,0,2,2.611
+Fall 2024,PHYS,1102,5,11669,College Physics II (lab),Wood,Lowell T,4,7,8,1,0,0,1,2.717
+Fall 2024,PHYS,1102,6,11670,College Physics II (lab),Wood,Lowell T,0,17,6,0,0,0,0,2.768
+Fall 2024,PHYS,1102,7,11671,College Physics II (lab),Wood,Lowell T,1,15,6,1,0,0,0,2.653
+Fall 2024,PHYS,1102,8,11672,College Physics II (lab),Wood,Lowell T,8,6,6,3,0,0,0,2.74
+Fall 2024,COSC,3380,1,11673,Database Systems,Ordonez,Carlos,21,32,14,2,3,0,15,2.985
+Fall 2024,COSC,4393,1,11674,Digital Image Processing,Mantini,Pranav,77,56,5,1,1,0,4,3.476
+Fall 2024,CHEM,4272,2,11678,Physical Chemistry Lab II,Czader,Arkadiusz,3,4,5,1,1,0,0,2.476
+Fall 2024,MATH,3340,1,11679,Intro To Fixed Income Math,Timofeyev,Ilya,6,6,11,2,0,0,9,2.627
+Fall 2024,BIOL,3306,2,11680,Evolutionary Biology,Azevedo,Ricardo,19,31,15,1,0,0,3,3.02
+Fall 2024,COSC,6358,1,11683,Interactive Game Development,Yun,Changhoon,3,6,0,1,0,0,0,3.034
+Fall 2024,COSC,4358,1,11684,Intro to Interactive Game Dev.,Yun,Changhoon,52,49,2,4,0,0,1,3.393
+Fall 2024,COSC,6355,1,11685,Ubiquitous Computing,Pavlidis,Ioannis T,0,3,0,0,0,0,0,2.89
+Fall 2024,COSC,4355,1,11686,Intro to Ubiquitous Computing,Pavlidis,Ioannis T,8,18,9,2,1,0,1,2.789
+Fall 2024,COSC,6380,1,11687,Digital Image Processing,Mantini,Pranav,23,7,0,0,0,0,0,3.745
+Fall 2024,BIOL,2120,3,11688,Microbiology for Non-Science,Knapp,Richard D,7,10,3,3,0,0,1,2.913
+Fall 2024,BIOL,2120,4,11689,Microbiology for Non-Science,Knapp,Richard D,5,12,4,1,0,0,1,2.94
+Fall 2024,MATH,2415,21,11695,Calculus III,West,James David,54,41,31,20,23,0,28,2.501
+Fall 2024,OPTO,5111,1,11698,Optics Lab I,Marsack,Jason,25,1,0,0,0,0,0,3.962
+Fall 2024,OPTO,5111,2,11699,Optics Lab I,Marsack,Jason,25,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,5111,3,11700,Optics Lab I,Marsack,Jason,24,0,0,0,0,0,0,3.986
+Fall 2024,OPTO,5111,4,11701,Optics Lab I,Marsack,Jason,25,1,0,0,0,0,0,3.962
+Fall 2024,OPTO,5133,3,11702,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,23,1,0,0,0,0,0,3.958
+Fall 2024,OPTO,5133,4,11703,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,15,9,2,0,0,0,0,3.5
+Fall 2024,OPTO,5134,1,11704,Neuroanatomy Laboratory,Cheng,Han,26,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,5134,2,11705,Neuroanatomy Laboratory,Cheng,Han,23,2,0,0,0,0,0,3.92
+Fall 2024,OPTO,5134,3,11706,Neuroanatomy Laboratory,Cheng,Han,25,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,5134,4,11707,Neuroanatomy Laboratory,Cheng,Han,25,0,1,0,0,0,0,3.923
+Fall 2024,OPTO,5171,1,11708,Clinic Practicum I,Kehinde,Lucy,16,10,0,0,0,0,0,3.615
+Fall 2024,OPTO,5171,2,11709,Clinic Practicum I,Kehinde,Lucy,10,14,1,0,0,0,0,3.36
+Fall 2024,OPTO,5171,3,11710,Clinic Practicum I,Kehinde,Lucy,19,5,0,0,0,0,0,3.792
+Fall 2024,OPTO,5171,4,11711,Clinic Practicum I,Berntsen,David A,9,16,1,0,0,0,0,3.308
+Fall 2024,OPTO,5233,1,11712,Adv Human Anatomy and Hist,Coulson-Thomas,Vivien J,59,30,9,3,0,0,0,3.436
+Fall 2024,OPTO,5271,1,11713,Optometry I,Kehinde,Lucy,62,37,2,0,0,0,0,3.607
+Fall 2024,OPTO,5314,1,11714,Optics I,Marsack,Jason,49,43,10,0,0,0,0,3.382
+Fall 2024,OPTO,5320,1,11715,Vision Science I,Yoon,Geunyoung,44,43,14,0,0,0,0,3.297
+Fall 2024,OPTO,5334,1,11716,Neuroanat and Physio,Cheng,Han,66,26,8,1,0,0,0,3.554
+Fall 2024,OPTO,5344,1,11717,Adv Physiol and Molecular Biol,Frishman,Laura J,25,49,19,8,0,0,0,3.009
+Fall 2024,OPTO,6132,1,11718,Med Laboratory Proced,Garza,Janet,25,1,0,0,0,0,0,3.962
+Fall 2024,OPTO,6132,2,11719,Med Laboratory Proced,Garza,Janet,22,2,0,0,0,0,0,3.917
+Fall 2024,OPTO,6132,3,11720,Med Laboratory Proced,Garza,Janet,19,3,0,0,0,0,0,3.864
+Fall 2024,OPTO,6132,4,11721,Med Laboratory Proced,Garza,Janet,20,2,0,0,0,0,0,3.909
+Fall 2024,OPTO,6163,1,11722,Primary Opt Lab,Chandler,Moriah Adine,21,4,0,0,0,0,0,3.84
+Fall 2024,OPTO,6163,2,11723,Primary Opt Lab,Chandler,Moriah Adine,20,4,0,0,0,0,0,3.833
+Fall 2024,OPTO,6163,3,11724,Primary Opt Lab,Chandler,Moriah Adine,19,4,0,0,0,0,0,3.826
+Fall 2024,OPTO,6163,4,11725,Primary Opt Lab,Chandler,Moriah Adine,22,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,6173,1,11726,Clinic Practicum III,Giannoni,Amber Gaume,19,5,1,0,0,0,0,3.72
+Fall 2024,OPTO,6173,2,11727,Clinic Practicum III,Giannoni,Amber Gaume,20,4,0,0,0,0,0,3.833
+Fall 2024,OPTO,6173,3,11728,Clinic Practicum III,Giannoni,Amber Gaume,20,1,2,0,0,0,0,3.783
+Fall 2024,OPTO,6173,4,11729,Clinic Practicum III,Giannoni,Amber Gaume,18,3,0,0,1,0,0,3.682
+Fall 2024,OPTO,6190,1,11730,Ophthalmic Optics Laboratory,Tucker,Ashley,25,1,0,0,0,0,0,3.962
+Fall 2024,OPTO,6190,2,11731,Ophthalmic Optics Laboratory,Tucker,Ashley,22,2,0,0,0,0,0,3.917
+Fall 2024,OPTO,6190,3,11732,Ophthalmic Optics Laboratory,Tucker,Ashley,20,1,2,0,0,0,0,3.783
+Fall 2024,OPTO,6190,4,11733,Ophthalmic Optics Laboratory,Tucker,Ashley,20,2,0,0,0,0,0,3.909
+Fall 2024,OPTO,6219,1,11734,Vision Science III,Das,Vallabh E,39,42,12,0,1,0,0,3.234
+Fall 2024,OPTO,6231,1,11735,Corneal Disease,Bergmanson,Jan Pg,0,0,0,0,0,32,0,
+Fall 2024,OPTO,6234,1,11736,Ocular Pathology I,Kehinde,Lucy,39,33,20,0,2,0,0,3.138
+Fall 2024,OPTO,6251,1,11737,Spanish for Optometrists,Cruz Wiley,Maria Cristina,0,0,0,0,0,8,0,
+Fall 2024,OPTO,6311,1,11738,Optics III,Ritchey,Eric R,51,34,9,0,1,0,0,3.411
+Fall 2024,OPTO,6363,1,11739,Primary Optometry,Stevenson,Scott Bailli,53,36,5,0,0,0,0,3.511
+Fall 2024,OPTO,6434,1,11740,General Pharmacology,Rump,Rachel,26,34,31,0,4,0,0,2.804
+Fall 2024,OPTO,7152,1,11741,Pediatric Optometry II Lab,Martinez,Muriel L,18,2,0,0,0,0,0,3.9
+Fall 2024,OPTO,7152,2,11742,Pediatric Optometry II Lab,Martinez,Muriel L,20,6,0,0,0,0,0,3.769
+Fall 2024,OPTO,7152,3,11743,Pediatric Optometry II Lab,Martinez,Muriel L,20,3,0,0,0,0,0,3.87
+Fall 2024,OPTO,7152,4,11744,Pediatric Optometry II Lab,Martinez,Muriel L,22,2,0,0,0,0,0,3.917
+Fall 2024,OPTO,7252,1,11745,Pediatric Optometry II,Plaumann,Maureen Daley,42,36,15,0,0,0,0,3.29
+Fall 2024,OPTO,7361,1,11746,Geriatric Optometry,Segu,Padhmalatha,77,18,1,0,0,0,0,3.792
+Fall 2024,OPTO,7494,1,11747,General Clinic IIIb,Herring,Ralph Jay,0,0,0,0,0,94,0,
+Fall 2024,OPTO,8990,1,11748,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,34,0,
+Fall 2024,OPTO,8991,1,11749,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,34,0,
+Fall 2024,OPTO,8992,1,11750,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,30,0,
+Fall 2024,OPTO,8993,1,11751,Community Health Clinic,Herring,Ralph Jay,0,0,0,0,0,30,0,
+Fall 2024,PHOP,6160,1,11752,Gen Sem Visual Sciences,Matynia,Anna,0,0,0,0,0,29,0,
+Fall 2024,PHOP,6241,1,11755,Vision Science Core-Part 1,Frishman,Laura J,5,1,2,0,0,0,0,3.458
+Fall 2024,PHOP,6242,1,11756,Vision Science Core-Part 2,Frishman,Laura J,5,3,0,0,0,0,0,3.666
+Fall 2024,OPTO,5198,2,11759,Spec Prob - Clerkship,Dempsey,Robert L,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6441,1,11760,Advanced Pharmacokinetics,Chow,Diana Shu-Lian,7,2,1,0,0,0,0,3.6
+Fall 2024,PCEU,6498,1,11761,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,6370,1,11762,Advanced Pharmacology,Boini,Krishna M,7,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,7180,1,11763,Pharmacology Seminar,McConnell,Bradley K,0,0,0,0,0,20,0,
+Fall 2024,PHAR,4270,1,11765,Communication Aspects of Pharm,Gee,Jodie Sue,64,48,2,0,0,0,0,3.544
+Fall 2024,PHAR,4320,1,11766,Physiology I,Salim,Samina,41,45,29,3,1,0,0,3.025
+Fall 2024,PHAR,4330,1,11767,Pharmaceutics I & Calculations,Guo,Bin,45,37,31,2,0,0,0,3.087
+Fall 2024,PHAR,5332,1,11768,Pharmacokinetics,Chow,Diana Shu-Lian,27,51,24,1,2,0,1,2.952
+Fall 2024,PHAR,5642,1,11769,Emergency Medicine,Truong,Mabel,6,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5643,1,11770,Neurology,Truong,Mabel,1,1,0,0,0,0,0,3.5
+Fall 2024,PHAR,5662,1,11771,Academic Scholarship,Surati,Dhara Divyang,2,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5663,1,11772,Pharmacy Management,Truong,Mabel,2,1,0,0,0,0,0,3.667
+Fall 2024,PHAR,5664,1,11773,Legal & Regulatory Affairs,Tolleson,Shane Russell,3,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5670,1,11774,Community Pharmaceutical Care,Tolleson,Shane Russell,12,5,0,0,0,0,0,3.706
+Fall 2024,PHAR,5675,1,11776,Disease State Management,Tolleson,Shane Russell,31,2,1,0,1,0,0,3.771
+Fall 2024,PHAR,5678,1,11777,Transplant Therapeutics,Truong,Mabel,1,1,0,0,0,0,0,3.5
+Fall 2024,PHAR,5679,1,11778,Women's Health Therapeutics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5680,1,11779,Oncology,Truong,Mabel,3,3,0,0,0,0,0,3.5
+Fall 2024,PHAR,5685,1,11781,Critical Care,Truong,Mabel,10,3,1,0,1,0,0,3.4
+Fall 2024,PHAR,5690,1,11784,Internal Medicine,Sherer,Jeffrey T,2,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5690,2,11785,Internal Medicine,Truong,Mabel,38,6,0,0,0,0,0,3.864
+Fall 2024,PHAR,5692,1,11787,Advanced Hospital Pharmacy,Truong,Mabel,41,6,0,0,0,0,0,3.872
+Fall 2024,PHAR,5693,1,11788,Advanced Community Pharmacy,Tolleson,Shane Russell,21,3,1,0,0,0,0,3.8
+Fall 2024,PHAR,5694,1,11789,Pediatrics,Truong,Mabel,5,2,0,0,0,0,0,3.714
+Fall 2024,PHAR,5695,1,11790,Geriatrics,Tolleson,Shane Russell,1,0,1,0,0,0,0,3.0
+Fall 2024,PHAR,5696,3,11792,Ambulatory Care - Primary Care,Tolleson,Shane Russell,5,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,3354,1,11795,Nonprofit Management,Battle,Jennifer Alene,4,0,0,0,0,0,0,3.918
+Fall 2024,SOCW,6354,1,11796,Managing Human Services Orgs,Battle,Jennifer Alene,15,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7356,1,11797,Groups: Adv Clinical Practice,Parks,Steven Lee,30,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7384,1,11798,SW Practicum III - Clinical,Gonzales,Shelley A,0,0,0,0,0,8,0,
+Fall 2024,SOCW,7385,1,11799,SW Practicum IV- Clinical,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Fall 2024,SOCW,8699,1,11804,Dissertation,Gearing,Robin Edward,0,0,0,0,0,1,0,
+Fall 2024,CNST,1301,1,11805,Constructn Materials & Methods,Zaheri,Mohammad J,63,74,5,1,0,0,3,3.41
+Fall 2024,CNST,2341,1,11806,Construction Documents,Murphy,Kevin Michael,36,20,7,0,0,0,2,3.413
+Fall 2024,CNST,4331,1,11807,Construction Management II,Khan,Taimoor,26,7,0,0,0,0,0,3.658
+Fall 2024,ELET,2101,1,11808,Poly-Phase Circuits Laboratory,Fan,Lei,10,4,0,0,0,0,0,3.667
+Fall 2024,ELET,2101,2,11809,Poly-Phase Circuits Laboratory,Fan,Lei,4,0,0,0,0,0,0,4.0
+Fall 2024,ELET,2300,1,11810,Introductn To C++ Programming,Lent,Marino Ricardo,7,11,11,3,1,0,7,2.606
+Fall 2024,ELET,2303,1,11811,Digital Systems,Yuan,Xiaojing,12,21,5,0,0,0,1,3.167
+Fall 2024,ELET,3107,1,11813,Electrical Mach & Control Lab,Fan,Lei,6,5,0,0,0,0,0,3.485
+Fall 2024,ELET,3107,2,11814,Electrical Mach & Control Lab,Fan,Lei,0,3,4,0,0,0,0,2.57
+Fall 2024,ELET,3307,1,11815,Electrical Machines & Controls,Fan,Lei,5,10,5,0,0,0,0,2.967
+Fall 2024,ELET,3405,1,11816,Microprocessor Architecture,Soneja,Chandrayee,10,7,1,1,0,0,1,3.334
+Fall 2024,ELET,3425,1,11817,Embedded Systems,Moges,Mequanint A,5,8,9,0,0,0,0,2.713
+Fall 2024,ELET,4208,1,11819,Senior Project Laboratory,Moges,Mequanint A,18,9,0,0,0,0,0,3.716
+Fall 2024,ELET,4308,1,11820,Senior Project,Moges,Mequanint A,21,3,0,0,0,0,0,3.765
+Fall 2024,ELET,4310,1,11821,Alternative Energy Sources,Shireen,Wajiha,10,11,1,0,0,0,0,3.379
+Fall 2024,ELET,4317,1,11822,Elec Sys Safety & Protection,Shi,Jian,17,3,0,0,0,0,0,3.784
+Fall 2024,ELET,4421,1,11823,Computer Networks,Hu,Bin,9,14,4,1,0,0,0,3.072
+Fall 2024,HDCS,1300,1,11825,Human Ecosystems & Tech Change,Mudd,Blake Stevens,40,3,0,1,2,0,4,3.681
+Fall 2024,HDCS,1300,2,11826,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,40,6,2,0,1,0,1,3.667
+Fall 2024,HDCS,1300,3,11827,Human Ecosystems & Tech Change,Ginwright,Alexis Jordan,22,19,1,0,3,0,4,3.267
+Fall 2024,HDCS,3300,1,11828,Org Decisions,Stewart,Quentin K,28,13,4,1,2,0,1,3.326
+Fall 2024,HDCS,2301,1,11829,Consumer Science,Stewart,Juliana Floriene,14,5,3,2,5,0,1,2.713
+Fall 2024,HDCS,3303,1,11830,Retailing and Consumer Science,Jacobs,Karen S,22,2,2,0,0,0,0,3.642
+Fall 2024,HDCS,3303,2,11831,Retailing and Consumer Science,Rifai,Rana Ihsan,32,7,3,5,1,0,2,3.271
+Fall 2024,HDCS,3304,1,11832,Visual Merchandising,Stewart,Barbara L,16,16,6,2,1,0,0,3.081
+Fall 2024,HDCS,4300,1,11833,Research Concepts in Hdcs,Gatterson,Beverly,24,6,3,2,0,0,1,3.42
+Fall 2024,HDCS,4302,1,11834,Apparel Analysis,Gatterson,Beverly,48,9,2,0,0,0,0,3.735
+Fall 2024,HDCS,4380,1,11835,Merchandising,Jacobs,Karen S,14,8,5,1,0,0,0,3.226
+Fall 2024,HDCS,4394,1,11837,Internship in RCS,Ezell,Shirley D,2,1,0,0,0,0,0,3.557
+Fall 2024,HRD,6304,30,11838,Research in Human Resource Dev,Waight,Consuelo L,6,0,0,0,0,0,0,4.0
+Fall 2024,TECH,1301,1,11839,Intro to Data Analytics Tools,Roberts,Phyllis Rayburn,15,21,6,1,2,0,2,3.059
+Fall 2024,MECT,3155,30,11840,Strength Materials Lab,Al Ibadi,Adnan,17,2,0,0,0,0,1,3.912
+Fall 2024,MECT,4172,30,11842,Materials Tech Lab,Al Ibadi,Adnan,9,10,1,0,0,0,0,3.4
+Fall 2024,MECT,4372,30,11843,Materials Technology,Robles Hernandez,Francisco C,10,11,13,2,2,0,0,2.632
+Fall 2024,TECH,3365,1,11844,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,40,3,2,0,1,0,3,3.761
+Fall 2024,TECH,3365,2,11845,Appl of Discrete Mthds in Tech,Larsen,Marilyn Annette,16,4,5,2,1,0,1,3.178
+Fall 2024,TLIM,4341,33,11846,Production & Service Operation,Cao,Shun,28,4,0,1,0,0,1,3.788
+Fall 2024,TMTH,3360,2,11848,Applied Technical Statistics,Thornton,Brandon Latroy,12,5,4,6,3,0,1,2.545
+Fall 2024,CNST,1330,1,11849,Graphics I,Clark,Peter J,57,65,18,0,7,0,3,3.096
+Fall 2024,MECT,4275,30,11851,Senior Design Project I,Afrin,Samia,18,7,0,0,0,0,0,3.628
+Fall 2024,ELET,3402,1,11852,Communications Circuits,Velusamy,Gandhimathi,14,14,2,0,0,0,0,3.367
+Fall 2024,MECT,3118,30,11854,Fluid Mechanic Application Lab,Al Ibadi,Adnan,18,2,0,0,0,0,0,3.867
+Fall 2024,TEPM,6395,20,11856,Integration Project,Carden,Lila L,3,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6302,20,11857,Leadership and Team Building,Hopkins,Ronald K,10,0,0,0,0,0,0,3.802
+Fall 2024,CNST,1361,1,11858,Construction Management I,Senouci,Ahmed,180,24,3,2,4,0,2,3.756
+Fall 2024,CNST,2321,1,11859,Mechanical & Electrical System,Gonzalez,Marcos G,39,30,4,0,0,0,1,3.543
+Fall 2024,CNST,3155,1,11860,Const Materials & Testing,Meyer,Joseph Ray,52,31,3,0,1,0,0,3.536
+Fall 2024,MECT,4276,30,11862,Senior Design Project II,Afrin,Samia,14,5,0,0,0,0,0,3.754
+Fall 2024,MECT,1330,30,11864,Engineering Graphics,Fan,Zheng,4,15,10,1,3,0,4,2.425
+Fall 2024,HRD,6305,1,11865,Organizational Learning,Greer,Tomika,12,4,1,0,1,0,0,3.499
+Fall 2024,HDCS,4372,1,11866,Forecasting for Tech Entrep.,Breaux,James William,26,6,3,2,3,0,0,3.192
+Fall 2024,BTEC,3200,30,11867,Biotech Research Methods,Ibrahim,Eman Refaat,16,1,0,0,0,0,0,3.922
+Fall 2024,GEOL,1103,6,11868,Physical Geology Lab,Hauptvogel,Daniel William,11,5,1,0,1,0,2,3.352
+Fall 2024,ACCT,5331,1,11869,Federal Income Tax,Fernandez,Ramon,3,9,1,0,1,0,2,2.976
+Fall 2024,MATH,3339,2,11870,Statistics for the Sciences,Niu,Yabo,67,18,13,0,0,0,1,3.558
+Fall 2024,MATH,3363,3,11871,Introduction To PDE,Mamonov,Alexander V,10,29,6,4,3,0,7,2.775
+Fall 2024,PSYC,3350,1,11872,Intro to Cognitive Psychology,Hernandez,Arturo E,47,59,19,4,5,0,6,3.035
+Fall 2024,MATH,4389,1,11873,Survey of Undergraduate Math,Climenhaga,Vaughn,11,14,8,0,1,0,0,2.981
+Fall 2024,ECE,5113,1,11875,Microwave Engineering Lab,Chen,Ji,1,0,0,0,0,0,0,4.0
+Fall 2024,HRD,3310,1,11876,Talent Management,Shakir,Khalimah,26,8,7,2,2,0,5,3.134
+Fall 2024,HDCS,1300,4,11877,Human Ecosystems & Tech Change,Selzer,Lori Michele,18,24,3,2,1,0,2,3.139
+Fall 2024,COMM,4366,1,11879,Advertising Account Planning,Tinnel,Jason Wayne,10,11,0,1,0,0,0,3.289
+Fall 2024,SOCW,6201,1,11880,Foundation of Social Work Prof,Gonzales,Shelley A,0,0,0,0,0,145,1,
+Fall 2024,GEOL,6396,1,11881,Graduate Seminar,Zhang,Honghai,0,0,0,0,0,5,0,
+Fall 2024,GHL,4336,1,11882,Beverage Marketing,Taylor,David C,9,8,3,0,1,0,0,3.08
+Fall 2024,GHL,6330,1,11883,Statistical Analysis in Hosp.,Shin,Min Jung,10,2,1,0,1,0,0,3.405
+Fall 2024,GHL,7353,1,11884,Services Management in Hosp.,Boger Jr,Carl A,5,0,0,0,0,0,0,4.0
+Fall 2024,MIS,3360,1,11885,Systems Analysis and Design,Fuller,Kalai,56,9,1,0,0,0,1,3.783
+Fall 2024,MIS,3360,2,11886,Systems Analysis and Design,Fuller,Kalai,45,20,2,0,0,0,0,3.617
+Fall 2024,FREN,2311,2,11887,Intermediate French I,Chalhoub,Rania Maria,11,6,2,1,0,0,0,3.334
+Fall 2024,AFSC,3301,3,11888,Air Force Leadership I,Whitfield,David,4,2,0,0,0,0,0,3.612
+Fall 2024,CUIN,3351,2,11890,Class Interact Science-Math,Latiolais,Cheryl S,7,0,0,0,0,0,0,3.906
+Fall 2024,BIOL,2101,10,11891,Anatomy & Physiology Lab I,Gill,Tejendra,7,11,3,2,0,0,1,3.029
+Fall 2024,BIOL,2101,11,11892,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,4,3,1,0,1,2.653
+Fall 2024,ARCH,3354,1,11893,The Culture of Architecture,Turner,Drexel,9,7,0,0,0,0,1,3.583
+Fall 2024,ARCH,4351,1,11894,Readings & Criticism in Arch,Turner,Drexel,12,6,0,0,0,0,0,3.502
+Fall 2024,ARCH,4355,1,11896,Houston Architecture,Fox,Stephen,11,0,1,0,0,0,2,3.723
+Fall 2024,ARCH,6355,1,11897,Houston Architecture,Fox,Stephen,4,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5408,1,11898,Property,Bregant,Jessica Lynn,13,19,0,0,0,0,0,3.417
+Fall 2024,LAW,5371,1,11899,Int'l Petroleum Transaction,Wright,Denney L,4,4,0,0,0,3,1,3.459
+Fall 2024,LAW,6355,1,11900,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,1,0,
+Fall 2024,SOCW,6306,1,11903,Social Work Practice Skills,Gonzales,Shelley A,28,1,0,0,0,0,0,3.966
+Fall 2024,LAW,5410,1,11904,Law Review,Sanders,Joseph,0,0,0,0,0,3,0,
+Fall 2024,PUBL,6310,1,11905,Administrative Theory,Francis,Sara Sands,9,6,0,0,0,0,0,3.556
+Fall 2024,PHLS,8361,1,11906,Eco-Behavioral Interventions,McPherson,Robert Harlan,6,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8363,1,11907,Research in School Psych,Smith,Bradley,3,2,0,0,0,0,0,3.666
+Fall 2024,ELED,3320,2,11908,Survey Literature Child Adol,Alba,Celeste,19,1,0,0,0,0,1,3.934
+Fall 2024,CUIN,4350,1,11909,Multiple Teaching Strategies,Segura,Perri F,11,0,0,0,0,0,0,3.91
+Fall 2024,PSYC,4344,2,11910,Cultural Psychology,Jewell,Rebecca D,65,6,3,4,1,0,1,3.666
+Fall 2024,SOCW,6306,2,11911,Social Work Practice Skills,Gonzales,Shelley A,27,1,0,0,0,0,0,3.964
+Fall 2024,SOCW,6306,3,11912,Social Work Practice Skills,Parker,Jamie Lynne,25,4,0,0,0,0,0,3.862
+Fall 2024,DRAM,2351,1,11913,Acting III,Pistorius,Allison Marie,7,3,3,0,0,0,0,3.257
+Fall 2024,THEA,2332,1,11914,Voice & Mvmnt for the Actor I,Majkowski,Vivian,15,3,0,0,0,0,0,3.723
+Fall 2024,DRAM,2331,1,11915,Lighting and Sound Technology,Webb,Matthew Clark,19,2,0,0,0,0,0,3.873
+Fall 2024,DANC,4307,1,11917,Teaching Dance in Education,Woodson,Elizabeth Ann,3,4,1,0,0,0,0,3.209
+Fall 2024,ACCT,3371,1,11919,Accounting Information Systems,Seijas,Nuria S,18,21,9,0,0,0,1,3.201
+Fall 2024,CNST,6310,1,11921,Construction Contract Administ,Ducran,Denis George,23,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6303,2,11922,Risk Assessment in Project Mgm,Rypien,David V,13,2,0,0,0,0,0,3.911
+Fall 2024,COMD,2338,2,11923,Phonetics,Bunta,Ferenc,14,8,4,1,0,0,3,3.235
+Fall 2024,COMD,1333,1,11924,Intro to Comm Sci & Disorders,Ross,Byron L,11,16,8,0,0,0,2,3.048
+Fall 2024,ENTR,3310,3,11927,Entrepreneurship,Ortega,Carlos Alberto,138,41,8,2,0,0,3,3.602
+Fall 2024,ENGL,1301,115,11928,First Year Writing I,Jones,Baylea,18,5,1,1,0,0,0,3.626
+Fall 2024,FREN,1501,3,11929,Elementary French I,Chalhoub,Rania Maria,13,7,2,1,0,0,0,3.277
+Fall 2024,FREN,1501,5,11931,Elementary French I,Gnanwo Hounfodji,Raymond,2,5,6,2,2,0,6,2.176
+Fall 2024,SOCW,6305,1,11933,Social Work Research,Leung,Yuk-Hi Patrick,28,1,0,0,0,0,0,3.966
+Fall 2024,SOCW,6305,2,11934,Social Work Research,Davies,Holly,19,8,1,0,0,0,0,3.643
+Fall 2024,SOCW,6305,3,11935,Social Work Research,Jacobs,Alexandra L,26,0,0,0,0,0,0,4.0
+Fall 2024,HON,3399,2,11936,Senior Honors Thesis,Gunaratne,Preethi H,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3310,1,11937,Indstrl-Orgnztnl Psy,Reyes,Denise Lucia,43,9,3,1,1,0,2,3.649
+Fall 2024,HDFS,3300,2,11938,Educational Psychology,Kamdar-Sharif,Amber,32,14,6,1,0,0,0,3.391
+Fall 2024,DRAM,1310,2,11939,Introduction to Theatre,Ostrow,Stuart,46,1,0,0,0,0,0,3.979
+Fall 2024,ACCT,6331,3,11942,Financial Accounting,Zhu,Limin,7,11,1,0,0,0,0,3.333
+Fall 2024,BIOL,2120,5,11948,Microbiology for Non-Science,Knapp,Richard D,10,9,5,0,0,0,0,3.181
+Fall 2024,MATH,2318,3,11952,Linear Algebra,Zhong,Ping,15,11,14,5,3,0,4,2.591
+Fall 2024,ENTR,3310,5,11956,Entrepreneurship,Ortega,Carlos Alberto,112,66,8,2,3,0,5,3.456
+Fall 2024,ARCH,5500,7,11957,Architecture Design Studio IX,Logan,Jason,11,4,0,0,0,0,0,3.645
+Fall 2024,PHLS,7393,1,11959,Internship and Practicum,Reyna,Ronda,5,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6102,1,11973,Acting for Opera,Belcher,Kathleen,9,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8398,9,11980,Independent Study,Zhang,Jie,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,1311,4,11981,Music Theory I,Guez,Jonathan Charles,5,6,3,0,1,0,3,2.977
+Fall 2024,MUSI,1116,4,11982,Aural Skills I,Guez,Jonathan Charles,4,4,2,1,1,0,4,2.723
+Fall 2024,MUSI,2210,2,11983,Theory III,Snyder,John L,8,9,6,0,0,0,2,3.058
+Fall 2024,MUSI,2210,4,11984,Theory III,Snyder,John L,11,8,1,1,0,0,2,3.35
+Fall 2024,MUSI,2116,2,11985,Aural Skills III,Snyder,John L,7,10,6,0,0,0,2,3.015
+Fall 2024,MUSI,2116,4,11986,Aural Skills III,Snyder,John L,6,12,2,0,0,0,4,3.184
+Fall 2024,ENGL,1302,52,11987,First Year Writing II,Raines,Daniel,3,7,3,1,2,0,3,2.376
+Fall 2024,GEOL,1103,3,12006,Physical Geology Lab,Hauptvogel,Daniel William,19,3,0,0,1,0,1,3.638
+Fall 2024,GEOL,1347,1,12007,Introduction To Meteorology,Jiang,Xun,266,28,3,0,0,0,1,3.804
+Fall 2024,ECON,2301,1,12008,Principles of Macroeconomics,Zhang,Yuwei,16,41,14,5,1,0,2,2.861
+Fall 2024,FINA,4320,1,12009,Investment Management,Doshi,Hitesh B,27,18,2,5,0,0,0,3.295
+Fall 2024,ARTS,2348,1,12010,Digital Tools,Hillerbrand,Stephan C,12,2,0,0,1,0,0,3.534
+Fall 2024,MIS,3370,2,12011,Info Systems Development Tools,Ingram,Barry,13,22,15,5,4,0,7,2.593
+Fall 2024,ITAL,1501,1,12012,Elementary Italian I,Ercolani,Monica,18,3,0,0,0,0,2,3.873
+Fall 2024,ITAL,1501,5,12014,Elementary Italian I,Ercolani,Monica,16,4,0,0,1,0,1,3.556
+Fall 2024,ECON,6475,1,12016,Macroeconomic Analysis,Thornton,Rebecca Achee,7,3,0,0,0,0,0,3.568
+Fall 2024,ECON,6485,1,12017,Microeconomic Analysis,Saboury,Piruz,7,6,0,0,0,0,0,3.488
+Fall 2024,ECON,6465,1,12018,Econometrics,Chin,Aimee,7,5,0,0,0,0,0,3.611
+Fall 2024,ARTS,2356,1,12019,Fundamentals of Photo/DM,Nava Ruiz,Amy Vianney,14,2,0,1,1,0,0,3.5
+Fall 2024,ARTS,2356,2,12020,Fundamentals of Photo/DM,Boncy,Jean Sebastien,15,2,1,0,0,0,0,3.759
+Fall 2024,ARTS,2356,3,12021,Fundamentals of Photo/DM,Durand,Claudia R,13,1,2,1,1,0,0,3.242
+Fall 2024,FINA,4341,1,12022,Commercial Bank Management,Lara,Alexander J,33,1,2,1,0,0,0,3.793
+Fall 2024,CUIN,3351,3,12023,Class Interact Science-Math,Mateer,Ramona Caravella,2,0,0,0,1,0,0,2.667
+Fall 2024,MUSA,1176,1,12024,Applied Jazz Percussion,Hubley,Robert L,6,3,0,0,0,0,1,3.557
+Fall 2024,MANA,3335,2,12025,Intro Org Behavior and Mgmt,Currie,Daniel David,167,71,7,2,0,0,2,3.573
+Fall 2024,EDUC,4314,3,12026,Clinical Teaching 1-Secondary,Evans,Paige K,6,1,0,0,0,0,0,3.904
+Fall 2024,EDUC,4315,3,12027,Clinical Teaching 2-Secondary,Evans,Paige K,6,1,0,0,0,0,0,3.857
+Fall 2024,ELED,3322,2,12028,Elem Reading Phonics Instructn,Alba,Celeste,23,0,1,0,0,0,0,3.848
+Fall 2024,EDUC,4324,1,12029,Clinical Teaching 1-Middle Sch,Culpepper,Shea Mosley,23,4,0,0,0,0,0,3.815
+Fall 2024,MUSI,3215,4,12030,Introduction To Large Forms,Guez,Jonathan Charles,10,5,0,0,0,0,0,3.645
+Fall 2024,MUED,4343,1,12031,Choral Materials Grades 4-12,Wilkinson,Loneka,6,1,0,0,0,0,0,3.81
+Fall 2024,GHL,6355,1,12032,Event Administration,Draper,Jason A,12,1,0,0,0,0,1,3.948
+Fall 2024,LAW,5488,1,12033,Constitutional Law,Berman,Emily,14,31,0,0,0,0,0,3.399
+Fall 2024,PHYS,4321,1,12034,Int Electromagnetic Theory I,Cherdack,Daniel David,6,4,4,1,1,0,3,2.813
+Fall 2024,LAW,5357,3,12035,Evidence,Crump,David L,33,42,5,0,0,0,0,3.375
+Fall 2024,HON,3310,1,12036,Creativity at Work,Cremins,Robert Paul,46,2,0,0,0,0,0,3.848
+Fall 2024,BIOL,1106,5,12037,Biol for Science Majors I(Lab),Medrano,Ana I,14,3,2,1,1,0,3,3.27
+Fall 2024,ELET,4326,1,12039,Power Converter Circuits,Shireen,Wajiha,8,9,2,0,0,0,0,3.351
+Fall 2024,CNST,2351,1,12040,Construction Estimating I,Sheppard,Travis,43,14,5,0,0,0,2,3.613
+Fall 2024,FINA,7371,1,12041,Energy Value Chain,Slaughter,Andrew Jeremy,7,2,0,0,0,0,0,3.778
+Fall 2024,CNST,6310,2,12042,Construction Contract Administ,Ducran,Denis George,40,0,0,0,0,0,0,4.0
+Fall 2024,COSC,4372,1,12043,Fundamental of Medical Imaging,Tsekos,Nikolaos V,61,8,4,0,0,0,0,3.727
+Fall 2024,CNST,6350,1,12044,Decision Making and Risk Mgmt,Gao,Lu,24,0,0,0,0,0,0,3.973
+Fall 2024,THEA,3320,1,12045,Acting V,Pistorius,Allison Marie,5,5,0,0,0,0,0,3.533
+Fall 2024,THEA,3350,1,12046,Movement for the Actor III,Clark,Kyle Richard,10,0,0,0,0,0,0,4.0
+Fall 2024,THEA,3380,1,12047,Voice for the Actor III,Wetzel,Molly Elizabeth,7,2,1,0,0,0,0,3.567
+Fall 2024,POLS,3390,1,12048,Women in Politics,Sims,Nancy Lou,33,12,1,0,0,0,0,3.653
+Fall 2024,THEA,1111,1,12049,Production,Vlahos,Kalliope,20,1,0,0,0,0,1,3.921
+Fall 2024,THEA,1111,2,12050,Production,Stepanik,Amber Yvonne,23,1,0,0,0,0,0,3.931
+Fall 2024,THEA,1112,1,12051,Production,Vlahos,Kalliope,14,0,0,0,0,0,2,3.953
+Fall 2024,THEA,2390,1,12052,Technical Drawing,Vintu,Tatiana,6,4,1,0,1,0,1,3.084
+Fall 2024,THEA,3387,1,12053,Lighting Design,Webb,Matthew Clark,10,0,1,1,0,0,0,3.583
+Fall 2024,WGSS,2350,5,12054,Intro To Women's Studies,Slatton,Brittany Chevon,25,2,1,1,0,0,0,3.736
+Fall 2024,MECE,4340,1,12055,Mechanical Engr Capstone I,Chang,Christiana,38,59,8,0,0,0,3,3.283
+Fall 2024,MIS,7376,1,12056,Systems Analysis and Design,Johnson,Glynn L,13,11,1,0,1,0,0,3.384
+Fall 2024,CUIN,4361,1,12057,Second Language Methodology,Burgess,Miguel,24,1,0,0,0,0,0,3.96
+Fall 2024,WGSS,2350,7,12058,Intro To Women's Studies,Pegoda,Andrew Joseph,9,6,8,0,2,0,5,2.708
+Fall 2024,ANTH,2351,1,12060,Intro to Cultural Anthropology,Hannaford,Dinah Rebecca,63,24,7,1,1,0,0,3.497
+Fall 2024,MUSA,4400,5,12061,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5668,1,12063,Managed Care Pharmacy,Tolleson,Shane Russell,5,1,0,0,0,0,0,3.833
+Fall 2024,ENGL,1301,127,12067,First Year Writing I,Jones,Baylea,15,4,2,0,3,0,1,3.07
+Fall 2024,ELET,4126,1,12068,Power Converter Circuits Lab,Shireen,Wajiha,19,0,0,0,0,0,0,3.861
+Fall 2024,BIOL,2101,12,12069,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,5,2,0,0,0,2.879
+Fall 2024,BIOL,2101,13,12070,Anatomy & Physiology Lab I,Gill,Tejendra,5,16,3,0,0,0,0,3.097
+Fall 2024,CNST,1325,1,12073,Process & Industrial Construct,Ponnusamy,Ravi Chandran,14,19,5,0,0,0,0,3.237
+Fall 2024,CNST,4341,1,12074,Project Controls,Bouhou,Nour-El Imane,19,39,4,0,0,0,0,3.247
+Fall 2024,ENGL,1301,128,12075,First Year Writing I,Penzien,Eugene Norman,15,7,0,0,1,0,1,3.407
+Fall 2024,ENGL,1302,1,12076,First Year Writing II,Lee,Nathanael D,13,8,0,0,1,0,2,3.26
+Fall 2024,SOC,6399,5,12078,Masters Thesis,Anderson,Kathryn,3,0,0,0,0,0,0,4.0
+Fall 2024,MANA,6332,2,12079,Organiztnl Behavior & Mangemnt,Werner,Steve,8,1,0,0,0,0,0,3.779
+Fall 2024,MUSA,4400,6,12080,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2320,1,12081,Abnormal Psychology,Venta,Amanda Cristina,13,26,5,0,0,0,1,3.189
+Fall 2024,ENGL,1301,129,12082,First Year Writing I,Penzien,Eugene Norman,16,3,3,0,1,0,1,3.334
+Fall 2024,ENGL,1301,130,12083,First Year Writing I,Dykes,Justin,9,10,1,1,1,0,2,3.136
+Fall 2024,COMD,7392,4,12084,Adv Pract Sp & Lang Dis,Walker,Dionne A,5,0,0,0,0,0,0,3.934
+Fall 2024,MATH,3331,2,12095,Intermediate Diff Equations,Puelz,Charles E,11,6,11,7,5,0,2,2.25
+Fall 2024,MUSI,6106,1,12096,Grad Large Ensemble,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1302,40,12098,First Year Writing II,Butler,Paul G,6,9,5,1,1,0,2,2.788
+Fall 2024,PHAR,5660,1,12100,Pharmaceutical Industry,Tolleson,Shane Russell,2,1,0,0,0,0,0,3.667
+Fall 2024,SOC,6399,7,12103,Masters Thesis,Baumle,Amanda K,0,0,0,0,0,2,0,
+Fall 2024,SOC,6399,8,12105,Masters Thesis,Tuthill,Zelma,2,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,26,12121,First Year Writing I,Presswood,Phillip Hilliard,24,1,0,0,0,0,0,3.934
+Fall 2024,MUSI,6300,1,12129,Intro Res Method in Musicology,Caton,Kathryn L.,3,1,0,0,0,0,0,3.75
+Fall 2024,MUSI,6300,2,12130,Intro Res Method in Musicology,Rakonjac,Damjan,12,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,2321,1,12131,Microbiology for Science Major,Knapp,Richard D,101,149,93,28,3,0,23,2.831
+Fall 2024,BCHS,4304,1,12132,Biophysics,Fox,Robert O,19,4,8,0,0,0,0,3.206
+Fall 2024,SCM,4330,1,12136,Bus Modeling and Dec Analysis,Cossick,Kathy L,13,3,4,3,0,0,2,3.102
+Fall 2024,SCM,4301,1,12137,Logistics Management,Tibodeau,Dale,26,43,4,0,0,0,1,3.265
+Fall 2024,SCM,4330,2,12138,Bus Modeling and Dec Analysis,Cossick,Kathy L,38,17,4,1,0,0,5,3.506
+Fall 2024,INDE,2331,1,12139,Computer Applications for IE,Chung,Christopher,20,18,4,0,1,0,1,3.31
+Fall 2024,INDE,6339,1,12140,Materials Handling,Keedy,Elias,16,35,4,0,0,0,0,3.254
+Fall 2024,CHEE,3321,1,12141,Analytical Methods Chem Engr,Grabow,Lars C,10,6,3,1,1,0,3,3.048
+Fall 2024,KIN,1304,4,12142,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,276,16,2,0,3,0,3,3.901
+Fall 2024,KIN,3304,1,12143,Human Structure & Phys Perform,LaVoy,Emily Claire-Pyle,35,65,30,7,6,0,5,2.744
+Fall 2024,KIN,3305,3,12144,Sport Sociology,Graham,Marilynn Hadassah,173,19,2,1,3,0,1,3.785
+Fall 2024,KIN,3350,1,12145,Psych Aspects Sport Exercise,Ferrara,Morgan Paige,131,33,9,1,1,0,0,3.661
+Fall 2024,KIN,3360,1,12146,Professional Prep for Sp Admin,Pearson,Demetrius W,9,15,18,3,8,0,7,2.277
+Fall 2024,KIN,3370,1,12147,Sport Facility Management,Ojemaye,Lukachukwu Fitzgerald,44,5,0,0,0,0,0,3.864
+Fall 2024,KIN,4190,1,12148,Sport Administration Seminar,Walsh,David W,12,6,1,1,0,0,0,3.384
+Fall 2024,KIN,4355,1,12149,Adm of Sport & Phys Activity,Walsh,David W,18,20,17,2,0,0,2,2.889
+Fall 2024,KIN,4390,1,12150,Internship in Kinesiology,Betts,Randi Jill,4,1,0,0,0,0,0,3.8
+Fall 2024,KIN,4690,1,12151,Internship in Sport Admin 1,Walsh,David W,21,6,0,0,0,0,0,3.766
+Fall 2024,NUTR,2133,1,12152,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,6,3,4,0,1,0,2,2.858
+Fall 2024,NUTR,2133,2,12153,Comm Food Prod I Lab,Svendsen-Sanchez,Ann Carol,4,6,0,0,0,0,1,3.367
+Fall 2024,NUTR,2333,1,12154,Comm Food Prod I,Svendsen-Sanchez,Ann Carol,11,7,3,0,2,0,3,3.03
+Fall 2024,NUTR,3101,1,12155,Dietetics As a Profession,Scott,Claudia W,32,2,1,0,0,0,1,3.839
+Fall 2024,NUTR,3330,1,12156,Mgmt in Food & Nutr Systems,Haubrick,Kevin,8,6,5,0,0,0,0,3.175
+Fall 2024,LAW,5406,6,12157,Civil Procedure,Hoffman,Lonny,8,21,0,0,0,0,0,3.356
+Fall 2024,ARTS,3371,1,12158,Photo-Dig Media Portfolio Dev,Chen,Shang-Yee Mark,16,0,0,0,0,0,1,4.0
+Fall 2024,ARTS,3372,1,12159,Intermediate Video Art,Kokoladze,Salome,10,3,2,0,0,0,0,3.467
+Fall 2024,NUTR,3334,1,12160,Advanced Nutrition,Svendsen-Sanchez,Ann Carol,109,67,8,0,1,0,1,3.421
+Fall 2024,NUTR,4312,1,12161,Nutrition Assessmnt & Planning,Ferrell,Carla Denise,18,15,4,3,0,0,1,3.142
+Fall 2024,NUTR,4333,1,12162,Med Nutr Therapy-Cardiovascula,Scott,Claudia W,6,9,1,1,0,0,0,3.079
+Fall 2024,NUTR,4334,1,12163,Community Nutrition,Hughes,Lindsay,84,27,2,0,2,0,3,3.606
+Fall 2024,NUTR,4346,1,12164,Research in Nutrition,Ledoux,Tracey A,23,8,0,0,1,0,0,3.512
+Fall 2024,NUTR,4348,1,12165,Intro to NUTR Counseling,Honig,Caryn A,14,11,5,0,1,0,0,3.108
+Fall 2024,PEP,6305,1,12166,Measurmnt Hlt & Phys Educ,Lee,Dong Hun,15,0,0,0,0,0,0,3.868
+Fall 2024,PEP,7306,1,12167,Adm Princs of Sprts/Exer Prgms,Pearson,Demetrius W,8,7,0,0,0,0,1,3.423
+Fall 2024,PEP,7393,1,12168,Internship & Practicum,Walsh,David W,7,0,0,0,0,0,0,3.953
+Fall 2024,GEOL,7324,1,12169,Rock Physics,Chesnokov,Evgeni M,9,1,0,0,0,0,0,3.801
+Fall 2024,SPAN,1502,3,12170,Elementary Spanish II,Reyes Ferrufino,Diana Eufemia,5,10,5,0,0,0,3,3.033
+Fall 2024,BUSI,1301,1,12172,Business Principles,Thompson,Joseph Lee,26,0,0,0,0,0,0,4.0
+Fall 2024,SCM,4350,1,12173,Strategic Supply Management,Wayhan,Victor Brian,93,34,6,0,1,0,0,3.637
+Fall 2024,FREN,2312,2,12174,Intermediate French II,Green,Viola V,5,7,3,1,0,0,0,3.021
+Fall 2024,BIOL,4340,1,12177,Research Methods,Ekeoba,Jacqueline Njideka,5,1,0,0,0,0,0,3.558
+Fall 2024,BIOE,8198,1,12182,Doctoral Research,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8298,1,12183,Doctoral Research,Akay,Metin,0,0,0,0,0,4,0,
+Fall 2024,BIOE,8298,2,12184,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8398,2,12186,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Fall 2024,BIOE,8598,1,12187,Doctoral Research,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2024,ECE,3355,1,12189,Electronics,Litvinov,Dmitri,27,11,26,6,7,0,0,2.597
+Fall 2024,MARK,4362,1,12191,Applied Buyer Behavior,Rudd,Melanie R,16,13,2,0,0,0,1,3.409
+Fall 2024,CUIN,3321,1,12192,Intro to Teaching Middle Grade,Mouton,Jocelyn Frances,21,2,2,0,0,0,0,3.773
+Fall 2024,MATH,4388,1,12193,History of Mathematics,Ji,Shanyu,12,13,2,1,1,0,0,3.138
+Fall 2024,HLT,3301,2,12194,Health Behavior Theories,Drenner,Kelli Linn,27,26,8,1,0,0,0,3.253
+Fall 2024,PHYS,1102,9,12195,College Physics II (lab),Wood,Lowell T,2,12,8,0,0,0,0,2.577
+Fall 2024,TEPM,6301,4,12196,Project Management Principles,Sherman,Dennis Louis,74,7,0,0,0,0,1,3.934
+Fall 2024,TEPM,6301,20,12197,Project Management Principles,Sherman,Dennis Louis,26,8,0,0,1,0,1,3.704
+Fall 2024,ARTS,3301,1,12198,Life Drawing,Forse,John,20,0,0,0,0,0,0,3.984
+Fall 2024,ARTS,2333,1,12199,Fundamentals of Printmaking,Alderson,Saran,12,0,1,0,0,0,0,3.846
+Fall 2024,TEPM,6302,1,12200,Leadership and Team Building,Hopkins,Ronald K,13,1,0,0,0,0,1,3.858
+Fall 2024,ARTS,1311,1,12201,Fundamentals of Graphic Design,Williams,Celeste,15,7,0,0,0,0,1,3.577
+Fall 2024,ARTS,1311,3,12202,Fundamentals of Graphic Design,Williams,Celeste,15,7,1,0,0,0,0,3.537
+Fall 2024,PSYC,2317,1,12203,Intro to Psychology Statistics,Steinberg,Lynne,11,12,7,1,1,0,8,2.969
+Fall 2024,PSYC,2317,3,12204,Intro to Psychology Statistics,Saiyed,Amna Shabbir,44,33,2,0,0,0,1,3.548
+Fall 2024,ARTS,2326,2,12206,Fundamentals of Sculpture,De Leon,Laura,12,0,0,0,0,0,0,3.945
+Fall 2024,BIOL,2121,1,12207,Microbiol for Science Maj(lab),Knapp,Richard D,8,11,5,0,0,0,0,3.139
+Fall 2024,BIOL,2121,2,12208,Microbiol for Science Maj(lab),Knapp,Richard D,8,9,3,2,0,0,2,3.06
+Fall 2024,BIOL,2121,3,12209,Microbiol for Science Maj(lab),Knapp,Richard D,11,11,1,0,0,0,1,3.406
+Fall 2024,BIOL,2121,4,12210,Microbiol for Science Maj(lab),Knapp,Richard D,6,10,5,1,0,0,0,2.865
+Fall 2024,BIOL,2121,5,12211,Microbiol for Science Maj(lab),Knapp,Richard D,8,9,3,3,0,0,1,2.928
+Fall 2024,ARTS,2311,1,12212,"Color, Materials and Methods",Bootwala,Jennifer Elizabeth,7,8,3,0,1,0,0,3.07
+Fall 2024,ARTS,2311,2,12213,"Color, Materials and Methods",Williams,Celeste,10,9,2,0,0,0,2,3.334
+Fall 2024,ARTS,3313,1,12214,Silkscreen,Masterson,Patrick D,13,0,0,0,0,0,0,3.949
+Fall 2024,ARTS,3314,1,12215,Lithography,Masterson,Patrick D,11,1,1,0,0,0,0,3.744
+Fall 2024,ARTS,3334,1,12216,Introduction to Typography,Unikel,Joshua,10,10,1,0,0,0,3,3.444
+Fall 2024,ARCH,5500,5,12217,Architecture Design Studio IX,Rodriguez Fernandez,Marta,4,2,0,0,0,0,0,3.502
+Fall 2024,ARCH,5500,9,12219,Architecture Design Studio IX,Olwi,Asmaa,10,0,0,0,0,0,0,3.835
+Fall 2024,ARCH,4327,1,12221,Technology 5,Taylor,Rives,49,64,3,0,0,0,1,3.419
+Fall 2024,FINA,4330,2,12222,Corporate Finance,Medina Palma,Paolina del Carmen,5,5,2,0,0,0,0,3.223
+Fall 2024,FINA,4330,4,12223,Corporate Finance,Berger,Elizabeth,22,24,7,2,0,0,0,3.158
+Fall 2024,CIS,2336,30,12225,Web Application Development,Huang,Yueqin,26,25,8,0,0,0,4,3.255
+Fall 2024,CIS,3343,30,12226,Info Systems Analysis & Design,Detillier,Bret James,4,21,27,5,3,0,3,2.278
+Fall 2024,CIS,3351,30,12227,Intrusion Detect & Incid Resp,Nsoh,Jovita T,79,8,1,0,3,0,2,3.74
+Fall 2024,CIS,4338,20,12228,Advanced Database Concepts,Miertschin,Susan L,13,17,5,0,1,0,2,3.075
+Fall 2024,CIS,4375,30,12229,Information Systems Capstone,Martinez,Jose C,6,23,9,1,0,0,1,2.872
+Fall 2024,CIS,6321,30,12230,Principles of Cybersecurity,Lee,Kyu In,72,1,0,0,1,0,0,3.91
+Fall 2024,CIS,6323,30,12231,Applied Cryptography,Zhang,Yunpeng,28,0,0,0,0,0,0,3.976
+Fall 2024,SCLT,4312,30,12232,Inventory & Materials Handling,Kennedy,Elizabeth Heyn,62,6,0,0,1,0,0,3.812
+Fall 2024,SCLT,4375,30,12233,Global Supply Chain,Velarde,Jose Manuel,28,18,5,0,0,0,0,3.367
+Fall 2024,SCLT,4380,31,12234,Quality Systems,Singh,Gulshan,14,36,9,0,0,0,1,3.085
+Fall 2024,ELET,2103,1,12235,Digital Systems Laboratory,Yuan,Xiaojing,17,5,2,0,0,0,1,3.556
+Fall 2024,ELET,3403,1,12236,Sensor Applications,Yuan,Xiaojing,19,7,0,1,1,0,0,3.429
+Fall 2024,NUTR,4347,1,12238,Med Nutritn Therapy-Metabolic,Ferrell,Carla Denise,6,7,2,0,0,0,0,3.157
+Fall 2024,TEPM,6307,1,12239,Advanced Project Management,Sherman,Dennis Louis,2,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6307,20,12240,Advanced Project Management,Sherman,Dennis Louis,10,1,0,0,0,0,0,3.939
+Fall 2024,MIS,4374,1,12241,Info Technology Project Mgmt,Scott,Carl P,27,11,2,0,0,0,0,3.584
+Fall 2024,MIS,4374,2,12242,Info Technology Project Mgmt,Scott,Carl P,38,3,0,0,0,0,0,3.879
+Fall 2024,BIOL,1308,2,12243,Biology for Non-Science Majors,Gifford,Jenifer,74,104,69,24,8,0,13,2.731
+Fall 2024,ARCH,3393,1,12244,Thesis Preparation,Johnson,Matthew W,12,0,0,0,0,0,0,3.78
+Fall 2024,THEA,3332,1,12245,Directing I,Holm,Eric Powell,16,0,0,0,0,0,0,4.0
+Fall 2024,THEA,4320,1,12246,Acting VII,Pistorius,Allison Marie,10,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,1101,11,12247,College Physics I (lab),Wood,Lowell T,5,11,7,0,0,0,1,2.841
+Fall 2024,MATH,3321,5,12248,Engineering Mathematics,Torok,Andrei S,17,21,25,7,3,0,6,2.571
+Fall 2024,PHYS,1101,12,12249,College Physics I (lab),Wood,Lowell T,1,5,5,0,0,0,2,2.666
+Fall 2024,HLT,4317,1,12250,Found of Epi in Public Health,Drenner,Kelli Linn,12,16,10,7,5,0,3,2.374
+Fall 2024,FINA,4320,2,12251,Investment Management,Doshi,Hitesh B,31,15,3,3,1,0,1,3.284
+Fall 2024,MUSI,8106,4,12252,Doctoral Large Ensemble,Krager,Franz A,10,3,0,0,0,0,0,3.744
+Fall 2024,MUSI,6106,4,12253,Grad Large Ensemble,Krager,Franz A,18,6,0,0,0,0,0,3.723
+Fall 2024,CNST,2325,1,12255,Process and Industrial Subsyst,Zayas,Frederick A,6,7,3,0,0,0,0,3.146
+Fall 2024,CNST,2345,1,12256,Contract Doc Capital Projects,Beadle,Dwight D,23,3,0,0,0,0,0,3.885
+Fall 2024,PSYC,2317,2,12257,Intro to Psychology Statistics,Steinberg,Lynne,11,7,10,3,4,0,7,2.514
+Fall 2024,THEA,4693,1,12258,Stage Management Internship,Bush,Rachel R,0,0,0,0,0,1,0,
+Fall 2024,PHAR,5662,3,12259,Academic Scholarship,Wallace,David A,3,0,0,0,0,0,0,4.0
+Fall 2024,FINA,4320,3,12268,Investment Management,Mateen,Haaris,19,27,3,0,0,0,1,3.374
+Fall 2024,SOCW,7319,1,12276,SW Practice in Organizations,Foster,Charday D,25,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,1106,23,12284,Biol for Science Majors I(Lab),Medrano,Ana I,15,3,0,1,1,0,3,3.467
+Fall 2024,BIOL,1106,24,12285,Biol for Science Majors I(Lab),Medrano,Ana I,15,6,1,1,0,0,0,3.479
+Fall 2024,BIOL,1106,25,12286,Biol for Science Majors I(Lab),Medrano,Ana I,14,10,0,0,0,0,0,3.556
+Fall 2024,BIOL,1106,26,12287,Biol for Science Majors I(Lab),Medrano,Ana I,20,2,0,0,0,0,2,3.924
+Fall 2024,PHAR,5674,2,12290,Nutritional Support,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2317,4,12291,Intro to Psychology Statistics,Granillo-Velasquez,Kenneth Eduardo,14,31,16,5,8,0,5,2.478
+Fall 2024,ELET,2300,2,12292,Introductn To C++ Programming,Hu,Bin,11,7,6,8,3,0,4,2.4
+Fall 2024,ECON,8362,1,12293,Workshop Research Methods IV,Liu,Elaine Meichen,0,0,0,0,0,5,0,
+Fall 2024,PHCA,8180,1,12300,Advanced Seminar,Aparasu,Rajender R,7,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,1106,27,12301,Biol for Science Majors I(Lab),Medrano,Ana I,19,4,0,0,0,0,0,3.754
+Fall 2024,BIOL,1106,28,12302,Biol for Science Majors I(Lab),Medrano,Ana I,19,1,0,0,2,0,1,3.546
+Fall 2024,BIOL,2101,14,12311,Anatomy & Physiology Lab I,Gill,Tejendra,7,11,5,0,0,0,1,3.015
+Fall 2024,BIOL,1106,29,12313,Biol for Science Majors I(Lab),Medrano,Ana I,17,3,3,0,0,0,1,3.652
+Fall 2024,BIOL,1106,30,12314,Biol for Science Majors I(Lab),Medrano,Ana I,14,7,0,0,0,0,2,3.682
+Fall 2024,BIOL,1106,31,12316,Biol for Science Majors I(Lab),Medrano,Ana I,7,12,1,0,2,0,0,3.09
+Fall 2024,BIOL,1106,32,12317,Biol for Science Majors I(Lab),Medrano,Ana I,15,4,2,0,3,0,0,3.194
+Fall 2024,BIOL,1306,5,12318,Biology for Science Majors I,Medrano,Ana I,73,90,59,23,11,0,31,2.751
+Fall 2024,COMD,7391,8,12319,Clinic in Speech Lang Disorder,Devore,Danielle R,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,119,12320,First Year Writing I,Jones,Baylea,17,4,1,0,2,0,0,3.362
+Fall 2024,DRAM,1310,5,12321,Introduction to Theatre,Young,Courtney Leigh,41,4,2,2,0,0,0,3.708
+Fall 2024,ENGL,1301,30,12326,First Year Writing I,Lee,Nathanael D,15,5,0,0,1,0,4,3.54
+Fall 2024,ENTR,4340,1,12327,Entrepreneurial Capital,Blair,Edward A,12,12,4,0,0,0,0,3.298
+Fall 2024,BTEC,1322,30,12337,Introduction to Biotechnology,Ibrahim,Eman Refaat,18,8,4,0,0,0,0,3.467
+Fall 2024,BTEC,3200,31,12338,Biotech Research Methods,Ibrahim,Eman Refaat,19,1,0,0,0,0,0,3.901
+Fall 2024,PSYC,2305,5,12341,Intro to Methods in Psychology,Tamber-Rosenau,Benjamin J,4,11,7,3,4,0,10,2.185
+Fall 2024,ECON,2301,2,12342,Principles of Macroeconomics,Maden,Bitaran Jang,97,164,89,27,22,0,15,2.726
+Fall 2024,GEOL,1103,7,12343,Physical Geology Lab,Hauptvogel,Daniel William,18,4,0,0,0,0,2,3.833
+Fall 2024,GEOL,1103,8,12344,Physical Geology Lab,Hauptvogel,Daniel William,17,5,1,1,0,0,0,3.57
+Fall 2024,GEOL,1103,9,12345,Physical Geology Lab,Hauptvogel,Daniel William,16,6,0,0,0,0,1,3.712
+Fall 2024,CHEM,1111,49,12346,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,10,0,0,1,0,1,3.089
+Fall 2024,CHEM,1112,14,12347,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,0,0,0,2,3.074
+Fall 2024,CHEM,1112,15,12348,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,16,1,0,0,0,0,3.15
+Fall 2024,CHEM,1112,17,12349,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,6,2,0,1,0,2,2.806
+Fall 2024,CHEM,1105,4,12350,Foundations of Chem Lab,Zaitsev,Vladimir G,2,7,0,0,0,0,2,3.296
+Fall 2024,CHEM,1105,3,12351,Foundations of Chem Lab,Zaitsev,Vladimir G,5,6,3,0,0,0,1,3.096
+Fall 2024,MARK,3365,2,12352,Intro to Digital Marketing,Tirunillai,Seshadri N,145,44,9,2,0,0,0,3.581
+Fall 2024,CHEM,2125,5,12353,Organic Chemistry Lab II,Bean,Mary B,5,4,4,2,1,0,1,2.604
+Fall 2024,BIOL,2302,1,12354,Anatomy & Physiology II (lect),Ogletree-Hughes,Monique L,84,85,67,34,6,0,38,2.732
+Fall 2024,MUSI,6350,1,12355,Applied Music Pedagogy,Averyt,Zachary Benjamin,9,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5663,2,12356,Pharmacy Management,Tolleson,Shane Russell,5,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5683,2,12357,Cardiology,Truong,Mabel,5,1,0,0,0,0,0,3.833
+Fall 2024,GEOL,3378,1,12358,Principles of Atmospheric Sci.,Choi,Yunsoo,21,7,6,2,1,0,0,3.207
+Fall 2024,ELED,4310,3,12360,Reading/Language in Elementary,Tyson,Eleanore S,19,0,0,0,0,0,0,4.0
+Fall 2024,ELED,4310,4,12361,Reading/Language in Elementary,Tyson,Eleanore S,21,0,0,0,0,0,0,3.969
+Fall 2024,EDUC,1301,1,12362,Intro to Teaching Profession,Eiland,Deanna,21,5,3,0,0,0,0,3.643
+Fall 2024,RELS,2310,1,12363,Intro Hebrew Bib/Old Testament,Tamber-Rosenau,Caryn M,21,13,9,1,1,0,1,3.134
+Fall 2024,PETR,6368,1,12364,Well Drilling and Completion I,Samuel,Robello,3,6,0,0,0,0,0,3.407
+Fall 2024,ARAB,3301,1,12365,Adv Modern Standard Arabic I,Hefter,Thomas H,2,0,0,0,0,0,0,4.0
+Fall 2024,PETR,5350,1,12366,Natural Gas Engineering,Farouq-Ali,Syed,3,1,0,0,0,0,0,3.833
+Fall 2024,PETR,6328,1,12367,Petro Fluid Prop & Phase Equil,Dindoruk,Birol,4,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,4354,1,12368,Endocrinology,Gill,Tejendra,11,58,3,0,1,0,12,3.01
+Fall 2024,BIOL,4374,1,12369,Cell Biology,Rea,Michael A,26,17,10,5,0,0,3,3.103
+Fall 2024,BCHS,4313,2,12370,Cell Biochemistry,Rea,Michael A,8,4,2,1,0,0,1,3.267
+Fall 2024,BIOL,6374,1,12371,Cell Biology,Rea,Michael A,1,1,0,0,0,0,0,3.5
+Fall 2024,AAS,2320,3,12372,Intro To African American Stdy,Wiggins,Gretchen Flowers,3,17,2,0,0,0,5,3.135
+Fall 2024,ECE,4119,1,12373,Solid State Devices Lab,Wolfe,John C,9,3,0,0,0,0,0,3.833
+Fall 2024,SOCW,7367,1,12374,Social Policy Analysis,Borja,Sharon G,17,1,0,0,0,0,0,3.944
+Fall 2024,ECE,5356,1,12375,Cmos Analog Integrated Circuit,Chen,Jinghong,7,1,0,0,0,0,0,3.793
+Fall 2024,ECE,6328,1,12376,Cmos Analog Integrated Circuit,Chen,Jinghong,8,6,0,0,0,0,3,3.548
+Fall 2024,INTN,2233,1,12377,History of Interpreting,Sheneman,Naomi,6,8,4,1,0,0,2,3.052
+Fall 2024,CUIN,4350,2,12378,Multiple Teaching Strategies,Latiolais,Cheryl S,8,1,0,0,0,0,0,3.852
+Fall 2024,MANA,4348,1,12379,Global Leadership,Tabesh,Pooya,38,19,7,1,0,0,0,3.431
+Fall 2024,SCM,4380,1,12380,Enterprise Resource Planning,Schrage,Frances Marie,18,16,1,0,0,0,2,3.429
+Fall 2024,MUSI,6200,1,12381,Accompanying Seminar,Hester,Timothy E,9,0,0,0,0,0,0,4.0
+Fall 2024,MANA,4346,1,12382,Leadership Development,Evans,Klavdia Markelova,57,3,4,0,1,0,0,3.734
+Fall 2024,FINA,4358,1,12383,Commercial Property,Kapatos,Nick Gus,10,8,3,0,0,0,5,3.318
+Fall 2024,SOCW,7367,2,12384,Social Policy Analysis,Sereno,Alba Donajhi,19,7,0,0,0,0,0,3.731
+Fall 2024,CIS,1348,1,12385,Info Systems Appl Development,Albayrak,Levent,25,7,3,1,1,0,4,3.415
+Fall 2024,ELET,2103,2,12386,Digital Systems Laboratory,Yuan,Xiaojing,10,4,1,1,0,0,0,3.458
+Fall 2024,ELET,2105,1,12387,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,13,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,2302,1,12388,Listening to Jazz,Hubley,Robert L,30,23,23,4,14,0,18,2.511
+Fall 2024,HLT,2320,2,12389,Introduction to Public Health,Proctor,Robin Ann,67,10,2,0,1,0,0,3.738
+Fall 2024,SOCI,1301,15,12390,Introduction To Sociology,Cooper,Chelsey Wells,50,3,1,1,0,0,0,3.855
+Fall 2024,ARTS,1372,1,12391,Fundamentals of Video Art,Hillerbrand,Stephan C,8,5,1,0,1,0,2,3.289
+Fall 2024,ARTS,3309,1,12392,Jr Painting Major,Frankfort,Dana M,11,1,0,0,0,0,0,3.862
+Fall 2024,ARTS,3310,1,12393,Jr Painting Major,Hecker,Rachel G,11,1,0,0,0,0,0,3.889
+Fall 2024,ARTS,3311,1,12394,Jr Painting Major,Frankfort,Dana M,11,1,0,0,0,0,0,3.862
+Fall 2024,ARTS,3335,1,12395,Junior Graphic Design I,Beckett,Cheryl A,19,5,0,0,0,0,0,3.764
+Fall 2024,ARTS,3336,1,12396,Junior Graphic Design II,Unikel,Joshua,22,2,0,0,0,0,0,3.848
+Fall 2024,ARTS,3337,1,12397,Junior Graphic Design III,Kim,Yoonkyung,21,3,0,0,0,0,0,3.765
+Fall 2024,ARTS,3365,1,12398,Jr Sculpture Major,Kittelson,Paul A,2,2,1,0,0,0,0,3.332
+Fall 2024,ARTS,3366,1,12399,Jr Sculpture Major,Jensen,Margaret,2,2,1,0,0,0,0,3.332
+Fall 2024,ARTS,3367,1,12400,Jr Sculpture Major,Kittelson,Paul A,5,0,0,0,0,0,0,3.802
+Fall 2024,ARTS,4300,1,12401,Senior Painting Major I,Suber,Anthony,13,0,0,0,0,0,1,3.924
+Fall 2024,ARTS,4301,1,12402,Senior Painting Major I,Suber,Anthony,13,0,0,0,0,0,1,3.924
+Fall 2024,ARTS,4302,1,12403,Senior Painting Major I,Hernandez Martinez,Guadalupe,13,0,0,0,0,0,1,3.924
+Fall 2024,ARTS,4303,1,12404,Senior Painting Major II,Suber,Anthony,15,0,0,0,0,0,0,3.978
+Fall 2024,ARTS,4304,1,12405,Senior Painting Major II,Suber,Anthony,15,0,0,0,0,0,0,3.978
+Fall 2024,ARTS,4305,1,12406,Senior Painting Major II,Suber,Anthony,15,0,0,0,0,0,0,3.978
+Fall 2024,ARTS,4330,1,12407,Senior Graphic Design Major I,Unikel,Joshua,20,4,0,0,0,0,0,3.847
+Fall 2024,ARTS,4331,1,12408,Senior Graphic Design Major I,Beckett,Cheryl A,18,5,1,0,0,0,0,3.626
+Fall 2024,ARTS,4332,1,12409,Senior Graphic Design Major I,Hagmann,Sibylle,23,1,0,0,0,0,0,3.876
+Fall 2024,ARTS,4360,1,12410,Senior Sculpture Major I,Kittelson,Paul A,2,1,0,0,0,0,0,3.447
+Fall 2024,ARTS,4361,1,12411,Senior Sculpture Major I,Jensen,Margaret,2,1,0,0,0,0,0,3.447
+Fall 2024,ARTS,4362,1,12412,Senior Sculpture Major I,Kittelson,Paul A,3,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,4363,1,12413,Senior Sculpture Major II,Kittelson,Paul A,4,0,0,0,0,0,0,3.918
+Fall 2024,ARTS,4364,1,12414,Senior Sculpture Major II,Jensen,Margaret,4,0,0,0,0,0,0,3.918
+Fall 2024,ARTS,4365,1,12415,Senior Sculpture Major II,Kittelson,Paul A,4,0,0,0,0,0,0,4.0
+Fall 2024,GOVT,2306,3,12416,US and Texas Const/Politics,Davis,Jenna,14,47,69,46,40,0,31,1.739
+Fall 2024,GOVT,2306,1,12417,US and Texas Const/Politics,Cole,Jeffrey Bryan,138,76,14,7,7,0,5,3.358
+Fall 2024,INDE,4370,1,12418,Discrete Event Simulation,Khator,Suresh K,7,8,9,1,1,0,1,2.693
+Fall 2024,INDE,4320,1,12420,Computer-Integrated Manufactur,Lin,Ying,11,11,7,0,0,0,0,3.104
+Fall 2024,MIS,4390,1,12421,Energy Trading Systems,Pena,Juan F,167,48,7,1,1,0,2,3.738
+Fall 2024,MIS,4386,1,12422,Busn Appls Database Mgmt II,Scamell,Richard W,18,13,0,0,0,0,11,3.581
+Fall 2024,PETR,1111,1,12424,Intro to Petroleum Engineering,Hathon,Lori A,2,8,3,1,0,0,1,2.833
+Fall 2024,HRD,6353,1,12425,Methods of Adult Learning,Shirmohammadi,Melika,10,1,0,0,0,0,1,3.879
+Fall 2024,INTN,3430,1,12426,Consecutive Interpreting,Sheneman,Naomi,3,5,0,0,0,0,0,3.416
+Fall 2024,MUSI,6330,1,12427,Adv Instrumental Conducting,Krager,Franz A,4,0,0,0,0,0,0,3.918
+Fall 2024,ARTS,6300,1,12428,Drawing Studio,Donnett,Nathaniel,11,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6305,1,12429,Painting Studio,Suber,Anthony,9,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6330,1,12430,Graphic Design Studio,Hagmann,Sibylle,4,1,0,0,0,0,0,3.734
+Fall 2024,ARTS,6360,1,12431,Sculpture Studio,Kittelson,Paul A,8,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6370,1,12432,Photography Studio,Boncy,Jean Sebastien,8,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6385,1,12433,IPEF Studio,Lowe,Rick,11,0,0,0,0,0,0,4.0
+Fall 2024,PETR,3362,1,12434,Reservoir Engineering I,Sakhaee Pour,Ahmad,6,8,0,0,0,0,0,3.429
+Fall 2024,FINA,7376,1,12435,Energy Trading,Smith III,Edwin A,3,1,1,0,0,0,0,3.466
+Fall 2024,ARTS,4370,1,12436,Sr Photo/Digital Media Major I,Anderson-Staley,Keliy,12,1,0,0,0,0,0,3.872
+Fall 2024,ARTS,4371,1,12437,Sr Photo/Digital Media Major I,Chen,Shang-Yee Mark,13,0,0,0,0,0,0,3.949
+Fall 2024,ARTS,4372,1,12438,Sr Photo/Digital Media Major I,Boncy,Jean Sebastien,13,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,3306,1,12439,Intro Study Span Language,Fairclough,Marta A,9,8,1,1,0,0,1,3.264
+Fall 2024,PHAR,5675,3,12442,Disease State Management,De La Cruz,Austin Isaac,2,1,0,0,0,0,0,3.667
+Fall 2024,HIST,3327,1,12443,Houston Since 1836,Harwell,Debbie Z,20,9,3,0,2,0,1,3.285
+Fall 2024,SPAN,7398,10,12445,Reading & Research,Sisk,Christina L,0,0,0,0,0,1,0,
+Fall 2024,ENGL,1301,31,12447,First Year Writing I,Brady,Louisa McKenna,15,2,1,0,1,0,0,3.527
+Fall 2024,ENGL,1301,32,12448,First Year Writing I,Brady,Louisa McKenna,12,5,0,0,1,0,1,3.5
+Fall 2024,ENGL,1301,36,12449,First Year Writing I,Pachuca,Adrian,11,4,2,2,0,0,0,3.194
+Fall 2024,ENGL,1301,41,12450,First Year Writing I,Presswood,Phillip Hilliard,22,0,1,0,1,0,1,3.736
+Fall 2024,MUSI,3303,2,12451,Pop Music of Americas Sn 1840,Garza,Paul Victor,58,6,3,0,4,0,1,3.559
+Fall 2024,IDNS,1101,1,12452,Physics 1301 Workshop,Pattison,Donna,20,7,1,1,0,0,3,3.609
+Fall 2024,CHEM,2132,1,12453,Problem Solving in Org Chem II,Lee,T Randall,0,0,0,0,0,4,0,
+Fall 2024,CHEM,2131,2,12455,Problem Solving in Org Chem I,Lee,T Randall,0,0,0,0,0,2,2,
+Fall 2024,ARTS,3361,1,12456,Wood and Metal Fabrication,Giampietro,Francis A,15,0,0,0,0,0,0,3.934
+Fall 2024,COMD,2376,2,12457,Anatomy for Communication,Daniels,Stephanie K,11,7,10,4,2,0,10,2.637
+Fall 2024,BIOL,2120,6,12458,Microbiology for Non-Science,Knapp,Richard D,17,7,0,0,0,0,0,3.736
+Fall 2024,BIOL,2121,6,12459,Microbiol for Science Maj(lab),Knapp,Richard D,5,9,9,1,0,0,0,2.778
+Fall 2024,ELCS,8399,1,12460,Doctoral Dissertation,Horn,Catherine Lynn,0,0,0,0,0,3,0,
+Fall 2024,MTLS,6111,1,12461,Materials Engineering Seminar,Shan,Xiaonan,0,0,0,0,0,30,0,
+Fall 2024,BIOL,1106,33,12462,Biol for Science Majors I(Lab),Medrano,Ana I,16,7,1,0,0,0,0,3.598
+Fall 2024,BIOL,1106,34,12463,Biol for Science Majors I(Lab),Medrano,Ana I,23,0,0,0,0,0,1,3.971
+Fall 2024,BIOL,1106,35,12464,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,1,0,0,0,1,3.753
+Fall 2024,BIOL,1106,36,12465,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,2,0,0,0,1,3.531
+Fall 2024,HON,3361,1,12466,Global Engagement and Research,Miljanic,Andra Olivia,5,1,0,0,0,0,1,3.668
+Fall 2024,PHAR,5644,1,12467,Amb C-Medication Therapy Mgmt,Tolleson,Shane Russell,9,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5645,1,12468,Pharmacy Informatics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2024,SCM,4351,1,12469,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,27,9,1,0,0,0,1,3.667
+Fall 2024,BIOL,1106,37,12470,Biol for Science Majors I(Lab),Medrano,Ana I,7,8,2,0,2,0,4,2.93
+Fall 2024,BIOL,1106,38,12471,Biol for Science Majors I(Lab),Medrano,Ana I,12,9,1,0,0,0,1,3.455
+Fall 2024,BIOL,1106,39,12472,Biol for Science Majors I(Lab),Medrano,Ana I,19,5,0,0,0,0,0,3.792
+Fall 2024,BIOL,1106,40,12473,Biol for Science Majors I(Lab),Medrano,Ana I,6,12,2,0,2,0,1,2.954
+Fall 2024,CUIN,8398,3,12474,Independent Study,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,2120,7,12482,Microbiology for Non-Science,Knapp,Richard D,5,13,4,1,0,0,0,2.799
+Fall 2024,BIOL,2121,7,12483,Microbiol for Science Maj(lab),Knapp,Richard D,4,13,6,0,0,0,1,2.927
+Fall 2024,BIOL,2101,15,12484,Anatomy & Physiology Lab I,Gill,Tejendra,4,15,3,0,0,0,2,2.925
+Fall 2024,BIOL,2101,16,12485,Anatomy & Physiology Lab I,Gill,Tejendra,4,13,2,2,0,0,3,2.936
+Fall 2024,BIOL,1106,41,12486,Biol for Science Majors I(Lab),Medrano,Ana I,13,7,1,1,0,0,1,3.44
+Fall 2024,BIOL,1106,42,12487,Biol for Science Majors I(Lab),Medrano,Ana I,17,4,2,0,0,0,0,3.652
+Fall 2024,HDFS,4316,1,12488,Dynamics of Family Relations,Schoger,Kimberly,36,3,0,1,0,0,1,3.85
+Fall 2024,COMD,1333,3,12494,Intro to Comm Sci & Disorders,Ross,Byron L,13,15,6,0,0,0,3,3.177
+Fall 2024,BIOL,1106,43,12496,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,1,0,0,0,0,3.725
+Fall 2024,CHEM,1111,3,12497,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,14,1,0,0,0,4,3.083
+Fall 2024,CHEM,1111,8,12498,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,1,0,0,0,0,3.295
+Fall 2024,CHEM,1111,21,12499,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,17,2,0,0,0,0,2.95
+Fall 2024,CHEM,1111,33,12500,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,12,2,1,0,0,0,3.034
+Fall 2024,CHEM,1111,42,12501,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,1,0,0,0,0,3.059
+Fall 2024,CHEM,1112,4,12504,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,4,0,0,0,1,3.093
+Fall 2024,CHEM,1112,11,12505,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,13,1,0,0,0,1,3.24
+Fall 2024,MATH,2450,1,12506,Accelerated Calculus I,Lutsko,Christopher,18,20,18,0,4,0,4,2.767
+Fall 2024,BIOL,1106,46,12507,Biol for Science Majors I(Lab),Medrano,Ana I,18,3,2,0,0,0,0,3.696
+Fall 2024,CHEE,8498,19,12510,Doctoral Research,Willson,Richard,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8398,14,12511,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,15,12512,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8298,15,12513,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,1,0,
+Fall 2024,BTEC,1322,1,12514,Introduction to Biotechnology,Ibrahim,Eman Refaat,32,22,7,0,0,0,0,3.34
+Fall 2024,BIOE,8398,3,12515,Doctoral Research,Abidian,Mohammad Reza,0,0,0,0,0,0,0,
+Fall 2024,DANC,3302,1,12530,Int. Technique and Theory,Prokop,Travis Cooper,12,3,1,0,0,0,0,3.626
+Fall 2024,CHEM,2123,13,12531,Organic Chemistry Lab I,Bean,Mary B,5,12,6,0,0,0,1,2.842
+Fall 2024,ENGL,2360,1,12533,Western World Lit I--Honors,Barnes,Michael,6,4,0,0,0,0,0,3.567
+Fall 2024,ENGL,2360,2,12534,Western World Lit I--Honors,Barnes,Michael,11,3,0,0,0,0,0,3.762
+Fall 2024,HIST,8677,4,12536,Reading for Comps Exams,Young,Nancy Beck,0,0,0,0,0,1,0,
+Fall 2024,COMM,6398,1,12538,Special Problems,Olson,Beth M,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,8398,1,12539,Special Problems,Lobo,Gerald,2,0,0,0,0,0,0,3.835
+Fall 2024,ECON,7301,1,12545,Seminar in Microecon Research,Friedman,Willa H,0,0,0,0,0,7,0,
+Fall 2024,ECON,7302,1,12546,Seminar in Macroecon Research,Cubas Norando,German,0,0,0,0,0,10,0,
+Fall 2024,MATH,2318,4,12547,Linear Algebra,Sanders,Richard,24,20,22,4,3,0,6,2.722
+Fall 2024,MATH,3333,3,12548,Intermediate Analysis,Vershynina,Anna,4,8,4,2,0,0,6,2.704
+Fall 2024,MATH,3339,4,12549,Statistics for the Sciences,Wang,Wenshuang,137,48,26,22,7,0,7,3.197
+Fall 2024,GEOL,1103,10,12550,Physical Geology Lab,Hauptvogel,Daniel William,18,3,0,1,0,0,1,3.622
+Fall 2024,GEOL,1304,1,12551,Historical Geology,Copeland,Peter,28,8,7,6,3,0,7,2.911
+Fall 2024,ANTH,6399,4,12552,Masters Thesis,Routon,Erin Danielle,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,3343,1,12553,Span for the Health Profession,Zubiate,Maria Laura,9,0,1,0,0,0,1,3.8
+Fall 2024,CHEM,6311,1,12554,Mechanisms,Mills,Leo Reginald,4,12,1,0,0,0,0,3.293
+Fall 2024,HDFS,4318,2,12555,Parent-Child Relationships,Frankel,Leslie Ann,28,8,3,0,0,0,1,3.548
+Fall 2024,PHYS,2326,5,12557,University Physics II(lecture),Morrison,Gregory C,12,12,3,0,0,0,2,3.346
+Fall 2024,ECE,4335,1,12558,Electrical Comp Engr Design I,Contreras-Vidal,Jose Luis,33,52,2,0,0,0,0,3.284
+Fall 2024,HLT,1353,2,12560,Personal Health,Rafique,Kiran Sajid,84,29,3,0,1,0,0,3.571
+Fall 2024,HLT,3381,2,12561,Hlt Promotn & Disease Preventn,Hill,Rosenda Murillo,82,2,0,0,0,0,1,3.933
+Fall 2024,HLT,4307,1,12562,Research and Eval in Health,Correa-Fernandez,Virmarie,17,11,6,2,0,0,1,3.167
+Fall 2024,PHAR,5681,3,12563,Infectious Diseases,Truong,Mabel,13,2,0,0,0,0,0,3.867
+Fall 2024,PSYC,4344,3,12564,Cultural Psychology,Phillips,Morgan,32,28,14,3,1,0,2,3.175
+Fall 2024,SCM,4351,2,12565,Stratgic Sourcing & Spend Anal,Wayhan,Victor Brian,1,6,1,0,0,0,0,3.0
+Fall 2024,ENGL,1301,20,12566,First Year Writing I,Rolater,Sara C,7,6,2,0,5,0,3,2.451
+Fall 2024,MANA,3335,3,12567,Intro Org Behavior and Mgmt,Carlin,Barbara A,93,122,50,10,4,0,1,3.017
+Fall 2024,MANA,4338,1,12568,Performance Management Systems,Sullivan,David Walter,46,13,1,0,0,0,0,3.805
+Fall 2024,ENGL,1302,14,12569,First Year Writing II,Womble,David Avari Patrick,5,9,3,1,1,0,6,2.825
+Fall 2024,ENGL,1302,20,12570,First Year Writing II,Stewart-Steele,Heather Marie,10,6,1,0,2,0,5,3.158
+Fall 2024,ENGL,1302,22,12571,First Year Writing II,Rajkumar,Nidhi,15,3,3,1,1,0,1,3.204
+Fall 2024,ENGL,2305,2,12572,Intro To Fiction,Hiers,Maria,28,0,0,1,0,0,1,3.908
+Fall 2024,INTB,3355,1,12573,Global Environment of Business,Thompson,Joseph Lee,234,11,1,0,1,0,2,3.927
+Fall 2024,INTB,3355,2,12574,Global Environment of Business,Wengelnik,Dorothee-Catherine,222,23,3,0,0,0,2,3.852
+Fall 2024,CNST,4385,1,12575,Field Operations Capital Proj,Velez,Ismael Damien,3,7,0,0,0,0,0,3.333
+Fall 2024,BUSI,1301,2,12576,Business Principles,Thompson,Joseph Lee,26,0,0,0,0,0,0,4.0
+Fall 2024,BUSI,1301,3,12577,Business Principles,Thompson,Joseph Lee,237,4,6,1,0,0,2,3.923
+Fall 2024,TMTH,3360,4,12578,Applied Technical Statistics,Daniel,Patrick Nathanial,6,2,4,0,0,0,1,3.194
+Fall 2024,PSYC,6303,1,12579,Foundation-Clinical Interven I,Babcock,Julia,12,0,0,0,0,0,0,3.945
+Fall 2024,EDUC,1301,2,12580,Intro to Teaching Profession,Eiland,Deanna,30,4,3,0,0,0,3,3.73
+Fall 2024,CIS,4365,30,12581,Database Management,Hu,Renjie,29,7,1,0,1,0,1,3.545
+Fall 2024,CIS,3339,30,12583,Enterprise Appls Development,Wu,Xuqing,129,13,4,0,0,0,0,3.863
+Fall 2024,HDCS,3300,2,12584,Org Decisions,Hitchman Sr,Cal M,42,1,1,2,2,0,2,3.632
+Fall 2024,GEOL,6324,1,12585,Sat. Positioning & Geodesy,Wang,Guoquan,14,1,0,0,0,0,0,3.801
+Fall 2024,FINA,4352,1,12588,Fin Planning for Professionals,Lopez,John C,2,10,15,0,1,0,0,2.558
+Fall 2024,LAW,5409,1,12589,Contracts,Bush,Darren,19,21,1,0,0,0,0,3.415
+Fall 2024,ENRG,3310,1,12590,Intro to Energy & Sustainblty,Jacobsen,Nicolas Fisher,20,4,1,0,0,0,0,3.681
+Fall 2024,ELED,4314,2,12593,Mathematics in Elem School I,Cutler,Carrie Sybil,19,2,1,0,0,0,0,3.818
+Fall 2024,BTEC,3320,30,12594,Intro to QA/QC in BTEC,Flavier,Albert B,2,13,4,1,1,0,0,2.745
+Fall 2024,ARCH,4510,1,12595,Integrated Arch Solutions,Wienert,Ross George,16,4,0,0,0,0,0,3.602
+Fall 2024,ARCH,4510,3,12597,Integrated Arch Solutions,Lutz,Shawn M,8,9,1,0,0,0,0,3.261
+Fall 2024,ARCH,4510,5,12599,Integrated Arch Solutions,Story,Jon Kevin,10,10,0,0,0,0,0,3.533
+Fall 2024,INAR,3500,1,12601,Interior Arch Design Studio V,Tucker de Vazquez,Sheryl,9,3,1,0,0,0,1,3.615
+Fall 2024,INTN,4346,1,12603,ASL Translit & Educ Interpret,Gietz,Merrilee Ruth,3,4,0,0,0,0,0,3.287
+Fall 2024,INTN,3434,1,12604,Simultaneous Interpreting II,Sheneman,Naomi,6,0,1,0,0,0,0,3.431
+Fall 2024,SGNL,2302,1,12605,Intermediate Sign Language II,Gietz,Merrilee Ruth,5,9,4,0,0,0,0,2.872
+Fall 2024,HON,3330,1,12606,Leadership Theory and Practice,Rhoden,Brenda,13,1,1,1,0,0,0,3.584
+Fall 2024,ECE,3337,1,12607,Signals and Systems Analysis,Roysam,Badrinath,15,18,19,1,0,0,0,2.856
+Fall 2024,ECE,3364,1,12608,Circuits and Systems,Hebert,Thomas James,10,12,11,0,0,0,0,3.0
+Fall 2024,ENGL,3306,1,12609,Shakespeare-Major Works,Christensen,Ann C,13,8,5,1,1,0,1,3.095
+Fall 2024,TECH,6360,1,12610,Exp Design & Data Analysis,Thornton,Brandon Latroy,22,0,0,0,0,0,1,3.955
+Fall 2024,MATH,3325,1,12611,Transition to Advanced Math,Wu,Yingying,37,23,0,0,2,0,5,3.463
+Fall 2024,COMD,6334,1,12612,Aphasia & Related Com Disorder,Dial,Heather Raye,12,13,0,0,0,0,1,3.401
+Fall 2024,NUTR,3336,1,12615,Nutritional Pathophysiology,Vollrath,Kirstin,36,12,0,0,0,0,0,3.585
+Fall 2024,BCIS,1305,3,12617,Business Computer Applications,Felvegi,Emese,200,31,10,3,0,0,4,3.745
+Fall 2024,MUSA,4440,2,12618,Applied Trumpet,Hughes,Mark Alan,3,0,0,0,0,0,0,4.0
+Fall 2024,MIS,4378,1,12619,Admin of Computer-Based MIS,Grimes,George M,28,20,4,0,0,0,1,3.462
+Fall 2024,MIS,4378,2,12620,Admin of Computer-Based MIS,Grimes,George M,27,2,2,0,0,0,0,3.806
+Fall 2024,SCM,4367,1,12621,Process and Quality Management,Miller,Bradley D,10,15,4,2,0,0,0,3.011
+Fall 2024,SCM,4367,2,12622,Process and Quality Management,Miller,Bradley D,13,31,11,3,0,0,0,2.965
+Fall 2024,MUSI,6370,1,12623,Art Song Repertoire,Sonnenberg,Melanie,5,1,0,0,0,0,0,3.723
+Fall 2024,ARED,4365,1,12624,Integrative Art Teaching,Chung,Sheng Kuan,10,1,0,0,0,0,0,3.909
+Fall 2024,SEDE,4312,1,12625,Teaching English in Sec School,Pauloski,Gwendolyn Jordan,23,8,0,0,0,0,0,3.721
+Fall 2024,MARK,4362,2,12626,Applied Buyer Behavior,Rudd,Melanie R,7,14,1,0,0,0,0,3.243
+Fall 2024,MARK,4362,3,12627,Applied Buyer Behavior,Rudd,Melanie R,17,18,1,2,0,0,0,3.281
+Fall 2024,CUIN,7303,1,12628,Professional Seminar I,Gronseth,Susie L B,22,3,0,0,0,0,0,3.893
+Fall 2024,CUIN,7303,3,12629,Professional Seminar I,Hausmann,Robert Carl,19,1,0,0,0,0,0,3.934
+Fall 2024,CUIN,7303,2,12630,Professional Seminar I,Gist,Conra D,17,3,0,0,0,0,0,3.867
+Fall 2024,PHYS,1101,13,12632,College Physics I (lab),Wood,Lowell T,3,9,5,1,1,0,3,2.666
+Fall 2024,PHYS,1101,14,12633,College Physics I (lab),Wood,Lowell T,2,8,5,0,0,0,1,2.734
+Fall 2024,SCM,7380,1,12634,Analytics & Enterprise Opertns,Murray,Michael J,14,10,0,0,0,0,0,3.57
+Fall 2024,COSC,4315,801,12635,Programming Languages and Para,Subramaniam,Venkat,14,7,0,0,0,0,1,3.62
+Fall 2024,COSC,6345,801,12636,Programming Languages,Subramaniam,Venkat,4,1,1,0,0,0,0,3.39
+Fall 2024,LAW,5314,1,12638,Lawyering Skills & Strategy I,Gomez,Alissa R,7,9,0,0,0,0,0,3.376
+Fall 2024,LAW,5314,2,12639,Lawyering Skills & Strategy I,Gomez,Alissa R,6,11,0,0,0,0,0,3.353
+Fall 2024,LAW,5314,4,12640,Lawyering Skills & Strategy I,Brantley,Maikieta Antoinette,7,5,2,0,0,0,0,3.381
+Fall 2024,LAW,5314,5,12641,Lawyering Skills & Strategy I,Swift,Kenneth Richard,5,10,0,0,0,0,0,3.399
+Fall 2024,LAW,5314,6,12642,Lawyering Skills & Strategy I,Heard,Whitney W,7,10,0,0,0,0,0,3.295
+Fall 2024,LAW,5314,8,12643,Lawyering Skills & Strategy I,Crozier,Christina Fontenot,7,10,1,0,0,0,0,3.388
+Fall 2024,LAW,5314,9,12644,Lawyering Skills & Strategy I,Brown,Maleaha L,5,11,1,0,0,0,0,3.391
+Fall 2024,LAW,5314,10,12645,Lawyering Skills & Strategy I,Reed,Hilary S,7,8,0,0,0,0,0,3.401
+Fall 2024,LAW,5314,12,12646,Lawyering Skills & Strategy I,Swift,Kenneth Richard,8,7,1,0,0,0,0,3.396
+Fall 2024,LAW,5314,13,12647,Lawyering Skills & Strategy I,Reed,Hilary S,9,7,1,0,0,0,0,3.393
+Fall 2024,LAW,5314,14,12648,Lawyering Skills & Strategy I,Heard,Whitney W,6,7,1,0,0,0,0,3.404
+Fall 2024,LAW,5314,16,12649,Lawyering Skills & Strategy I,Brantley,Maikieta Antoinette,6,9,0,0,0,0,0,3.4
+Fall 2024,THEA,4345,1,12650,Dramaturgy Practicum,Coen,Elizabeth Manya,4,1,0,0,0,0,0,3.8
+Fall 2024,GRET,6336,1,12651,Global Retail Analysis,Robinson,Ebony M,1,2,0,0,0,0,1,3.333
+Fall 2024,GRET,6332,1,12652,Consumer Issues and Apps.,Johnson,Olivia,1,0,1,0,1,0,0,2.0
+Fall 2024,GRET,6334,20,12653,Global E-Tailing Systems,Ezell,Shirley D,2,0,1,0,0,0,0,3.223
+Fall 2024,ARLD,6310,1,12654,Fundraising for the Arts,Hays,Carolyn Jane,10,2,1,0,2,0,0,3.112
+Fall 2024,FORE,6331,20,12655,Social Change,Mudge,James Thomas,3,0,0,0,0,0,0,3.89
+Fall 2024,FORE,6351,20,12656,Futures Research,Cowart,Adam David,7,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,131,12657,First Year Writing I,Dykes,Justin,5,12,6,1,1,0,0,2.654
+Fall 2024,ENGI,1100,2,12658,Introduction To Engineering,Burleson,Daniel W,32,10,3,0,0,0,0,3.696
+Fall 2024,ENGI,1100,3,12659,Introduction To Engineering,Landon,Alexandra Maley,36,2,0,0,0,0,0,3.93
+Fall 2024,KIN,1352,4,12660,"Foundations of KIN, HLT, FIT",Hodgman,Charles F,142,72,20,7,6,0,2,3.302
+Fall 2024,KIN,1352,5,12661,"Foundations of KIN, HLT, FIT",Rinehart,Seth,157,50,17,1,3,0,3,3.512
+Fall 2024,KIN,1352,3,12662,"Foundations of KIN, HLT, FIT",Harrison,Layci,186,34,27,3,4,0,3,3.529
+Fall 2024,PHYS,8399,40,12670,Doctoral Dissertation,Varghese,Oomman K,0,0,0,0,0,1,0,
+Fall 2024,MUSI,8296,4,12676,Doctoral Essay,Pollack,Howard J,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6106,3,12677,Grad Large Ensemble,DeSpain,Kaitlin Elizabeth,2,0,0,0,0,0,0,4.0
+Fall 2024,SOC,6399,9,12678,Masters Thesis,Katz,Sheila,2,0,0,0,0,0,0,4.0
+Fall 2024,SOC,6302,1,12679,Research and Writing,Kwan,Samantha S,7,2,0,0,0,0,3,3.558
+Fall 2024,PHYS,6315,1,12680,Quantum Mechanics I,Koerner,Lisa Whitehead,8,12,0,0,0,0,0,3.433
+Fall 2024,MUSI,8296,5,12683,Doctoral Essay,Guez,Jonathan Charles,0,0,0,0,0,1,0,
+Fall 2024,HRD,4344,20,12684,Designing E-Learning,Bennett,LaTasha,35,3,1,0,1,0,0,3.734
+Fall 2024,POLS,8999,19,12685,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,3,0,
+Fall 2024,COMD,6261,1,12686,Research and Critical Thinking,Thompson,Austin,24,1,0,0,0,0,1,3.841
+Fall 2024,POLS,8999,20,12687,Doctoral Dissertation,Badas,Alex,0,0,0,0,0,1,0,
+Fall 2024,ENGL,1301,132,12689,First Year Writing I,Dykes,Justin,6,8,6,1,3,0,1,2.528
+Fall 2024,ENGL,1301,133,12690,First Year Writing I,Bass,Kasey Dawn,12,5,1,1,0,0,0,3.422
+Fall 2024,ENGL,1302,32,12691,First Year Writing II,Brinkley,Paola Garcia,7,6,1,2,2,0,1,2.778
+Fall 2024,MARK,4396,1,12692,Marketing Internship,Krishnamurthy,Parthasarathy,0,0,0,0,0,2,0,
+Fall 2024,POLS,8999,21,12701,Doctoral Dissertation,Clark,Jennifer H,0,0,0,0,0,1,0,
+Fall 2024,POLS,8999,22,12702,Doctoral Dissertation,Scarrow,Susan E,0,0,0,0,0,2,0,
+Fall 2024,POLS,8999,24,12703,Doctoral Dissertation,Archer,Allison Michelle Nam,0,0,0,0,0,2,0,
+Fall 2024,POLS,8999,25,12704,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,3,0,
+Fall 2024,HIST,8999,5,12705,Doctoral Dissertation,Ramos,Raul,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8999,6,12706,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,4,0,
+Fall 2024,GOVT,2305,4,12707,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,108,74,42,8,1,0,15,3.156
+Fall 2024,POLS,8699,6,12710,Doctoral Dissertation,Rottinghaus,Brandon J,0,0,0,0,0,1,0,
+Fall 2024,THEA,7221,1,12716,Graduate Voice I,Majkowski,Vivian,8,0,0,0,0,0,0,3.918
+Fall 2024,THEA,7251,1,12717,Graduate Speech I,Wetzel,Molly Elizabeth,7,1,0,0,0,0,0,3.875
+Fall 2024,THEA,7211,1,12718,Graduate Movement I,Noble,Adam S,7,1,0,0,0,0,0,3.793
+Fall 2024,CHEE,8598,10,12722,Doctoral Research,Krishnamoorti,Ramanan,0,0,0,0,0,1,0,
+Fall 2024,POLS,8399,23,12724,Doctoral Dissertation,Clark,Jennifer H,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,4396,1,12725,Management Internship,Carlin,Barbara A,0,0,0,0,0,9,0,
+Fall 2024,FINA,4396,1,12728,Finance Internship,Kumar,Praveen,0,0,0,0,0,15,0,
+Fall 2024,BIOE,8298,4,12729,Doctoral Research,Al-Ubaidi,Muayyad,0,0,0,0,0,2,0,
+Fall 2024,POLS,8399,24,12730,Doctoral Dissertation,Zhu,Ling,0,0,0,0,0,1,0,
+Fall 2024,GEOL,1340,2,12732,Earth Systems,Lytwyn,Jennifer N,90,67,31,8,4,0,13,3.153
+Fall 2024,CHEE,8298,16,12734,Doctoral Research,Robertson,Megan L,0,0,0,0,0,5,0,
+Fall 2024,MANA,8399,3,12738,Doctoral Dissertation,Miller,Carl Chet,0,0,0,0,0,0,0,
+Fall 2024,BIOE,8598,6,12741,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Fall 2024,BIOE,8298,5,12742,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,3,0,
+Fall 2024,COMM,6399,2,12743,Masters Thesis,Bhat,Nandikoor R Prashanth,1,0,0,0,0,0,0,4.0
+Fall 2024,GOVT,2306,6,12748,US and Texas Const/Politics,Hanna,Tom Leard,201,33,5,1,1,0,5,3.783
+Fall 2024,KIN,3303,1,12749,Sports Communication,Walsh,David W,7,19,5,0,0,0,1,3.022
+Fall 2024,KIN,4302,1,12750,Fitness and Human Sexuality,Alastuey,Lisa L,39,39,19,14,5,0,3,2.708
+Fall 2024,SPAN,3312,1,12751,English/Spanish Translation,Arboleda,Paola,10,5,2,0,0,0,0,3.393
+Fall 2024,MUSI,8106,3,12752,Doctoral Large Ensemble,DeSpain,Kaitlin Elizabeth,3,0,0,0,0,0,0,4.0
+Fall 2024,MATH,2318,5,12753,Linear Algebra,Perepelitsa,Mikhail Antolyevic,21,34,11,7,0,0,5,2.9
+Fall 2024,MATH,4331,2,12754,Intro to Real Analysis I,Nicol,Matthew J,7,1,0,0,0,0,0,3.793
+Fall 2024,MATH,6312,2,12755,Introduction to Real Analysis,Nicol,Matthew J,2,0,0,0,0,0,0,4.0
+Fall 2024,MATH,4377,4,12756,Advanced Linear Algebra I,Heier,Gordon,6,10,1,0,0,0,1,3.275
+Fall 2024,MATH,6308,4,12757,Advanced Linear Algebra I,Heier,Gordon,9,0,0,0,0,0,1,3.963
+Fall 2024,CNST,4315,1,12766,Steel Construction,Chang,Chi Chung,32,33,1,0,0,0,0,3.45
+Fall 2024,BIOE,8298,9,12769,Doctoral Research,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8298,12,12772,Doctoral Research,Roh,Jinsook,0,0,0,0,0,3,0,
+Fall 2024,FINA,3332,4,12774,Prin of Financial Management,Chisholm,Darla,14,37,44,34,13,0,50,2.005
+Fall 2024,NUTR,4349,1,12775,Public Policy in Nutrition,Vollrath,Kirstin,24,29,2,1,0,0,0,3.257
+Fall 2024,BIOE,8398,5,12776,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,0,0,
+Fall 2024,BIOE,8398,7,12777,Doctoral Research,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8398,9,12779,Doctoral Research,Larin,Kirill,0,0,0,0,0,8,0,
+Fall 2024,BIOE,8398,10,12780,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8398,12,12782,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2024,PSYC,3339,1,12784,Intro To Clinical Psychology,Szafranski,Derek D,40,27,6,2,0,0,5,3.382
+Fall 2024,PSYC,2301,1,12785,Introduction to Psychology,Agan,Herb W,111,83,34,8,8,0,2,3.13
+Fall 2024,PSYC,2301,2,12786,Introduction to Psychology,Agan,Herb W,150,77,20,10,4,0,3,3.339
+Fall 2024,PSYC,2301,3,12787,Introduction to Psychology,Henderson,Perla R,60,14,2,2,0,0,0,3.658
+Fall 2024,GEOL,1340,3,12788,Earth Systems,Lytwyn,Jennifer N,75,59,27,8,5,0,13,3.109
+Fall 2024,SCM,4301,2,12789,Logistics Management,Tibodeau,Dale,27,37,9,0,0,0,0,3.215
+Fall 2024,BIOL,4374,2,12790,Cell Biology,Rea,Michael A,44,34,28,4,1,0,9,3.045
+Fall 2024,FORE,6395,1,12791,Master's Project in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Fall 2024,FORE,6398,1,12792,Special Problems in Foresight,Hines,Andrew Lewis,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7329,1,12793,Behavioral Finance,Rude,Dale,2,3,0,0,0,0,0,3.466
+Fall 2024,BIOE,8498,7,12795,Doctoral Research,Francis,Joseph Thachil,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8498,11,12798,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,
+Fall 2024,BIOE,8598,9,12803,Doctoral Research,Horton,Renita Elillian,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,10,12804,Doctoral Research,Larin,Kirill,0,0,0,0,0,7,0,
+Fall 2024,BIOE,8598,11,12805,Doctoral Research,Majd,Sheereen,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,13,12807,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2024,COMM,6310,1,12808,Mass Comm Theory and Research,Bhat,Nandikoor R Prashanth,15,0,0,0,0,0,0,3.956
+Fall 2024,FINA,7329,1,12809,Behavioral Finance,Rude,Dale,5,3,0,0,0,0,1,3.625
+Fall 2024,GEOL,3383,1,12810,Remote Sensing,Khan,Shuhab D,5,13,6,0,0,0,0,2.931
+Fall 2024,GEOL,6325,1,12812,Remote Sensing,Khan,Shuhab D,5,5,2,0,0,0,0,3.36
+Fall 2024,ACCT,3367,1,12814,Intermediate Accounting I,Gamble,George O,4,0,1,1,0,0,1,3.112
+Fall 2024,PHYS,1302,2,12815,College Physics II (lecture),Forrest,Rebecca L,38,37,56,20,6,0,15,2.499
+Fall 2024,PETR,6399,2,12821,Masters Thesis,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2024,PHYS,3315,1,12824,Modern Physics,Bittner,Eric R,6,2,1,0,0,0,1,3.519
+Fall 2024,PHYS,3309,1,12826,Intermediate Mechanics,Wood,Lowell T,6,9,3,0,1,0,4,2.913
+Fall 2024,MIS,4477,3,12827,Network & Security Infrastruct,Khan,Hina F,34,9,0,0,0,0,0,3.691
+Fall 2024,ELED,4312,2,12829,Science in the Elem School II,Bailer,Jill,23,1,0,0,0,0,0,3.945
+Fall 2024,ECE,4336,1,12830,Electrical Comp Engr Design II,Verret,Douglas,9,30,4,0,0,0,0,3.224
+Fall 2024,MECE,3345,1,12832,Materials Science,Ryou,Jae-Hyun,38,47,14,0,2,0,3,3.165
+Fall 2024,MIS,3370,3,12833,Info Systems Development Tools,Ingram,Barry,20,11,10,7,2,0,15,2.8
+Fall 2024,MECT,3331,31,12834,Applied Thermodynamics,El Nahas,Medhat A,0,8,12,6,4,0,0,1.69
+Fall 2024,LAW,5383,1,12835,Family Law,Willis,Tasha L,9,28,0,0,0,23,0,3.395
+Fall 2024,LAW,5418,7,12836,Torts,Mantel,Jessica,25,52,3,0,0,0,0,3.333
+Fall 2024,LAW,5332,1,12837,Patent Law,Michaels,Andrew Charles,10,17,0,0,0,3,0,3.395
+Fall 2024,FINA,4320,4,12838,Investment Management,Mateen,Haaris,32,16,3,0,0,0,2,3.569
+Fall 2024,ENGL,2330,1,12839,Writing Discipline English,Zachow,Alix V,4,7,3,1,3,0,2,2.371
+Fall 2024,POLS,3312,3,12840,"Arguments, Data, Politics",Austin,Amanda T,20,8,4,2,3,0,4,3.028
+Fall 2024,CHEM,1311,4,12841,Fundamentals of Chemistry,Guloy,Arnold M,52,79,63,9,17,0,43,2.623
+Fall 2024,SPEC,3361,1,12843,Behavior: Interventions,Carp,Charlotte Lynn,6,3,2,0,0,0,1,3.244
+Fall 2024,SPEC,4363,2,12844,Instructional Interventions,Rigby-Wills,Hope,6,5,2,0,1,0,0,2.977
+Fall 2024,PSYC,2301,51,12845,Introduction to Psychology,Saiyed,Amna Shabbir,22,4,1,0,1,0,0,3.572
+Fall 2024,PSYC,2301,50,12846,Introduction to Psychology,Saiyed,Amna Shabbir,24,3,0,1,1,0,0,3.632
+Fall 2024,CUIN,3111,4,12847,Educational Tech Elem Teachers,Davis,Kelly M,25,1,0,0,0,0,0,3.923
+Fall 2024,PHYS,1101,15,12848,College Physics I (lab),Wood,Lowell T,13,6,1,0,0,0,1,3.518
+Fall 2024,PHYS,1101,16,12849,College Physics I (lab),Wood,Lowell T,1,10,4,0,0,0,1,2.8
+Fall 2024,PHYS,1102,10,12850,College Physics II (lab),Wood,Lowell T,2,10,10,1,0,0,0,2.594
+Fall 2024,INAR,4500,1,12851,Interior Arch Studio VII,Mantz,Ophelia,8,11,0,0,0,0,0,3.438
+Fall 2024,ARCH,3327,1,12853,Technology 3,Smith,Joshua S,55,25,3,0,5,0,1,3.405
+Fall 2024,LAW,5401,1,12856,Entrpr Community Dev Clinic II,Heard,Christopher D,1,0,0,0,0,0,0,3.67
+Fall 2024,GHL,2350,2,12857,Mgmt Principles in Hospitality,Boger Jr,Carl A,30,11,7,0,0,0,0,3.41
+Fall 2024,GHL,3341,1,12858,Hospitality Managerial Acct,Johnson,Tucker A,19,11,1,0,0,0,0,3.623
+Fall 2024,PETR,4301,1,12859,Resvr Character and Modeling,Lee,Kyung Jae,1,6,0,0,0,0,0,3.237
+Fall 2024,PHAR,5690,3,12860,Internal Medicine,Fernandez,Julianna M,4,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5683,3,12861,Cardiology,Wanat,Matthew A,4,0,0,0,0,0,0,4.0
+Fall 2024,GHL,2340,1,12862,System of Accts in Hospitality,DeFranco,Agnes L,24,17,6,7,0,0,2,3.044
+Fall 2024,PHYS,1302,3,12864,College Physics II (lecture),Vovchenko,Volodymyr,26,12,22,19,6,0,4,2.384
+Fall 2024,MARK,7362,1,12865,Mgmt of Marketing Information,Hui,Kachuen Sam,18,1,0,0,0,0,0,3.965
+Fall 2024,MARK,4338,1,12866,Marketing Research,Hui,Kachuen Sam,16,10,1,0,0,0,2,3.58
+Fall 2024,MECE,4331,1,12867,Design of Machine Elements,Wang,Su Su,20,80,14,5,0,0,5,2.922
+Fall 2024,DANC,2304,1,12870,Dance Kinesiology,Chapman,Teresa Lynn,4,3,2,3,0,0,0,2.777
+Fall 2024,HDFS,3300,1,12871,Educational Psychology,Conston,Toya,135,16,6,0,2,0,0,3.765
+Fall 2024,TLIM,3340,20,12872,Org Leadership & Supervision,Evans,Gerald S,240,8,6,0,2,0,0,3.802
+Fall 2024,HLT,3325,1,12873,Medical Terminology,Bloom,Joel A,145,3,1,0,0,0,0,3.96
+Fall 2024,BIOE,4115,1,12874,Intro Bioinstrumentation Lab,Akay,Yasemin M,16,0,0,0,0,0,0,3.979
+Fall 2024,BIOE,4315,1,12875,Bioinstrumentation,An,Ran,29,4,2,0,0,0,0,3.743
+Fall 2024,BIOE,4335,1,12876,Capstone Design I,Akay,Metin,37,0,0,0,0,0,0,3.982
+Fall 2024,MECT,4188,30,12877,Ethics in Engineering Tech,Bose,Anima B,22,13,2,0,0,0,1,3.567
+Fall 2024,MECT,4188,31,12878,Ethics in Engineering Tech,Bose,Anima B,10,10,0,1,1,0,0,3.137
+Fall 2024,TLIM,4341,34,12879,Production & Service Operation,Chance,Michael Dean,14,13,0,0,2,0,0,3.276
+Fall 2024,TLIM,4342,32,12880,Quality Improvement Methods,O'Kelley,Donna K,25,16,3,0,1,0,2,3.334
+Fall 2024,TLIM,4372,20,12881,Proposal and Project Writing,Thomas,Jamie M,2,11,9,0,1,0,1,2.551
+Fall 2024,BIOE,6399,7,12883,Masters Thesis,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,7600,3,12886,Architecture Design Studio V,Munenzon Titelboim,Dalia,4,2,0,0,0,0,0,3.557
+Fall 2024,ARLD,6320,1,12888,Financial Management for Arts,Townsend,Justine M,11,1,0,1,0,0,0,3.616
+Fall 2024,ENGL,1301,13,12889,First Year Writing I,Penzien,Eugene Norman,14,4,4,0,1,0,2,3.204
+Fall 2024,ENGL,1301,105,12890,First Year Writing I,Bradley,Jari,13,3,1,0,2,0,0,3.298
+Fall 2024,COSC,6344,1,12891,Visualization,Chen,Guoning,24,20,0,0,0,0,1,3.508
+Fall 2024,ACCT,3367,2,12893,Intermediate Accounting I,Gamble,George O,1,0,0,1,0,0,0,2.5
+Fall 2024,ARTS,3313,2,12896,Silkscreen,Masterson,Patrick D,15,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,6347,1,12898,Intro Opt Sense & Biophotonics,Larin,Kirill,5,0,0,0,0,0,0,3.868
+Fall 2024,INDE,6333,2,12900,Probability Stat For Engineers,Feng,Qianmei,11,11,4,0,0,0,5,3.307
+Fall 2024,ARTH,7380,1,12901,Graduate Art History Methods I,Harren,Natilee O,5,0,0,0,0,0,0,3.868
+Fall 2024,FORE,6311,20,12902,Introduction to Foresight,Rush,Julie,9,0,0,0,0,0,0,4.0
+Fall 2024,BZAN,6310,2,12905,Quant Analysis for Busn Dec,Hou,Jinghui,14,3,0,0,0,0,0,3.843
+Fall 2024,WGSS,2350,6,12906,Intro To Women's Studies,Ford,Devan,29,0,0,0,1,0,0,3.856
+Fall 2024,CHEE,8398,16,12907,Doctoral Research,Robertson,Megan L,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,17,12909,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,18,12910,Doctoral Research,Vekilov,Peter,0,0,0,0,0,1,0,
+Fall 2024,MATH,8698,2,12912,Doctoral Research,Timofeyev,Ilya,0,0,0,0,0,4,0,
+Fall 2024,FINA,4380,1,12913,R E Fin & Investment,Adams,James S,30,6,1,0,0,0,1,3.686
+Fall 2024,CUIN,3350,3,12914,Knowing/Learning Science-Math,McIntush,Karen E,2,0,0,1,0,0,0,2.89
+Fall 2024,ARTS,3383,1,12915,Digital Fabrication,Clarke,Chelsea,10,2,0,0,0,0,0,3.723
+Fall 2024,ENGL,3351,1,12916,Am Lit Since 1865,Ellis,Amanda,20,2,3,1,3,0,2,3.173
+Fall 2024,MUSI,6101,1,12917,Opera Role Performance,Belcher,Kathleen,24,0,0,0,0,0,1,4.0
+Fall 2024,MUSA,6140,1,12919,Graduate Recital I,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6140,2,12920,Graduate Recital I,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4370,1,12921,Art Song Repertoire,Sonnenberg,Melanie,3,1,0,0,0,0,0,3.668
+Fall 2024,MUSI,6341,1,12923,Graduate Music Theory Review,Lee,Ji Yeon,4,4,3,1,0,0,1,2.944
+Fall 2024,SOC,6398,2,12928,Special Problems,Quiroz,Pamela Anne,0,0,0,0,0,0,0,
+Fall 2024,MUSA,3400,4,12929,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2024,ECON,3370,2,12930,Introduction To Econometrics,Zhivan,Natalia A,11,14,12,7,3,0,0,2.461
+Fall 2024,ATP,6311,1,12931,Research in Athletic Training,Knoblauch,Mark Alan,6,8,0,0,0,0,0,3.429
+Fall 2024,ATP,6312,1,12932,Therapeutic Intervention 1,Elliott,Ashlyne Paige,11,3,0,0,0,0,0,3.786
+Fall 2024,ATP,6192,1,12933,Clinical Experience II,Harrison,Layci,14,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6275,1,12934,Professional Development,Porter,Jason,7,0,1,0,0,0,0,3.791
+Fall 2024,LAW,5314,18,12936,Lawyering Skills & Strategy I,Simpson,Lauren J,4,10,0,0,0,0,0,3.333
+Fall 2024,LAW,5314,22,12937,Lawyering Skills & Strategy I,Simpson,Lauren J,4,11,0,0,0,0,0,3.355
+Fall 2024,MECT,4172,31,12939,Materials Tech Lab,Al Ibadi,Adnan,7,13,0,0,0,0,0,3.433
+Fall 2024,ARLD,6691,1,12943,Internship in Arts Organizatn,Fernando,Fleurette S,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,8303,1,12944,Seminar in Music Theory,Koozin,Timothy,12,0,0,0,0,0,0,3.918
+Fall 2024,CHEM,8998,20,12945,Doctoral Research,Baldelli,Steve,0,0,0,0,0,1,0,
+Fall 2024,WGSS,2350,8,12950,Intro To Women's Studies,Pegoda,Andrew Joseph,7,10,10,0,0,0,1,2.95
+Fall 2024,CHEM,6698,24,12959,Special Problems,Carrow,Bradley,0,0,0,0,0,2,0,
+Fall 2024,PHYS,1102,11,12960,College Physics II (lab),Wood,Lowell T,1,13,4,3,0,0,3,2.666
+Fall 2024,PHLS,7393,2,12961,Internship and Practicum,Reyna,Ronda,5,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,1106,47,12964,Biol for Science Majors I(Lab),Medrano,Ana I,18,3,1,0,0,0,2,3.728
+Fall 2024,BIOL,1106,48,12965,Biol for Science Majors I(Lab),Medrano,Ana I,15,5,0,0,0,0,2,3.75
+Fall 2024,CHEM,1111,52,12966,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,0,0,0,1,3.111
+Fall 2024,CHEM,1111,55,12967,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,0,0,1,0,2,3.061
+Fall 2024,CHEM,1112,18,12968,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,2,0,0,0,1,3.183
+Fall 2024,CHEM,1112,19,12969,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,12,1,0,0,0,2,3.228
+Fall 2024,ARCH,1500,17,12970,Design Studio I,Gonzales,Michael A,11,3,1,0,0,0,1,3.645
+Fall 2024,MECT,3118,31,12973,Fluid Mechanic Application Lab,Al Ibadi,Adnan,15,3,0,0,0,0,0,3.815
+Fall 2024,MECT,3155,31,12974,Strength Materials Lab,Al Ibadi,Adnan,13,1,0,0,0,0,1,3.929
+Fall 2024,MATH,8698,3,12979,Doctoral Research,Bodmann,Bernhard G,0,0,0,0,0,1,0,
+Fall 2024,SPAN,6305,1,12981,Teaching Span. for Acquisition,Gellon,Sofia,8,0,0,0,0,0,0,3.876
+Fall 2024,ECON,8363,1,12982,Workshop in Research Methods V,Cubas Norando,German,0,0,0,0,0,12,0,
+Fall 2024,PHIL,1321,2,12983,Logic I,Haaga,Curtis W,32,15,7,2,2,0,13,3.253
+Fall 2024,ECON,8399,3,12984,Doctoral Dissertation,Sorensen,Bent E,0,0,0,0,0,2,0,
+Fall 2024,PEP,8699,1,12988,Doctoral Dissertation,Cottingham,Michael,0,0,0,0,0,1,0,
+Fall 2024,ENGL,1301,22,12991,First Year Writing I,Rolater,Sara C,9,7,6,0,2,0,0,2.793
+Fall 2024,ENGL,1301,25,12992,First Year Writing I,Downey,Carlton M,19,5,0,0,1,0,0,3.614
+Fall 2024,BIOL,2101,17,12993,Anatomy & Physiology Lab I,Gill,Tejendra,10,10,2,0,1,0,1,3.146
+Fall 2024,BIOL,2101,18,12994,Anatomy & Physiology Lab I,Gill,Tejendra,9,12,2,0,0,0,0,3.304
+Fall 2024,BIOL,2101,19,12995,Anatomy & Physiology Lab I,Gill,Tejendra,1,15,3,1,1,0,3,2.588
+Fall 2024,ECON,8399,2,13000,Doctoral Dissertation,Papell,David H,0,0,0,0,0,1,0,
+Fall 2024,PEP,8699,2,13004,Doctoral Dissertation,Johnston,Craig Allen,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8298,17,13005,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Fall 2024,PETR,6399,6,13006,Masters Thesis,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Fall 2024,SOC,7399,8,13007,Masters Thesis,Savage,Scott Vandenburgh,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8399,1,13008,Doctoral Dissertation,McNally,David Joseph,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8399,4,13010,Doctoral Dissertation,Lee,Mimi Miyoung,0,0,0,0,0,1,0,
+Fall 2024,ELCS,6301,1,13021,Leadership for Equity,Davis,Bradley,25,0,0,0,1,0,0,3.846
+Fall 2024,BCHS,3304,3,13024,General Biochemistry I,Liu,Yu,44,39,25,6,2,0,7,2.963
+Fall 2024,BIOE,6351,1,13025,Diseases and Biomarkers,Mohan,Chandra,17,4,0,0,0,0,0,3.715
+Fall 2024,BIOE,6350,1,13026,Genomic and Proteomic Engr,Wu,Tianfu,17,1,0,0,0,0,0,3.944
+Fall 2024,SCM,4390,1,13027,Supply Chain Strategy,Smith,Gordon D,20,38,2,0,0,0,0,3.289
+Fall 2024,PETR,4311,1,13028,Petroleum Capstone Project I,Zargar,Zeinab,2,3,0,0,0,0,0,3.466
+Fall 2024,SPAN,3339,1,13029,Span for Global Professions,Zubiate,Maria Laura,4,3,0,1,0,0,1,3.168
+Fall 2024,ARTS,3374,3,13030,Computer Imaging,Thomas,Britt,12,6,0,0,0,0,0,3.557
+Fall 2024,PETR,7399,2,13032,Masters Thesis,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2024,PETR,8298,1,13037,Doctoral Research,Soliman,Mohamed Yousef,0,0,0,0,0,3,0,
+Fall 2024,PETR,8699,1,13041,Doctoral Dissertation,Soliman,Mohamed Yousef,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,4365,1,13042,Inorganic Chemistry II,Hoffman,David M,4,7,11,1,0,0,0,2.566
+Fall 2024,PSYC,3350,2,13043,Intro to Cognitive Psychology,Harlan,Pamela Kay,47,28,4,0,0,0,0,3.486
+Fall 2024,BIOE,4115,2,13044,Intro Bioinstrumentation Lab,Akay,Yasemin M,11,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,1147,1,13045,Introductory Meteorology Lab,Jiang,Xun,3,5,0,0,0,0,0,3.21
+Fall 2024,CUIN,8341,1,13046,Crit Issues & Research Urb Ed,Hutchison,Laveria F,19,0,0,0,0,0,0,4.0
+Fall 2024,COSC,4351,702,13047,Fundamentals of Software Engr,Hilford,Victoria,39,38,6,3,0,0,0,3.299
+Fall 2024,ECE,2100,1,13048,Circuit Analysis Laboratory,Ramachandran,Deepa,18,6,1,0,2,0,3,3.432
+Fall 2024,ECE,2201,1,13049,Circuit Analysis I,Ramachandran,Deepa,14,9,16,4,6,0,14,2.429
+Fall 2024,ECE,3340,1,13050,Numerical Methods for ECE,Zheng,Jianfeng,13,29,4,0,0,0,0,3.16
+Fall 2024,ECE,3155,1,13051,Electronics Laboratory,Shattuck,David P,86,9,1,1,0,0,0,3.873
+Fall 2024,COMM,2320,1,13052,Fundamentals Media Production,Crowe,Craig Warren,64,16,0,0,0,0,1,3.751
+Fall 2024,COMM,2322,1,13053,Television Production I,Crowe,Craig Warren,21,12,3,0,0,0,0,3.399
+Fall 2024,ECE,6340,1,13054,Interm Electromag Waves,Chen,Jiefu,7,1,0,0,0,0,0,3.875
+Fall 2024,GEOL,3370,1,13055,Mineralogy,Antonelli,Michael Ariel,11,30,5,0,0,0,0,3.095
+Fall 2024,ACCT,5379,1,13058,Enterprise Risk Management,Neely,Gregory Wayne,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,1100,8,13059,Introduction To Engineering,Zelisko,Matthew Raymond,24,25,14,5,8,0,0,2.649
+Fall 2024,PHLS,8393,1,13060,Doctoral Practicum in Psy,McPherson,Robert Harlan,0,0,0,0,0,6,0,
+Fall 2024,AAMS,2300,1,13061,Intro Asian American Studies,Nguyen,An,12,5,3,0,1,0,1,3.239
+Fall 2024,PETR,8298,4,13066,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,2,0,
+Fall 2024,PETR,8398,2,13067,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2024,ELET,1401,1,13076,Circuit Theory and Lab II,Barbieri,Enrique,3,7,16,1,1,0,3,2.298
+Fall 2024,FINA,4329,1,13079,Life Insurance and Annuities,Hong,James,29,35,2,0,0,0,0,3.454
+Fall 2024,PETR,8598,2,13080,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,2,0,
+Fall 2024,PETR,8598,3,13081,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Fall 2024,PETR,8399,2,13084,Doctoral Dissertation,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2024,PETR,8399,3,13085,Doctoral Dissertation,Ehlig-Economides,Christine A,1,0,0,0,0,1,0,4.0
+Fall 2024,BCHS,3201,1,13088,Biochemistry I Laboratory,Pattison,Donna,5,8,3,3,0,0,0,2.737
+Fall 2024,BCHS,3201,2,13089,Biochemistry I Laboratory,Pattison,Donna,5,10,5,0,0,0,0,2.967
+Fall 2024,BCHS,3201,3,13090,Biochemistry I Laboratory,Pattison,Donna,5,5,0,1,0,0,0,3.333
+Fall 2024,BCHS,3201,4,13091,Biochemistry I Laboratory,Pattison,Donna,5,8,4,2,0,0,1,2.773
+Fall 2024,BCHS,3201,5,13092,Biochemistry I Laboratory,Pattison,Donna,6,9,2,1,0,0,2,3.019
+Fall 2024,BCHS,3201,6,13093,Biochemistry I Laboratory,Pattison,Donna,11,7,2,0,0,0,1,3.401
+Fall 2024,BCHS,3201,7,13094,Biochemistry I Laboratory,Pattison,Donna,8,8,0,0,0,0,0,3.479
+Fall 2024,BCHS,3201,8,13095,Biochemistry I Laboratory,Pattison,Donna,6,14,3,0,0,0,1,3.116
+Fall 2024,BCHS,3201,9,13096,Biochemistry I Laboratory,Pattison,Donna,5,9,3,0,0,0,1,3.176
+Fall 2024,BIOL,4103,1,13098,Integration Biol Knowledge,Wayne,Chad M,48,15,9,0,0,0,1,3.565
+Fall 2024,BIOL,4103,2,13099,Integration Biol Knowledge,Wayne,Chad M,59,18,7,0,0,0,1,3.635
+Fall 2024,PETR,8699,2,13101,Doctoral Dissertation,Dindoruk,Birol,0,0,0,0,0,3,0,
+Fall 2024,PETR,8699,3,13102,Doctoral Dissertation,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Fall 2024,COMM,4360,2,13105,Media Planning & Placement,Jin,Eunjoo,10,12,1,0,0,0,1,3.348
+Fall 2024,COMM,4368,1,13106,Public Relations Campaigns,Vardeman,Jennifer E,21,0,0,0,0,0,0,3.921
+Fall 2024,POLS,3348,1,13107,"Left, Right, and Center",Cheng,Eric,31,13,0,0,0,0,0,3.615
+Fall 2024,COSC,3360,2,13108,Operating Systems,Rincon Castro,Carlos Alberto,28,44,34,7,2,0,18,2.794
+Fall 2024,HDCS,3300,3,13109,Org Decisions,Stewart,Quentin K,16,10,2,0,1,0,0,3.368
+Fall 2024,MECE,3363,1,13110,Intro To Fluid Mechanics,Floryan,Daniel,15,45,8,0,0,0,1,3.098
+Fall 2024,ARCH,6359,1,13111,Modern Architecture & Urbanism,Bassi Cendra,Giovanna Maria,22,9,0,0,0,0,0,3.614
+Fall 2024,ECE,3317,2,13112,Applied Electromagnetic Waves,Long,Stuart A,8,9,5,0,0,0,1,3.091
+Fall 2024,COMD,4489,1,13113,Clinical Procedures,Ivey,Michelle L,16,1,0,0,0,0,1,3.902
+Fall 2024,MARK,3336,1,13114,Introduction to Marketing,Koch,Steven F,21,5,0,0,0,0,0,3.77
+Fall 2024,MARK,3336,2,13115,Introduction to Marketing,Kraemer,Martin,340,148,39,10,4,0,8,3.473
+Fall 2024,MARK,3336,3,13116,Introduction to Marketing,Koch,Steven F,142,179,69,9,3,0,25,3.1
+Fall 2024,MARK,3336,4,13117,Introduction to Marketing,Kraemer,Martin,261,138,33,9,6,0,5,3.404
+Fall 2024,HON,3301,3,13118,Readings in Medicine & Society,Liddell,Robert B,23,0,0,0,0,0,0,4.0
+Fall 2024,MATH,1324,1,13119,Finite Math with Applications,Sosa,Moses,162,118,82,48,60,0,70,2.51
+Fall 2024,MATH,1324,2,13120,Finite Math with Applications,Winkle,James J,132,122,80,42,62,0,102,2.462
+Fall 2024,MATH,1324,3,13121,Finite Math with Applications,Meraz,Cristian,72,50,52,28,48,0,16,2.219
+Fall 2024,MATH,1324,5,13122,Finite Math with Applications,Constante,Beatrice,242,118,76,32,26,0,44,3.018
+Fall 2024,MATH,1324,6,13123,Finite Math with Applications,Sosa,Moses,276,118,74,26,48,0,54,2.955
+Fall 2024,MATH,1325,2,13124,Calc for Bus & Social Sciences,Constante,Beatrice,136,140,40,22,18,0,20,2.955
+Fall 2024,MATH,4364,1,13125,Intro to Numerical Analysis,Pan,Tsorng-Whay,16,14,8,1,0,0,1,3.188
+Fall 2024,BUSI,3302,1,13126,Connecting Bauer to Business,Belinne,Jamie King,135,51,11,5,4,0,4,3.495
+Fall 2024,BUSI,3302,2,13127,Connecting Bauer to Business,Belinne,Jamie King,385,32,2,1,1,0,4,3.898
+Fall 2024,COSC,4353,801,13128,Software Design,Singh,Raj Kumar,162,17,3,0,1,0,1,3.831
+Fall 2024,COSC,6353,802,13129,Software Design,Subramaniam,Venkat,4,2,0,0,0,0,1,3.777
+Fall 2024,BIOL,4272,1,13130,Cell and Develop Biol Lab,Gifford,Jenifer,23,1,0,0,0,0,0,3.917
+Fall 2024,COMM,3314,1,13131,Intermediate Reporting,Roth,Geoffrey,24,2,0,0,1,0,0,3.766
+Fall 2024,THEA,4307,1,13132,Intro to Educational Theatre,Hickman,Margo Louise,4,0,0,0,0,0,0,4.0
+Fall 2024,MSCI,1210,4,13134,Introduction to the Army,Bradford,Todd F,8,1,0,0,0,0,0,3.779
+Fall 2024,SOCW,8311,1,13135,Research Methods I,Acquati,Chiara,4,3,0,0,0,0,0,3.571
+Fall 2024,MSCI,4398,1,13136,Independent Study,Thomas,Roland,5,2,0,0,0,0,1,3.62
+Fall 2024,BIOL,4272,2,13137,Cell and Develop Biol Lab,Gifford,Jenifer,19,5,0,0,0,0,0,3.792
+Fall 2024,SOCW,8424,1,13138,Statistics and Data Analysis I,Leung,Yuk-Hi Patrick,4,3,0,0,0,0,0,3.571
+Fall 2024,COMM,6305,1,13140,Qualitative Research Methods,Platenburg,Gheni Nicole,13,7,2,0,0,0,3,3.455
+Fall 2024,PSYC,2319,1,13141,Intro to Social Psychology,Fetterman,Adam Kent,19,23,7,2,1,0,1,3.141
+Fall 2024,GHL,1301,1,13142,Hospitality Technology,Li,Ningqiao,21,9,3,1,0,0,0,3.422
+Fall 2024,GHL,1301,2,13143,Hospitality Technology,Hernandez Calderon,Araceli,23,5,1,2,2,0,1,3.344
+Fall 2024,GHL,2160,1,13144,Hospitality Internship,Shepherd,Ashley,45,2,0,0,0,0,1,3.964
+Fall 2024,GHL,8303,1,13145,Multivariate Anal. in Hosp. Ad,Guchait,Priyanko,3,1,0,0,0,0,0,3.75
+Fall 2024,GHL,3348,1,13146,Principles of Hosp Revenue Mgt,Cheatham,Cathy A,20,4,0,2,0,0,0,3.628
+Fall 2024,COMD,4489,3,13147,Clinical Procedures,Ermgodts,Katherine Natalie,19,2,0,0,0,0,0,3.858
+Fall 2024,FINA,4351,1,13148,"Derivs II: Frwds, Futrs&Swaps",Rabinovitch,Ramon,20,11,1,0,0,0,1,3.553
+Fall 2024,LAW,5314,23,13149,Lawyering Skills & Strategy I,Crozier,Christina Fontenot,8,8,0,0,0,0,0,3.397
+Fall 2024,THEA,2383,1,13152,Stage Management II,Bush,Rachel R,3,1,0,0,0,0,0,3.668
+Fall 2024,THEA,3283,1,13153,Stage Management III,Bush,Rachel R,4,1,0,0,0,0,0,3.8
+Fall 2024,COMM,4392,1,13160,Prof. Internship for Credit,Ashley,Laura B,0,0,0,0,0,29,0,
+Fall 2024,TLIM,3355,31,13161,Project Management Principles,Moore,George P,33,21,5,0,5,0,0,3.167
+Fall 2024,CIVE,6111,1,13162,Graduate Seminar,Momen,Mostafa,0,0,0,0,0,18,0,
+Fall 2024,MECT,3367,30,13163,Quality Control Technology,Afrin,Samia,13,13,2,0,0,0,1,3.381
+Fall 2024,MECT,3342,30,13164,Elements of Plant Design,El Nahas,Medhat A,0,13,6,0,0,0,0,2.58
+Fall 2024,MECT,3358,30,13166,Dynamics of Mechanisms,Basaran,Burak,5,11,25,8,1,0,6,2.2
+Fall 2024,MECT,3365,30,13168,Computer-Aided Design I,El Nahas,Medhat A,2,9,5,0,1,0,0,2.569
+Fall 2024,PHYS,2326,1,13170,University Physics II(lecture),Forrest,Rebecca L,12,42,76,10,4,0,8,2.276
+Fall 2024,PHYS,1101,17,13171,College Physics I (lab),Wood,Lowell T,5,9,7,0,0,0,3,2.858
+Fall 2024,PHYS,1101,18,13172,College Physics I (lab),Wood,Lowell T,0,14,6,1,0,0,2,2.666
+Fall 2024,ENGL,3322,1,13173,Contemporary Novel,Majumder,Auritro,11,17,0,0,2,0,0,3.266
+Fall 2024,PHYS,1102,12,13174,College Physics II (lab),Wood,Lowell T,2,12,8,1,0,0,0,2.623
+Fall 2024,ACCT,2301,5,13175,Prin of Financial Accounting,Zhu,Limin,9,34,12,17,1,0,7,2.57
+Fall 2024,ACCT,3366,1,13176,Financial Reporting Frameworks,Harris,Kathleen L,16,19,9,6,2,0,13,2.827
+Fall 2024,ECE,3457,1,13177,Digital Electronics,Bao,Jiming,44,43,1,0,0,0,1,3.44
+Fall 2024,PETR,2111,1,13179,Petroleum Petrophysics Lab,Hathon,Lori A,17,0,0,0,0,0,1,4.0
+Fall 2024,MECE,3400,1,13180,Intro To Mechanics,Wang,Su Su,16,27,5,2,1,0,1,3.027
+Fall 2024,SPAC,6201,1,13183,Man Systems Integration,Toups,Larry David,16,0,0,0,0,0,1,4.0
+Fall 2024,SPAC,6401,1,13184,Space Systems Tech Studio,Bannova,Olga,14,2,0,0,0,0,0,3.71
+Fall 2024,BIOE,8298,16,13186,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,15,13194,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,3,0,
+Fall 2024,BIOE,8399,1,13201,Doctoral Dissertation,Akay,Metin,1,0,0,0,0,2,0,4.0
+Fall 2024,BIOE,8399,2,13202,Doctoral Dissertation,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8399,6,13204,Doctoral Dissertation,Al-Ubaidi,Muayyad,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8399,7,13205,Doctoral Dissertation,Francis,Joseph Thachil,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8399,8,13206,Doctoral Dissertation,Gifford,Howard,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8399,10,13208,Doctoral Dissertation,Larin,Kirill,1,0,0,0,0,1,0,4.0
+Fall 2024,BIOE,8399,14,13211,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8699,1,13213,Doctoral Dissertation,Akay,Metin,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8699,6,13216,Doctoral Dissertation,Al-Ubaidi,Muayyad,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8699,7,13217,Doctoral Dissertation,Francis,Joseph Thachil,2,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8399,14,13219,Doctoral Dissertation,Palmer,Jeremy,4,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8398,18,13220,Doctoral Research,Das,Mini,0,0,0,0,0,1,0,
+Fall 2024,BIOE,6398,17,13221,Research,Zhang,Yingchun,0,0,0,0,0,0,0,
+Fall 2024,PETR,8598,7,13223,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2024,INDE,3310,1,13224,Quality Control & Improvement,Wang,Yaping,12,10,4,1,1,0,1,3.025
+Fall 2024,CHEE,8298,18,13227,Doctoral Research,Vekilov,Peter,0,0,0,0,0,1,0,
+Fall 2024,ENGI,1331,2,13228,Computing for Engineers,Kota,Venkata Krishna Tulasi,33,14,10,1,1,0,10,3.255
+Fall 2024,ENGI,1331,6,13229,Computing for Engineers,Burleson,Daniel W,23,24,9,0,4,0,7,3.055
+Fall 2024,ENGI,1100,9,13230,Introduction To Engineering,Aksu,Gulin Tulunay,40,24,8,1,0,0,3,3.388
+Fall 2024,ENGI,1100,12,13232,Introduction To Engineering,Metrovich,Brian,39,10,3,0,1,0,4,3.573
+Fall 2024,ENGI,1100,13,13233,Introduction To Engineering,Luna Singh,Jennifer Austin,56,9,6,0,2,0,2,3.639
+Fall 2024,PETR,8298,7,13234,Doctoral Research,Ehlig-Economides,Christine A,0,0,0,0,0,1,0,
+Fall 2024,ENGR,2301,2,13239,Mechanics I (Statics),Kalliontzis,Dimitrios,30,22,16,13,3,0,5,2.703
+Fall 2024,PETR,4312,1,13240,Petroleum Capstone Project II,Zargar,Zeinab,4,0,0,0,0,0,0,3.67
+Fall 2024,MECE,2334,2,13241,Thermodynamics,Malamataris,Nikolaos,51,19,17,20,1,0,7,2.868
+Fall 2024,MECE,3336,1,13242,Mechanics II,Sharma,Pradeep,7,18,19,1,2,0,1,2.511
+Fall 2024,MECE,3369,1,13243,Solid Mechanics,Baxevanis,Theocharis,15,53,37,5,2,0,1,2.587
+Fall 2024,MECE,3381,1,13244,Finite Elements for Mech Engr,Rao,Jagannatha R,16,17,7,4,0,0,0,3.038
+Fall 2024,ECE,3436,3,13245,Microprocessor Systems,Le,Hung Quang,23,18,0,0,0,0,0,3.561
+Fall 2024,BIOE,3351,1,13247,Introduction to Diseases,Mohan,Chandra,23,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,6355,2,13248,Intro-Dynamics of Structures,Zhang,Ruda,3,0,1,0,0,0,0,3.418
+Fall 2024,CIVE,6362,1,13249,Water Quality Engineering,Shaffer,Devin,3,0,0,0,0,0,0,4.0
+Fall 2024,ECE,4339,2,13250,Phy Prin of Solid State Device,Wolfe,John C,9,3,0,0,0,0,0,3.833
+Fall 2024,MECE,3338,1,13251,Dynamics & Controls Mech Syst,Cescon,Marzia,16,54,8,0,2,0,4,3.05
+Fall 2024,MECE,4343,1,13252,Thermal Design,Ghasemi,Hadi,13,29,42,0,3,0,6,2.518
+Fall 2024,CHEE,6335,1,13253,Classicl-Statist Thermo,Vekilov,Peter,16,34,0,0,0,0,1,3.241
+Fall 2024,CHEE,6333,1,13254,Transport Processes,Conrad,Jacinta C,18,16,0,0,1,0,2,3.344
+Fall 2024,INDE,3432,1,13255,Manufacturing Processes,Kamrani,Ali K,4,26,13,0,0,0,2,2.814
+Fall 2024,SPAC,6405,1,13257,Advanced Design and Analysis,Bannova,Olga,3,4,1,0,0,0,0,3.25
+Fall 2024,BIOE,8298,18,13259,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8298,21,13262,Doctoral Research,Sajja,Aaryani,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8298,22,13263,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8399,16,13268,Doctoral Dissertation,Shevkoplyas,Sergey,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8399,19,13271,Doctoral Dissertation,Kakadiaris,Ioannis A,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8399,20,13272,Doctoral Dissertation,Das,Mini,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8399,22,13274,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8598,18,13281,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,20,13283,Doctoral Research,Das,Mini,0,0,0,0,0,2,0,
+Fall 2024,BIOE,8699,10,13289,Doctoral Dissertation,Larin,Kirill,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8699,13,13292,Doctoral Dissertation,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8699,16,13295,Doctoral Dissertation,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8298,19,13300,Doctoral Research,Willson,Richard,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8399,15,13301,Doctoral Dissertation,Rimer,Jeffrey,0,0,0,0,0,10,0,
+Fall 2024,CHEE,8399,16,13302,Doctoral Dissertation,Robertson,Megan L,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8399,17,13303,Doctoral Dissertation,Varadarajan,Navin,6,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8399,18,13304,Doctoral Dissertation,Vekilov,Peter,2,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8399,19,13305,Doctoral Dissertation,Willson,Richard,1,0,0,0,0,0,0,4.0
+Fall 2024,PETR,3315,1,13306,Introduction to Well Logging,Hathon,Lori A,6,6,0,0,0,0,0,3.5
+Fall 2024,PETR,6399,7,13309,Masters Thesis,Hatzignatiou,Dimitrios Georgios,0,0,0,0,0,1,0,
+Fall 2024,ENGI,1100,15,13317,Introduction To Engineering,Aksu,Gulin Tulunay,35,22,10,2,4,0,3,3.132
+Fall 2024,ENGI,1331,3,13318,Computing for Engineers,Zelisko,Matthew Raymond,18,13,21,1,2,0,13,2.788
+Fall 2024,ENGI,1331,7,13319,Computing for Engineers,Aksu,Gulin Tulunay,22,14,10,9,2,0,9,2.703
+Fall 2024,BIOE,4307,1,13320,Optical Imaging,Larin,Kirill,2,0,0,1,0,0,0,3.0
+Fall 2024,BIOE,6303,1,13321,Biomaterials,Abidian,Mohammad Reza,3,1,0,0,0,0,0,3.585
+Fall 2024,BIOE,6305,1,13322,Brain Machine Interfacing,Francis,Joseph Thachil,7,0,0,0,0,0,0,3.859
+Fall 2024,ENGI,2304,5,13323,Technical Communications,Wilson,Chad A,11,6,2,1,2,0,1,2.91
+Fall 2024,CHEE,3367,1,13324,Process Modeling and Control,Kaspar,Michael,7,8,6,0,0,0,1,3.0
+Fall 2024,CHEE,3369,1,13325,Chemical Engr Transport Proc,Harold,Michael P,5,4,4,1,0,0,10,2.952
+Fall 2024,CHEE,3466,1,13326,Bio & Physical Chemistry,Willson,Richard,15,10,4,0,0,0,0,3.368
+Fall 2024,MECE,4341,1,13327,Mechanical Engr Capstone II,Agrawal,Ashutosh,25,36,6,0,0,0,0,3.328
+Fall 2024,ECE,2100,2,13328,Circuit Analysis Laboratory,Leigh,Kevin Benny,6,8,0,0,1,0,1,3.156
+Fall 2024,ECE,2202,1,13329,Circuit Analysis II,Trombetta,Leonard P,19,9,12,7,5,0,10,2.564
+Fall 2024,ECE,4115,1,13331,Control Systems Laboratory I,Provence,Robert S,6,14,2,0,1,0,0,3.058
+Fall 2024,ECE,4375,1,13332,Automatic Control Systems,Provence,Robert S,7,17,11,0,1,0,0,2.787
+Fall 2024,ECE,4437,1,13333,Embedded Microcomputer Systems,Le,Hung Quang,31,1,0,0,0,0,1,3.938
+Fall 2024,PETR,6332,1,13335,Deterministic Reserves Estimat,Zargar,Zeinab,9,1,0,0,0,0,0,3.801
+Fall 2024,ECE,5335,2,13336,State-Space Control Systems,Ortiz,James Norman,4,4,1,0,0,0,0,3.26
+Fall 2024,ECE,6325,2,13337,State-Space Control Systems,Ortiz,James Norman,8,8,6,0,1,0,2,2.899
+Fall 2024,MECE,2336,1,13338,Mechanics I,Hammami,Farah,6,7,2,1,0,0,0,3.063
+Fall 2024,CHEE,6331,1,13339,Math Mtds in Chem Engr,Balakotaiah,Vemuri,9,30,0,0,0,0,1,3.18
+Fall 2024,PETR,8398,8,13344,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2024,PETR,6399,10,13348,Masters Thesis,Lee,Kyung Jae,0,0,0,0,0,1,0,
+Fall 2024,PETR,8298,10,13351,Doctoral Research,Wong,George K,0,0,0,0,0,2,0,
+Fall 2024,POLC,6313,1,13352,Policy Analysis I: Microecon,Wong,Man Chiu,13,14,0,0,0,0,1,3.469
+Fall 2024,POLC,6316,1,13353,Pol Res III: Adv Quant Mod,Atsusaka,Yuki,17,1,4,0,0,0,1,3.516
+Fall 2024,POLC,6331,1,13354,Philosophy and Pub Policy II,Williams,Brandon,22,1,1,0,0,0,0,3.834
+Fall 2024,POLC,6314,1,13355,Pol Res I: Intro to Statistics,Buttorff,Gail J,10,15,3,0,0,0,1,3.262
+Fall 2024,POLC,6311,2,13356,Leader and Prof Development,Witt,Lawrence A,20,1,0,0,0,0,1,3.952
+Fall 2024,CUIN,7358,1,13360,Educ Uses Digital Storytelling,Dogan,Bulent,16,0,0,0,0,0,1,3.979
+Fall 2024,PHLS,8193,1,13361,Internship in Psychology,Arbona,Consuelo,0,0,0,0,0,5,0,
+Fall 2024,CUIN,3111,1,13365,Educational Tech Elem Teachers,Davis,Kelly M,18,1,0,0,0,0,0,3.895
+Fall 2024,CUIN,4375,5,13367,Classroom Management,Castillo,Bernadette Marie,19,0,1,1,0,0,0,3.746
+Fall 2024,ELED,3320,1,13368,Survey Literature Child Adol,Stubbs,Susan,28,0,0,0,0,0,0,3.965
+Fall 2024,EDUC,2301,1,13370,Intro to Special Populations,Rigby-Wills,Hope,110,43,13,3,1,0,2,3.457
+Fall 2024,ELED,4314,5,13372,Mathematics in Elem School I,Burris,Justin T,21,2,0,0,0,0,0,3.884
+Fall 2024,SEDE,7335,1,13373,Literature for Adolescents,Stubbs,Susan,8,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8302,1,13374,Research Meth in Psych/Educ,Matta,Michael,15,0,0,0,0,0,0,3.912
+Fall 2024,CUIN,8371,1,13375,Introduction to Quant Research,Zhang,Jie,7,2,0,0,0,0,1,3.668
+Fall 2024,HLT,4307,2,13376,Research and Eval in Health,Correa-Fernandez,Virmarie,18,13,3,1,0,0,1,3.39
+Fall 2024,PHLS,8241,1,13377,Prof Seminar in School Psych,Margulis,Milena A,4,2,0,0,0,0,0,3.557
+Fall 2024,PHLS,8341,1,13378,Professional Seminar,Allan,Blake A,6,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8345,1,13380,CUIN Seminar,Alarcon,Jeannette Driscoll,17,0,0,0,0,0,0,4.0
+Fall 2024,HLT,3325,2,13385,Medical Terminology,Bloom,Joel A,139,3,5,1,0,0,1,3.87
+Fall 2024,HDFS,3350,1,13386,Observation and Assessment,Schroder,Kathleen Anne,41,5,1,0,1,0,1,3.757
+Fall 2024,HDFS,4316,2,13387,Dynamics of Family Relations,Schroder,Kathleen Anne,31,8,0,0,1,0,0,3.626
+Fall 2024,HDFS,3318,1,13388,Human Ecol of Adult Developmt,Schoger,Kimberly,35,15,2,4,4,0,0,3.206
+Fall 2024,HLT,3325,3,13389,Medical Terminology,Burk,Kelly Ann,142,6,0,0,0,0,0,3.939
+Fall 2024,ELED,4312,3,13391,Science in the Elem School II,Domjan,Heather N,25,0,0,0,0,0,0,3.987
+Fall 2024,AAMS,2300,2,13392,Intro Asian American Studies,Nguyen,An,9,3,2,1,0,0,2,3.179
+Fall 2024,HDFS,4317,1,13394,Intro to Early Childhood Dev,Jelsma,Elizabeth,5,4,7,2,1,0,0,2.422
+Fall 2024,CUIN,4303,1,13396,Sec Language Acq,Leon,Maredil Josefina,20,4,0,0,0,0,1,3.82
+Fall 2024,CUIN,8393,1,13400,Adv Internship & Prac,Zhang,Jie,2,0,0,0,0,0,0,4.0
+Fall 2024,ELED,7320,1,13403,Foundations of Literacy Instru,Dahl-Leonard,Katlynn,2,2,0,0,0,0,0,3.665
+Fall 2024,SPEC,6361,1,13406,Behavior: Interventions,Carp,Charlotte Lynn,12,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,6363,1,13407,Instructional Interventions,Rigby-Wills,Hope,16,4,1,0,1,0,0,3.545
+Fall 2024,SPEC,6360,1,13408,Individuals with Disabilities,Dulas,Heather,8,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,7340,1,13409,Assessment of Acad Achievement,Cole,Jana Belinda,14,3,0,0,0,0,0,3.843
+Fall 2024,CUIN,1350,1,13411,Mathematics for Teachers 1,Burris,Justin T,21,7,2,0,0,0,0,3.589
+Fall 2024,ELED,4314,1,13412,Mathematics in Elem School I,Cutler,Carrie Sybil,26,2,0,0,0,0,0,3.893
+Fall 2024,SEDE,4311,2,13413,Teaching Social Studie Sec Sch,Brower,Samuel Richard,17,2,1,0,0,0,0,3.784
+Fall 2024,CUIN,4375,4,13414,Classroom Management,Thompson,Alan M,17,8,1,0,0,0,0,3.603
+Fall 2024,ELED,3322,5,13415,Elem Reading Phonics Instructn,Alba,Celeste,21,1,0,0,0,0,1,3.91
+Fall 2024,CUIN,3312,1,13417,Educational Technology,Chavez Cubas,Nelson Wilfredo,22,4,2,1,0,0,0,3.575
+Fall 2024,PHLS,8321,1,13418,Struct Equ Mod in Psy/Educ Res,Wiesner,Margit F,10,0,0,0,0,0,0,3.934
+Fall 2024,CUIN,4101,3,13419,Content for Teaching,Thompson,Alan M,39,2,1,0,3,0,0,3.652
+Fall 2024,CUIN,1103,1,13420,Educator Dispositions,Culpepper,Shea Mosley,100,5,1,0,1,0,1,3.86
+Fall 2024,PHLS,7193,2,13421,Internship and Practicum,Margulis,Milena A,6,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8312,1,13422,Lab of Practice-Res Meth Devel,Hawkins,Jacqueline McLean,0,0,0,0,0,4,0,
+Fall 2024,ELCS,8312,3,13423,Lab of Practice-Res Meth Devel,Santi,Kristi L,5,0,1,0,0,0,0,3.667
+Fall 2024,CUIN,8393,2,13425,Adv Internship & Prac,Gronseth,Susie L B,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,3312,2,13426,Educational Technology,Hebert,Waneta Suzanne,28,3,0,0,0,0,0,3.839
+Fall 2024,CUIN,3302,1,13428,Social Education,Thomas,Dustine J,19,2,0,0,0,0,0,3.905
+Fall 2024,CUIN,4375,6,13429,Classroom Management,Castillo,Bernadette Marie,14,1,1,0,0,0,0,3.771
+Fall 2024,CUIN,3111,2,13430,Educational Tech Elem Teachers,Itani,Amani,17,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,3317,2,13432,Prenatal and Infant Developmt,Storch,Jill Frenchman,20,12,3,1,0,0,0,3.325
+Fall 2024,PHLS,8199,1,13435,Dissertation,Smith,Bradley,0,0,0,0,0,6,0,
+Fall 2024,CUIN,8398,10,13436,Independent Study,Hausmann,Robert Carl,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8393,7,13438,Adv Internship & Prac,Lee,Mimi Miyoung,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8399,5,13440,Doctoral Dissertation,Alarcon,Jeannette Driscoll,0,0,0,0,0,1,0,
+Fall 2024,CUIN,4350,3,13441,Multiple Teaching Strategies,Mateer,Ramona Caravella,2,0,0,0,1,0,0,2.667
+Fall 2024,CUIN,3351,1,13442,Class Interact Science-Math,Manuel,Mariam A,9,2,0,0,0,0,0,3.848
+Fall 2024,CUST,8375,1,13443,Hist & Phil of Higher Educ,McKinney,Lonnie Lyle,7,0,0,0,0,0,0,4.0
+Fall 2024,ELED,4312,4,13444,Science in the Elem School II,Bailer,Jill,18,1,0,0,0,0,1,3.947
+Fall 2024,ELED,4315,3,13446,Mathematics in Elem School II,Cutler,Carrie Sybil,22,2,0,0,0,0,0,3.889
+Fall 2024,ELED,4315,4,13447,Mathematics in Elem School II,Burris,Justin T,19,0,0,0,0,0,1,3.983
+Fall 2024,ELED,4320,1,13448,Social Studies Ele Sch,Campbell,Matthew,31,2,0,0,1,0,0,3.804
+Fall 2024,ELED,4320,2,13449,Social Studies Ele Sch,Campbell,Matthew,25,0,0,0,1,0,0,3.808
+Fall 2024,SPEC,4364,1,13451,Ed Students Giifts and Talents,Johnson,Detra DeVerne,34,0,1,0,0,0,0,3.933
+Fall 2024,SPEC,7341,1,13452,Assessment of Learning Diff,Rigby-Wills,Hope,4,0,1,0,0,0,0,3.468
+Fall 2024,SPEC,7394,1,13453,Diagnostician Practicum I,Hassett,Kristen Spring,0,0,0,0,0,9,0,
+Fall 2024,SPEC,7395,1,13454,Diagnostician Practicum II,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Fall 2024,SPEC,8375,2,13455,Research for Special Pops,Santi,Kristi L,9,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,4325,1,13456,Theory to Practice in HDFS,Jordan,Erica F,23,3,0,0,2,0,1,3.572
+Fall 2024,CUIN,4344,1,13457,Teaching Math in Grades 4-8,Sanchez,Jesus Trinidad,18,1,1,0,0,0,0,3.834
+Fall 2024,ELCS,8310,1,13458,The Superintendency,Butcher,Keith,5,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,3350,3,13464,Observation and Assessment,Schroder,Kathleen Anne,40,3,2,0,2,0,3,3.639
+Fall 2024,HDFS,3320,1,13466,Careers in HDFS,Jordan,Erica F,15,3,1,2,0,0,0,3.492
+Fall 2024,PHLS,8306,1,13467,Health Psych Res Prev Interv,Carmack,Chakema,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8393,8,13469,Adv Internship & Prac,Alarcon,Jeannette Driscoll,3,0,0,0,0,0,0,4.0
+Fall 2024,EDUC,4511,1,13470,Clinical Teaching 1-Elementary,Culpepper,Shea Mosley,87,8,1,0,0,0,0,3.834
+Fall 2024,CUIN,7347,1,13473,"Sem in Learning, Design & Tech",Dogan,Bulent,13,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,7398,1,13474,Independent Study,Brower,Samuel Richard,2,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8398,5,13475,Independent Study,Lee,Mimi Miyoung,3,0,0,0,0,0,0,4.0
+Fall 2024,EDUC,4512,1,13476,Clinical Teaching 2-Elementary,Thompson,Amber M,62,4,1,0,0,0,1,3.896
+Fall 2024,CUIN,4331,1,13477,Adolescent Literature,Hale,Margaret Ann,40,4,0,0,0,0,0,3.872
+Fall 2024,CUIN,3311,1,13478,Methods/Tech in Bilingual Educ,Leon,Maredil Josefina,10,2,0,0,0,0,0,3.861
+Fall 2024,EDUC,3101,1,13479,Practicum for Preservice Tchrs,Thompson,Amber M,78,3,0,0,1,0,0,3.907
+Fall 2024,CUIN,3333,1,13480,Differentiating Diverse Learn,Maalouf,Rania,13,6,1,0,0,0,0,3.551
+Fall 2024,CUIN,6375,2,13481,Classroom Mgt,Castillo,Bernadette Marie,3,1,1,0,0,0,0,3.466
+Fall 2024,CUIN,6375,3,13482,Classroom Mgt,Castillo,Bernadette Marie,2,1,0,0,0,0,0,3.777
+Fall 2024,PHLS,6311,1,13484,Introduction to Counseling,Hurt,Kara Marie,12,0,0,0,0,0,0,4.0
+Fall 2024,HLT,4303,1,13485,The Obesity Epidemic,Olvera,Norma E,32,20,6,0,0,0,1,3.334
+Fall 2024,EDRS,8381,1,13486,Rsch Mthds in Educ,Hawkins,Jacqueline McLean,9,0,0,0,0,0,0,3.963
+Fall 2024,CUIN,4332,1,13487,Literacy Assess Rdg Writing,Reis,Nancy,22,1,0,0,1,0,0,3.778
+Fall 2024,ELED,4315,2,13488,Mathematics in Elem School II,Burris,Justin T,24,1,0,0,0,0,0,3.934
+Fall 2024,PHLS,8337,2,13489,Multicul Iss Coun Psych,McCain,Morgan,19,0,0,0,0,0,0,3.931
+Fall 2024,CUIN,4375,10,13490,Classroom Management,Mateer,Ramona Caravella,3,0,0,0,0,0,1,4.0
+Fall 2024,CUIN,4304,3,13493,La/Read Meth in Span,Burgess,Miguel,18,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,6301,2,13495,Leadership for Equity,Shockley,Gerald,17,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8399,3,13496,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8399,4,13497,Doctoral Dissertation,Zou,Yali,2,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,6340,1,13498,Learning & Education Sciences,Santi,Kristi L,26,1,0,0,1,0,0,3.774
+Fall 2024,PHLS,8699,1,13500,Doctoral Dissertation,Smith,Bradley,0,0,0,0,0,1,0,
+Fall 2024,CUIN,4315,5,13504,Assessment of Children,Henderson,Linda Fay,19,6,0,0,2,0,0,3.433
+Fall 2024,PHED,1306,1,13505,Emergency Care & First Aid,Brown,Korey J,30,3,1,0,0,0,1,3.804
+Fall 2024,PHED,1306,3,13506,Emergency Care & First Aid,Monreal,Daniel Joseph,31,2,0,0,1,0,0,3.746
+Fall 2024,CUIN,8303,1,13508,Seminal Thinkers,Santi,Kristi L,8,4,0,0,0,0,1,3.639
+Fall 2024,CUIN,8399,6,13512,Doctoral Dissertation,Hutchison,Laveria F,0,0,0,0,0,1,0,
+Fall 2024,PHLS,8999,1,13514,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2024,CUIN,6380,1,13515,Teaching Young Children,Wilson,Jahnette,7,2,0,0,0,0,0,3.668
+Fall 2024,CUIN,1350,2,13516,Mathematics for Teachers 1,Burris,Justin T,17,3,0,0,0,0,0,3.751
+Fall 2024,CUIN,7366,1,13517,Sci instruct in Middle Grades,Varnado,Jakarda Wiltz,3,0,0,0,0,0,0,3.89
+Fall 2024,CUIN,2300,1,13518,Introduction to STEM Teaching,Manuel,Mariam A,24,1,0,0,0,0,0,3.947
+Fall 2024,CUIN,2300,2,13519,Introduction to STEM Teaching,Ekeoba,Jacqueline Njideka,14,3,1,0,2,0,1,3.383
+Fall 2024,CUIN,2300,4,13520,Introduction to STEM Teaching,Campos,Amanda Renee,12,1,0,0,0,0,1,3.923
+Fall 2024,CUIN,4332,2,13522,Literacy Assess Rdg Writing,Reis,Nancy,20,0,0,0,0,0,0,3.984
+Fall 2024,CUIN,4332,3,13523,Literacy Assess Rdg Writing,Reis,Nancy,24,0,0,0,0,0,0,3.973
+Fall 2024,CUIN,3302,2,13524,Social Education,Thomas,Dustine J,29,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,3316,2,13525,Prekindergarten Curr & Instr,Katz,Denise Annette,21,2,0,0,0,0,0,3.884
+Fall 2024,CUIN,3316,3,13526,Prekindergarten Curr & Instr,Katz,Denise Annette,19,0,0,0,0,0,0,3.983
+Fall 2024,CUIN,3317,3,13527,Kindergarten/Elem Curr & Instr,Wilson,Jahnette,37,1,0,0,0,0,0,3.939
+Fall 2024,CUIN,3317,4,13528,Kindergarten/Elem Curr & Instr,Henderson,Linda Fay,20,5,0,0,2,0,0,3.457
+Fall 2024,CUIN,3347,2,13529,Reading in the Content Area,Morris,Alana,26,5,5,0,0,0,0,3.51
+Fall 2024,CUIN,4315,3,13530,Assessment of Children,Wilson,Jahnette,35,3,0,0,0,0,0,3.86
+Fall 2024,CUIN,4361,3,13531,Second Language Methodology,Scrivner,Shaimaa Abouzeid,18,2,2,1,1,0,1,3.376
+Fall 2024,ARED,2310,1,13533,Intro Critical Visual Culture,Chung,Sheng Kuan,16,4,1,0,0,0,3,3.714
+Fall 2024,EDRS,8382,1,13535,Statistical Analyses in Eductn,Kim,Heeyun,7,0,0,0,1,0,0,3.5
+Fall 2024,ACCT,3366,2,13539,Financial Reporting Frameworks,Harris,Kathleen L,28,23,12,3,1,0,11,3.173
+Fall 2024,ACCT,4331,1,13540,Federal Income Tax,Meade,Janet,4,10,19,3,1,0,3,2.369
+Fall 2024,MARK,4389,6,13541,Marketing Strategy & Planning,Muschalik,Monica Harper,22,5,2,0,0,0,0,3.621
+Fall 2024,TLIM,3363,20,13542,Technical Communications,Piercy,Penelope Junker,19,10,6,0,1,0,0,3.177
+Fall 2024,TLIM,3363,30,13543,Technical Communications,Piercy,Penelope Junker,24,11,0,0,1,0,0,3.51
+Fall 2024,BTEC,3317,30,13544,Biotech Regulatory Environment,Flavier,Albert B,10,19,14,2,1,0,1,2.768
+Fall 2024,BTEC,3301,30,13545,Genomics/Proteomics & Bioinfo.,Flavier,Albert B,15,16,12,1,1,0,0,2.875
+Fall 2024,BTEC,3321,30,13546,Good Manufacturing Practices,Aghoghovbia-Pugh,Alero,4,13,15,3,1,0,1,2.463
+Fall 2024,ELET,2301,1,13547,Poly-Phase Circuits & Trans,Fan,Lei,2,10,7,0,0,0,0,2.772
+Fall 2024,ELET,2305,1,13548,Semicond Devices & Circuits,Talusani,Pratap Reddy,14,9,2,0,0,0,0,3.493
+Fall 2024,MARK,4376,1,13550,Sales CRM,Suki,Yara D,21,6,1,0,0,0,0,3.679
+Fall 2024,ELET,3301,1,13551,Linear Systems Analysis,Barbieri,Enrique,3,1,14,0,1,0,0,2.089
+Fall 2024,PHAR,5646,1,13554,Medication Safety,Truong,Mabel,2,1,0,0,0,0,0,3.667
+Fall 2024,SGNL,1301,6,13555,Elementary Sign Language I,Brittain,Terrell,3,7,4,1,0,0,3,2.8
+Fall 2024,BUSI,4335,1,13556,Brainstorming to Bankrolling,Khumawala,Saleha B,4,1,0,0,0,0,0,3.8
+Fall 2024,GENB,7334,1,13557,Brainstorming to Bankrolling,Khumawala,Saleha B,4,0,0,0,0,0,0,4.0
+Fall 2024,MATH,2318,1,13558,Linear Algebra,Mamonov,Alexander V,10,19,19,11,8,0,10,2.179
+Fall 2024,MECT,3318,30,13559,Fluid Mechanics Applications,Alba,Kamran,33,8,0,1,0,0,1,3.73
+Fall 2024,MECT,3355,30,13560,Strength of Materials,Basaran,Burak,0,4,29,8,0,0,3,1.894
+Fall 2024,LAW,5339,1,13562,Trusts and Wills,Tamborello,Gus Gerard,22,32,2,0,0,0,0,3.328
+Fall 2024,ARCH,2500,3,13565,Arc/Int Arc Design Studio III,Lee,Seo Hee,5,7,4,1,0,0,1,2.941
+Fall 2024,CNST,3265,1,13567,Construction Layout & Site Dvp,Moghaddam,Hassan,11,20,8,0,0,0,2,3.068
+Fall 2024,ACCT,5376,1,13568,Adv Fin Statement Auditing,Zhao,Yuping,3,2,0,0,0,0,0,3.666
+Fall 2024,WGSS,3350,1,13569,Feminist Theory,Gregory,Elizabeth,9,1,1,0,0,0,0,3.667
+Fall 2024,HDCS,4393,20,13570,Internship in RCS,Ezell,Shirley D,12,4,1,0,0,0,0,3.628
+Fall 2024,CNST,3205,1,13572,Construction Safety Management,Hart,Lee J,40,1,1,0,0,0,0,3.929
+Fall 2024,CNST,3331,1,13573,Constructn Plan and Scheduling,Lyon,Eva Yaneth,31,20,1,0,0,0,0,3.52
+Fall 2024,CNST,3355,1,13574,Strength of Construction Mtrls,Hossain,Sk Amjad,51,29,8,0,0,0,0,3.489
+Fall 2024,CNST,3351,1,13575,Construction Estimating II,Siddiqui,Muhammad Ali,41,10,1,0,1,0,0,3.611
+Fall 2024,CNST,3365,1,13576,Cost Estimating Capital Projec,Glumac,Carmel,8,18,1,0,0,0,0,3.333
+Fall 2024,CNST,3372,1,13577,Soil Mechanics & Foundations,Meyer,Joseph Ray,44,24,2,0,0,0,0,3.624
+Fall 2024,ATP,7311,1,13578,Human Performance,Knoblauch,Mark Alan,10,5,0,0,0,0,0,3.667
+Fall 2024,RELS,3370,1,13580,The Bible and Modern Science,Ott,Aaron Frederick,22,8,6,7,5,0,1,2.722
+Fall 2024,GHL,8310,1,13582,Teaching Methods in Hosp. Adm.,DeFranco,Agnes L,4,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6A48,1,13583,Environmental Technology 3,Kyropoulou,Amygdalia,19,11,0,0,0,0,0,3.567
+Fall 2024,ARCH,6A50,1,13585,Construction Technology 3,Thaddeus,David J,14,15,0,0,0,0,0,3.426
+Fall 2024,NAVY,1301,1,13587,Naval Orientation,Davis,Danyelle,9,1,0,0,0,0,1,3.702
+Fall 2024,NAVY,2302,1,13589,Naval Engineering-Ship Sys I,Konoza,Emily M,2,0,0,0,0,0,0,3.835
+Fall 2024,DRAM,1310,20,13591,Introduction to Theatre,Brincks,Alan,32,12,1,2,1,0,2,3.424
+Fall 2024,SPAN,2610,2,13593,Intensive Intermediate Spanish,Benalcazar Astudillo,Diana Salome,1,11,8,1,0,0,2,2.587
+Fall 2024,CHEM,6698,25,13598,Special Problems,Chiang,Naihao,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6698,26,13599,Special Problems,Chen,Tai-Yen,0,0,0,0,0,2,0,
+Fall 2024,BTEC,6304,30,13600,Computational Methods in BTEC,Chitrala,Kumaraswamy Naidu,13,0,0,0,0,0,0,4.0
+Fall 2024,BTEC,6302,30,13601,Intro to Regulatory Affairs,Flavier,Albert B,1,1,0,0,0,0,1,3.665
+Fall 2024,DANC,1309,1,13602,Dance Production,Valle,Toni Leago,6,7,3,1,0,0,1,3.059
+Fall 2024,ATP,7295,1,13603,Clinical Experience 5,Elliott,Ashlyne Paige,15,0,0,0,0,0,0,4.0
+Fall 2024,ATP,7312,1,13604,Therapeutic Intervention 2,Elliott,Ashlyne Paige,10,5,0,0,0,0,0,3.667
+Fall 2024,ARTS,3304,2,13606,Intermediate Painting,Hernandez Martinez,Guadalupe,14,3,0,0,0,0,0,3.765
+Fall 2024,COMM,6399,3,13607,Masters Thesis,Huang,Yan,0,0,0,0,0,1,0,
+Fall 2024,COMM,7399,1,13608,Masters Thesis,Platenburg,Gheni Nicole,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6338,1,13609,Fndtns of Social Psyc,Derrick,Jaye L,17,1,0,0,0,0,0,3.853
+Fall 2024,ENGL,1302,6,13622,First Year Writing II,Zachow,Alix V,13,6,2,2,0,0,1,3.319
+Fall 2024,ENGL,1302,7,13623,First Year Writing II,Wolff,Alexander Lazarus,5,6,4,1,2,0,1,2.556
+Fall 2024,ENGL,1302,8,13624,First Year Writing II,Sicinski,Michael J,16,7,0,0,0,0,1,3.638
+Fall 2024,ENGL,1302,9,13625,First Year Writing II,Cowan,Joshua Jared,10,5,3,0,2,0,5,2.935
+Fall 2024,CHEM,8998,22,13628,Doctoral Research,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2024,MATH,8698,7,13630,Doctoral Research,Josic,Kresimir,0,0,0,0,0,4,0,
+Fall 2024,ENGL,1301,112,13631,First Year Writing I,Fretwell,Leah M,14,1,2,0,2,0,0,3.264
+Fall 2024,ENGL,1301,113,13632,First Year Writing I,Klopp,Chelsea Gordon,12,3,2,0,1,0,1,3.297
+Fall 2024,ENGL,3301,1,13633,Intro To Literary Studies,Singh,Kavita Ashana,13,3,2,0,0,0,0,3.574
+Fall 2024,CHEM,1111,61,13634,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,13,0,1,0,0,0,3.175
+Fall 2024,CHEM,1111,62,13635,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,0,0,1,0,2,2.918
+Fall 2024,CHEM,1111,63,13636,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,1,1,0,0,2,3.039
+Fall 2024,CHEM,1111,64,13637,Fundamentals of Chm Lab,Zaitsev,Vladimir G,5,14,0,0,0,0,1,3.263
+Fall 2024,CHEM,1111,65,13638,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,14,2,0,0,0,1,3.038
+Fall 2024,CHEM,1111,67,13639,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,16,1,0,0,0,1,3.018
+Fall 2024,CHEM,1111,69,13640,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,17,0,0,0,0,1,3.221
+Fall 2024,CHEM,1111,70,13641,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,1,1,0,0,1,3.019
+Fall 2024,CHEM,1111,71,13642,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,12,3,1,0,0,0,2.964
+Fall 2024,PSYC,4344,4,13644,Cultural Psychology,Murphy,Elijah Rayvon,64,8,4,1,2,0,1,3.675
+Fall 2024,BIOL,1306,50,13645,Biology for Science Majors I,Cheek,Ann Oliver,15,13,4,0,2,0,3,3.215
+Fall 2024,AAS,3348,1,13646,African Americans and the Law,Putman,Eronn A,9,12,0,0,0,0,1,3.429
+Fall 2024,PHOP,6243,1,13649,Vision Science Core-Part 3,Frishman,Laura J,8,0,0,0,0,0,0,3.959
+Fall 2024,PSYC,2319,2,13658,Intro to Social Psychology,Ravey,Eriksen,58,19,1,0,0,0,2,3.722
+Fall 2024,PHLA,6100,1,13659,Leadership Seminar,Varkey,Divya A,7,7,0,0,0,0,0,3.5
+Fall 2024,PHOP,6257,10,13661,Research Practicum B,Berntsen,David A,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,2101,20,13666,Anatomy & Physiology Lab I,Gill,Tejendra,2,9,4,2,2,0,3,2.386
+Fall 2024,CHEM,1111,73,13669,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,12,4,1,0,0,0,2.824
+Fall 2024,CHEM,1111,74,13670,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,11,3,0,0,0,0,3.111
+Fall 2024,CHEM,1111,75,13671,Fundamentals of Chm Lab,Zaitsev,Vladimir G,0,14,2,0,0,0,2,2.978
+Fall 2024,CHEM,1111,76,13672,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,11,2,0,0,0,0,3.158
+Fall 2024,MATH,8698,8,13674,Doctoral Research,Jun,Mikyoung,0,0,0,0,0,1,0,
+Fall 2024,CHEM,2123,26,13676,Organic Chemistry Lab I,Bean,Mary B,4,6,7,0,0,0,5,2.726
+Fall 2024,CHEM,2123,27,13677,Organic Chemistry Lab I,Bean,Mary B,2,12,3,0,1,0,3,2.704
+Fall 2024,POLS,8399,12,13679,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,1,0,
+Fall 2024,CIS,3343,31,13680,Info Systems Analysis & Design,Detillier,Bret James,8,30,31,1,1,0,3,2.592
+Fall 2024,TLIM,4341,32,13681,Production & Service Operation,Chance,Michael Dean,23,8,7,2,0,0,1,3.292
+Fall 2024,ENGL,1302,11,13684,First Year Writing II,Sicinski,Michael J,16,3,1,0,4,0,1,2.974
+Fall 2024,MATH,8698,9,13685,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,3,0,
+Fall 2024,MATH,8698,10,13686,Doctoral Research,Cappanera,Loic,0,0,0,0,0,3,0,
+Fall 2024,CNST,3301,1,13687,Constructn Equipment & Methods,Al-Nahhas,Amer Faisal,36,60,12,3,2,0,2,3.106
+Fall 2024,CHEM,8999,20,13688,Doctoral Dissertation,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Fall 2024,MUSA,1300,8,13690,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,8698,11,13694,Doctoral Research,Mang,Andreas,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6398,26,13697,Special Problems,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2024,PHAR,5681,5,13699,Infectious Diseases,Tam,Vincent H,2,0,0,0,0,0,0,4.0
+Fall 2024,MAS,2340,2,13700,Intro Mexican American Studies,Pino,Diana,2,4,3,1,0,0,1,2.7
+Fall 2024,ARTS,2326,3,13701,Fundamentals of Sculpture,Ahern,Dylan,7,3,2,0,0,0,0,3.389
+Fall 2024,PHIL,1305,2,13702,Intro To Ethics,Coates,Daniel J,54,31,18,0,0,0,3,3.41
+Fall 2024,DIGM,3354,30,13703,Visual Production,Dawson,Michael John,64,17,4,2,1,0,5,3.524
+Fall 2024,COMM,3316,2,13707,Electronic News,Roth,Geoffrey,11,4,4,1,1,0,1,3.017
+Fall 2024,COMM,3353,1,13708,Information & Comm Tech I,Lee,Taeyoung,16,7,0,0,0,0,0,3.653
+Fall 2024,COMM,4378,1,13709,Social Impact of Info Tech,Ashley,Laura B,53,4,0,0,1,0,0,3.834
+Fall 2024,DIGM,4372,30,13710,DIGM Production Management,Hargrove,Mark Stephen,60,20,7,0,2,0,0,3.484
+Fall 2024,PSYC,2307,1,13715,Psychology of Adolescence,Anderson,Jill Annette,33,13,4,0,1,0,1,3.393
+Fall 2024,HRD,3351,20,13716,Instructional Design for HRD,Pereira-Leon,Maura Josefina,17,15,2,1,0,0,2,3.315
+Fall 2024,PSYC,2319,3,13717,Intro to Social Psychology,Baltes,Hannah G,41,19,7,0,4,0,3,3.24
+Fall 2024,GHL,4355,1,13718,Event Administration,Kenyan,Erin Oeser,10,4,0,0,0,0,0,3.714
+Fall 2024,MATH,2312,6,13719,Precalculus,Almus,Melahat,108,70,74,28,50,0,100,2.439
+Fall 2024,NURS,3735,1,13721,Clinical Nursing Practice III,Sansom,Amanda,31,3,0,0,0,0,3,3.912
+Fall 2024,NURS,3737,1,13722,Nurs Proc Collabrtive Prac II,Simon-Campbell,E'Loria,0,34,0,0,0,0,3,3.0
+Fall 2024,LST,3357,1,13723,Con Law - Civil Liberties,Wall,Kenneth S,5,2,6,4,0,0,0,2.412
+Fall 2024,SCLT,3389,31,13724,Transportation Law,Blount,James,46,14,1,0,1,0,0,3.544
+Fall 2024,SCLT,4387,30,13725,Financial Evaluation For SCM,Reyes,Jorge,37,11,10,0,1,0,0,3.407
+Fall 2024,SCLT,4389,30,13726,Practicum in Supply Chain,Kidd,Margaret A,15,6,0,1,0,0,1,3.621
+Fall 2024,SCLT,3387,30,13727,Procurement,Velarde,Jose Manuel,36,25,5,0,1,0,5,3.408
+Fall 2024,MATH,3339,3,13728,Statistics for the Sciences,Ryan,John M,81,22,17,5,4,0,5,3.318
+Fall 2024,PSYC,3350,3,13729,Intro to Cognitive Psychology,Paredes Raquel,Sara Abigail,47,24,6,3,0,0,0,3.405
+Fall 2024,BCHS,3304,4,13730,General Biochemistry I,Fox,Robert O,51,33,10,2,0,0,4,3.33
+Fall 2024,COMM,3369,2,13731,Strategic Comm. Writing,Williams,Uniqua Janae,20,13,0,0,0,0,1,3.616
+Fall 2024,COMM,3383,1,13732,Non-linear Editing,Crowe,Craig Warren,51,11,2,0,0,0,1,3.652
+Fall 2024,COMM,4303,3,13733,Communication Law and Ethics,Payne,Latosha Lewis Terrell,76,18,2,1,1,0,0,3.67
+Fall 2024,MATH,2131,2,13734,Linear Alg Labs w/MATLAB,Simmons,Mark Bryce,23,2,1,1,5,0,7,3.136
+Fall 2024,BIOL,3304,1,13736,The Biology of Social Behavior,Cole,Blaine J,11,15,23,0,1,0,8,2.707
+Fall 2024,GOVT,2305,3,13737,"US Govt: Congress,Pres & Crts",Contractor,Cyrus Ali,11,8,5,3,6,0,4,2.455
+Fall 2024,POLS,3316,1,13738,Stats for Political Scientists,Karimov,Samad,9,15,4,4,1,0,7,2.738
+Fall 2024,CHEM,4364,1,13739,Advanced Organic Chem,Wu,Judy,4,8,4,0,0,0,0,2.897
+Fall 2024,PHYS,1301,2,13740,College Physics I (lecture),Cardoso Barato,Andre,74,60,71,13,2,0,67,2.829
+Fall 2024,PHYS,3313,1,13741,Advanced Laboratory I,Curran,Seamus A,4,3,4,0,0,0,1,3.0
+Fall 2024,RELS,3366,1,13742,Magic and Occult,Ullrey,Aaron Michael,13,9,2,1,4,0,3,2.806
+Fall 2024,PSYC,7306,1,13743,Adv. Stats: Multilevel Model.,Francis,David J,5,1,0,0,0,0,1,3.613
+Fall 2024,COSC,1336,1,13744,Computer Science & Program,Shah,Shishir,63,30,9,5,1,0,10,3.398
+Fall 2024,COSC,2436,1,13745,Programming and Data Structure,Biediger,Daniel Edward,35,26,16,9,4,0,22,2.852
+Fall 2024,SOCW,8335,1,13747,Teaching in Higher Education,Barthelemy,Juan,3,0,0,0,0,0,0,4.0
+Fall 2024,ENTR,3311,1,13748,Technology Entrepreneurship,Chatterji,Tanushree,17,4,0,0,0,0,1,3.747
+Fall 2024,MARK,4332,1,13749,Social Media Marketing,Zahn,William J,14,45,6,3,2,0,0,2.943
+Fall 2024,SCM,3301,2,13750,SCM Fundamentals,Miller,Bradley D,356,165,23,1,0,0,1,3.583
+Fall 2024,SCM,4385,1,13751,Supply Chain Analytics,Murray,Michael J,8,7,0,1,0,0,0,3.375
+Fall 2024,BIOL,6374,2,13752,Cell Biology,Rea,Michael A,2,2,0,0,0,0,0,3.5
+Fall 2024,MANA,3335,9,13753,Intro Org Behavior and Mgmt,Miljanic,Andra Olivia,144,72,25,2,2,0,5,3.379
+Fall 2024,POLS,6344,1,13754,Dissertation Prospectus,Scarrow,Susan E,6,0,0,0,0,0,0,4.0
+Fall 2024,MARK,7333,1,13756,Search Engine Marketing,Gavin,Daniel Yaakov,24,2,0,0,0,0,0,3.898
+Fall 2024,HON,3301,4,13758,Readings in Medicine & Society,Macdonald,Arlene,22,0,0,0,0,0,0,3.91
+Fall 2024,GHL,1345,2,13759,"Safety, Sanitation in Hosp Ind",Sirsat,Sujata Ashok,20,9,1,0,0,0,0,3.567
+Fall 2024,GHL,3348,2,13760,Principles of Hosp Revenue Mgt,Johnson,Tucker A,25,13,8,1,2,0,1,3.137
+Fall 2024,HRD,4396,1,13761,Internship in HRD,Owens-Shepard,Toya,15,2,1,0,0,0,1,3.778
+Fall 2024,GHL,6368,1,13762,Career Capstone Project,Kim,Jaewook,1,0,0,0,0,0,0,4.0
+Fall 2024,GHL,7361,1,13763,Hospitality Marketing Analysis,Shin,Min Jung,21,2,0,0,0,0,0,3.87
+Fall 2024,MIS,4378,3,13764,Admin of Computer-Based MIS,Knighton,William B,38,11,1,0,0,0,0,3.74
+Fall 2024,GOVT,2306,5,13765,US and Texas Const/Politics,Davis,Jenna,3,17,24,24,12,0,8,1.675
+Fall 2024,LAW,5203,1,13768,Govt Nonprofit Extshp I,Powers,William,0,0,0,0,0,10,0,
+Fall 2024,LAW,5206,1,13769,Govt Nonprofit Extshp II,Powers,William,0,0,0,0,0,2,0,
+Fall 2024,LAW,5228,1,13770,Judicial Externship I,Powers,William,0,0,0,0,0,5,0,
+Fall 2024,LAW,5229,1,13771,Judicial Externship II,Powers,William,0,0,0,0,0,2,0,
+Fall 2024,LAW,7334,1,13772,WRS: Int'l Law & Use of Force,Foteh,Samir Jabra,2,7,0,0,0,0,0,3.406
+Fall 2024,HRD,3351,1,13773,Instructional Design for HRD,Pereira-Leon,Maura Josefina,5,8,2,0,2,0,0,2.862
+Fall 2024,COMM,3377,1,13774,Strategic PR Planning,Uhrick,Jan,29,1,0,0,0,0,1,3.846
+Fall 2024,KIN,1304,2,13775,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,276,12,4,0,2,0,4,3.913
+Fall 2024,KIN,3301,1,13776,Design/Eval Phys Activity Prog,Betts,Charles Raphael,47,8,0,3,0,0,2,3.69
+Fall 2024,LAW,5361,1,13777,Financial Statement Analysis,Brennan,Daniel,6,6,0,0,0,2,1,3.308
+Fall 2024,PSYC,2316,4,13778,Psychology of Personality,Harlan,Pamela Kay,48,26,4,1,1,0,0,3.417
+Fall 2024,IDNS,2115,1,13779,Physics 2325 SEP Workshop,Pattison,Donna,7,9,4,0,1,0,1,2.937
+Fall 2024,IDNS,2116,1,13780,Physics 2326 SEP Workshop,Pattison,Donna,11,10,4,0,0,0,1,3.28
+Fall 2024,WGSS,4360,1,13781,Capstone Internship Course,Gregory,Elizabeth,5,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,3368,2,13782,Intermediate Accounting II,Muslu,Volkan,19,17,6,1,1,0,1,3.129
+Fall 2024,KIN,3306,3,13783,Physiology-Human Performance,Park,Yoonjung,66,17,10,4,0,0,3,3.471
+Fall 2024,KIN,3309,2,13784,Biomechanics,Paulson,Sally,30,18,2,0,0,0,0,3.527
+Fall 2024,KIN,4301,1,13785,Workplace Wellness,Alastuey,Lisa L,11,18,7,0,1,0,1,3.027
+Fall 2024,KIN,4310,1,13786,Measurement Tech Human Perf,Thrasher,Timothy Adam,23,35,29,4,3,0,4,2.766
+Fall 2024,MARK,3337,3,13787,Professional Selling,Vandaveer,Amy L,120,98,18,1,2,0,8,3.371
+Fall 2024,BTEC,6101,30,13788,Biotechnology Techniques Metho,Ibrahim,Eman Refaat,1,0,0,0,0,0,0,4.0
+Fall 2024,SCLT,6396,1,13789,Internship in Logistics,Wang,Kailai,1,0,0,0,0,0,0,3.67
+Fall 2024,BTEC,3302,30,13790,Molecular Genetics and Biotech,Lin,Yuheng,21,15,8,0,1,0,0,3.2
+Fall 2024,TLIM,3363,31,13791,Technical Communications,Tangeman,Anthony C,13,16,3,1,0,0,1,3.312
+Fall 2024,TLIM,3363,32,13792,Technical Communications,Tangeman,Anthony C,14,16,1,0,2,0,2,3.292
+Fall 2024,TLIM,3363,22,13793,Technical Communications,Tangeman,Anthony C,18,9,6,0,2,0,1,3.209
+Fall 2024,TLIM,3365,30,13794,Team Leadership,Feriante,Chris,34,6,6,0,0,0,0,3.573
+Fall 2024,TLIM,4341,31,13795,Production & Service Operation,Cao,Shun,35,2,2,0,0,0,0,3.821
+Fall 2024,TLIM,4342,30,13796,Quality Improvement Methods,Chance,Michael Dean,7,15,8,0,0,0,0,3.022
+Fall 2024,TLIM,4390,30,13797,Current Issues Ldshp & Innov,Mehring,Brian George,21,10,1,1,2,0,0,3.211
+Fall 2024,MATH,3363,4,13798,Introduction To PDE,Wang,Min,13,17,18,5,0,0,2,2.673
+Fall 2024,ENGL,7390,1,13799,Intro to Doctoral Studies,Snediker,Michael,7,3,0,0,0,0,0,3.667
+Fall 2024,ENGL,3350,1,13800,Am Lit To 1865,Berger,Jason,23,2,2,0,0,0,0,3.717
+Fall 2024,ENTR,4110,1,13801,Entrepren Values & Leadership,Cook,David B,23,5,0,0,0,0,0,3.739
+Fall 2024,SCLT,3376,30,13802,Global Trade Intermediaries,Crockett,Brianne,14,5,2,1,1,0,0,3.204
+Fall 2024,SCLT,6318,1,13803,Supply Chain Strategies,Bian,Zheyong,52,7,1,0,0,0,0,3.845
+Fall 2024,MARK,4333,1,13804,Search Engine Marketing,Buffaloe,Bonnie Lora-Lee,29,12,2,2,0,0,0,3.504
+Fall 2024,MATH,1332,1,13805,Contemporary Mathematics,Chern,Haley Nicole,22,52,41,32,27,0,21,2.008
+Fall 2024,MATH,1351,1,13806,Intro to Geometric Reasoning,Watkins,Katie Nicole,50,60,88,24,64,0,62,2.01
+Fall 2024,PHYS,3110,1,13808,Sem-Adv Lab Analysis,Curran,Seamus A,11,1,1,0,0,0,2,3.718
+Fall 2024,SCM,7350,1,13809,Strategic Supply Management,Wayhan,Victor Brian,8,0,0,0,0,0,1,4.0
+Fall 2024,PSYC,6392,1,13810,Intervention Practicum,Vincent,John P,13,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8321,1,13811,Clinical Psyc Internship,Woods,Steven Paul,0,0,0,0,0,5,0,
+Fall 2024,PSYC,8399,1,13812,Doctoral Dissertation,Sharp,Carla,2,0,0,0,0,0,0,4.0
+Fall 2024,GHL,3341,2,13813,Hospitality Managerial Acct,Johnson,Tucker A,6,10,1,0,0,0,0,3.352
+Fall 2024,GHL,3358,1,13814,Hospitality Industry Law,Abbott,Jeanna L,40,4,2,1,2,0,0,3.572
+Fall 2024,MARK,4379,1,13815,Personal Branding,Vandaveer,Amy L,48,9,0,0,0,0,0,3.802
+Fall 2024,MATH,3305,2,13816,Formal & Informal Geometry,Gibson,Rebecca Ann,12,9,1,1,0,0,0,3.391
+Fall 2024,PSYC,6399,1,13817,Masters Thesis,Reyes,Denise Lucia,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,2,13818,Doctoral Dissertation,Woods,Steven Paul,0,0,0,0,0,5,0,
+Fall 2024,ENGL,8322,1,13819,Master Workshop: Poetry,Harris,Francine Julia,11,0,0,0,0,0,0,4.0
+Fall 2024,COMM,4328,1,13823,Broadcast & Film Writing,Vaughan,Thomas Michael,22,1,0,0,0,0,1,3.942
+Fall 2024,PSYC,6398,1,13824,Independent Studies,Ng,Vincent,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,3,13825,Doctoral Dissertation,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6352,1,13826,Directed Rsch in I/O Psyc,Reyes,Denise Lucia,6,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,6322,1,13827,Poetry Workshop,Belieu,Erin Colleen,5,0,0,0,0,0,0,4.0
+Fall 2024,THEA,6362,1,13828,Dramatic Thry&Criticism,Romero,Gregory John,11,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,8399,10,13829,Dissertation,Goodin-Mayeda,Carrie Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2306,1,13831,Psychology of Human Sexuality,St Amand,Colton,10,17,7,3,2,0,8,2.718
+Fall 2024,CHEM,1112,20,13833,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,16,0,0,0,0,0,3.297
+Fall 2024,CHEM,1112,21,13834,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,13,0,0,0,0,2,3.208
+Fall 2024,CHEM,1112,22,13835,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,13,1,0,0,0,1,3.063
+Fall 2024,PHAR,5675,6,13836,Disease State Management,Gee,Jodie Sue,3,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5681,6,13837,Infectious Diseases,Garey,Kevin W,2,0,0,0,0,0,0,4.0
+Fall 2024,COMM,1307,1,13838,Media and Society,Olson,Beth M,41,126,48,23,12,0,19,2.64
+Fall 2024,PSYC,7393,1,13839,Field Practicum in Psychology,Woods,Steven Paul,0,0,0,0,0,28,0,
+Fall 2024,COMM,3311,1,13840,Editing Print & Digital Media,Crixell,Charles A,12,10,1,0,0,0,0,3.45
+Fall 2024,COMM,3311,2,13841,Editing Print & Digital Media,Crixell,Charles A,13,7,0,0,0,0,0,3.584
+Fall 2024,COMM,3311,3,13842,Editing Print & Digital Media,Crixell,Charles A,11,5,3,0,0,0,1,3.352
+Fall 2024,PSYC,7399,3,13843,Masters Thesis,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2024,PSYC,3399,1,13844,Senior Honors Thesis,Zvolensky,Michael J,0,0,0,0,0,0,0,
+Fall 2024,PSYC,6298,1,13847,Special Problems,Neighbors,Clayton T,0,0,0,0,0,1,0,
+Fall 2024,PSYC,3399,2,13849,Senior Honors Thesis,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1302,55,13850,First Year Writing II,Berg,Caleb J.,8,5,5,0,1,0,0,3.017
+Fall 2024,ENGL,1302,56,13851,First Year Writing II,Berg,Caleb J.,10,4,4,0,1,0,1,3.158
+Fall 2024,ENGL,1302,57,13852,First Year Writing II,Raines,Daniel,8,1,7,0,1,0,0,2.863
+Fall 2024,SOCW,6201,2,13853,Foundation of Social Work Prof,Lucas,Virginia,0,0,0,0,0,109,0,
+Fall 2024,ARTH,3332,1,13854,20th Century Design,Orto,Luisa,12,9,1,0,0,0,0,3.425
+Fall 2024,ARTH,6332,1,13855,20th Century Design,Orto,Luisa,2,1,0,0,0,0,0,3.777
+Fall 2024,PSYC,8399,4,13856,Doctoral Dissertation,Viana,Andres G,2,0,0,0,0,0,0,4.0
+Fall 2024,CHIN,3360,2,13857,A Look Into Modern China,McArthur,Charles M,12,12,7,2,0,0,1,3.05
+Fall 2024,MUSA,6140,3,13858,Graduate Recital I,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8121,1,13860,Clinical Psychology Internship,Woods,Steven Paul,0,0,0,0,0,5,0,
+Fall 2024,GEOL,3330,1,13861,Paleobiology,Maddocks,Rosalie F,3,3,4,7,0,0,3,2.156
+Fall 2024,MUSI,6200,2,13864,Accompanying Seminar,Suits,Brian J,4,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,8998,25,13865,Doctoral Research,Miljanic,Ognjen S,0,0,0,0,0,2,0,
+Fall 2024,SPAN,2312,4,13866,Intermediate Spanish II,Pueyo Castan,Josefa,0,12,7,4,2,0,1,2.226
+Fall 2024,PSYC,6393,2,13867,Clinical Research Practicum,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6498,3,13871,Special Problems,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2024,AAS,2320,4,13875,Intro To African American Stdy,Walker,Alan,35,2,0,0,0,0,3,3.875
+Fall 2024,MUSI,1181,3,13886,Group Piano I,Van Kekerix,Todd Evan,11,1,1,0,0,0,0,3.693
+Fall 2024,PSYC,8399,5,13890,Doctoral Dissertation,Alfano,Candice A,4,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7399,6,13891,Masters Thesis,Grigorenko,Elena L,0,0,0,0,0,4,0,
+Fall 2024,PSYC,8390,1,13892,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,2,0,
+Fall 2024,PHOP,6257,14,13897,Research Practicum B,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,1306,54,13899,Biology for Science Majors I,Hanke,Marc H,6,11,9,3,1,0,3,2.545
+Fall 2024,PSYC,7390,1,13900,Clin Neuropsychology Practicum,Woods,Steven Paul,0,0,0,0,0,10,0,
+Fall 2024,PSYC,8399,6,13901,Doctoral Dissertation,Grigorenko,Elena L,0,0,0,0,0,2,0,
+Fall 2024,MUSI,6260,1,13903,Internship in Piano Teaching I,Van Kekerix,Todd Evan,3,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,8699,10,13909,Dissertation,Hasbun,Rodrigo,0,0,0,0,0,2,0,
+Fall 2024,PSYC,6498,4,13910,Special Problems,Neighbors,Clayton T,0,0,0,0,0,1,0,
+Fall 2024,ENGL,1301,92,13912,First Year Writing I,Khalil,Rand Omar,15,3,0,0,0,0,1,3.778
+Fall 2024,MATH,8698,12,13916,Doctoral Research,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6399,6,13918,Masters Thesis,Brummel,Bradley James,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,7,13919,Doctoral Dissertation,Walker,Rheeda L,0,0,0,0,0,0,0,
+Fall 2024,MATH,8698,13,13925,Doctoral Research,Kalantar,Mehrdad,0,0,0,0,0,1,0,
+Fall 2024,PSYC,7399,9,13926,Masters Thesis,Sharp,Carla,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8190,1,13927,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6398,4,13928,Independent Studies,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6352,2,13929,Directed Rsch in I/O Psyc,Ng,Vincent,5,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,8,13930,Doctoral Dissertation,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,9,13931,Doctoral Dissertation,Medina,Luis Daniel,0,0,0,0,0,2,0,
+Fall 2024,MATH,8698,14,13932,Doctoral Research,Haynes,Alan K,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6352,3,13933,Directed Rsch in I/O Psyc,Brummel,Bradley James,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1302,59,13938,First Year Writing II,Hiers,Maria,25,1,0,0,0,0,0,3.847
+Fall 2024,WGSS,2350,9,13939,Intro To Women's Studies,Pegoda,Andrew Joseph,7,5,11,0,1,0,2,2.653
+Fall 2024,COSC,1336,2,13941,Computer Science & Program,Subhlok,Jaspal,56,6,11,22,2,0,19,2.867
+Fall 2024,CHEM,2123,28,13950,Organic Chemistry Lab I,Bean,Mary B,4,9,5,3,0,0,2,2.682
+Fall 2024,CHEM,2125,8,13951,Organic Chemistry Lab II,Bean,Mary B,1,10,8,1,0,0,2,2.55
+Fall 2024,ECON,8399,4,13952,Doctoral Dissertation,Juhn,Chinhui,0,0,0,0,0,3,0,
+Fall 2024,PSYC,8399,10,13953,Doctoral Dissertation,Williams,Michael W,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6398,5,13954,Independent Studies,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6352,4,13955,Directed Rsch in I/O Psyc,Sabat,Isaac Emmanuel,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,12,13956,Doctoral Dissertation,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,13,13957,Doctoral Dissertation,Hernandez,Arturo E,2,0,0,0,0,0,0,4.0
+Fall 2024,WGSS,2360,3,13958,Introduction to LGBT Studies,Stone,Lauren Michelle,25,3,0,0,0,0,2,3.846
+Fall 2024,CHEM,1111,77,13959,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,2,0,0,0,1,3.111
+Fall 2024,PSYC,6398,9,13962,Independent Studies,Yoshida,Hanako,0,0,0,0,0,1,0,
+Fall 2024,PSYC,8399,14,13963,Doctoral Dissertation,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2024,DRAM,1310,7,13966,Introduction to Theatre,Hinkel,Heidi Anne,42,8,0,0,0,0,0,3.794
+Fall 2024,ENGL,1301,93,13967,First Year Writing I,Farrell,Miles Alexander,7,6,3,1,0,0,1,3.001
+Fall 2024,PSYC,6498,7,13971,Special Problems,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6398,10,13972,Independent Studies,Leasure,Jennifer Leigh,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,1111,78,13973,Fundamentals of Chm Lab,Zaitsev,Vladimir G,4,12,1,0,0,0,0,3.196
+Fall 2024,GEOL,3150,2,13974,Prin-Stratigraphy Lab,Wellner,Julia S,9,4,1,0,0,0,1,3.571
+Fall 2024,PSYC,6398,12,13980,Independent Studies,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6399,8,13982,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6393,4,13983,Clinical Research Practicum,Medina,Luis Daniel,0,0,0,0,0,2,0,
+Fall 2024,PSYC,6393,5,13985,Clinical Research Practicum,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,6998,22,13988,Special Problems,Baldelli,Steve,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6998,23,13989,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Fall 2024,MATH,8698,16,13993,Doctoral Research,Nicol,Matthew J,0,0,0,0,0,1,0,
+Fall 2024,ECON,8361,1,14002,Workshop Research Methods III,Ujhelyi,Gergely,0,0,0,0,0,9,0,
+Fall 2024,ECON,3332,3,14003,Intermediate Microeconomics,Saboury,Piruz,17,6,2,0,1,0,1,3.423
+Fall 2024,PHIL,1301,1,14004,Intro To Philosophy,Hattab,Helen,13,49,22,10,0,0,5,2.695
+Fall 2024,WCL,3366,1,14006,Latin American and Latino Film,Ramirez,Marie Theresa,12,9,4,4,5,0,0,2.588
+Fall 2024,GEOL,1102,1,14007,Intro to Climate Change Lab,Zhang,Honghai,12,4,1,2,2,0,2,2.953
+Fall 2024,GEOL,1103,11,14008,Physical Geology Lab,Hauptvogel,Daniel William,13,5,2,0,0,0,0,3.517
+Fall 2024,MATH,1314,6,14009,College Algebra,Campos,Marco,72,49,54,26,44,0,25,2.251
+Fall 2024,MATH,2131,1,14014,Linear Alg Labs w/MATLAB,Goligerdian,Arash,19,10,1,0,3,0,1,3.263
+Fall 2024,POLS,3312,1,14015,"Arguments, Data, Politics",Ollerenshaw,Trent,14,18,4,1,0,0,2,3.234
+Fall 2024,MATH,2305,4,14016,Discrete Mathematics,Leger,Nicholas M,15,16,31,9,6,0,3,2.256
+Fall 2024,BIOL,3345,1,14017,Plant Physiology,Farmer,Lisa M,22,8,1,0,1,0,1,3.501
+Fall 2024,COSC,3380,2,14018,Database Systems,Hilford,Victoria,48,59,12,1,0,0,0,3.217
+Fall 2024,POLS,3310,1,14019,Intro to Political Theory,Cheng,Eric,24,16,1,0,0,0,1,3.537
+Fall 2024,FINA,4381,1,14020,Essentials of Real Estate,Jacobus,Charles J,13,9,4,0,0,0,1,3.283
+Fall 2024,PSYC,2307,2,14021,Psychology of Adolescence,Anderson,Jill Annette,29,16,4,1,0,0,1,3.42
+Fall 2024,PSYC,4344,5,14022,Cultural Psychology,Bautista,Ashley,22,8,5,2,3,0,0,3.166
+Fall 2024,PSYC,2308,1,14023,Child Development,Griep,Christina Diaz,48,16,11,2,1,0,2,3.385
+Fall 2024,PSYC,2330,3,14025,Biological Psychology,Bick,Johanna R,12,13,21,3,1,0,5,2.627
+Fall 2024,MANA,4385,1,14026,Intro to Strategic Management,Chiu,Shih-chi,15,6,1,0,0,0,0,3.591
+Fall 2024,CNST,4302,2,14027,Construction Law and Ethics,Ducran,Denis George,39,32,7,0,1,0,0,3.338
+Fall 2024,CNST,4331,2,14028,Construction Management II,Menendez,Daniel,10,15,3,0,0,0,1,3.285
+Fall 2024,MATH,4335,1,14029,Partial Diff  Equations I,Fitzgibbon,William E,5,4,0,0,4,0,1,2.411
+Fall 2024,BCIS,1305,4,14030,Business Computer Applications,Felvegi,Emese,181,44,10,7,2,0,6,3.596
+Fall 2024,MARK,3337,4,14031,Professional Selling,Vandaveer,Amy L,114,96,20,5,7,0,6,3.226
+Fall 2024,PSYC,4343,1,14032,Perception,Tamber-Rosenau,Benjamin J,6,18,16,1,0,0,2,2.788
+Fall 2024,COMD,3381,1,14033,Audiology,Andrews,Chereece N,30,10,0,0,0,0,0,3.75
+Fall 2024,FINA,4328,1,14034,Principles of Personal Finance,Coleman,Alfred G,35,3,3,2,0,0,0,3.62
+Fall 2024,TEPM,6305,20,14035,Project Manager Tools,Sherman,Dennis Louis,3,0,0,0,0,0,0,4.0
+Fall 2024,KIN,4360,1,14036,Adaptive Athletics Management,Cottingham,Michael,14,1,0,0,0,0,0,3.889
+Fall 2024,TEPM,6304,20,14037,Quality Improvemnt in Proj Mgt,Kovach,Jamison,7,0,0,0,0,0,0,4.0
+Fall 2024,HRD,6352,1,14038,Inst Design for Training Envir,Waight,Consuelo L,15,4,0,0,0,0,1,3.859
+Fall 2024,HRD,6356,1,14039,Consulting & Prof. Practice,Salomon,Lauren Manning,5,2,0,0,1,0,0,3.25
+Fall 2024,WGSS,2360,4,14042,Introduction to LGBT Studies,Pegoda,Andrew Joseph,8,8,6,0,1,0,7,2.842
+Fall 2024,WGSS,2360,5,14043,Introduction to LGBT Studies,Pegoda,Andrew Joseph,7,5,9,0,1,0,6,2.683
+Fall 2024,NUTR,4353,1,14044,Cultural Comp for Nutr Prof,Honig,Caryn A,54,16,2,0,0,0,0,3.617
+Fall 2024,SCLT,3340,30,14045,Geography for GSC,Henson,Alfred Bernard,21,3,1,1,3,0,0,3.276
+Fall 2024,SCLT,3375,30,14046,Maritime Operations,Chopra,Anuj,17,13,3,0,0,0,0,3.404
+Fall 2024,SCLT,3384,31,14047,Logistics Tech and Processes,Blount,James,38,32,7,0,1,0,0,3.283
+Fall 2024,GEOL,1102,2,14048,Intro to Climate Change Lab,Zhang,Honghai,19,1,1,0,0,0,2,3.747
+Fall 2024,HON,4130,1,14049,E-Portfolio,Bettinger,Rikki,12,0,0,0,2,0,0,3.381
+Fall 2024,GHL,3352,2,14050,Human Resource Management,Madera,Juan Manuel,28,0,2,0,1,0,0,3.699
+Fall 2024,GHL,3357,1,14051,Gaming and Casino Managment,Hahn,Simon Jumong,2,4,2,0,0,0,0,3.041
+Fall 2024,GHL,6357,1,14052,Gaming and Casino Mgmt,Hahn,Simon Jumong,8,0,0,0,0,0,0,3.959
+Fall 2024,PSYC,4344,6,14056,Cultural Psychology,Cotton,Mallory R,42,22,8,3,6,0,0,3.189
+Fall 2024,LAW,5199,1,14059,Special Problems,Vetter,Greg R,0,0,0,0,0,29,0,
+Fall 2024,LAW,5299,1,14061,Special Problems,Vetter,Greg R,0,0,0,0,0,32,0,
+Fall 2024,LAW,6238,1,14063,International Risk Management,Rivero,Francisco,3,0,0,0,0,0,0,3.67
+Fall 2024,LAW,5403,1,14065,Street Law,Turboff,Lisa Lepow,1,6,0,0,0,0,0,3.237
+Fall 2024,LAW,5418,11,14066,Torts,Sanders,Joseph,32,51,0,0,0,0,0,3.397
+Fall 2024,LAW,6360,1,14067,Trial Advocy for NonLitigators,Lukin,Karen B,3,5,0,0,0,3,0,3.375
+Fall 2024,ENGL,3331,1,14068,Beg Creative Writing-Poetry,Niaz,Zarlasht,14,6,0,0,0,0,0,3.717
+Fall 2024,LAW,6321,2,14069,Professional Responsibility,Warren,Jeremy E,14,26,3,1,0,0,0,3.212
+Fall 2024,COMM,3360,3,14070,Principles of Strategic Comm,Ashley,Laura B,71,17,2,1,3,0,1,3.617
+Fall 2024,COMM,3331,1,14071,Communication in the Family,Uhrick,Jan,32,0,0,0,1,0,0,3.839
+Fall 2024,PETR,8399,8,14072,Doctoral Dissertation,Myers,Michael Tolbert,2,0,0,0,0,2,0,4.0
+Fall 2024,PETR,8399,10,14074,Doctoral Dissertation,Sakhaee Pour,Ahmad,0,0,0,0,0,1,0,
+Fall 2024,PETR,8598,8,14080,Doctoral Research,Myers,Michael Tolbert,0,0,0,0,0,4,0,
+Fall 2024,PETR,8699,8,14081,Doctoral Dissertation,Myers,Michael Tolbert,0,0,0,0,0,1,0,
+Fall 2024,ENTR,7390,1,14084,Technology Entrepreneurship,Chatterji,Tanushree,8,0,0,0,0,0,0,3.959
+Fall 2024,ENGL,1301,135,14085,First Year Writing I,Braniger,Leslie,1,14,7,2,0,0,1,2.597
+Fall 2024,PHYS,3316,1,14086,Quantum Mechanics,Ordonez,Carlos,9,3,1,0,2,0,2,3.023
+Fall 2024,ENGL,1301,136,14087,First Year Writing I,Abdelwahab,Maha Ahmed Ibraheem,15,1,1,0,1,0,1,3.629
+Fall 2024,ENGL,1301,137,14088,First Year Writing I,Backus,Margot Gayle,14,8,2,0,1,0,0,3.281
+Fall 2024,ENGL,1301,138,14089,First Year Writing I,Backus,Margot Gayle,6,11,5,1,2,0,0,2.76
+Fall 2024,ENGL,1301,139,14090,First Year Writing I,Bernardi,Muriel,17,3,4,0,1,0,0,3.255
+Fall 2024,ENGL,1301,140,14091,First Year Writing I,Braniger,Leslie,9,6,8,1,1,0,0,2.774
+Fall 2024,CIVE,3434,1,14092,Fluid Mech and Hydraulic Engr,Wang,Keh-Han,9,5,3,0,0,0,0,3.314
+Fall 2024,MATH,6382,2,14094,Probability,Azencott,Robert Guy,5,4,1,0,0,0,4,3.301
+Fall 2024,TLIM,3345,30,14095,Human Resources in Technology,Mehring,Brian George,32,32,22,1,0,0,1,3.081
+Fall 2024,CIS,2368,30,14096,Adv Info Systems Development,Dobretsberger,Otto,18,4,1,0,0,0,3,3.768
+Fall 2024,TLIM,4350,20,14097,Occup Safety & Envir Health,Freedkin,Aaron Samuel,31,16,0,1,0,0,0,3.48
+Fall 2024,TLIM,4371,30,14098,Leading Change in the Wrkplace,Mehring,Brian George,7,14,8,2,3,0,2,2.598
+Fall 2024,KIN,4691,1,14099,Internship in Sport Admin 2,Walsh,David W,20,8,1,0,0,0,0,3.632
+Fall 2024,KIN,4398,1,14101,Independent Study,Cottingham,Michael,4,0,0,0,0,0,0,4.0
+Fall 2024,KIN,1304,3,14102,Public Hlt Issues in Phys/Obes,Graham,Marilynn Hadassah,179,14,1,0,3,0,1,3.873
+Fall 2024,LAW,6365,1,14103,Health Law Finance Transactns,Mantel,Jessica,10,13,0,0,0,2,0,3.392
+Fall 2024,NUTR,2332,3,14106,Intro To Human Nutrition,Hughes,Lindsay,52,34,13,0,1,0,1,3.32
+Fall 2024,BTEC,4319,30,14107,Microbial Biotechnology,Flavier,Albert B,0,13,5,1,0,0,0,2.579
+Fall 2024,PSYC,2316,5,14108,Psychology of Personality,Quadri,Tobiloba,48,19,3,4,3,0,1,3.329
+Fall 2024,DRAM,1341,1,14109,Make up for Actors,Mason,Meghann D,2,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5370,1,14112,International Law,Jackson,Craig Leonard,7,5,4,0,0,0,0,3.188
+Fall 2024,ARTS,3360,1,14114,Intermediate Sculpture,Jensen,Margaret,8,6,1,0,0,0,1,3.445
+Fall 2024,MUED,3102,1,14115,Brasses,Bell,Priscilla Garrett,14,5,4,0,0,0,0,3.392
+Fall 2024,MUSA,3420,2,14116,Applied Violin,Lo,Mann-Wen,3,0,0,0,0,0,0,3.78
+Fall 2024,ARCH,1500,19,14117,Design Studio I,Handanovic,Dijana,8,10,3,0,0,0,5,3.175
+Fall 2024,PHYS,1101,19,14119,College Physics I (lab),Wood,Lowell T,1,10,8,0,0,0,4,2.684
+Fall 2024,CHEM,6698,29,14120,Special Problems,Comito,Robert Joseph,0,0,0,0,0,2,0,
+Fall 2024,INAR,3300,1,14121,Hist of Interior Architecture,Washington,Dranoel Micole,8,12,3,0,0,0,1,3.174
+Fall 2024,MUSA,3438,1,14123,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,3.67
+Fall 2024,PSYC,6399,10,14125,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,
+Fall 2024,BTEC,4300,31,14126,Principles of Bioinformatics,Balan,Venkatesh,4,7,3,1,0,0,0,2.911
+Fall 2024,CHEM,6698,30,14127,Special Problems,Bocarsly,Joshua David,0,0,0,0,0,3,0,
+Fall 2024,CHEM,6398,31,14131,Special Problems,Cai,Chengzhi,0,0,0,0,0,2,0,
+Fall 2024,CHEM,8998,26,14133,Doctoral Research,Xu,Shoujun,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8320,1,14135,Doctoral Applied Music,Dorough,Aralee,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,3,14136,Doctoral Applied Music,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,8,14137,Doctoral Applied Music,Morgulis,Tali,3,0,0,0,0,0,0,3.78
+Fall 2024,MUSA,8320,9,14138,Doctoral Applied Music,Robinson,Daryl Allen,3,0,0,0,0,0,0,3.89
+Fall 2024,MUSA,8320,16,14139,Doctoral Applied Music,Wagner,Elise L,2,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6381,1,14140,Writing Seminar,Williams,Matthew Joseph,10,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,1321,1,14145,Logic I,Loewenstein,Yael R,30,20,8,12,12,0,19,2.484
+Fall 2024,ENGL,2315,1,14147,Literature and Film,Stock,Lorraine K,4,15,7,0,2,0,1,2.714
+Fall 2024,ARTS,4398,1,14148,Independent Study,Hecker,Rachel G,0,1,0,0,0,0,0,3.0
+Fall 2024,COSC,4351,701,14162,Fundamentals of Software Engr,Hilford,Victoria,52,48,9,0,0,0,1,3.355
+Fall 2024,BIOL,6320,1,14165,Molecular Biology,Chung,Sanghyuk,1,0,0,0,0,0,0,3.67
+Fall 2024,CHEM,6498,34,14167,Special Problems,Wu,Judy,0,0,0,0,0,1,0,
+Fall 2024,HON,4399,1,14168,Senior Honors Thesis,Belco,Michelle Helene,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8395,1,14179,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,1,0,
+Fall 2024,ARTS,4398,2,14181,Independent Study,Suber,Anthony,2,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,4398,3,14182,Independent Study,Kittelson,Paul A,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6399,12,14190,Masters Thesis,Fetterman,Adam Kent,0,0,0,0,0,0,0,
+Fall 2024,LACP,2111,1,14196,Liberal Arts Career Planning,Benavides,Bina,0,0,0,0,0,32,2,
+Fall 2024,ACCT,4331,2,14197,Federal Income Tax,Fernandez,Ramon,5,19,8,0,1,0,1,2.918
+Fall 2024,HDCS,1300,5,14199,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,37,10,2,0,1,0,0,3.647
+Fall 2024,ENGL,4319,1,14203,English in Secondary Schools,Bachmann,Abbey Marie,26,2,1,1,0,0,1,3.69
+Fall 2024,MATH,6358,2,14204,Probability & Stat. Computing,Poliak,Cathy Dawn,13,1,0,0,0,0,0,3.905
+Fall 2024,PHOP,8299,1,14205,Doctoral Dissertation,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2317,6,14214,Intro to Psychology Statistics,Saiyed,Amna Shabbir,35,36,5,2,0,0,0,3.35
+Fall 2024,HON,3399,1,14223,Senior Honors Thesis,Morrison,Gregory C,0,0,0,0,0,0,0,
+Fall 2024,MARK,4389,7,14229,Marketing Strategy & Planning,Randazzo,Gary W,17,12,0,0,1,0,1,3.324
+Fall 2024,SOCW,8999,3,14231,Dissertation,Walton,Quenette,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6393,8,14235,Clinical Research Practicum,Sharp,Carla,2,0,0,0,0,0,0,4.0
+Fall 2024,NURS,3315,1,14236,Pathophysiology,Edwards-Maddox,Shermel Vinese,10,26,0,6,0,0,4,2.952
+Fall 2024,POLS,3313,2,14237,Intro Internatl Relatns,Soules,Michael,20,16,4,0,0,0,0,3.334
+Fall 2024,PHAR,5686,2,14242,Psychiatry,Truong,Mabel,2,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5695,2,14243,Geriatrics,Truong,Mabel,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,2425,701,14247,Computer Org & Architecture,Long,Kevin B,11,22,13,0,0,0,3,2.957
+Fall 2024,PHOP,6257,2,14248,Research Practicum B,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2024,POLS,3316,2,14251,Stats for Political Scientists,Karimov,Samad,12,12,8,2,1,0,5,2.877
+Fall 2024,PSYC,7392,1,14252,Psychology Practicum,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7392,3,14254,Psychology Practicum,Fetterman,Adam Kent,3,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6567,2,14263,Research Practicum A,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2024,POLS,8399,28,14265,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Fall 2024,PHLA,6221,1,14266,Adv Health System Mgmt,Varkey,Divya A,6,2,0,0,0,0,0,3.75
+Fall 2024,BIOL,1106,45,14267,Biol for Science Majors I(Lab),Medrano,Ana I,17,4,1,0,0,0,1,3.727
+Fall 2024,BIOL,1106,44,14268,Biol for Science Majors I(Lab),Medrano,Ana I,18,4,1,0,0,0,0,3.725
+Fall 2024,PHOP,8299,3,14273,Doctoral Dissertation,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6257,1,14274,Research Practicum B,Walker,Maria Kelly,2,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8399,3,14278,Doctoral Dissertation,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8598,3,14279,Doctoral Research,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Fall 2024,BIOE,6399,15,14282,Masters Thesis,Roh,Jinsook,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6399,14,14286,Masters Thesis,Damian,Rodica Ioana,0,0,0,0,0,2,0,
+Fall 2024,PHOP,8399,5,14292,Doctoral Dissertation,Patel,Nimesh Bhikhu,2,0,0,0,0,0,0,4.0
+Fall 2024,PHLA,7299,1,14297,Masters Thesis,Varkey,Divya A,0,0,0,0,0,2,0,
+Fall 2024,MUSA,8320,25,14298,Doctoral Applied Music,Staupe,Andrew Paul,4,0,0,0,0,0,0,4.0
+Fall 2024,ECON,3332,1,14299,Intermediate Microeconomics,Craig,Steven G,10,22,2,0,1,0,3,3.133
+Fall 2024,MANA,4356,1,14302,Managing Diversity,Fernandez,Alejandro,26,2,0,0,0,0,0,3.881
+Fall 2024,SGNL,1301,8,14303,Elementary Sign Language I,Brittain,Terrell,8,6,2,1,0,0,2,3.08
+Fall 2024,PSYC,6336,2,14305,Directed Rsch in Social Psyc,Derrick,Jaye L,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3399,3,14307,Senior Honors Thesis,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3426,1,14310,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,3.835
+Fall 2024,PSYC,8399,17,14311,Doctoral Dissertation,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2024,MSCI,1210,2,14312,Introduction to the Army,Bradford,Todd F,8,1,0,0,0,0,4,3.852
+Fall 2024,ARCH,2500,17,14313,Arc/Int Arc Design Studio III,Soto,Carlos E,13,3,1,0,0,0,1,3.628
+Fall 2024,PSYC,8999,1,14315,Doctoral Dissertation,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2024,MATH,6315,10,14317,Masters Tutorial,Cappanera,Loic,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7392,4,14322,Psychology Practicum,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6358,1,14328,Directed Rsch in Neuropsyc,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6336,4,14329,Directed Rsch in Social Psyc,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6598,5,14330,Special Problems,Alward,Beau Andrew,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6365,1,14331,Dir Rsch in Dev Cog Beh Neuro,Hernandez,Arturo E,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7392,5,14336,Psychology Practicum,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Fall 2024,PETR,8198,11,14339,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2024,PETR,8298,11,14341,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,3,0,
+Fall 2024,PETR,8298,12,14342,Doctoral Research,Lee,Kyung Jae,0,0,0,0,0,2,0,
+Fall 2024,PETR,8399,11,14345,Doctoral Dissertation,Thakur,Ganesh Chandra,1,0,0,0,0,1,0,4.0
+Fall 2024,PETR,8399,12,14346,Doctoral Dissertation,Wong,George K,0,0,0,0,0,1,0,
+Fall 2024,PETR,8598,11,14349,Doctoral Research,Thakur,Ganesh Chandra,0,0,0,0,0,1,0,
+Fall 2024,MUSA,2202,1,14353,Applied Composition,Maroney,Marcus K,2,1,1,0,0,0,0,3.333
+Fall 2024,MUSA,2202,2,14355,Applied Composition,Smith,Robert Thomas,0,0,1,0,0,0,0,1.67
+Fall 2024,MATH,8698,20,14362,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Fall 2024,PHYS,3399,2,14364,Senior Honors Thesis,Bellwied,Rene,0,0,0,0,0,0,0,
+Fall 2024,SOC,7395,2,14365,Internship in Sociology,Langa,Neema Michael,0,0,0,0,0,0,0,
+Fall 2024,SPAN,6398,13,14366,Special Problems,Gutierrez,Manuel J,0,0,0,0,0,0,0,
+Fall 2024,PSYC,8399,18,14371,Doctoral Dissertation,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2024,PHIL,1361,2,14376,Philosophy and the Arts,Drapela,Nick Gerard,14,15,8,3,0,0,8,2.959
+Fall 2024,PHIL,1361,3,14377,Philosophy and the Arts,Drapela,Nick Gerard,7,12,9,3,4,0,15,2.438
+Fall 2024,ECON,2302,3,14378,Principles of Microeconomics,Paluszynski,Radoslaw,26,3,0,0,0,0,1,3.874
+Fall 2024,ECON,3334,4,14379,Intermediate Macroeconomics,Troncoso,Pablo A,18,12,9,5,1,0,5,2.896
+Fall 2024,MATH,1314,4,14380,College Algebra,Caglar,Atife,84,71,62,27,26,0,25,2.551
+Fall 2024,SPAN,2615,1,14384,Intsve Inter Span Heritg Lrnrs,Lopez Otero,Julio Cesar,17,5,1,0,1,0,0,3.487
+Fall 2024,HRD,6305,30,14385,Organizational Learning,Waight,Consuelo L,11,0,0,0,0,0,0,4.0
+Fall 2024,MIS,4477,1,14386,Network & Security Infrastruct,Messinger,Jacob Nelson,17,15,1,3,0,0,1,3.223
+Fall 2024,ENGL,1302,60,14388,First Year Writing II,Cooper,Jacquelyn Ruth,19,1,2,1,0,0,0,3.652
+Fall 2024,ENGL,1301,141,14389,First Year Writing I,Braniger,Leslie,5,6,10,2,0,0,2,2.594
+Fall 2024,MANA,4330,3,14390,Intro to Strategic HR Mgt,Reinoso,Gaston,7,7,0,0,0,0,0,3.476
+Fall 2024,ENGL,3331,2,14391,Beg Creative Writing-Poetry,Charara,Hayan S,19,0,0,0,0,0,0,3.861
+Fall 2024,ENGL,3301,2,14392,Intro To Literary Studies,Mazella,David S,10,4,0,0,0,0,1,3.714
+Fall 2024,ENGL,3365,1,14393,Postcolonial Literature,Chatterjee,Sreya,23,4,0,0,0,0,1,3.779
+Fall 2024,ENGL,4315,1,14395,Sociolinguistics,Pogue,Donovan A,18,1,0,0,0,0,1,3.93
+Fall 2024,MANA,4310,1,14397,Behavioral Finance,Rude,Dale,5,0,0,0,0,0,0,3.736
+Fall 2024,HON,3301,1,14398,Readings in Medicine & Society,Macdonald,Arlene,22,0,1,0,0,0,2,3.827
+Fall 2024,POLS,3311,1,14399,Intro Compar Politics,Jung,Jae Hee,27,11,3,0,0,0,1,3.561
+Fall 2024,POLS,3312,2,14400,"Arguments, Data, Politics",Chatagnier,John Tyson,20,10,6,0,3,0,5,3.094
+Fall 2024,PSYC,3350,4,14401,Intro to Cognitive Psychology,Le,Giang Xuan,73,3,1,2,0,0,1,3.84
+Fall 2024,GEOL,1102,3,14402,Intro to Climate Change Lab,Zhang,Honghai,18,3,2,0,0,0,1,3.681
+Fall 2024,TEPM,6306,20,14403,Project Management Office,Rypien,David V,9,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2316,6,14404,Psychology of Personality,Inman,Tonya N,62,24,4,2,2,0,1,3.507
+Fall 2024,PSYC,2330,4,14405,Biological Psychology,Bick,Johanna R,26,9,7,3,7,0,5,2.776
+Fall 2024,ACCT,2301,7,14407,Prin of Financial Accounting,Parthasarathy,Kiran M,93,84,28,19,8,0,16,3.09
+Fall 2024,KIN,4315,2,14409,Motor Learning and Control,Layne,Charles S,34,52,12,0,0,0,0,3.214
+Fall 2024,ENTR,3312,5,14411,Corporate Entrepreneurship,Karonika,John R,34,10,3,1,0,0,1,3.487
+Fall 2024,ENTR,3312,6,14412,Corporate Entrepreneurship,Karonika,John R,30,12,2,2,2,0,0,3.32
+Fall 2024,CHIN,3350,1,14413,Chinese Culture Through Films,McArthur,Charles M,17,14,2,1,0,0,1,3.45
+Fall 2024,COMM,3321,1,14415,Single Camera Studio Productn,Houk,Keith R,34,0,0,0,0,0,0,4.0
+Fall 2024,AAS,2320,2,14417,Intro To African American Stdy,Wright,Kelechi Chinyere,31,3,2,0,0,0,0,3.796
+Fall 2024,BIOL,6120,1,14418,Responsible Conduct Bio Rsrch,Sater,Amy,39,3,0,0,0,0,0,3.913
+Fall 2024,PETR,6111,1,14419,Petroleum Graduate Seminar,Dindoruk,Birol,0,0,0,0,0,27,0,
+Fall 2024,COMM,3377,2,14420,Strategic PR Planning,Ni,Lan,12,4,1,0,0,0,1,3.55
+Fall 2024,BIOL,7124,1,14421,Cell Biology Seminar,Lekven,Arne,0,0,0,0,0,12,0,
+Fall 2024,PSYC,4344,7,14422,Cultural Psychology,Kilani,Mohamed Hechmi,34,31,9,2,5,0,0,3.074
+Fall 2024,HRD,3350,20,14423,Workforce Diversity and Global,Lopez,Johana,18,8,3,0,0,0,1,3.483
+Fall 2024,ENGL,1301,142,14424,First Year Writing I,Yates,Kaitlyn,10,7,3,1,4,0,0,2.694
+Fall 2024,ENGL,1301,143,14425,First Year Writing I,Raza,Iqra,16,2,0,0,1,0,0,3.684
+Fall 2024,ENGL,1301,144,14426,First Year Writing I,Garcia,Serena Mari,20,3,1,0,1,0,0,3.561
+Fall 2024,ENGL,1301,145,14427,First Year Writing I,Garcia,Serena Mari,14,6,1,1,1,0,2,3.29
+Fall 2024,ENGL,1301,146,14428,First Year Writing I,Garcia,Serena Mari,14,5,4,0,1,0,1,3.347
+Fall 2024,ENGL,1301,147,14429,First Year Writing I,Raza,Iqra,15,2,1,0,0,0,0,3.814
+Fall 2024,INTB,3355,3,14430,Global Environment of Business,Miljanic,Andra Olivia,156,53,23,5,7,0,5,3.392
+Fall 2024,ECE,6311,1,14432,Introduction to Robotics,Becker,Aaron T,11,5,0,1,2,0,0,3.088
+Fall 2024,MARK,3337,2,14435,Professional Selling,Boehm-Miller,Elizabeth A,143,71,13,1,0,0,4,3.538
+Fall 2024,ENTR,3310,4,14436,Entrepreneurship,Ortega,Carlos Alberto,127,48,9,3,3,0,6,3.532
+Fall 2024,IDNS,1101,2,14437,Physics 1301 Workshop,Pattison,Donna,6,4,3,0,1,0,4,3.071
+Fall 2024,IDNS,1102,1,14438,Physics 1302 Workshop,Pattison,Donna,22,7,3,1,0,0,0,3.455
+Fall 2024,COMD,3301,1,14439,History and Culture of Deaf,Brittain,Terrell,9,12,2,2,0,0,2,3.054
+Fall 2024,INTN,4210,1,14440,ASL Literature,Gietz,Merrilee Ruth,5,2,0,0,0,0,0,3.62
+Fall 2024,FINA,4320,5,14441,Investment Management,Mateen,Haaris,23,8,1,0,0,0,0,3.667
+Fall 2024,BIOE,2331,1,14442,Biomedical Processes,Shevkoplyas,Sergey,16,11,2,0,0,0,0,3.414
+Fall 2024,BIOE,3340,1,14443,Quantitative Physiology,Roh,Jinsook,9,4,3,0,0,0,0,3.313
+Fall 2024,PSYC,2301,6,14444,Introduction to Psychology,Lopez,Mariana Selene,29,37,5,1,4,0,4,3.119
+Fall 2024,GOVT,2306,15,14445,US and Texas Const/Politics,Davis,Jenna,18,39,32,14,30,0,32,1.978
+Fall 2024,GOVT,2306,16,14446,US and Texas Const/Politics,Davis,Jenna,6,12,21,7,8,0,18,1.982
+Fall 2024,GOVT,2306,17,14447,US and Texas Const/Politics,Church,Jeffrey,73,88,15,1,1,0,8,3.225
+Fall 2024,GOVT,2305,50,14451,"US Govt: Congress,Pres & Crts",Belco,Michelle Helene,25,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6380,1,14452,Business Analytics,Lee,Minwoo,5,3,0,0,0,0,0,3.625
+Fall 2024,CHEM,1312,2,14453,Fundamentals of Chemistry 2,Young,Crystal Ann,28,26,38,2,8,0,29,2.618
+Fall 2024,CHEM,1311,3,14454,Fundamentals of Chemistry,Yang,Ding-Shyue,61,56,52,13,7,0,37,2.75
+Fall 2024,FINA,4310,1,14455,Behavioral Finance,Rude,Dale,20,18,0,0,0,0,0,3.457
+Fall 2024,ECE,6373,1,14456,Adv Computer Arch,Fu,Xin,33,24,3,0,0,0,0,3.412
+Fall 2024,DIGM,2353,30,14457,Page Layout and Design,De Vega,Jaime M,35,12,3,0,1,0,3,3.523
+Fall 2024,HON,4198,1,14460,Independent Study,Rayder,Benjamin Taylor,4,0,0,0,0,0,0,4.0
+Fall 2024,THEA,1340,1,14461,Fundamentals of Acting,Diamond,Nadia Rose,12,0,0,0,0,0,1,3.945
+Fall 2024,LAW,5262,1,14463,Healthcare Compliance,Ingraham,Ryan,8,8,1,0,0,2,0,3.354
+Fall 2024,INDS,6322,1,14464,Visual Communication,Jamjoom,Zain Ahmed,2,0,0,0,0,0,0,3.835
+Fall 2024,CHEM,6351,1,14465,Organic Structure Detrm,Carrow,Bradley,5,12,0,0,0,0,0,3.275
+Fall 2024,LAW,5357,7,14467,Evidence,Brem,Katherine B,29,47,1,0,0,3,0,3.402
+Fall 2024,LAW,5330,1,14468,Anti-Trust Law,Bush,Darren,6,10,0,0,0,17,0,3.437
+Fall 2024,LAW,6366,1,14470,Int'l Arbitration Advocacy,Neufeld,Paul James,3,5,0,0,0,0,0,3.375
+Fall 2024,LAW,5221,1,14471,Int'l Commercial Arbitration,Dimitroff,Sashe Dimanin,3,7,0,0,0,1,1,3.234
+Fall 2024,FINA,4382,1,14473,Developing R E Project,Williams,Junious E,34,3,0,0,0,0,0,3.91
+Fall 2024,FINA,4383,1,14474,R E Mkt Research & Valuation,Wright,Larry Thomas,24,7,0,0,0,0,0,3.732
+Fall 2024,PETR,6399,13,14484,Masters Thesis,Farouq-Ali,Syed,0,0,0,0,0,1,0,
+Fall 2024,PETR,8398,13,14489,Doctoral Research,Wong,George K,0,0,0,0,0,1,0,
+Fall 2024,MUSI,1301,1,14491,Rudiments of Theory,Estrada Valadez,Eric,14,3,1,3,0,0,1,3.365
+Fall 2024,PHYS,2126,2,14492,University Physics Lab II,Wood,Lowell T,1,12,7,0,0,0,0,2.684
+Fall 2024,PHYS,2126,3,14493,University Physics Lab II,Wood,Lowell T,3,9,4,1,0,0,0,2.765
+Fall 2024,PHYS,2126,4,14494,University Physics Lab II,Wood,Lowell T,4,8,7,1,0,0,1,2.816
+Fall 2024,PHYS,2126,5,14495,University Physics Lab II,Wood,Lowell T,2,13,5,0,0,0,0,2.751
+Fall 2024,PHYS,2126,6,14496,University Physics Lab II,Wood,Lowell T,2,10,6,0,0,0,1,2.741
+Fall 2024,COMM,1307,3,14497,Media and Society,Ashley,Laura B,64,30,4,1,0,0,1,3.489
+Fall 2024,PHYS,2126,7,14498,University Physics Lab II,Wood,Lowell T,3,14,2,0,2,0,0,2.715
+Fall 2024,PHYS,2125,1,14499,University Physics Lab I,Wood,Lowell T,4,6,11,0,0,0,1,2.635
+Fall 2024,PHYS,2125,2,14500,University Physics Lab I,Wood,Lowell T,3,12,7,0,0,0,1,2.803
+Fall 2024,PHYS,2125,3,14501,University Physics Lab I,Wood,Lowell T,0,8,3,1,0,0,7,2.583
+Fall 2024,PHYS,2125,4,14502,University Physics Lab I,Wood,Lowell T,2,14,4,1,1,0,2,2.772
+Fall 2024,PHYS,2125,5,14503,University Physics Lab I,Wood,Lowell T,2,7,7,1,0,0,4,2.627
+Fall 2024,PHYS,2125,6,14504,University Physics Lab I,Wood,Lowell T,2,14,4,2,0,0,1,2.607
+Fall 2024,LST,3385,1,14505,Introduction to Law,Abbott Jr,Kenneth Wayne,39,4,0,0,0,0,0,3.853
+Fall 2024,MUSI,3160,1,14506,Adv Sightrding for Kybrd Plyrs,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Fall 2024,MSCI,1131,1,14508,Intermediate Physical Fitness,Thomas,Roland,2,1,0,0,0,0,0,3.557
+Fall 2024,ARTS,1311,2,14509,Fundamentals of Graphic Design,Kim,Yoonkyung,7,15,1,1,0,0,0,3.139
+Fall 2024,INDE,6337,1,14511,Human Factors Syst Dsgn,Schulze,Lawrence John Henry,4,3,0,0,0,0,0,3.619
+Fall 2024,ARTS,3384,1,14512,Sound Art,Meza,Abinadi,14,2,3,0,1,0,4,3.351
+Fall 2024,LACP,2111,2,14513,Liberal Arts Career Planning,Hayes,Olivia Kaye,0,0,0,0,0,22,0,
+Fall 2024,ARTH,3334,1,14514,History of Graphic Design,Orto,Luisa,16,24,0,1,0,0,2,3.333
+Fall 2024,ARTH,6331,1,14515,Contemporary Painting,Barrera,Debra,3,0,0,0,0,0,0,4.0
+Fall 2024,ARTH,6334,1,14516,History of Graphic Design,Orto,Luisa,0,1,0,0,0,0,0,2.67
+Fall 2024,BIOE,4305,1,14518,Brain Machine Interfacing,Francis,Joseph Thachil,2,0,0,0,0,0,0,3.67
+Fall 2024,CHEM,6698,33,14520,Special Problems,Cai,Chengzhi,0,0,0,0,0,3,0,
+Fall 2024,FINA,4330,1,14525,Corporate Finance,Medina Palma,Paolina del Carmen,6,2,4,0,0,0,0,3.057
+Fall 2024,TLIM,4342,20,14526,Quality Improvement Methods,O'Kelley,Donna K,22,11,8,1,2,0,3,3.031
+Fall 2024,TLIM,4342,31,14527,Quality Improvement Methods,Chance,Michael Dean,29,14,4,0,0,0,0,3.462
+Fall 2024,COMM,4335,1,14528,Crisis Communication,Graham,Catherine Burch,17,19,1,0,3,0,0,3.167
+Fall 2024,NAVY,2301,1,14529,Leadership Management,Collins,Daniel W,1,4,0,0,0,0,0,3.332
+Fall 2024,PHYS,1301,3,14530,College Physics I (lecture),Mondaini,Rubem,11,23,30,9,3,0,24,2.369
+Fall 2024,THEA,2334,1,14534,Fundamentals of Design,Willson,Paige A,10,7,0,0,0,0,1,3.685
+Fall 2024,PHAR,4300,1,14535,Biochemistry I,Hussain,Tahir,39,41,34,3,2,0,0,2.941
+Fall 2024,PHAR,4260,1,14536,Intro to the Healthcare System,Essien,Ekere James,46,55,13,0,0,0,0,3.289
+Fall 2024,PHAR,4250,1,14537,Pharmacy Skills Program I,Shamsi,Aayna,68,40,6,0,0,0,0,3.544
+Fall 2024,CHEE,2331,1,14538,Chemical Processes,Nikolaou,Michael,16,22,17,0,8,0,8,2.619
+Fall 2024,CHEE,2331,2,14539,Chemical Processes,Nikolaou,Michael,3,2,0,0,1,0,1,2.945
+Fall 2024,MUSA,3430,1,14540,Applied Flute,Russell,Peggy,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,3140,2,14542,Quantitative Physiology Lab,Roh,Jinsook,12,1,2,0,0,0,0,3.667
+Fall 2024,WGSS,2360,2,14544,Introduction to LGBT Studies,Stone,Lauren Michelle,24,3,2,0,0,0,1,3.645
+Fall 2024,MUSA,4424,2,14545,Applied Violoncello,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2024,NUTR,2332,1,14547,Intro To Human Nutrition,Zeraattalabmotlagh,Sheida,21,19,9,0,0,0,1,3.218
+Fall 2024,ARTS,2333,2,14548,Fundamentals of Printmaking,Sawhney,Ashita,13,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,3316,1,14549,Relief Printmaking,Alderson,Saran,12,1,0,0,0,0,0,3.898
+Fall 2024,ARTS,6310,1,14550,Printmaking Studio,Alderson,Saran,2,0,0,0,0,0,0,4.0
+Fall 2024,CNST,6340,1,14554,Best Practices in Construction,Kim,Kinam,16,6,1,0,0,0,0,3.58
+Fall 2024,CNST,6340,2,14555,Best Practices in Construction,Kim,Kinam,12,1,0,1,0,0,0,3.667
+Fall 2024,ARTS,1372,2,14556,Fundamentals of Video Art,Marion,Jennifer L,12,4,0,0,2,0,0,3.242
+Fall 2024,ARTS,3374,1,14557,Computer Imaging,Ranjbarcheshmehsorkhi,Mandana,8,6,1,0,2,0,1,3.039
+Fall 2024,ARTS,3304,1,14558,Intermediate Painting,Hecker,Rachel G,13,3,1,0,1,0,1,3.445
+Fall 2024,ARTS,3334,2,14559,Introduction to Typography,Gamble,Travis Hunter,13,8,1,0,0,0,1,3.365
+Fall 2024,ARTS,3330,1,14560,Intermediate Graphic Design,Jamaluddin,Mohd Ikhram,8,7,3,0,1,0,2,3.018
+Fall 2024,KIN,3304,2,14561,Human Structure & Phys Perform,Maddux,Rebekah Mary,16,21,7,1,2,0,2,2.979
+Fall 2024,MUSA,1340,1,14565,Applied Trumpet,Hughes,Mark Alan,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3422,1,14566,Applied Viola,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,2326,5,14567,Fundamentals of Sculpture,Ahern,Dylan,7,2,0,1,0,0,1,3.335
+Fall 2024,ARTS,6310,2,14569,Printmaking Studio,Masterson,Patrick D,0,0,0,0,0,0,0,
+Fall 2024,MUSA,1342,1,14571,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2024,NUTR,2332,2,14572,Intro To Human Nutrition,Hughes,Lindsay,66,26,5,1,0,0,1,3.514
+Fall 2024,ARTS,3330,2,14575,Intermediate Graphic Design,Lopez,Jonathan Christopher,12,8,0,0,0,0,3,3.435
+Fall 2024,SOC,3313,1,14576,Criminology,Nelson,Steven M,24,14,7,2,0,0,0,3.298
+Fall 2024,COMD,1333,4,14578,Intro to Comm Sci & Disorders,Ross,Byron L,13,16,4,2,0,0,1,3.067
+Fall 2024,INDE,8398,5,14579,Doctoral Research,Lin,Ying,0,0,0,0,0,2,0,
+Fall 2024,PHIL,1361,4,14580,Philosophy and the Arts,Drapela,Nick Gerard,11,15,6,4,1,0,13,2.793
+Fall 2024,PSYC,3347,1,14590,Problems of Normal Life,Anderson,Jill Annette,30,20,4,0,1,0,0,3.394
+Fall 2024,MUSA,8320,11,14591,Doctoral Applied Music,Yon,Kirsten A,3,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8499,1,14594,Doctoral Dissertation,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,1340,2,14598,Applied Trumpet,Vassallo,Jim Cates,8,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6377,1,14599,Continuum Mechs I,Chen,Yi-Chao,4,3,0,0,0,0,1,3.383
+Fall 2024,ECE,6337,1,14600,Stochastic Processes,Prasad,Saurabh,15,2,0,0,0,0,0,3.844
+Fall 2024,DRAM,1310,6,14602,Introduction to Theatre,Hinkel,Heidi Anne,608,119,19,8,3,0,8,3.693
+Fall 2024,MECT,1365,30,14604,Elements Materials & Processes,Rypien,David V,12,22,8,0,3,0,0,2.926
+Fall 2024,PSYC,8399,22,14611,Doctoral Dissertation,Babcock,Julia,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6340,1,14612,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,8698,21,14618,Doctoral Research,Quaini,Annalisa,0,0,0,0,0,3,0,
+Fall 2024,PHCA,8298,2,14619,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2024,HRD,6301,30,14620,Leadership Development in HRD,Hausmann,Robert Carl,13,0,0,0,0,0,0,4.0
+Fall 2024,MANA,4331,1,14621,Current Issues Human Res Mgmt,Babalola,Olusegun,13,2,1,2,2,0,0,3.051
+Fall 2024,WGSS,2350,10,14622,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,29,3,0,0,0,0,0,3.844
+Fall 2024,COSC,3337,1,14623,Data Science I,Ni,Jingchao,14,24,5,1,2,0,5,3.072
+Fall 2024,PCOL,6398,4,14624,Special Problems,Garey,Kevin W,0,0,0,0,0,2,0,
+Fall 2024,INDE,8298,6,14627,Doctoral Research,Khator,Suresh K,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6398,14,14629,Independent Studies,Neighbors,Clayton T,0,0,0,0,0,1,0,
+Fall 2024,POLS,8699,11,14630,Doctoral Dissertation,Clark,Jennifer H,0,0,0,0,0,1,0,
+Fall 2024,SCM,4330,3,14631,Bus Modeling and Dec Analysis,Cossick,Kathy L,27,17,11,4,1,0,5,3.094
+Fall 2024,MARK,4363,1,14632,International Marketing,Blair,Edward A,38,0,0,0,0,0,1,3.974
+Fall 2024,ECON,8399,5,14635,Doctoral Dissertation,Liu,Elaine Meichen,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6498,3,14636,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,2,0,
+Fall 2024,MUSA,3410,3,14637,Applied Piano,Morgulis,Tali,3,0,0,0,0,0,0,3.89
+Fall 2024,PHOP,6257,3,14640,Research Practicum B,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8199,1,14641,Doctoral Dissertation,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8198,2,14649,Doctoral Research,Coulson-Thomas,Vivien J,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8298,3,14654,Doctoral Research,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,1501,21,14656,Elementary Spanish I,Gonzalez Torres,Leonardo Elian Maximiliano Ilovik,9,7,2,1,1,0,4,3.084
+Fall 2024,SPAN,1502,9,14658,Elementary Spanish II,Fernandez-Asenjo,Maria-Mercedes,8,7,8,0,2,0,1,2.786
+Fall 2024,GOVT,2306,9,14665,US and Texas Const/Politics,Badas,Alex,65,93,57,11,16,0,5,2.708
+Fall 2024,PSYC,6352,5,14667,Directed Rsch in I/O Psyc,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,6498,4,14668,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6398,2,14670,Special Problems,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2024,DRAM,1310,1,14671,Introduction to Theatre,Ostrow,Stuart,42,0,0,0,0,0,2,4.0
+Fall 2024,PHYS,1101,20,14672,College Physics I (lab),Wood,Lowell T,0,16,5,0,0,0,3,2.699
+Fall 2024,PHYS,1101,21,14673,College Physics I (lab),Wood,Lowell T,1,12,10,0,0,0,1,2.738
+Fall 2024,PHCA,8698,3,14674,Doctoral Dissertation Research,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6257,4,14680,Research Practicum B,Ostrin,Lisa,5,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6257,8,14682,Research Practicum B,Plaumann,Maureen Daley,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLA,7299,3,14684,Masters Thesis,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2024,SOCI,1301,8,14685,Introduction To Sociology,Dorsey,Patricia Lynne,17,26,7,4,2,0,2,2.899
+Fall 2024,PEP,8699,12,14686,Doctoral Dissertation,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2300,5,14688,Applied Voice,Vasquez,Hector A,1,1,0,0,0,0,0,3.5
+Fall 2024,POLS,4398,1,14689,Independent Study,Cross,Renee Danielle,6,0,0,0,0,1,0,4.0
+Fall 2024,COMM,6398,2,14690,Special Problems,Vardeman,Jennifer E,2,0,0,0,0,0,0,4.0
+Fall 2024,WGSS,2350,1,14691,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,30,0,0,0,1,0,0,3.85
+Fall 2024,ARCH,2500,21,14692,Arc/Int Arc Design Studio III,Lutz,Shawn M,11,3,2,1,0,0,1,3.315
+Fall 2024,WGSS,2350,11,14695,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,29,2,0,0,0,0,1,3.893
+Fall 2024,PCEU,6398,5,14696,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Fall 2024,PHCA,8298,3,14706,Doctoral Dissertation Research,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,3500,19,14707,Architecture Design Studio V,Story,Jon Kevin,7,6,1,1,0,0,0,3.113
+Fall 2024,PSYC,6365,3,14711,Dir Rsch in Dev Cog Beh Neuro,Yoshida,Hanako,0,0,0,0,0,3,0,
+Fall 2024,BIOL,3399,3,14712,Senior Honors Thesis,Sen,Mehmet,0,0,0,0,0,0,0,
+Fall 2024,PHYS,8999,23,14735,Doctoral Dissertation,Ordonez,Carlos,1,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,8998,3,14748,Doctoral Research,Liu,Xinli,0,0,0,0,0,2,0,
+Fall 2024,CIS,2368,31,14749,Adv Info Systems Development,Dobretsberger,Otto,13,2,2,0,2,0,1,3.228
+Fall 2024,PCEU,6698,2,14750,Special Problems,Hu,Ming,0,0,0,0,0,0,0,
+Fall 2024,PCEU,6398,1,14751,Special Problems,Hu,Ming,0,0,0,0,0,0,0,
+Fall 2024,PSYC,6365,4,14752,Dir Rsch in Dev Cog Beh Neuro,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6398,16,14755,Independent Studies,Grigorenko,Elena L,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6398,18,14756,Independent Studies,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,2304,9,14758,Technical Communications,Ettelson,Jennifer Jane,14,6,2,0,1,0,2,3.363
+Fall 2024,PSYC,6365,6,14759,Dir Rsch in Dev Cog Beh Neuro,Tamber-Rosenau,Benjamin J,3,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6598,9,14760,Special Problems,Leasure,Jennifer Leigh,0,0,0,0,0,1,0,
+Fall 2024,SPAN,8699,12,14763,Dissertation,Goodin-Mayeda,Carrie Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2300,6,14764,Applied Voice,Belcher,Daniel,7,0,0,0,0,0,0,3.906
+Fall 2024,MUSA,3400,8,14765,Applied Voice,Vasquez,Hector A,3,2,0,0,0,0,0,3.666
+Fall 2024,PHOP,6267,1,14772,Research Practicum A,Ferreira,Tarsis Gesteira,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,2100,2,14774,Intro To Biomedical Engr,Akay,Yasemin M,48,2,1,0,0,0,0,3.889
+Fall 2024,ENGI,1100,22,14775,Introduction To Engineering,Zelisko,Matthew Raymond,24,23,6,1,3,0,0,3.082
+Fall 2024,TLIM,3363,21,14776,Technical Communications,Piercy,Penelope Junker,19,13,2,1,2,0,0,3.19
+Fall 2024,PHIL,1334,1,14777,Minds and Machines,Weisberg,Joshua,42,26,14,3,2,0,7,3.15
+Fall 2024,BIOE,4303,1,14778,Biomaterials,Abidian,Mohammad Reza,3,1,0,0,0,0,0,3.585
+Fall 2024,MATH,3339,5,14780,Statistics for the Sciences,Jeon,Hyeongseon,37,21,17,16,2,0,7,2.767
+Fall 2024,GEOL,1102,4,14781,Intro to Climate Change Lab,Zhang,Honghai,17,5,1,1,0,0,0,3.611
+Fall 2024,GEOL,1147,2,14782,Introductory Meteorology Lab,Jiang,Xun,5,8,6,0,0,0,2,2.93
+Fall 2024,HDCS,6331,20,14783,Adv Strat For Futures Planning,Hines,Andrew Lewis,13,2,0,0,0,0,0,3.823
+Fall 2024,WCL,2351,1,14784,World Cultures Thru Lit & Arts,Tiwari,Bhavya,11,15,2,5,0,0,1,3.0
+Fall 2024,ARCH,6361,1,14787,Integrated Practice,Hager,Jesse,12,10,0,0,0,0,0,3.515
+Fall 2024,MAS,3343,1,14789,Latino Psychology,Pino,Diana,11,18,6,2,4,0,3,2.756
+Fall 2024,ARCH,6393,3,14792,Master's Project Preparation,Borden,Gail,9,0,0,0,0,0,0,4.0
+Fall 2024,HDCS,3376,1,14793,Resources in Technology Entrep,Robinson,Ebony M,9,11,1,1,1,0,1,3.13
+Fall 2024,BIOL,2301,2,14794,Anatomy & Physiology I (lect),Gill,Tejendra,103,253,64,28,5,0,31,2.942
+Fall 2024,BIOL,6315,2,14798,Neuroscience,Ziburkus,Jokubas,7,3,0,0,0,0,0,3.601
+Fall 2024,ENGI,2304,7,14800,Technical Communications,Estrada,Carl,9,8,3,0,1,0,2,3.127
+Fall 2024,ENGI,2304,12,14801,Technical Communications,Wilson,Chad A,14,0,2,0,0,0,1,3.626
+Fall 2024,CHEM,4115,3,14802,Inorganic Chem Laboratory II,Zaitsev,Vladimir G,7,13,2,0,0,0,0,3.197
+Fall 2024,PETR,6372,1,14804,Petroleum Production Operation,Wong,George K,10,2,1,0,0,0,0,3.591
+Fall 2024,POLS,3313,3,14805,Intro Internatl Relatns,Bagashka,Tanya G,8,18,8,3,2,0,2,2.658
+Fall 2024,WGSS,3360,1,14806,Sexuality and Queer Theory,Boffone,Trevor James,15,4,0,0,1,0,2,3.584
+Fall 2024,PSYC,6344,1,14807,Functional Neuroanatomy,Leasure,Jennifer Leigh,4,3,1,0,0,0,0,3.293
+Fall 2024,COMM,1302,1,14808,Intro To Comm Theory,Lee,Jaesub,12,19,10,1,3,0,4,2.844
+Fall 2024,BZAN,6310,1,14809,Quant Analysis for Busn Dec,Hou,Jinghui,63,3,5,2,1,0,1,3.671
+Fall 2024,COMM,3317,1,14810,Multimedia Journalism,Baruch Blanco,Maria Felicitas,16,4,0,0,0,0,0,3.817
+Fall 2024,PSYC,2305,8,14812,Intro to Methods in Psychology,Laughlin,Haley Marie,46,13,4,3,3,0,8,3.315
+Fall 2024,PSYC,2305,11,14814,Intro to Methods in Psychology,Merrill,Livia Christine,52,16,5,1,3,0,3,3.438
+Fall 2024,INDS,3397,1,14816,Selected Topics,Jackson,Megan H,11,0,0,0,0,0,1,4.0
+Fall 2024,BIOL,4384,1,14817,Developmental Biology,Lekven,Arne,20,26,6,0,0,0,1,3.25
+Fall 2024,BIOL,4355,1,14818,Human Virology,Zhang,Shaun Xiaoliu,49,37,8,3,0,0,5,3.313
+Fall 2024,BIOL,6384,1,14819,Developmental Biology,Lekven,Arne,3,0,0,0,0,0,0,4.0
+Fall 2024,GOVT,2306,2,14820,US and Texas Const/Politics,Cole,Jeffrey Bryan,24,7,3,2,1,0,0,3.316
+Fall 2024,SOCI,1301,6,14823,Introduction To Sociology,Cooper,Chelsey Wells,51,8,2,0,0,0,1,3.792
+Fall 2024,SOCI,1301,7,14824,Introduction To Sociology,Cooper,Chelsey Wells,38,15,5,1,1,0,0,3.445
+Fall 2024,COMM,3369,3,14826,Strategic Comm. Writing,Emery II,Philip M,25,5,0,0,0,0,0,3.778
+Fall 2024,COMM,3380,1,14827,Electronic Field Production,Crowe,Craig Warren,15,3,4,0,0,0,0,3.44
+Fall 2024,PSYC,2317,5,14829,Intro to Psychology Statistics,Saiyed,Amna Shabbir,40,35,3,0,2,0,0,3.334
+Fall 2024,COMM,4371,1,14830,American Cinema: The Directors,Carter,Nestor Gregory,12,4,1,0,0,0,1,3.647
+Fall 2024,PSYC,3339,2,14831,Intro To Clinical Psychology,Szafranski,Derek D,46,20,6,3,1,0,3,3.369
+Fall 2024,MANA,4353,1,14832,Mgmt Training and Career Devel,Bozeman,Dennis,25,30,4,0,0,0,0,3.417
+Fall 2024,MANA,6310,1,14833,Fundamentals of Business,Celly,Nikhil,29,0,0,0,0,0,0,3.989
+Fall 2024,SOCW,7335,2,14834,SW Practice in Communities,Kennedy,Priscilla P,19,2,0,0,0,0,0,3.905
+Fall 2024,KIN,3306,1,14835,Physiology-Human Performance,Hamilton,Marc,23,17,16,2,4,0,7,2.839
+Fall 2024,PSYC,4344,8,14836,Cultural Psychology,Haddad,Sana,64,10,1,3,0,0,2,3.71
+Fall 2024,MATH,4310,1,14844,Biostatistics,Labate,Demetrio,11,2,1,0,1,0,2,3.467
+Fall 2024,PSYC,2317,7,14845,Intro to Psychology Statistics,Mehta,Paras D,10,8,7,0,0,0,1,3.014
+Fall 2024,PSYC,2317,10,14846,Intro to Psychology Statistics,Vahedi,Meisam,61,7,4,0,0,0,3,3.792
+Fall 2024,PSYC,2317,8,14850,Intro to Psychology Statistics,Mehta,Paras D,8,14,2,0,3,0,3,2.901
+Fall 2024,MATH,6350,1,14851,Stat. Learning and Data Mining,Ryan,John M,20,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,4303,1,14855,Teaching Engl as a Second Lang,Duran,Chatwara,20,6,1,0,0,0,3,3.704
+Fall 2024,ECE,6331,1,14856,Advanced Telecommunications,Han,Zhu,9,4,0,0,0,0,0,3.515
+Fall 2024,NUTR,6303,1,14857,Nutrition Mgmt & Leadership,Haubrick,Kevin,21,3,0,0,0,0,0,3.806
+Fall 2024,NUTR,6302,1,14858,Adv Medical Nutrition Therapy,Ferrell,Carla Denise,10,4,0,0,0,0,0,3.667
+Fall 2024,ECE,5388,1,14859,Renewable Energy Technology,Huang,Hao,15,8,2,1,0,0,0,3.448
+Fall 2024,ECE,6372,1,14860,Advanced Hardware Design,Chen,Yuhua,27,3,0,1,0,0,2,3.7
+Fall 2024,ECE,5451,1,14861,Principles of Internetworking,Wolfe,John C,51,3,0,0,0,0,0,3.902
+Fall 2024,ECE,6321,1,14862,Principles of Internetworking,Wolfe,John C,54,3,0,0,0,0,0,3.82
+Fall 2024,TEPM,6391,2,14863,Project Management Seminar,Carden,Lila L,10,1,0,0,0,0,0,3.879
+Fall 2024,ACCT,3377,3,14864,Cost Accounting,Lin,Haijin,20,10,12,4,0,0,8,2.914
+Fall 2024,SCLT,4389,31,14865,Practicum in Supply Chain,Henson,Alfred Bernard,25,5,0,0,0,0,0,3.789
+Fall 2024,BIOL,4323,1,14866,Immunology,Sen,Mehmet,25,23,21,0,0,0,13,3.01
+Fall 2024,BIOL,6323,1,14867,Immunology,Peng,Weiyi,14,2,0,0,0,0,0,3.813
+Fall 2024,SOCW,7356,2,14868,Groups: Adv Clinical Practice,Parks,Steven Lee,25,2,0,0,0,0,0,3.926
+Fall 2024,SOCW,7356,3,14869,Groups: Adv Clinical Practice,Robinson,Demetria,22,6,0,0,0,0,0,3.786
+Fall 2024,FINA,7323,1,14870,Applied Equity Fund Management,George,Thomas J,16,0,0,0,0,0,0,3.979
+Fall 2024,COSC,3320,1,14872,Algorithms and Data Structures,Leiss,Ernst L,141,86,17,2,2,0,15,3.425
+Fall 2024,NUTR,4201,1,14873,Dietetics as a Profession II,Ferrell,Carla Denise,18,5,1,0,0,0,0,3.695
+Fall 2024,KIN,4300,1,14874,Phys Activity Older Adults,Alastuey,Lisa L,50,21,26,15,7,0,4,2.729
+Fall 2024,GHL,1320,1,14875,Foodservice Management,Haskell,Rebecca Erin,55,7,1,1,1,0,0,3.723
+Fall 2024,GHL,2356,1,14876,Comm Strategies for Hospitalty,Haskell,Rebecca Erin,29,8,2,1,1,0,2,3.496
+Fall 2024,ARCH,1358,1,14877,Introduction to Design Culture,Lo,Ruth W,103,63,19,4,5,0,2,3.289
+Fall 2024,CIVE,3380,1,14883,Plane Surveying Fundamentals,Glennie,Craig Len,10,13,8,2,1,0,0,2.727
+Fall 2024,HON,3331,1,14885,Intro to Civic Engagement,Lawler,Janet Marie,12,2,0,0,0,0,1,3.716
+Fall 2024,CNST,6307,1,14886,Stati and Optimiz Method in CM,Senouci,Ahmed,55,9,0,0,0,0,0,3.694
+Fall 2024,CNST,6308,1,14887,Data Analysis in Construc Mgmt,Gao,Lu,71,2,0,0,0,0,0,3.964
+Fall 2024,CNST,6350,20,14888,Decision Making and Risk Mgmt,Gao,Lu,25,0,0,0,0,0,1,4.0
+Fall 2024,GHL,3346,1,14889,Beer Appreciation,Corsi,Aaron James,20,1,0,0,1,0,1,3.683
+Fall 2024,GHL,3349,1,14890,Hosp Procurement & Purchasing,Corsi,Aaron James,8,3,1,0,0,0,1,3.611
+Fall 2024,HON,3306,1,14892,Health and Human Rights,Lunstroth,John,16,3,0,0,0,0,2,3.825
+Fall 2024,BUSI,1301,4,14894,Business Principles,Carvalho,Diogo,179,49,12,7,2,0,0,3.549
+Fall 2024,GEOL,3320,1,14895,Principles of Geophysics,Wang,Guoquan,11,5,0,0,1,0,0,3.412
+Fall 2024,GEOL,4381,1,14896,Geophysical Signals,Zheng,Yingcai,3,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,3350,1,14898,Stratigraphy,Wellner,Julia S,14,4,7,1,0,0,1,3.268
+Fall 2024,ENGL,6323,1,14900,Fiction Workshop,Divakaruni,Chitra B,6,0,0,0,0,0,0,4.0
+Fall 2024,ECE,5115,1,14901,Control Systems Lab II,Provence,Robert S,5,0,0,0,0,0,0,3.802
+Fall 2024,ENRG,4320,1,14903,Case Studies-Enrgy & Sustainbl,Jacobsen,Nicolas Fisher,18,5,2,0,0,0,0,3.627
+Fall 2024,COMM,1303,1,14904,Writing for Communicators,Lyn,Robyn,71,8,4,1,3,0,7,3.64
+Fall 2024,COMM,2326,1,14905,Intro to Sports Broadcasting,Trupiano,Jerome,21,3,0,0,0,0,0,3.889
+Fall 2024,COMM,2356,1,14906,Business & Professional Comm,Kim,Jinsuk,190,46,24,9,14,0,13,3.365
+Fall 2024,TEPM,6303,20,14907,Risk Assessment in Project Mgm,Rypien,David V,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,4350,1,14908,Genomic & Proteomic Engr,Wu,Tianfu,0,1,0,0,0,0,0,3.33
+Fall 2024,TEPM,6305,2,14910,Project Manager Tools,Sherman,Dennis Louis,9,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6306,21,14911,Project Management Office,Rypien,David V,2,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6308,1,14912,Project Procurement Practices,Conover,Sharon Cecilia,8,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6395,2,14914,Integration Project,Carden,Lila L,8,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5409,10,14915,Contracts,Trujillo,Elizabeth I,14,25,2,0,0,0,0,3.269
+Fall 2024,LAW,5323,1,14917,Conflict of Laws,Ungureanu,Razvan C,5,16,0,0,0,0,0,3.254
+Fall 2024,LAW,5368,1,14918,Estate Planning,Buckles,Johnny R,2,5,0,0,0,2,0,3.38
+Fall 2024,ELET,4352,1,14925,Computational Tools for Tech,Zouridakis,George,23,29,2,0,2,0,0,3.256
+Fall 2024,ELET,2105,2,14926,Semicond. Device & Circuit Lab,Talusani,Pratap Reddy,12,1,0,0,0,0,0,3.923
+Fall 2024,MUSI,6100,1,14928,Chamber Music,Archibald,Amber Cristina,19,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,1101,22,14929,College Physics I (lab),Wood,Lowell T,1,10,5,0,0,0,4,2.668
+Fall 2024,TEPM,6308,20,14930,Project Procurement Practices,Conover,Sharon Cecilia,3,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,1102,13,14931,College Physics II (lab),Wood,Lowell T,1,12,8,0,1,0,0,2.635
+Fall 2024,PHYS,1102,14,14932,College Physics II (lab),Wood,Lowell T,1,11,11,1,0,0,0,2.569
+Fall 2024,PHYS,1102,15,14933,College Physics II (lab),Wood,Lowell T,3,13,8,0,0,0,0,2.778
+Fall 2024,ENGL,7324,1,14935,Writers On Literature,Serpas,Martha R,11,0,0,0,0,0,0,3.94
+Fall 2024,MUSI,4198,50,14936,SP-Opera Production,Belcher,Kathleen,1,0,0,0,0,0,0,4.0
+Fall 2024,THEA,3379,1,14937,Stage Design for Educators,Minor,Blake,5,0,0,0,0,0,0,3.934
+Fall 2024,THEA,6394,1,14939,"Design, Prod & Perf Studio",Vintu,Tatiana,5,0,0,0,0,0,0,3.934
+Fall 2024,COSC,2436,5,14942,Programming and Data Structure,Rizk,Nouhad J,5,4,7,2,3,0,9,2.207
+Fall 2024,COSC,2436,7,14944,Programming and Data Structure,Rizk,Nouhad J,21,16,26,9,11,0,9,2.345
+Fall 2024,ARTH,3301,1,14945,Critical Theory,Meza,Abinadi,12,1,2,0,0,0,0,3.667
+Fall 2024,ARTH,6301,1,14946,Critical Theory,Meza,Abinadi,5,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,4347,1,14948,Cell Biology for BME,Al-Ubaidi,Muayyad,2,4,0,0,0,0,1,3.498
+Fall 2024,PSYC,6308,1,14951,Foundations of Neuropsychology,Medina,Luis Daniel,2,2,0,0,0,0,0,3.5
+Fall 2024,BIOL,6350,1,14952,Biomedical Sciences Practicum,Lin,Chin-Yo,29,0,0,0,0,0,0,3.989
+Fall 2024,BIOL,6351,1,14953,Integrative Anatomy & Physiol,Ogletree-Hughes,Monique L,17,11,1,0,0,0,0,3.518
+Fall 2024,MUSA,4430,1,14954,Applied Flute,Russell,Peggy,2,0,0,0,0,0,0,4.0
+Fall 2024,TLIM,3300,20,14955,Leadership & Innovation Fund,Evans,Gerald S,35,6,2,0,1,0,0,3.569
+Fall 2024,TLIM,3330,33,14956,Innovation Principles,Crawley,David L,6,3,8,0,1,0,0,2.649
+Fall 2024,MATH,6357,1,14957,Lin. Models & Des. Experiments,Wang,Wenshuang,22,0,0,0,0,0,0,4.0
+Fall 2024,MATH,4339,2,14959,Multivariate Statistics,Poliak,Cathy Dawn,31,10,1,0,0,0,1,3.675
+Fall 2024,CHEM,8998,28,14961,Doctoral Research,Carrow,Bradley,0,0,0,0,0,5,0,
+Fall 2024,NUTR,6312,1,14962,Capstone II,Haubrick,Kevin,7,7,0,0,0,0,0,3.406
+Fall 2024,MIS,7374,1,14964,Bus Appls Database Mgt Sys II,Scamell,Richard W,5,0,0,0,0,0,1,3.868
+Fall 2024,ECON,3332,4,14965,Intermediate Microeconomics,Rivera,Javier Amilkar,15,15,5,3,0,0,2,3.053
+Fall 2024,CHEM,8998,29,14967,Doctoral Research,Wu,Judy,0,0,0,0,0,1,0,
+Fall 2024,PHAR,5325,1,14968,Literature Evaluation,Hatfield,Catherine L,49,37,16,1,1,0,1,3.269
+Fall 2024,PHAR,5224,1,14969,Integrated Renal Module,Marwaha,Aditi,46,32,23,3,2,0,1,3.104
+Fall 2024,PHAR,5225,1,14970,Integrated GI Module,Udugamasooriya,Damith Gomika,34,41,25,3,2,0,1,2.971
+Fall 2024,PHAR,5226,1,14971,Integrated Respiratory Module,Eriksen,Jason,36,47,17,3,3,0,1,3.038
+Fall 2024,PHAR,5111,1,14972,Leadership and IPE,Varkey,Divya A,101,2,0,0,0,0,1,3.981
+Fall 2024,PHAR,5195,1,14973,Pharmacy Skills Program III,Davis,Shantera Rayford,54,10,0,0,0,0,0,3.844
+Fall 2024,PHAR,5158,1,14974,Module Related Skills Lab I,Diec,Sandy,49,15,0,0,0,0,0,3.766
+Fall 2024,ECE,6377,1,14977,Power Systems Analysis,Viswanath,Padmavati Aparna,7,4,4,0,0,0,0,3.288
+Fall 2024,ECE,5377,1,14978,Power System Analysis,Viswanath,Padmavati Aparna,19,6,1,1,0,0,0,3.641
+Fall 2024,GHL,1367,1,14979,Lodging Management,Kenyan,Erin Oeser,35,11,2,1,0,0,2,3.612
+Fall 2024,GHL,1367,2,14980,Lodging Management,Mihiretu,Haimanot Asmamaw,15,14,1,0,1,0,1,3.302
+Fall 2024,ECE,6342,1,14981,Digital Signal Process,Hebert,Thomas James,6,7,2,0,0,0,2,3.223
+Fall 2024,DRAM,1310,8,14983,Introduction to Theatre,Egging,Jon Leo,37,3,0,1,3,0,3,3.583
+Fall 2024,THEA,6353,1,14985,"Scenic, Cost,& Light Design I",Vintu,Tatiana,2,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5158,2,14987,Module Related Skills Lab I,Diec,Sandy,31,7,1,0,1,0,1,3.675
+Fall 2024,PHAR,5195,2,14988,Pharmacy Skills Program III,Davis,Shantera Rayford,28,11,0,0,1,0,1,3.625
+Fall 2024,MUSA,2340,3,14989,Applied Trumpet,Vassallo,Jim Cates,4,0,0,0,0,0,0,3.918
+Fall 2024,MUSA,3446,1,14990,Applied Tuba,Barton,Mark,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8399,1,14992,Doctoral Dissertation,Wingard,Jennifer L,0,0,0,0,0,2,0,
+Fall 2024,MECE,6345,1,14993,Fluid Dynamics 1,Yang,Di,14,9,0,0,0,0,0,3.58
+Fall 2024,MUSI,8399,1,14994,Doctoral Document,Meals,Cory Dewitt,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7399,1,14995,Essay,Parsons,Alexander M,0,0,0,0,0,2,0,
+Fall 2024,GHL,6291,1,14996,Project Implementation,Haskell,Rebecca Erin,0,0,0,0,0,7,0,
+Fall 2024,GHL,6348,1,14997,Beer Appreciation,Corsi,Aaron James,5,0,0,0,0,0,0,3.934
+Fall 2024,ENGL,7398,1,14999,Special Problems,Divakaruni,Chitra B,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,3331,1,15000,Program Appl in Elec Comp Engr,Hebert,Thomas James,15,26,19,8,1,0,10,2.758
+Fall 2024,CHEM,6698,34,15002,Special Problems,Guloy,Arnold M,0,0,0,0,0,1,0,
+Fall 2024,ARTS,4398,4,15003,Independent Study,Frankfort,Dana M,1,0,0,0,0,0,0,4.0
+Fall 2024,ILAS,2350,1,15006,Knowledge and Methods,Oliva,Luca,34,17,7,2,12,0,7,2.783
+Fall 2024,MUSA,2332,1,15008,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTH,7393,1,15011,Art History Internship,Harren,Natilee O,4,0,0,0,0,0,0,4.0
+Fall 2024,COMM,3374,1,15012,Strategic Social Media,Uhrick,Jan,28,2,1,0,0,0,0,3.85
+Fall 2024,ENGL,4399,1,15013,Senior Honors Thesis,Duran,Chatwara,1,0,0,0,0,0,0,3.67
+Fall 2024,ENGL,8698,1,15014,Graduate Research,Majumder,Auritro,0,0,0,0,0,1,0,
+Fall 2024,SCLT,2362,32,15016,Intro To Logistics Technology,Kidd,Margaret A,3,16,1,3,0,0,1,2.869
+Fall 2024,POLS,3312,4,15017,"Arguments, Data, Politics",Austin,Amanda T,19,11,3,2,0,0,1,3.39
+Fall 2024,HRD,4352,1,15019,Facilitation Strategies,Clancy,James Patrick,26,8,1,0,0,0,0,3.62
+Fall 2024,PHYS,4399,1,15020,Senior Honors Thesis,Bering,Edgar A,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,3399,1,15021,Senior Honors Thesis,Majumder,Auritro,0,0,0,0,0,0,0,
+Fall 2024,MIS,7375,1,15022,Transaction Processing Systems,Messinger,Jacob Nelson,20,0,0,0,0,0,1,3.984
+Fall 2024,ARTS,3374,2,15023,Computer Imaging,Thomas,Britt,12,4,1,1,0,0,0,3.427
+Fall 2024,MUSA,4400,7,15024,Applied Voice,Vasquez,Hector A,1,1,0,0,0,0,0,3.665
+Fall 2024,MANA,3335,10,15025,Intro Org Behavior and Mgmt,Sebastijanovic,Marina,196,50,0,1,1,0,2,3.74
+Fall 2024,MATH,6398,5,15032,Special Problems,Timofeyev,Ilya,0,0,0,0,0,1,0,
+Fall 2024,PHOP,7275,1,15033,Intro Comp Thinking w/Python,Della Santina,Luca,6,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6377,1,15034,Intro Opt Sense &Biophotonics,Larin,Kirill,0,1,0,0,0,0,0,2.67
+Fall 2024,PHAR,5683,1,15035,Cardiology,Wang,Elisabeth,2,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6257,12,15038,Research Practicum B,Cheng,Han,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6467,2,15042,Research Practicuum A,Rump,Rachel,1,0,0,0,0,0,0,3.67
+Fall 2024,PHOP,6257,13,15043,Research Practicum B,Della Santina,Luca,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6667,1,15045,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2024,NURS,3310,1,15057,Prof Role Dev & Practice Issue,Kleinhans,Alicia Diane,25,15,0,2,0,0,0,3.5
+Fall 2024,PSYC,6359,3,15058,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,2326,1,15065,Fundamentals of Sculpture,De Leon,Laura,12,0,0,0,0,0,0,3.945
+Fall 2024,CIS,2347,30,15066,IS Infrastructure & Networking,Peddoju,Suresh Kumar,50,2,3,1,1,0,3,3.737
+Fall 2024,BIOL,3396,6,15068,Senior Research Project,Lekven,Arne,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6380,1,15069,Programming for Data Analytics,Shastri,Dvijesh J,3,8,0,0,0,0,0,3.273
+Fall 2024,MUSA,8241,2,15071,Doctoral Recital II,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2024,MIS,4374,4,15075,Info Technology Project Mgmt,Jagtap,Pankaj,24,23,2,0,0,0,1,3.422
+Fall 2024,PCOL,8998,3,15077,Doctoral Research,Hussain,Tahir,0,0,0,0,0,1,0,
+Fall 2024,PHCA,8698,5,15078,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,8298,4,15079,Doctoral Dissertation Research,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,2101,21,15089,Anatomy & Physiology Lab I,Gill,Tejendra,6,15,0,1,0,0,1,3.182
+Fall 2024,PHOP,6267,2,15090,Research Practicum A,Porter,Jason,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8598,3,15095,Doctoral Research,Mohan,Chandra,0,0,0,0,0,2,0,
+Fall 2024,CHEE,6399,1,15101,Masters Thesis,Karim,Alamgir,1,0,0,0,0,3,0,3.67
+Fall 2024,CHEE,7399,1,15102,Masters Thesis,Karim,Alamgir,1,0,0,0,0,0,0,3.67
+Fall 2024,COMM,1303,2,15104,Writing for Communicators,Lyn,Robyn,62,6,8,2,6,0,12,3.377
+Fall 2024,MIS,7378,1,15105,Info.Tech Management & Control,Grimes,George M,11,4,0,1,0,0,0,3.563
+Fall 2024,MUSA,6142,2,15106,Graduate Recital III,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6400,3,15107,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2305,13,15108,Intro to Methods in Psychology,Hall,Nicole Amber,21,11,0,1,3,0,3,3.241
+Fall 2024,CHEE,6398,1,15110,Research,Karim,Alamgir,0,0,0,0,0,4,0,
+Fall 2024,PHCA,8298,5,15111,Doctoral Dissertation Research,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2024,MIS,4374,3,15112,Info Technology Project Mgmt,Campbell,Phillip James,19,12,2,0,0,0,0,3.525
+Fall 2024,MECT,4331,30,15114,Heat Transfer Applications,Alba,Kamran,32,1,0,0,0,0,0,3.95
+Fall 2024,PETR,2311,1,15116,Reservoir Petrophysics,Hathon,Lori A,7,10,0,0,0,0,1,3.489
+Fall 2024,PHCA,6298,6,15117,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,5133,1,15118,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,25,1,0,0,0,0,0,3.962
+Fall 2024,OPTO,5133,2,15119,Adv Human Anat/Hist Lab,Coulson-Thomas,Vivien J,18,7,0,0,0,0,0,3.72
+Fall 2024,MUSA,6342,1,15120,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2024,SOC,6399,10,15123,Masters Thesis,Savage,Scott Vandenburgh,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,4300,1,15124,Intro-Study of Language,Zentz,Lauren R,18,4,4,0,2,0,2,3.333
+Fall 2024,MUSA,4434,1,15126,Applied Clarinet,Griffin,Randall S,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,5330,2,15142,Advanced Accounting,Larson,Chad R,2,3,1,0,0,0,2,3.112
+Fall 2024,PHCA,6298,7,15143,Special Problems,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCI,1301,4,15145,Introduction To Sociology,Dorsey,Patricia Lynne,14,22,13,5,1,0,4,2.74
+Fall 2024,PEP,8699,3,15146,Doctoral Dissertation,LaVoy,Emily Claire-Pyle,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,3396,2,15148,Senior Research Project,Meisel,Richard P,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6322,1,15150,Applied Viola,Archibald,Amber Cristina,2,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,2326,4,15151,Fundamentals of Sculpture,VanMeter,Charles Edward,10,2,0,0,0,0,0,3.861
+Fall 2024,PHCA,6298,8,15152,Special Problems,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,8998,7,15153,Doctoral Research,Cuny,Gregory D,1,0,0,0,0,1,0,4.0
+Fall 2024,CNST,3185,2,15154,Construction Experience,Lyon,Eva Yaneth,52,21,11,4,0,0,0,3.311
+Fall 2024,ENGL,1301,43,15164,First Year Writing I,Farrell,Miles Alexander,8,7,1,3,0,0,0,2.879
+Fall 2024,ENGL,1301,44,15165,First Year Writing I,Cervantes,Kimberly Ann,8,11,0,0,0,0,0,3.456
+Fall 2024,SPAN,1501,19,15169,Elementary Spanish I,Lumbierres Pallas,Maria Pilar,9,9,3,1,2,0,0,2.889
+Fall 2024,SPAN,2311,1,15170,Intermediate Spanish I,Said,Erika,7,10,3,1,2,0,1,2.812
+Fall 2024,PHCA,6298,2,15172,Special Problems,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2024,DIGM,4396,30,15173,Internship in Digital Media,Liao,Tony Chung-Li,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,30,15176,Doctoral Applied Music,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,5337,1,15181,Management Accounting,Lin,Haijin,3,5,1,0,0,0,3,3.186
+Fall 2024,PHYS,1101,23,15182,College Physics I (lab),Wood,Lowell T,2,10,8,2,0,0,1,2.53
+Fall 2024,BIOE,8298,3,15184,Doctoral Research,Abidian,Mohammad Reza,0,0,0,0,0,0,0,
+Fall 2024,PSYC,8399,26,15188,Doctoral Dissertation,Tamber-Rosenau,Benjamin J,1,0,0,0,0,0,0,4.0
+Fall 2024,COMD,7392,5,15189,Adv Pract Sp & Lang Dis,Bolling,Kenyetta,3,2,0,0,0,0,0,3.534
+Fall 2024,COMD,7391,9,15194,Clinic in Speech Lang Disorder,Townsend,Alayna,1,0,0,0,0,0,0,3.67
+Fall 2024,COMD,7391,1,15195,Clinic in Speech Lang Disorder,Fitch,Jennifer,3,0,0,0,0,0,0,3.67
+Fall 2024,POLS,8699,15,15196,Doctoral Dissertation,Chatagnier,John Tyson,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8242,3,15197,Doctoral Recital III,Wagner,Elise L,0,0,0,0,0,0,0,
+Fall 2024,RELS,2340,1,15200,Lived Hindu Religion,Borkataky-Varma,Sravana,30,5,2,1,0,0,0,3.615
+Fall 2024,BIOL,3396,7,15205,Senior Research Project,Liu,Yu,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,4396,2,15207,Senior Research Project,Gunaratne,Preethi H,2,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,8241,3,15208,Doctoral Recital II,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,6698,1,15209,Research,Flynn,Nicholas,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8398,1,15212,Doctoral Research,Akay,Metin,0,0,0,0,0,1,0,
+Fall 2024,ENGL,4398,1,15214,Independent Study,Nelson,Antonya,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8999,3,15215,Doctoral Dissertation,Klieman,Kairn,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2334,2,15217,Applied Clarinet,Rowell,Chester D,3,0,0,0,0,0,0,4.0
+Fall 2024,ECON,3357,1,15220,Data Mgmt with Econ Appl,Peru Durayalage,Dhanushka Arunasiri,27,8,2,1,0,0,3,3.631
+Fall 2024,CLAS,3308,2,15221,Myths & Cult of the Greek Gods,Due Hackney,Casey L,70,25,12,8,0,0,4,3.316
+Fall 2024,WCL,2351,2,15222,World Cultures Thru Lit & Arts,Nguyen,Duy,13,11,6,1,2,0,1,2.87
+Fall 2024,WCL,2352,1,15223,World Cinema,Zaretsky,Robert D,18,14,4,2,0,0,4,3.202
+Fall 2024,WCL,3366,2,15224,Latin American and Latino Film,Centeno,Daniel,9,20,13,1,3,0,1,2.645
+Fall 2024,MATH,1351,2,15225,Intro to Geometric Reasoning,Hollyer,Virginia Leigh,22,36,40,12,12,0,12,2.252
+Fall 2024,MATH,1342,3,15227,Elementary Statistical Methods,Kartheiser,Abigail Louise,74,90,92,48,58,0,30,2.177
+Fall 2024,MATH,2305,5,15229,Discrete Mathematics,Leger,Nicholas M,12,27,32,20,10,0,21,2.017
+Fall 2024,MATH,3338,1,15230,Probability,Deng,Xiaoxue,10,17,10,1,1,0,3,2.863
+Fall 2024,MATH,3339,1,15231,Statistics for the Sciences,Fu,Wenjiang,42,33,24,19,14,0,12,2.49
+Fall 2024,MATH,4364,2,15232,Intro to Numerical Analysis,Zhong,Ming,9,10,3,0,0,0,0,3.303
+Fall 2024,MATH,1100,1,15233,Developmental Math,Chern,Haley Nicole,0,0,0,0,0,289,24,
+Fall 2024,BIOL,4315,1,15235,Neuroscience,Ziburkus,Jokubas,97,26,19,0,0,0,9,3.512
+Fall 2024,BIOL,4315,2,15236,Neuroscience,Ziburkus,Jokubas,86,23,23,1,0,0,12,3.421
+Fall 2024,COMD,2376,3,15237,Anatomy for Communication,Daniels,Stephanie K,12,9,3,4,0,0,7,2.989
+Fall 2024,COMD,4333,1,15239,Neuroscience for COMD,Blake,Margaret T,16,16,4,2,1,0,0,3.111
+Fall 2024,ILAS,4350,1,15240,Interdisciplinary Problem Solv,Oliva,Luca,9,5,3,0,2,0,2,3.035
+Fall 2024,ENGI,1100,25,15241,Introduction To Engineering,Kota,Venkata Krishna Tulasi,15,9,6,1,0,0,1,3.205
+Fall 2024,NUTR,4351,1,15242,Gerontology and Nutrition,Svendsen-Sanchez,Ann Carol,80,56,7,3,7,0,1,3.245
+Fall 2024,CHEM,6312,1,15243,Bonding,Wu,Judy,7,9,0,0,0,0,0,3.438
+Fall 2024,BIOL,6315,1,15244,Neuroscience,Ziburkus,Jokubas,1,1,0,0,0,0,0,3.335
+Fall 2024,PHYS,4360,1,15245,Space and Atmospheric Physics,Bering,Edgar A,6,1,0,0,0,0,0,3.81
+Fall 2024,GEOL,3150,1,15246,Prin-Stratigraphy Lab,Wellner,Julia S,9,3,0,0,0,0,0,3.668
+Fall 2024,GOVT,2306,7,15247,US and Texas Const/Politics,Karimov,Samad,79,89,42,13,14,0,11,2.861
+Fall 2024,GOVT,2306,8,15248,US and Texas Const/Politics,Badas,Alex,65,94,52,19,12,0,6,2.733
+Fall 2024,GOVT,2306,12,15249,US and Texas Const/Politics,Littlepage,Kelley G,184,40,13,4,5,0,0,3.603
+Fall 2024,BIOE,4319,1,15250,Mass Transport Biosystems,Majd,Sheereen,1,0,0,0,0,0,0,4.0
+Fall 2024,IDNS,2112,1,15251,Precalculus SEP Workshop,Pattison,Donna,19,1,5,0,0,0,3,3.441
+Fall 2024,IDNS,2112,2,15252,Precalculus SEP Workshop,Pattison,Donna,21,6,1,1,0,0,2,3.655
+Fall 2024,BIOL,6354,1,15253,Endocrinology,Gill,Tejendra,6,3,0,0,0,0,0,3.593
+Fall 2024,BZAN,6354,1,15255,DB Mgt Tools Bus Analytics,Grimes,George M,27,5,3,0,0,0,0,3.686
+Fall 2024,BZAN,6356,1,15256,Adv DB Mgt Tools Bus Analytics,Grimes,George M,18,6,0,0,0,0,0,3.75
+Fall 2024,MIS,3360,4,15257,Systems Analysis and Design,Ruff,Eniscia R,23,10,0,0,2,0,1,3.542
+Fall 2024,MIS,3376,3,15258,Busn Appls Database Mgmt I,Jiang,Lianlian,44,12,4,0,1,0,1,3.661
+Fall 2024,IDNS,2113,1,15259,Calculus I SEP Workshop,Pattison,Donna,14,5,2,0,0,0,0,3.603
+Fall 2024,IDNS,2113,2,15260,Calculus I SEP Workshop,Pattison,Donna,20,0,4,2,1,0,3,3.346
+Fall 2024,IDNS,2113,3,15261,Calculus I SEP Workshop,Pattison,Donna,16,4,4,2,1,0,3,3.259
+Fall 2024,IDNS,2113,4,15262,Calculus I SEP Workshop,Pattison,Donna,17,5,6,1,0,0,0,3.31
+Fall 2024,IDNS,2114,1,15263,Calculus II SEP Workshop,Pattison,Donna,16,5,3,6,0,0,5,3.033
+Fall 2024,IDNS,2114,2,15264,Calculus II SEP Workshop,Pattison,Donna,20,5,2,2,0,0,4,3.46
+Fall 2024,IDNS,2133,1,15265,Calculus III SEP Workshop,Pattison,Donna,16,3,4,1,1,0,1,3.24
+Fall 2024,IDNS,3121,1,15266,Engineering Math SEP Workshop,Pattison,Donna,12,4,2,0,0,0,0,3.482
+Fall 2024,IDNS,1141,1,15267,Chemistry I SEP Workshop,Pattison,Donna,18,10,2,1,0,0,2,3.43
+Fall 2024,IDNS,1141,2,15268,Chemistry I SEP Workshop,Pattison,Donna,19,4,2,2,2,0,3,3.196
+Fall 2024,IDNS,1141,4,15270,Chemistry I SEP Workshop,Pattison,Donna,18,7,7,1,0,0,2,3.353
+Fall 2024,IDNS,1141,5,15272,Chemistry I SEP Workshop,Pattison,Donna,13,8,5,0,1,0,1,3.21
+Fall 2024,IDNS,1141,6,15273,Chemistry I SEP Workshop,Pattison,Donna,20,3,5,0,0,0,7,3.512
+Fall 2024,IDNS,1142,1,15274,Chemistry II SEP Workshop,Pattison,Donna,14,6,4,1,1,0,3,3.18
+Fall 2024,IDNS,1142,2,15275,Chemistry II SEP Workshop,Pattison,Donna,20,12,1,0,0,0,2,3.526
+Fall 2024,IDNS,1142,3,15276,Chemistry II SEP Workshop,Pattison,Donna,15,7,0,0,2,0,4,3.348
+Fall 2024,IDNS,1142,4,15277,Chemistry II SEP Workshop,Pattison,Donna,12,7,6,2,2,0,2,2.873
+Fall 2024,IDNS,2123,1,15278,Organic Chem I SEP Workshop,Pattison,Donna,16,12,4,1,0,0,3,3.303
+Fall 2024,IDNS,2123,2,15279,Organic Chem I SEP Workshop,Pattison,Donna,20,9,2,0,0,0,3,3.559
+Fall 2024,IDNS,2123,3,15280,Organic Chem I SEP Workshop,Pattison,Donna,25,4,0,3,0,0,2,3.594
+Fall 2024,IDNS,2123,5,15281,Organic Chem I SEP Workshop,Pattison,Donna,15,12,3,1,0,0,4,3.333
+Fall 2024,IDNS,2123,6,15283,Organic Chem I SEP Workshop,Pattison,Donna,22,5,3,2,0,0,2,3.448
+Fall 2024,IDNS,2123,7,15284,Organic Chem I SEP Workshop,Pattison,Donna,22,8,2,1,0,0,1,3.515
+Fall 2024,IDNS,2123,8,15285,Organic Chem I SEP Workshop,Pattison,Donna,18,7,0,5,0,0,1,3.289
+Fall 2024,IDNS,2123,9,15286,Organic Chem I SEP Workshop,Pattison,Donna,15,7,7,2,2,0,3,2.929
+Fall 2024,IDNS,2125,1,15287,Organic Chem II SEP Workshop,Pattison,Donna,7,4,3,1,0,0,14,3.111
+Fall 2024,IDNS,2125,2,15288,Organic Chem II SEP Workshop,Pattison,Donna,7,7,6,0,0,0,9,2.984
+Fall 2024,MATH,5382,1,15289,Probability,Torok,Andrei S,8,10,2,0,0,0,0,3.201
+Fall 2024,GOVT,2305,8,15290,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,108,62,16,2,0,0,16,3.459
+Fall 2024,POLS,3366,1,15291,Political Parties,Cole,Jeffrey Bryan,12,15,4,3,2,0,3,2.926
+Fall 2024,SOC,3301,1,15292,Intro to Sociological Research,Tuthill,Zelma,27,2,1,0,0,0,0,3.878
+Fall 2024,BIOE,6319,1,15293,Mass Transport Bio Systems,Majd,Sheereen,1,0,0,0,0,0,0,4.0
+Fall 2024,CIS,6396,30,15294,Internship in Infor. Security,Conklin,William A,4,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7334,1,15295,Learning Sys &Mgmt Development,Bozeman,Dennis,16,6,3,0,0,0,0,3.546
+Fall 2024,MANA,7355,1,15297,Staffing & Talent Management,Bozeman,Dennis,16,8,2,0,0,0,0,3.577
+Fall 2024,GHL,1320,2,15298,Foodservice Management,Haskell,Rebecca Erin,37,8,1,2,1,0,0,3.538
+Fall 2024,MANA,4355,1,15299,Selection and Staffing,Phillips,James S,37,15,2,1,1,0,3,3.471
+Fall 2024,MANA,4341,1,15300,Leading Organizational Change,Evans,Klavdia Markelova,54,4,2,0,2,0,1,3.715
+Fall 2024,PSYC,2305,15,15301,Intro to Methods in Psychology,Myers,Annika Mariah,52,17,5,3,1,0,1,3.47
+Fall 2024,PSYC,2305,17,15303,Intro to Methods in Psychology,Kennedy,Caitlin Grace,29,26,12,4,4,0,5,2.916
+Fall 2024,COMM,2311,1,15305,Writing for Print and Digital,Crixell,Charles A,17,5,3,1,0,0,1,3.449
+Fall 2024,INDE,6377,1,15306,Ind Eng Application,Irani,Shahrukh A,7,0,0,0,0,0,1,3.953
+Fall 2024,GHL,3364,1,15307,Hotel Sales,Kenyan,Erin Oeser,35,12,4,1,0,0,0,3.57
+Fall 2024,BUSI,4350,1,15308,Business Law and Ethics,Krylova,Ksenia O,13,11,0,0,0,0,0,3.5
+Fall 2024,GHL,3420,1,15309,Foodservice Operations,Ginapp,Kathrine,13,11,5,0,0,0,0,3.264
+Fall 2024,SCM,4390,3,15311,Supply Chain Strategy,Smith,Gordon D,10,14,10,0,0,0,0,3.0
+Fall 2024,SCM,7325,1,15312,Process Analysis and Design,Robinson Jr,Powell Ersell,10,10,1,0,0,0,0,3.397
+Fall 2024,BUSI,4350,2,15313,Business Law and Ethics,Currie,Daniel David,233,28,10,0,3,0,1,3.732
+Fall 2024,BUSI,4350,4,15315,Business Law and Ethics,Currie,Daniel David,226,41,4,0,0,0,3,3.752
+Fall 2024,BUSI,4350,6,15317,Business Law and Ethics,Williams,John M,143,69,19,4,5,0,2,3.366
+Fall 2024,BUSI,4350,8,15319,Business Law and Ethics,Williams,John M,58,16,2,0,0,0,1,3.685
+Fall 2024,BUSI,4350,10,15321,Business Law and Ethics,Williams,John M,65,26,10,0,0,0,0,3.456
+Fall 2024,PSYC,2305,19,15323,Intro to Methods in Psychology,Avci,Gunes,19,23,10,2,2,0,5,2.982
+Fall 2024,PSYC,2305,21,15325,Intro to Methods in Psychology,Avci,Gunes,11,29,12,2,4,0,2,2.758
+Fall 2024,CNST,4220,20,15327,Comp CM & Emerging Practices,Beadle,Dwight D,43,31,27,0,1,0,1,3.127
+Fall 2024,ECE,3317,1,15328,Applied Electromagnetic Waves,Jackson,David R,17,30,10,2,1,0,4,3.05
+Fall 2024,ECE,4117,1,15329,Telecommunications Laboratory,Han,Zhu,19,0,0,0,0,0,0,4.0
+Fall 2024,MECE,4364,1,15330,Heat Transfer,Liu,Dong,19,37,59,9,0,0,3,2.503
+Fall 2024,GHL,4350,1,15331,Strategy&Innovation Hosp Ind,Kim,Jaewook,11,3,0,0,0,0,0,3.739
+Fall 2024,GHL,4352,1,15332,Hosp Organizational Behavior,Maneethai,Dustin,24,4,2,0,1,0,0,3.602
+Fall 2024,GHL,4360,1,15333,Professional Development,Kenyan,Erin Oeser,47,10,0,0,0,0,3,3.813
+Fall 2024,ECE,5127,1,15334,Power System Analysis Lab,Viswanath,Padmavati Aparna,27,0,0,0,0,0,0,4.0
+Fall 2024,GHL,4352,2,15335,Hosp Organizational Behavior,Doudna,Simone P,39,8,2,0,1,0,0,3.621
+Fall 2024,COMM,2311,2,15338,Writing for Print and Digital,Crixell,Charles A,13,7,4,0,0,0,1,3.416
+Fall 2024,ENGL,3301,3,15339,Intro To Literary Studies,Voskuil,Lynn M,10,4,3,1,1,0,0,3.088
+Fall 2024,ENGL,4340,1,15344,Feminist Criticism and Theory,Gregory,Elizabeth,9,3,0,0,1,0,0,3.385
+Fall 2024,PSYC,2301,7,15345,Introduction to Psychology,Schoolfield,Lucy,67,7,2,1,2,0,1,3.751
+Fall 2024,FINA,7382,1,15346,Developing Real Estate Project,Azuike,Acho Kelechi,11,0,0,0,0,0,0,3.88
+Fall 2024,INDE,6360,1,15347,Engineering Analytics,Lin,Ying,20,11,0,0,0,0,0,3.688
+Fall 2024,IEEM,6360,1,15348,Data Analytics for Engr. Mgt,Hu,Minxiang,75,3,2,0,0,0,0,3.875
+Fall 2024,ACCT,2301,8,15349,Prin of Financial Accounting,Newman,Michael Ray,21,4,0,0,0,0,1,3.88
+Fall 2024,ACCT,3366,3,15350,Financial Reporting Frameworks,Harris,Kathleen L,30,19,16,1,1,0,7,3.208
+Fall 2024,PSYC,2307,3,15351,Psychology of Adolescence,Martin,Rebecca B,61,14,1,0,2,0,1,3.663
+Fall 2024,INDE,6380,1,15352,Accounting for Engr Managers,Hu,Minxiang,15,5,2,0,0,0,0,3.576
+Fall 2024,IEEM,6331,1,15353,Quant Methods for Engr Mgmt,Kamrani,Ali K,16,0,0,0,0,0,0,3.814
+Fall 2024,PETR,6352,1,15354,Shale Reservoirs,Hathon,Lori A,3,2,0,0,0,0,0,3.666
+Fall 2024,ECE,3337,2,15355,Signals and Systems Analysis,Reddy,Rohith Krishna,7,12,16,4,1,0,1,2.508
+Fall 2024,BUSI,2305,1,15356,Business Statistics,Patterson,Staci A,124,104,92,70,22,0,130,2.522
+Fall 2024,BUSI,2305,2,15357,Business Statistics,Patterson,Staci A,84,94,60,60,16,0,94,2.501
+Fall 2024,COSC,1437,1,15358,Introduction to Programming,Rincon Castro,Carlos Alberto,33,20,12,4,22,0,32,2.385
+Fall 2024,COSC,1437,3,15360,Introduction to Programming,Biediger,Daniel Edward,56,19,12,3,5,0,24,3.242
+Fall 2024,ARCH,1198,1,15362,Special Problems,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,3332,6,15363,Prin of Financial Management,Suleymanov,Masim,105,65,37,10,0,0,7,3.211
+Fall 2024,ACCT,7378,1,15364,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,17,1,1,0,0,0,0,3.825
+Fall 2024,POLS,3315,1,15365,International Organization,Kharmats,Polina G,42,4,0,0,0,0,0,3.92
+Fall 2024,ELET,6352,1,15366,Matlab Engineering Technology,Zouridakis,George,10,1,0,0,0,0,0,3.789
+Fall 2024,ELET,6353,1,15367,Applied Stats for Technology,Pollonini,Luca,29,3,1,0,0,0,0,3.808
+Fall 2024,ELET,6350,1,15368,Overview Com Health Informatic,Pollonini,Luca,2,0,0,0,0,0,0,4.0
+Fall 2024,BUSI,1301,5,15369,Business Principles,Carvalho,Diogo,199,30,9,1,6,0,3,3.635
+Fall 2024,HRD,4344,1,15371,Designing E-Learning,Bennett,LaTasha,47,4,2,0,0,0,0,3.824
+Fall 2024,HRD,4352,30,15372,Facilitation Strategies,Polesello,Daiane,12,1,0,0,0,0,2,3.898
+Fall 2024,SOCW,6307,1,15373,Policy in the Soc Environment,Ortiz,Lillian Aguirre,29,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6307,2,15374,Policy in the Soc Environment,Strohl,Katyayani Rao,28,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6307,3,15375,Policy in the Soc Environment,Sanchez,Chelsea Marie,27,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6308,1,15376,Human Diversity & Development,Bagneris,Jessica Rene',28,1,0,0,0,0,0,3.966
+Fall 2024,SOCW,6308,2,15377,Human Diversity & Development,Barthelemy,Juan,29,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6308,3,15378,Human Diversity & Development,Bagneris,Jessica Rene',24,1,1,0,0,0,0,3.885
+Fall 2024,HON,3341,1,15381,Pre-Modern Science & Medicine,Bland,Laura Elizabeth,18,0,0,0,0,0,0,4.0
+Fall 2024,HDCS,4374,1,15382,Entrepreneurial E-Tailing,Gatterson,Beverly,53,2,0,0,0,0,0,3.934
+Fall 2024,ENGI,8111,1,15383,FFP,Sharma,Pradeep,0,0,0,0,0,17,0,
+Fall 2024,HRD,3310,2,15384,Talent Management,Clancy,James Patrick,26,4,0,1,0,0,0,3.742
+Fall 2024,SCLT,3385,30,15385,Transport Economics and Policy,Henson,Alfred Bernard,45,28,4,0,1,0,2,3.415
+Fall 2024,ELET,4360,1,15386,Sustainable & Resilient Tech,Yuan,Xiaojing,8,8,0,0,1,0,2,3.236
+Fall 2024,HRD,3350,21,15387,Workforce Diversity and Global,Polesello,Daiane,20,5,0,0,0,0,2,3.694
+Fall 2024,SOCW,7310,1,15388,Program Planning & Evaluation,Guzman,Paola E,24,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6306,5,15389,Social Work Practice Skills,White,Tamika Alonzo,24,2,0,0,0,0,0,3.923
+Fall 2024,ELET,4350,1,15390,Computation Health Informatics,Pollonini,Luca,22,5,3,0,1,0,1,3.495
+Fall 2024,INTB,3355,4,15391,Global Environment of Business,Farah,Elena,96,21,4,1,0,0,1,3.678
+Fall 2024,TLIM,3360,31,15392,Law & Ethics-Tech & Innovation,Feriante,Chris,89,21,5,0,0,0,4,3.699
+Fall 2024,COMM,2327,1,15393,Introduction to Screen Writing,Vaughan,Thomas Michael,16,8,1,0,0,0,0,3.521
+Fall 2024,COMM,3300,1,15394,Health Communication,Yamasaki,Jill S,111,9,1,0,0,0,0,3.887
+Fall 2024,COMM,3315,1,15395,News and Social Media,Bhat,Nandikoor R Prashanth,17,7,0,0,0,0,1,3.695
+Fall 2024,COMM,3328,1,15396,Intro to Sports Production,Crowe,Craig Warren,25,3,0,0,1,0,1,3.645
+Fall 2024,HRD,4350,30,15397,Org Dev & Consulting,Polesello,Daiane,8,2,0,2,1,0,0,3.026
+Fall 2024,ENGL,3328,1,15398,Masterpieces of British Lit II,Wood,Barry Albert,19,9,3,1,1,0,1,3.203
+Fall 2024,DIGM,1300,20,15401,Introduction to Digital Media,Liao,Pamara F,42,26,5,1,4,0,1,3.236
+Fall 2024,MECT,2354,30,15402,Introduction to Mechanics,Basaran,Burak,2,6,12,7,2,0,1,1.943
+Fall 2024,LAW,5258,1,15405,Eminent Domain Property Rights,Hodge,Justin Allen,7,3,2,0,0,2,0,3.389
+Fall 2024,MUED,3106,1,15406,Percussion,Warren,Paul Alexander,6,5,0,0,0,0,1,3.425
+Fall 2024,PHAR,5371,1,15407,Ambulatory Practice Management,Thornton,James D,26,75,7,0,0,0,0,3.176
+Fall 2024,PHAR,5335,1,15408,Integrated Neurology Module,Tejada-Simon,Maria Victoria,39,52,18,0,0,0,0,3.193
+Fall 2024,PHAR,5236,1,15409,Integrated Immunology Module,Beyda,Nicholas D,29,52,29,0,0,0,0,3.0
+Fall 2024,PHAR,5337,1,15410,Integrated ID I Module,Williams,Louis,27,52,29,1,0,0,0,2.963
+Fall 2024,PHAR,5338,1,15411,Integrated ID II Module,Cuny,Gregory D,31,55,22,1,0,0,0,3.064
+Fall 2024,PHAR,5268,1,15412,Module Related Skills Lab III,Surati,Dhara Divyang,55,52,4,0,0,0,0,3.459
+Fall 2024,HON,3350,1,15413,Principles of Data and Society,Lawler,Janet Marie,11,10,0,0,0,0,1,3.587
+Fall 2024,MUSI,1121,2,15414,Concert Chorus,Koppel,Alexander,33,0,0,0,0,0,0,3.99
+Fall 2024,MUSI,1122,1,15415,Concert Chorale,DeSpain,Kaitlin Elizabeth,41,1,0,0,0,0,0,3.953
+Fall 2024,COMM,3376,1,15416,Media Effects,Archer,Allison Michelle Nam,21,7,2,0,0,0,0,3.501
+Fall 2024,BZAN,6357,1,15417,BZAN-Frameworks & Methods,Ma,Xiao,18,3,0,0,0,0,1,3.747
+Fall 2024,COMM,4365,2,15419,Digital PR and Advertising,Huang,Yan,17,3,0,0,0,0,0,3.768
+Fall 2024,MATH,4323,1,15420,Data Science and Stats Learn,Wang,Wenshuang,55,25,6,0,3,0,2,3.401
+Fall 2024,COSC,3320,702,15422,Algorithms and Data Structures,Wu,Panruo,15,44,24,3,2,0,11,2.791
+Fall 2024,COMM,4381,1,15425,Digital Cinematography,Houk,Keith R,16,0,0,0,0,0,0,4.0
+Fall 2024,TLIM,3350,20,15428,Emergency Management Principle,Freedkin,Aaron Samuel,28,10,0,0,0,0,0,3.563
+Fall 2024,LAW,6233,1,15430,Internet Law,Raimer,Anna,7,11,0,0,0,2,0,3.407
+Fall 2024,LAW,5267,1,15431,Tax Accounting,Gupta,Ajay,0,2,0,0,0,1,0,3.33
+Fall 2024,LAW,6377,1,15432,Entertainment Law,Alonso,Yocel,14,10,3,0,0,8,0,3.383
+Fall 2024,LAW,7341,1,15433,WRS: Modern Corporation,Nelson,James D,3,5,0,0,0,0,0,3.416
+Fall 2024,LAW,6376,1,15434,Intellectual Property Survey,Michaels,Andrew Charles,20,35,0,0,0,4,0,3.412
+Fall 2024,LAW,6369,1,15435,Legal Analysis and Writing,Nieuwveld,Lisa Bench,0,0,0,0,0,7,0,
+Fall 2024,ARTH,3380,1,15437,17Th Century Dutch Art,Nevitt Jr,Hugh R,15,5,0,0,0,0,0,3.635
+Fall 2024,ARTH,6322,1,15438,17th Century Dutch Art,Nevitt Jr,Hugh R,5,0,0,0,0,0,0,4.0
+Fall 2024,NURS,4215,1,15439,Maternal Newborn Women Hlth,Ecby,Chanique,3,24,0,0,0,0,1,3.111
+Fall 2024,NURS,4217,1,15440,Maternal Newborn Women Clin,Ecby,Chanique,12,15,0,0,0,0,1,3.444
+Fall 2024,NURS,4316,1,15441,Medical Surgical Concepts,Edwards-Maddox,Shermel Vinese,0,27,0,1,0,0,1,2.929
+Fall 2024,NURS,4417,1,15442,Medical Surgical Clinical,Moore,Ryan,18,9,0,1,0,0,1,3.571
+Fall 2024,DIGM,2357,30,15443,Content Strategy & Development,Alters,Monika Joanna,35,24,5,0,1,0,3,3.4
+Fall 2024,POLS,6382,1,15444,Quantitative Methods III,Zhu,Ling,4,1,0,0,0,0,0,3.734
+Fall 2024,ARLD,6370,1,15448,Intro to Museum Management,Cachia,Amanda,11,0,0,0,0,0,1,4.0
+Fall 2024,MATH,4322,2,15451,Data Science and Machine Learn,Poliak,Cathy Dawn,91,6,1,0,0,0,1,3.875
+Fall 2024,PHYS,4340,3,15452,Research Methods,Ekeoba,Jacqueline Njideka,7,0,0,0,0,0,0,3.859
+Fall 2024,MECT,1364,30,15454,Materials & Processes,Afrin,Samia,11,10,2,3,1,0,0,2.976
+Fall 2024,MUSA,3402,1,15456,Applied Composition,Maroney,Marcus K,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,2340,1,15460,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,8998,30,15462,Doctoral Research,Lubchenko,Vassiliy,0,0,0,0,0,1,0,
+Fall 2024,COSC,6398,109,15470,Special Problems,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2024,COSC,6398,114,15475,Special Problems,Kakadiaris,Ioannis A,0,0,0,0,0,3,0,
+Fall 2024,COSC,6398,124,15485,Special Problems,Shah,Shishir,0,0,0,0,0,1,0,
+Fall 2024,COSC,6398,125,15486,Special Problems,Shi,Weidong,0,0,0,0,0,2,0,
+Fall 2024,COSC,8398,101,15493,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,103,15495,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Fall 2024,COSC,8398,106,15498,Doctoral Research,Deng,Zhigang,0,0,0,0,0,2,0,
+Fall 2024,COSC,8398,115,15507,Doctoral Research,Lin,Sen,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,118,15510,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,120,15512,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,122,15514,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,124,15516,Doctoral Research,Shah,Shishir,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,125,15517,Doctoral Research,Shi,Weidong,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,127,15519,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,3,0,
+Fall 2024,COSC,8398,128,15520,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Fall 2024,COSC,8398,129,15521,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2024,COSC,8399,101,15524,Doctoral Dissertation,Alipour,Mohammad Amin,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,8399,107,15530,Doctoral Dissertation,Eick,Christoph F,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,8399,114,15537,Doctoral Dissertation,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2024,COSC,8399,117,15540,Doctoral Dissertation,Merchant,Fatima Aziz,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,8399,122,15545,Doctoral Dissertation,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2024,COSC,8399,129,15552,Doctoral Dissertation,Verma,Rakesh M,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,8698,101,15555,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,102,15556,Doctoral Research,Chen,Guoning,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,103,15557,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,2,0,
+Fall 2024,COSC,8698,107,15561,Doctoral Research,Eick,Christoph F,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,109,15563,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,112,15566,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,113,15567,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,114,15568,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,115,15569,Doctoral Research,Lin,Sen,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,117,15571,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,3,0,
+Fall 2024,COSC,8698,120,15574,Doctoral Research,Pandurangan,Gopal,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,122,15576,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,128,15582,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,1,0,
+Fall 2024,COSC,8698,129,15583,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2024,COSC,8699,125,15610,Doctoral Dissertation,Shi,Weidong,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,101,15617,Doctoral Research,Alipour,Mohammad Amin,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,102,15618,Doctoral Research,Chen,Guoning,0,0,0,0,0,3,0,
+Fall 2024,COSC,8998,106,15622,Doctoral Research,Deng,Zhigang,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,107,15623,Doctoral Research,Eick,Christoph F,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,109,15625,Doctoral Research,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,112,15628,Doctoral Research,Huang,Shou-Hsuan Stephen,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,113,15629,Doctoral Research,Johnsson,Lennart,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,114,15630,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,115,15631,Doctoral Research,Lin,Sen,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,117,15633,Doctoral Research,Merchant,Fatima Aziz,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,118,15634,Doctoral Research,Mukherjee,Arjun,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,122,15638,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,124,15640,Doctoral Research,Shah,Shishir,0,0,0,0,0,3,0,
+Fall 2024,COSC,8998,125,15641,Doctoral Research,Shi,Weidong,0,0,0,0,0,2,0,
+Fall 2024,COSC,8998,127,15643,Doctoral Research,Subhlok,Jaspal,0,0,0,0,0,3,0,
+Fall 2024,COSC,8998,128,15644,Doctoral Research,Tsekos,Nikolaos V,0,0,0,0,0,6,0,
+Fall 2024,COSC,8998,129,15645,Doctoral Research,Verma,Rakesh M,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,131,15647,Doctoral Research,Wu,Panruo,0,0,0,0,0,2,0,
+Fall 2024,FINA,4325,1,15648,Retirement and Estate Planning,Lopez,John C,14,5,1,0,0,0,1,3.601
+Fall 2024,COSC,6399,107,15655,Masters Thesis,Eick,Christoph F,0,0,0,0,0,1,0,
+Fall 2024,COSC,6399,124,15672,Masters Thesis,Shah,Shishir,0,0,0,0,0,1,0,
+Fall 2024,IART,1300,1,15680,The Arts in Society,Noble,Melissa Lynn,20,4,0,0,0,0,0,3.751
+Fall 2024,IART,1300,2,15681,The Arts in Society,Bootwala,Jennifer Elizabeth,14,5,3,0,1,0,2,3.29
+Fall 2024,IART,1300,3,15682,The Arts in Society,Newkirk,Elizabeth Diane,21,2,1,0,0,0,0,3.778
+Fall 2024,IART,1300,4,15683,The Arts in Society,Harris,Jeanette Joy,20,3,0,0,1,0,0,3.667
+Fall 2024,BIOE,4302,1,15715,Numerical Analysis for BME,An,Ran,17,0,1,0,0,0,0,3.889
+Fall 2024,ENGL,3352,1,15716,19th Century American Fiction,Wood,Barry Albert,13,13,3,0,1,0,3,3.101
+Fall 2024,DIGM,1350,30,15717,Graphics for Digital Media,Beyl,Charles Eugene,13,10,0,0,3,0,2,3.128
+Fall 2024,DIGM,1350,32,15718,Graphics for Digital Media,Beyl,Charles Eugene,13,12,2,0,1,0,2,3.18
+Fall 2024,DIGM,1350,33,15719,Graphics for Digital Media,De Vega,Jaime M,19,4,0,0,1,0,4,3.612
+Fall 2024,ENGL,4382,1,15721,Poetry Writing,Serpas,Martha R,14,4,1,0,0,0,1,3.563
+Fall 2024,MUSA,1300,5,15722,Applied Voice,Vasquez,Hector A,4,0,0,0,0,0,0,3.835
+Fall 2024,MUSA,3424,2,15724,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3440,1,15725,Applied Trumpet,Hughes,Mark Alan,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3440,2,15726,Applied Trumpet,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,2304,14,15730,Technical Communications,Ettelson,Jennifer Jane,15,5,3,1,1,0,0,3.254
+Fall 2024,ENGI,2304,15,15731,Technical Communications,Estrada,Carl,6,12,5,0,1,0,0,2.93
+Fall 2024,BIOE,8598,16,15732,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8999,23,15740,Doctoral Dissertation,Zastrow,Melissa L,0,0,0,0,0,0,0,
+Fall 2024,ARTS,1303,1,15741,Art Hist I(Prehistoric 14th C),Koontz,Rex A,157,10,3,2,1,0,4,3.823
+Fall 2024,MECE,4398,2,15742,Independent Study,Bering,Edgar A,3,0,2,0,0,0,0,3.134
+Fall 2024,ENGL,7699,1,15744,Thesis,Tejada,Roberto Jose,0,0,0,0,0,2,0,
+Fall 2024,ENGL,7699,2,15745,Thesis,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8399,2,15746,Doctoral Dissertation,Chatterjee,Sreya,0,0,0,0,0,1,0,
+Fall 2024,ARTH,6399,2,15747,Master's Thesis,Tejada,Roberto Jose,0,0,0,0,0,1,0,
+Fall 2024,BIOL,3399,4,15749,Senior Honors Thesis,Fox,Robert O,0,0,0,0,0,0,0,
+Fall 2024,MUSA,8320,4,15751,Doctoral Applied Music,Krager,Franz A,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6304,3,15752,Conducting,Bertman,David Garry,2,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,8999,25,15755,Doctoral Dissertation,Daugulis,Olafs,0,0,0,0,0,1,0,
+Fall 2024,ENGL,7399,2,15758,Essay,Shepley,Nathan,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,8999,26,15762,Doctoral Dissertation,May,Jeremy A,1,0,0,0,0,1,0,4.0
+Fall 2024,HIST,2301,1,15764,Texas History to 1865,Ramos,Raul,23,4,3,0,2,0,2,3.334
+Fall 2024,MANA,4333,1,15766,Current Issues in Mgmt,Tang,Yijia,15,4,0,0,0,0,0,3.755
+Fall 2024,ENGL,7399,3,15768,Essay,Voskuil,Lynn M,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8698,2,15770,Graduate Research,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8399,4,15771,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Fall 2024,CHEM,8999,27,15773,Doctoral Dissertation,Xu,Shoujun,0,0,0,0,0,2,0,
+Fall 2024,GHL,4350,2,15774,Strategy&Innovation Hosp Ind,Morosan,Cristian,15,15,6,0,3,0,2,3.034
+Fall 2024,ENGL,8399,5,15776,Doctoral Dissertation,Mazella,David S,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8699,3,15777,Doctoral Dissertation,Berger,Jason,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8699,4,15779,Doctoral Dissertation,Davies,Daniel,0,0,0,0,0,1,0,
+Fall 2024,INDE,8598,2,15784,Doctoral Research,Feng,Qianmei,0,0,0,0,0,1,0,
+Fall 2024,INDE,8598,5,15787,Doctoral Research,Lin,Ying,0,0,0,0,0,1,0,
+Fall 2024,PETR,5352,1,15789,Shale Reservoirs,Hathon,Lori A,7,0,0,0,0,0,0,3.811
+Fall 2024,MARK,3365,3,15790,Intro to Digital Marketing,Tirunillai,Seshadri N,132,56,5,4,2,0,1,3.525
+Fall 2024,BZAN,6353,1,15792,Res Design-Probs Busi Anlytcs,Aron,Ravi,6,21,0,0,0,0,0,3.296
+Fall 2024,MECE,4398,1,15797,Independent Study,Bering,Edgar A,4,0,0,0,0,0,1,4.0
+Fall 2024,MUSI,8296,3,15798,Doctoral Essay,Koozin,Timothy,2,0,0,0,0,0,0,4.0
+Fall 2024,CNST,6308,2,15799,Data Analysis in Construc Mgmt,Gao,Lu,54,0,0,0,0,0,0,4.0
+Fall 2024,FINA,3332,5,15803,Prin of Financial Management,Lopez,John C,34,68,72,29,10,0,17,2.559
+Fall 2024,ENGL,8698,3,15804,Graduate Research,Prufer,Kevin D,0,0,0,0,0,2,0,
+Fall 2024,ENGL,8698,4,15805,Graduate Research,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8698,7,15808,Graduate Research,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8698,8,15809,Graduate Research,Belieu,Erin Colleen,0,0,0,0,0,0,0,
+Fall 2024,MANA,4358,1,15810,Compensation and Benefits,Zamanipour,Tina,46,12,3,1,1,0,1,3.603
+Fall 2024,ENGL,8698,10,15812,Graduate Research,Shepley,Nathan,0,0,0,0,0,2,0,
+Fall 2024,SPAN,1507,3,15813,Intns Elem Span Heritage Learn,Sandra,Nevarez Yadira,12,6,1,1,1,0,0,3.129
+Fall 2024,PSYC,6359,5,15816,Directed Rsch in Clinical Psyc,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,6335,1,15821,Managerial Finance,Berta,Dominique,4,1,1,0,0,0,0,3.335
+Fall 2024,GEOL,1102,7,15822,Intro to Climate Change Lab,Zhang,Honghai,13,2,1,1,1,0,0,3.242
+Fall 2024,MATH,2413,51,15823,Calculus I,Constante,Beatrice,254,104,48,30,32,0,36,3.115
+Fall 2024,ENGL,8399,8,15829,Doctoral Dissertation,Ehlers,Sarah E,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8699,5,15830,Doctoral Dissertation,Serpas,Martha R,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8399,9,15831,Doctoral Dissertation,Zamora,Lois,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8699,6,15835,Doctoral Dissertation,Lee,Eunjeong,0,0,0,0,0,2,0,
+Fall 2024,ENGL,8698,11,15837,Graduate Research,Boswell,Robert L,0,0,0,0,0,1,0,
+Fall 2024,HIST,8388,1,15839,Dissertation Proposal,McNally,David Joseph,0,0,0,0,0,1,0,
+Fall 2024,ECON,3385,1,15840,Economics of Energy,Hirs,Edward A,34,21,3,0,0,0,9,3.534
+Fall 2024,ENGL,8699,8,15841,Doctoral Dissertation,Tejada,Roberto Jose,0,0,0,0,0,1,0,
+Fall 2024,MUSI,8106,1,15842,Doctoral Large Ensemble,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,7340,1,15843,Data Analytics for PHOP,Varisco,Tyler J,5,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,7305,1,15844,Theory in PHOP,Sansgiry,Sujit Sharad,6,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,4398,2,15845,Independent Study,Gonzalez,Maria C,0,0,0,0,0,0,0,
+Fall 2024,ENGL,8699,9,15846,Doctoral Dissertation,Nelson,Antonya,1,0,0,0,0,2,0,4.0
+Fall 2024,GENB,5303,1,15847,Prof Acct Communication,Newman,Michael Ray,1,5,0,0,0,0,1,3.222
+Fall 2024,GENB,7303,2,15848,Prof Accounting Communication,Newman,Michael Ray,26,13,0,0,0,0,0,3.751
+Fall 2024,ENGL,8699,2,15849,Doctoral Dissertation,Christensen,Ann C,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8320,7,15850,Doctoral Applied Music,Hester,Timothy E,6,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6140,5,15853,Graduate Recital I,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2024,CNST,3265,2,15854,Construction Layout & Site Dvp,Lupher,Jacob John,31,8,3,0,0,0,0,3.659
+Fall 2024,MUSA,1338,1,15857,Saxophone,Witt,Woodrow W,3,2,0,0,0,0,0,3.468
+Fall 2024,MUSA,1350,1,15858,Applied Percussion,Warren,Paul Alexander,2,2,0,0,0,0,0,3.418
+Fall 2024,HIST,2328,1,15859,Chicano History since 1910,San Miguel Jr,Guadalupe,16,12,3,0,1,0,2,3.323
+Fall 2024,CHEM,3336,1,15860,Org Chem Biol Molecules,Gilbertson,Scott R,8,9,2,2,1,0,8,2.85
+Fall 2024,MUSA,2310,3,15861,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2320,2,15862,Applied Violin,Lo,Mann-Wen,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2338,1,15863,Applied Saxophone,Witt,Woodrow W,7,0,0,0,0,0,0,3.811
+Fall 2024,MUSA,3444,1,15864,Applied Trombone,Kauk,Brian Keith,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3450,2,15865,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4420,2,15866,Applied Violin,Lo,Mann-Wen,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,4450,2,15867,Applied Percussion,Wilkins,Blake M,2,1,0,0,0,0,0,3.667
+Fall 2024,POLS,3313,4,15868,Intro Internatl Relatns,Zwald,Zachary J,12,22,4,2,1,0,4,3.024
+Fall 2024,MUSA,6330,2,15869,Applied Flute,Martin,Tyler Craig,1,0,0,0,0,0,0,4.0
+Fall 2024,CIS,4365,31,15872,Database Management,Hu,Renjie,39,7,1,0,2,0,0,3.532
+Fall 2024,CIS,3367,30,15873,Cloud Computing Architecture,Martinez,Jose C,44,7,1,0,0,0,0,3.827
+Fall 2024,TLIM,3330,35,15874,Innovation Principles,Crawley,David L,6,5,10,0,0,0,0,2.668
+Fall 2024,ARCH,3380,2,15875,Architecture Plus Film,Froehlich,Dietmar,19,1,0,0,0,0,0,3.802
+Fall 2024,EGRP,1141,2,15876,Engineering Applications IV,Luna Singh,Jennifer Austin,5,0,0,0,0,0,0,4.0
+Fall 2024,EGRP,1150,2,15877,Engineering Applications VI,Luna Singh,Jennifer Austin,11,11,1,0,1,0,2,3.223
+Fall 2024,EGRP,1142,2,15878,Engineering Applications V,Luna Singh,Jennifer Austin,9,1,0,2,0,0,0,3.417
+Fall 2024,EGRP,1170,2,15879,Engineering Applications IX,Luna Singh,Jennifer Austin,11,4,2,1,0,0,0,3.389
+Fall 2024,HIST,1301,50,15880,The U.S. to 1877,Vale,Timothy Eli,25,0,0,0,0,0,0,3.921
+Fall 2024,MUSI,1220,1,15881,Class Piano I,Van Kekerix,Todd Evan,6,2,0,1,0,0,1,3.371
+Fall 2024,ECE,5330,1,15882,Introduction to Robotics,Becker,Aaron T,4,7,0,0,0,0,0,3.364
+Fall 2024,ECE,6111,1,15884,Graduate Research Seminar,Zheng,Jianfeng,0,0,0,0,0,1,0,
+Fall 2024,ARCH,6380,2,15885,Architecture Plus Film,Froehlich,Dietmar,6,2,1,0,0,0,0,3.482
+Fall 2024,ACCT,2301,4,15886,Prin of Financial Accounting,Newman,Michael Ray,13,8,2,0,0,0,0,3.507
+Fall 2024,ACCT,2301,6,15887,Prin of Financial Accounting,Newman,Michael Ray,20,4,0,0,0,0,0,3.875
+Fall 2024,MUSI,6350,2,15889,Applied Music Pedagogy,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2024,MUED,3320,1,15891,Intro To Education in Music,McGinnis,Emily Jane,17,11,0,0,0,0,0,3.607
+Fall 2024,MARK,4377,1,15893,Sales for Social Impact,Suki,Yara D,12,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7332,1,15894,Effective Negotiating,Miller,Carl Chet,14,8,0,0,0,0,0,3.561
+Fall 2024,ENTR,4350,1,15895,Entrepreneurial Strategy,Boles,James Read,28,0,0,0,0,0,0,3.929
+Fall 2024,CHEE,5323,1,15896,Fundamental of Tissue Engineer,Horton,Renita Elillian,1,1,0,0,0,0,2,3.5
+Fall 2024,CHEE,6323,1,15897,Fund of Tissue Engineering,Horton,Renita Elillian,0,1,0,0,0,0,0,3.0
+Fall 2024,BIOE,8398,15,15898,Doctoral Research,Wu,Tianfu,0,0,0,0,0,1,0,
+Fall 2024,PCEU,7180,1,15902,Pharmaceutics Seminar,McConnell,Bradley K,0,0,0,0,0,4,0,
+Fall 2024,PHCA,7180,1,15903,Seminar,Aparasu,Rajender R,13,0,0,0,0,0,0,4.0
+Fall 2024,DRAM,1351,1,15904,Acting I,Ferrarone,Jessica,9,1,0,0,1,0,0,3.455
+Fall 2024,DRAM,1351,2,15905,Acting I,Ferrarone,Jessica,5,1,0,0,0,0,0,3.833
+Fall 2024,PHCA,7308,1,15906,Biostatistics,Abughosh,Susan M,17,5,0,0,0,0,0,3.773
+Fall 2024,GENB,5304,1,15907,Business Ethics for Accountant,Brant Jr,Robert Edward,0,5,1,0,0,0,0,2.943
+Fall 2024,GENB,7304,1,15908,Bus Ethics for Accountants,Brant Jr,Robert Edward,4,5,0,0,0,0,0,3.481
+Fall 2024,INDS,3360,2,15909,Human Factors,Vos,Gordon A,19,3,0,0,0,0,0,3.849
+Fall 2024,INAR,3360,2,15910,Human Factors in Interior Arch,Vos,Gordon A,12,1,0,0,0,0,0,3.898
+Fall 2024,INDS,6333,2,15911,Human Factors,Vos,Gordon A,3,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6361,3,15912,Integrated Practice,Rivers,Paul Joseph,1,3,1,0,0,0,0,2.934
+Fall 2024,ARCH,1500,23,15915,Design Studio I,Plauche',Roya,7,9,0,0,0,0,0,3.479
+Fall 2024,ARCH,4510,21,15917,Integrated Arch Solutions,Roldan Caballero,Jose Manuel,6,11,2,1,0,0,0,3.15
+Fall 2024,ARCH,2500,35,15919,Arc/Int Arc Design Studio III,Canak,Emine,8,7,2,0,0,0,1,3.372
+Fall 2024,AAS,2320,5,15921,Intro To African American Stdy,Odewale,Alicia D,25,5,3,0,1,0,1,3.559
+Fall 2024,ARCH,6600,5,15928,Architecture Design Studio I,Brancaccio,Anna Sophia,6,6,0,0,0,0,2,3.555
+Fall 2024,PHLA,7320,1,15932,Capstone,Varkey,Divya A,6,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4330,1,15933,Adv Instrumental Conducting,Krager,Franz A,3,0,1,0,0,0,0,3.418
+Fall 2024,MSCI,4310,3,15934,The Army Officer,Bradford,Todd F,1,0,0,0,0,0,0,4.0
+Fall 2024,RELS,1301,1,15936,Intro To Religious Studies,Borkataky-Varma,Sravana,62,20,7,3,3,0,6,3.348
+Fall 2024,MANA,4356,2,15938,Managing Diversity,Ruggs,Enrica N,25,28,4,0,0,0,1,3.426
+Fall 2024,ENGL,7399,5,15939,Essay,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2024,MATH,8698,5,15940,Doctoral Research,Labate,Demetrio,0,0,0,0,0,4,0,
+Fall 2024,PHOP,6198,2,15944,Spec Prob-Physio Optics,Frishman,Laura J,1,0,0,0,0,0,0,3.67
+Fall 2024,PHOP,6567,5,15947,Research Practicum A,Harrison,Wendy W,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1302,21,15948,First Year Writing II,Rajkumar,Nidhi,14,3,1,2,1,0,4,3.176
+Fall 2024,ENGL,1302,23,15949,First Year Writing II,Rajkumar,Nidhi,12,4,2,2,3,0,2,2.855
+Fall 2024,ENGL,1302,24,15950,First Year Writing II,Lee,Nathanael D,8,10,0,1,2,0,4,2.921
+Fall 2024,ENGL,2305,4,15951,Intro To Fiction,Guajardo,Paul,12,9,0,0,1,0,3,3.334
+Fall 2024,ENGL,2307,2,15952,Intro To Drama,Presswood,Phillip Hilliard,22,0,2,0,1,0,0,3.64
+Fall 2024,ENGL,2330,2,15953,Writing Discipline English,Zachow,Alix V,4,8,2,1,1,0,3,2.771
+Fall 2024,ENGL,1301,148,15954,First Year Writing I,Kastely,James L,11,7,4,0,1,0,2,3.145
+Fall 2024,PHOP,6198,5,15958,Spec Prob-Physio Optics,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6198,6,15960,Spec Prob-Physio Optics,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6198,9,15969,Spec Prob-Physio Optics,Yoon,Geunyoung,2,0,0,0,0,0,0,3.67
+Fall 2024,PHOP,6198,7,15971,Spec Prob-Physio Optics,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6356,1,15973,Medical Ethics,Determeyer,Peggy Lee,25,1,0,0,0,0,0,3.962
+Fall 2024,ENGL,3330,3,15974,Beg Creative Writing-Fiction,Bellomy,Charlotte Seychelles,19,1,0,0,0,0,0,3.901
+Fall 2024,PSYC,7398,1,15977,Statistics in PSYC Practicum,Francis,David J,0,0,0,0,0,5,0,
+Fall 2024,ENGL,1302,12,15980,First Year Writing II,Stewart-Steele,Heather Marie,8,8,0,0,4,0,5,2.734
+Fall 2024,ENGL,2305,1,15981,Intro To Fiction,Zamora,Lois,5,8,3,1,3,0,5,2.534
+Fall 2024,ENGL,2306,2,15982,Intro To Poetry,Harris,Francine Julia,21,6,1,0,0,0,1,3.667
+Fall 2024,ENGL,1301,64,15983,First Year Writing I,Downey,Carlton M,17,5,1,0,2,0,0,3.308
+Fall 2024,ENGL,1301,65,15984,First Year Writing I,Campese,Kathleen Ann,18,4,0,1,2,0,0,3.4
+Fall 2024,ENGL,1301,66,15985,First Year Writing I,Feizbakhsh Tavana,Zahra,16,2,1,0,0,0,0,3.789
+Fall 2024,ENGL,1301,68,15986,First Year Writing I,Al-Bedawi,Layla,8,5,2,2,0,0,0,3.079
+Fall 2024,ENGL,1301,69,15987,First Year Writing I,Al-Bedawi,Layla,12,3,2,1,0,0,1,3.426
+Fall 2024,PHOP,8598,6,15988,Doctoral Research,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,3201,12,15996,Biochemistry I Laboratory,Pattison,Donna,3,9,7,0,2,0,0,2.508
+Fall 2024,BIOL,2101,22,15997,Anatomy & Physiology Lab I,Gill,Tejendra,7,7,4,2,2,0,2,2.667
+Fall 2024,BIOL,2101,23,15998,Anatomy & Physiology Lab I,Gill,Tejendra,7,7,4,1,0,0,4,3.07
+Fall 2024,BIOL,2101,24,15999,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,1,2,1,0,5,2.895
+Fall 2024,WGSS,2350,12,16001,Intro To Women's Studies,Deremer,Melissa Gale,29,1,0,0,1,0,0,3.743
+Fall 2024,PHCA,6297,1,16003,Selected Topics,Varkey,Divya A,2,0,0,0,0,0,0,4.0
+Fall 2024,ECON,8399,8,16009,Doctoral Dissertation,Yi,Kei-Mu,0,0,0,0,0,8,0,
+Fall 2024,PCOL,6398,1,16010,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Fall 2024,ENTR,3342,1,16011,Women in Entrepreneurship,McCormick,Kelly,27,9,1,0,0,0,0,3.729
+Fall 2024,ENTR,7342,1,16012,Women in Entrepreneurship,McCormick,Kelly,3,0,0,0,0,0,0,4.0
+Fall 2024,MANA,3335,8,16013,Intro Org Behavior and Mgmt,Rude,Dale,19,5,0,0,0,0,0,3.792
+Fall 2024,HDCS,4303,1,16017,Merchandising Systems,Johnson,Olivia,3,5,3,0,0,0,0,3.0
+Fall 2024,PHLA,7299,4,16019,Masters Thesis,Wallace,David A,0,0,0,0,0,1,0,
+Fall 2024,ENGL,1301,71,16021,First Year Writing I,Feizbakhsh Tavana,Zahra,17,1,0,0,1,0,0,3.685
+Fall 2024,ENGL,1301,72,16022,First Year Writing I,Arayilakath Mohammed,Ibrahim Badshah,11,2,3,1,1,0,1,3.075
+Fall 2024,ENGL,1301,74,16023,First Year Writing I,Islam,Muhammad Nurul,7,7,4,0,1,0,0,3.0
+Fall 2024,MIS,3360,3,16026,Systems Analysis and Design,Netzel,Andrew,58,8,2,0,0,0,2,3.828
+Fall 2024,ENGL,1301,75,16032,First Year Writing I,Weitman,Mathew,15,3,0,0,0,0,0,3.833
+Fall 2024,MATH,8398,23,16033,Doctoral Research,Ott,William R,0,0,0,0,0,3,0,
+Fall 2024,BCHS,6198,1,16034,Special Problems,Widger,William R,0,0,0,0,0,1,0,
+Fall 2024,SPAN,1501,3,16037,Elementary Spanish I,Morales Utria,Yordanis,6,18,2,0,0,0,0,3.128
+Fall 2024,ENGL,1301,53,16040,First Year Writing I,Murray,Christopher Brean,20,3,0,1,1,0,0,3.547
+Fall 2024,ENGL,1301,55,16041,First Year Writing I,Zachow,Alix V,16,5,3,1,0,0,0,3.321
+Fall 2024,ENGL,1301,56,16042,First Year Writing I,Campese,Kathleen Ann,13,4,3,0,4,0,0,2.917
+Fall 2024,ENGL,1302,17,16043,First Year Writing II,Mengesha,Abigail Mulatu,10,5,2,0,1,0,1,3.278
+Fall 2024,ENGL,1302,18,16044,First Year Writing II,Stewart-Steele,Heather Marie,11,6,1,0,4,0,2,2.864
+Fall 2024,PHCA,7310,1,16045,Teaching Practicum,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6214,1,16050,Applied Harpsichord,Robinson,Daryl Allen,2,0,0,0,0,0,0,4.0
+Fall 2024,COSC,3340,802,16051,Intro. to Automata and Comp.,Singh,Raj Kumar,148,65,3,0,1,0,2,3.583
+Fall 2024,BCHS,3399,1,16056,Senior Honors Thesis,Widger,William R,0,0,0,0,0,0,0,
+Fall 2024,IRW,1300,1,16057,Integrated Reading and Writing,Walker,ShaTriece,0,0,0,0,0,33,2,
+Fall 2024,CHEM,6399,21,16059,Masters Thesis,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2024,SOCI,1301,10,16063,Introduction To Sociology,Adams,Jennifer Lauren,42,7,2,3,0,0,1,3.642
+Fall 2024,ENGL,7699,3,16065,Thesis,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6365,8,16069,Dir Rsch in Dev Cog Beh Neuro,Grigorenko,Elena L,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7699,4,16070,Thesis,Serpas,Martha R,0,0,0,0,0,3,0,
+Fall 2024,SOCI,1301,12,16071,Introduction To Sociology,Davis,Mary A,34,11,1,3,4,0,2,3.215
+Fall 2024,COSC,4198,2,16072,Independent Study,Gnawali,Omprakash D,0,0,0,0,0,1,0,
+Fall 2024,HDCS,4369,1,16073,Entrepreneurship,Hitchman Sr,Cal M,33,4,0,0,0,0,2,3.812
+Fall 2024,ENGL,3399,2,16076,Senior Honors Thesis,Guajardo,Paul,0,0,0,0,0,0,0,
+Fall 2024,ENGL,3399,3,16077,Senior Honors Thesis,Harrell,Haylee C,0,0,0,0,0,0,0,
+Fall 2024,ENGL,3399,4,16078,Senior Honors Thesis,Harrell,Haylee C,0,0,0,0,0,0,0,
+Fall 2024,ENGL,7398,2,16085,Special Problems,Womble,David Avari Patrick,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6420,1,16086,Applied Violin,Yon,Kirsten A,5,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,3399,5,16091,Senior Honors Thesis,Serpas,Martha R,0,0,0,0,0,0,0,
+Fall 2024,PHOP,6298,8,16099,Spec Prob-Physio Optics,Ostrin,Lisa,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7335,1,16102,SW Practice in Communities,Mayer,Margaret,20,2,0,0,0,0,0,3.909
+Fall 2024,MATH,2312,8,16103,Precalculus,Almus,Melahat,34,18,32,4,38,0,26,2.069
+Fall 2024,MARK,6A61,3,16104,Marketing Administration,Krishnamurthy,Parthasarathy,19,10,0,0,0,0,0,3.632
+Fall 2024,FINA,6A35,1,16105,Managerial Finance,Povel,Paul,11,5,3,0,0,0,0,3.352
+Fall 2024,FINA,6A35,3,16106,Managerial Finance,Berger,Elizabeth,19,14,8,0,2,0,0,3.086
+Fall 2024,SCM,6A01,1,16107,SCM Concepts,Sahin,Funda,11,7,1,0,0,0,0,3.474
+Fall 2024,MARK,6A61,4,16108,Marketing Administration,Lish,Alan D,11,18,8,1,2,0,0,2.859
+Fall 2024,SCM,6A01,3,16109,SCM Concepts,Sahin,Funda,7,6,1,0,0,0,0,3.429
+Fall 2024,MANA,6A32,1,16110,Organizational Behavior & Mgt,Krylova,Ksenia O,25,5,0,0,0,0,0,3.712
+Fall 2024,FINA,7A20,1,16111,Capital Markets,Jacobs,Kris,4,1,0,0,0,0,0,3.734
+Fall 2024,MATH,1342,6,16113,Elementary Statistical Methods,Wang,Wenshuang,44,42,74,84,18,0,8,1.945
+Fall 2024,GENB,6A50,1,16114,Business Communications,Pineda,Dalia Rivera,16,7,0,0,0,0,0,3.667
+Fall 2024,GENB,6A50,2,16120,Business Communications,Pettiette,Michael R,28,0,0,0,0,0,2,3.847
+Fall 2024,MATH,1314,8,16121,College Algebra,Caglar,Atife,15,5,15,5,11,0,8,2.092
+Fall 2024,MATH,1324,7,16122,Finite Math with Applications,Sosa,Moses,56,46,32,16,34,0,58,2.359
+Fall 2024,MATH,1325,3,16123,Calc for Bus & Social Sciences,Constante,Beatrice,32,8,14,14,26,0,8,2.085
+Fall 2024,GHL,6317,1,16124,Innovative Hosp. Technologies,Lee,Minwoo,32,0,0,0,0,0,0,3.918
+Fall 2024,GHL,6324,1,16125,Hosp. Busn Strategies in Amer,Kim,Jaewook,32,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6340,1,16126,Behavior and Hosp. Lead. Strat,Guchait,Priyanko,18,10,4,0,0,0,0,3.396
+Fall 2024,NURS,4314,2,16127,Nursing Research,Simon-Campbell,E'Loria,29,4,0,3,0,0,4,3.639
+Fall 2024,BCHS,6230,1,16128,Grad Biochem Lab Rotation I,Widger,William R,4,1,0,0,0,0,0,3.8
+Fall 2024,BCHS,6231,1,16129,Grad Biochem Lab Rotation II,Widger,William R,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,6A83,1,16135,Strategic Analysis,Celly,Nikhil,12,1,0,0,1,0,0,3.596
+Fall 2024,GHL,6317,2,16137,Innovative Hosp. Technologies,Morosan,Cristian,7,0,0,0,0,0,0,4.0
+Fall 2024,GENB,6A50,3,16138,Business Communications,Pettiette,Michael R,19,1,0,0,2,0,1,3.441
+Fall 2024,SOCW,7334,1,16139,Social Work Leadership,Powell,Torey Ian,24,2,0,0,0,0,0,3.923
+Fall 2024,MANA,6A25,5,16141,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,25,7,0,0,1,0,0,3.627
+Fall 2024,MANA,6A32,2,16142,Organizational Behavior & Mgt,Witt,Lawrence A,15,0,0,0,1,0,0,3.75
+Fall 2024,MANA,7A49,1,16143,Managerial Decision Making,Carlin,Barbara A,15,10,1,0,0,0,0,3.513
+Fall 2024,BIOL,6230,1,16144,Advanced Cell Biology I,Dryer,Stuart E,10,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6231,1,16145,Advanced Cell Biology II,Khurana,Seema,6,0,4,0,0,0,0,3.2
+Fall 2024,FINA,7A20,2,16146,Capital Markets,Jacobs,Kris,28,9,0,0,1,0,0,3.614
+Fall 2024,FINA,7A30,1,16147,Advanced Corporate Finance,Povel,Paul,11,8,0,0,0,0,1,3.544
+Fall 2024,SOCW,7356,4,16148,Groups: Adv Clinical Practice,Eisenbaum,Stephanie,17,3,0,0,0,0,0,3.85
+Fall 2024,INDS,2260,1,16154,Materials and Fab Methods,Wells,Adam C,11,3,2,0,0,0,1,3.501
+Fall 2024,MARK,7A75,1,16161,Marketing Strategy,Lish,Alan D,5,10,1,0,1,0,0,3.098
+Fall 2024,SOCW,6306,6,16162,Social Work Practice Skills,Fernandez,Jason,23,2,0,0,0,0,0,3.92
+Fall 2024,SOCW,6308,4,16163,Human Diversity & Development,Scott Jr,Edward Douglas,19,6,0,0,0,0,0,3.76
+Fall 2024,SOCW,6308,5,16164,Human Diversity & Development,Alexander,Michelle,21,4,0,0,0,0,0,3.84
+Fall 2024,SOCW,6308,6,16165,Human Diversity & Development,Boyd,Reiko K,19,5,0,0,0,0,0,3.792
+Fall 2024,SOCW,7356,5,16166,Groups: Adv Clinical Practice,Cheung,Poi Ten Ada,25,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7A50,1,16168,Derivatives I,Rabinovitch,Ramon,2,2,0,0,0,0,0,3.5
+Fall 2024,FINA,7A51,1,16169,Derivatives II,Rabinovitch,Ramon,2,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7A40,1,16170,Fixed Income I,Doshi,Hitesh B,10,7,2,1,0,0,0,3.267
+Fall 2024,FINA,7A41,1,16171,Fixed Income II,Doshi,Hitesh B,6,0,1,0,0,0,0,3.667
+Fall 2024,FINA,7A37,1,16172,Corp Strategy-Equity Fund Mgt,Kumar,Praveen,16,0,0,0,0,0,0,3.918
+Fall 2024,INDS,3160,2,16173,Design Issues I,Jackson,Megan H,15,1,0,0,0,0,0,3.938
+Fall 2024,CHEM,1305,1,16174,Foundations of Chemistry,St Hill,Lydia Ruth,2,12,17,5,12,0,29,1.681
+Fall 2024,FINA,6A31,2,16176,Analyzing Financial Statements,Woods,James D,5,5,0,1,1,0,1,3.028
+Fall 2024,FINA,7A10,3,16177,Valuation,Yerramilli,Vijay,25,11,3,0,0,0,1,3.547
+Fall 2024,PSYC,2301,8,16178,Introduction to Psychology,Grossberg,Ivy Rae,61,15,1,0,0,0,2,3.749
+Fall 2024,PEP,8999,2,16180,Doctoral Dissertation,LaVoy,Emily Claire-Pyle,0,0,0,0,0,2,0,
+Fall 2024,ENGL,1301,102,16181,First Year Writing I,Lopez,Reese D,8,6,4,0,0,0,0,3.204
+Fall 2024,MATH,3330,1,16185,Abstract Algebra,Heier,Gordon,10,5,8,0,2,0,0,2.866
+Fall 2024,GEOL,1102,8,16186,Intro to Climate Change Lab,Zhang,Honghai,13,5,0,0,1,0,4,3.526
+Fall 2024,COMM,1303,3,16187,Writing for Communicators,Lyn,Robyn,65,7,2,3,5,0,12,3.5
+Fall 2024,COMM,2327,2,16188,Introduction to Screen Writing,Vaughan,Thomas Michael,19,2,2,0,1,0,1,3.542
+Fall 2024,COMM,2328,3,16189,Broadcast Writing Basics,Baruch Blanco,Maria Felicitas,21,7,0,0,1,0,0,3.609
+Fall 2024,PHYS,1301,5,16190,College Physics I (lecture),Maric,Sladjana,8,41,30,3,8,0,17,2.408
+Fall 2024,GEOL,1303,3,16191,Physical Geology,Fu,Qi,12,26,14,6,4,0,4,2.581
+Fall 2024,GEOL,1303,2,16192,Physical Geology,Hauptvogel,Daniel William,184,193,79,20,9,0,10,3.06
+Fall 2024,GEOL,1303,5,16193,Physical Geology,Capuano,Regina M,66,44,25,2,5,0,18,3.106
+Fall 2024,GEOL,1303,7,16194,Physical Geology,Lytwyn,Jennifer N,77,54,32,13,2,0,11,3.062
+Fall 2024,GEOL,1303,8,16195,Physical Geology,Lytwyn,Jennifer N,60,38,20,12,11,0,19,2.856
+Fall 2024,COMM,4382,1,16197,Narrative Non-Linear Editing,Houk,Keith R,15,8,1,0,1,0,0,3.427
+Fall 2024,COMM,2311,3,16199,Writing for Print and Digital,Butler,Bryan C,4,10,1,1,1,0,1,2.844
+Fall 2024,COMM,2311,4,16201,Writing for Print and Digital,Radcliffe Andre,Jennifer,20,2,2,0,0,0,1,3.668
+Fall 2024,COMM,2311,5,16203,Writing for Print and Digital,Radcliffe Andre,Jennifer,14,9,2,0,0,0,0,3.414
+Fall 2024,BIOL,7124,2,16205,Cell Biology Seminar,Kelleher Meisel,Erin S,0,0,0,0,0,8,0,
+Fall 2024,GEOL,7331,1,16206,Seismic Structural Geology,Suppe,John,9,0,0,0,0,0,0,3.78
+Fall 2024,MATH,1314,3,16209,College Algebra,Hafeez,Shahinda,41,30,64,31,66,0,52,1.732
+Fall 2024,MATH,1324,4,16210,Finite Math with Applications,Watkins,Katie Nicole,122,90,82,40,90,0,118,2.239
+Fall 2024,HON,4350,1,16211,Data and Society in Practice,Kapral,Andrew J,8,3,0,0,0,0,0,3.757
+Fall 2024,COMM,3317,2,16212,Multimedia Journalism,Roth,Geoffrey,10,5,0,0,0,0,0,3.601
+Fall 2024,COMM,2331,1,16213,Relational Communication,Uhrick,Jan,19,9,1,0,0,0,0,3.587
+Fall 2024,ECON,7330,1,16214,Quantitative Economic Analysis,Sorensen,Bent E,12,2,0,0,0,0,0,3.81
+Fall 2024,ECON,7341,1,16215,Microeconomic Theory I,Wang,Fan,2,15,0,0,0,0,0,3.254
+Fall 2024,ECON,7343,1,16216,Macroeconomic Theory I,Lee,Hyunju,1,7,0,0,0,0,0,3.208
+Fall 2024,ECON,8331,1,16217,Econometrics II,Sorensen,Bent E,5,5,0,0,0,0,0,3.533
+Fall 2024,ECON,2302,4,16218,Principles of Microeconomics,Bernal Pavas,Victor David,17,29,23,8,3,0,1,2.567
+Fall 2024,ECON,3320,1,16219,Intro to Econ Data Analysis,Troncoso,Pablo A,76,52,18,7,8,0,5,3.081
+Fall 2024,KIN,3301,2,16223,Design/Eval Phys Activity Prog,Graham,Marilynn Hadassah,49,7,2,0,0,0,1,3.765
+Fall 2024,KIN,3305,2,16224,Sport Sociology,Hawkins,Billy J,17,22,19,1,2,0,3,2.847
+Fall 2024,KIN,4315,1,16226,Motor Learning and Control,Park,Seoung Hoon,26,4,1,0,0,0,0,3.785
+Fall 2024,ENGL,3323,1,16227,Development of Lit Crit & Thry,Majumder,Auritro,13,13,1,0,1,0,2,3.345
+Fall 2024,ECON,3344,1,16229,History of Economic Doctrine,Saboury,Piruz,20,8,2,0,0,0,0,3.589
+Fall 2024,HIST,1302,7,16232,The U.S. Since 1877,Amaral,Lindsay Nicole,138,100,26,14,17,0,12,3.087
+Fall 2024,HIST,1302,52,16233,The U.S. Since 1877,Vale,Timothy Eli,24,1,0,0,0,0,0,3.947
+Fall 2024,COMD,6372,3,16237,Remediation of Child Lang Dis,Ivey,Michelle L,14,11,0,0,0,0,0,3.507
+Fall 2024,BIOE,8298,15,16238,Doctoral Research,Du,Yuncheng,0,0,0,0,0,1,0,
+Fall 2024,PSYC,7339,1,16240,CDLNeuropsych: Assess/App III,Medina,Luis Daniel,5,0,0,0,0,0,0,3.934
+Fall 2024,COMD,2339,5,16241,Language Development,Mills,Monique T,24,7,0,0,2,0,1,3.535
+Fall 2024,COMD,2339,6,16242,Language Development,Mills,Monique T,33,5,1,1,0,0,1,3.717
+Fall 2024,ENGI,2304,16,16243,Technical Communications,Salvo,Deborah C,16,9,0,0,0,0,0,3.666
+Fall 2024,KIN,4330,1,16244,Child and Adolescent Obesity,Paulson,Sally,13,9,6,1,0,0,3,3.116
+Fall 2024,KIN,4365,1,16245,Legal/Ethical Aspects of Sport,Cottingham,Michael,12,10,20,7,6,0,4,2.261
+Fall 2024,BIOL,1306,51,16246,Biology for Science Majors I,Hanke,Marc H,7,11,9,3,2,0,3,2.552
+Fall 2024,BIOL,1306,52,16247,Biology for Science Majors I,Hanke,Marc H,7,10,11,4,0,0,3,2.646
+Fall 2024,GHL,4343,2,16249,Financial Admin for Hosp.Ind.,Koh,Yoon,13,11,3,2,0,0,0,3.139
+Fall 2024,HIST,3324,1,16250,Oral History Methods,Harwell,Debbie Z,17,1,0,0,0,0,1,3.908
+Fall 2024,HON,3304,1,16251,Material Cultures of Medicine,Lunstroth,John,12,10,0,0,0,0,0,3.485
+Fall 2024,ARCH,6393,4,16252,Master's Project Preparation,Longoria,Rafael R,7,1,0,0,0,0,0,3.834
+Fall 2024,GHL,3440,1,16254,Hotel Operations,Cheatham,Cathy A,22,12,1,0,1,0,1,3.518
+Fall 2024,GHL,4361,1,16255,Marketing Strategies,Mohamed,Mohamed Elsayed AbdElaziz,5,3,0,0,0,0,0,3.543
+Fall 2024,GHL,4370,1,16256,Project Dev & Mgmt in Hosp Ind,Li,Ningqiao,7,3,1,0,0,0,0,3.605
+Fall 2024,PEP,6355,3,16257,Promotional Strategies,Cottingham,Michael,10,3,1,0,0,0,0,3.454
+Fall 2024,SOCW,7301,2,16260,Confronting Oppression & Injus,Barthelemy,Juan,22,1,1,0,2,0,0,3.577
+Fall 2024,SOCW,7301,3,16261,Confronting Oppression & Injus,Dettlaff,Alan J,21,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7301,4,16262,Confronting Oppression & Injus,Dettlaff,Alan J,28,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,1301,5,16263,Intro To Philosophy,Aiman,Edwin E,46,12,1,0,1,0,4,3.651
+Fall 2024,GHL,7337,1,16264,Human Resources in Hospitality,Madera,Juan Manuel,13,0,0,0,1,0,0,3.691
+Fall 2024,HIST,2312,1,16267,Western Civilization from 1450,Ittmann,Karl,8,18,7,0,0,0,3,3.04
+Fall 2024,CHEM,1312,3,16268,Fundamentals of Chemistry 2,Czernuszewicz,Roman S,5,11,10,4,5,0,20,2.106
+Fall 2024,PHIL,1321,3,16270,Logic I,Haaga,Curtis W,32,21,9,3,0,0,7,3.206
+Fall 2024,COSC,1437,5,16271,Introduction to Programming,Biediger,Daniel Edward,55,25,13,2,4,0,25,3.253
+Fall 2024,COSC,2306,1,16273,Data Programming,Liu,Jinyang,27,10,0,0,3,0,8,3.442
+Fall 2024,COSC,4337,1,16274,Data Science II,Rizk,Nouhad J,28,37,11,0,0,0,0,3.206
+Fall 2024,COSC,6376,1,16275,Cloud Computing,Yan,Feng,48,1,1,0,0,0,0,3.933
+Fall 2024,GHL,6352,1,16276,Hospitality Market Analysis,McCaslin,Glynn Randle,32,0,0,0,0,0,0,4.0
+Fall 2024,NUTR,4345,2,16287,The Obesity Epidemic,Alastuey,Lisa L,29,19,9,3,1,0,2,3.121
+Fall 2024,TEPM,6304,1,16288,Quality Improvemnt in Proj Mgt,Kovach,Jamison,22,0,0,0,0,0,2,4.0
+Fall 2024,ATP,6113,3,16289,Lower Extremity Evaluation Lab,Harrison,Layci,13,1,0,0,0,0,0,3.929
+Fall 2024,ATP,6112,3,16290,Therapeutic Intervention 1 Lab,Elliott,Ashlyne Paige,15,0,0,0,0,0,0,4.0
+Fall 2024,ATP,6313,3,16291,Lower Extremity Evaluation,Harrison,Layci,5,9,0,0,0,0,0,3.357
+Fall 2024,ATP,7112,1,16292,Therapeutic Intervention 2 Lab,Elliott,Ashlyne Paige,14,1,0,0,0,0,0,3.933
+Fall 2024,BUSI,3300,4,16293,Intro to Personal Finance,Munchbach,Jim,40,5,2,0,0,0,2,3.752
+Fall 2024,FINA,4320,6,16294,Investment Management,Suleymanov,Masim,12,17,2,1,0,0,0,3.229
+Fall 2024,FINA,4353,3,16295,Practicum Pers Finan Planning,Lopez,John C,13,3,0,0,0,0,0,3.833
+Fall 2024,BUSI,3300,5,16296,Intro to Personal Finance,Munchbach,Jim,39,9,0,0,2,0,3,3.568
+Fall 2024,BUSI,3300,6,16297,Intro to Personal Finance,Harvey,Danny,54,0,0,0,1,0,0,3.891
+Fall 2024,BUSI,3300,7,16298,Intro to Personal Finance,Harvey,Danny,51,2,0,0,1,0,1,3.858
+Fall 2024,DIGM,4351,30,16304,Portfolio Development,Hargrove,Mark Stephen,47,21,1,0,1,0,2,3.52
+Fall 2024,INDS,3340,1,16306,Computer Aided Indus Design II,Chow,George K,5,9,0,0,0,0,0,3.31
+Fall 2024,SPAN,1501,5,16311,Elementary Spanish I,Cruz Lopez,Maria Elena,13,8,2,2,0,0,0,3.28
+Fall 2024,SPAN,1502,7,16313,Elementary Spanish II,Bello Malagon,Ana Maribel,15,3,2,0,1,0,1,3.413
+Fall 2024,SPAN,2311,3,16315,Intermediate Spanish I,Nieves Cabrera,Wendy,6,7,11,2,0,0,0,2.489
+Fall 2024,PSYC,2316,2,16318,Psychology of Personality,Inman,Tonya N,64,17,7,0,3,0,3,3.462
+Fall 2024,PSYC,2316,3,16319,Psychology of Personality,Harlan,Pamela Kay,47,30,2,1,0,0,0,3.439
+Fall 2024,INDS,6360,3,16320,Industrial Design Studio,Kang,Chul Min,1,3,0,0,0,0,0,3.498
+Fall 2024,SCLT,2362,33,16322,Intro To Logistics Technology,Cassler,Daniel,6,27,7,1,1,0,3,2.771
+Fall 2024,SCLT,2380,30,16323,Distribution Channels,Kidd,Margaret A,37,21,4,1,3,0,0,3.273
+Fall 2024,SCLT,3381,32,16324,Industrial and Consumer Sales,Cassler,Daniel,17,17,5,0,2,0,0,3.114
+Fall 2024,SCLT,6316,1,16325,Global Supply Chain Logistics,Wang,Kailai,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2319,4,16326,Intro to Social Psychology,Ayers,Zachary Scott,63,11,3,1,1,0,1,3.667
+Fall 2024,SCLT,6318,2,16327,Supply Chain Strategies,Bian,Zheyong,7,1,0,0,0,0,0,3.916
+Fall 2024,PSYC,3339,3,16328,Intro To Clinical Psychology,Szafranski,Derek D,41,17,16,3,0,0,3,3.234
+Fall 2024,CNST,1330,2,16329,Graphics I,Clark,Peter J,11,30,10,2,2,0,3,2.836
+Fall 2024,CNST,6396,5,16334,Master's Project,Gao,Lu,1,0,0,0,0,0,0,4.0
+Fall 2024,CNST,2351,2,16336,Construction Estimating I,Sheppard,Travis,12,15,10,4,3,0,1,2.659
+Fall 2024,CNST,3331,2,16337,Constructn Plan and Scheduling,Lyon,Eva Yaneth,12,26,11,0,1,0,0,2.953
+Fall 2024,CNST,3351,2,16338,Construction Estimating II,Siddiqui,Muhammad Ali,24,17,4,2,0,0,0,3.319
+Fall 2024,USS,1101,2,16339,College Success,Mahan,Erica Gayle,8,4,1,2,0,0,0,3.178
+Fall 2024,USS,1101,7,16343,College Success,Mahoney,Margaret Elizabeth,3,3,2,0,0,0,1,3.084
+Fall 2024,USS,1101,8,16344,College Success,Guidry,Vanessa Lynn,9,6,1,0,1,0,0,3.255
+Fall 2024,INTB,3361,1,16345,Global Engagement and Research,Miljanic,Andra Olivia,5,0,0,0,0,0,0,4.0
+Fall 2024,USS,1101,12,16346,College Success,King,Kelly N,7,2,3,1,2,0,0,2.667
+Fall 2024,USS,1101,15,16349,College Success,Perry,Deidra,1,2,2,1,1,0,3,2.19
+Fall 2024,USS,1101,16,16350,College Success,Simpson,James Keir,5,2,6,2,2,0,0,2.372
+Fall 2024,ARTS,2346,1,16352,Fundamentals of Ceramics,Oloshove,Angel,13,2,0,0,0,0,1,3.845
+Fall 2024,ARTS,2346,2,16353,Fundamentals of Ceramics,Oloshove,Angel,13,2,1,0,0,0,0,3.668
+Fall 2024,USS,1101,24,16354,College Success,Vernon-Harrison,Miranda Angelena,3,1,0,1,0,0,1,3.134
+Fall 2024,USS,1101,25,16355,College Success,Phan,Trang Anh Thuc,9,4,0,0,0,0,0,3.768
+Fall 2024,ARTS,7310,1,16357,Printmaking Studio,Masterson,Patrick D,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6384,2,16358,Methods of Applied Math I,Chen,Yi-Chao,2,2,0,1,1,0,2,2.5
+Fall 2024,MECE,6345,2,16359,Fluid Dynamics 1,Yang,Di,3,6,0,0,0,0,1,3.333
+Fall 2024,ELET,4105,1,16361,Senior Design Lab in EPET,Shi,Jian,2,0,0,0,0,0,0,4.0
+Fall 2024,ELET,4305,1,16362,Senior Design in EPET,Shi,Jian,17,3,0,0,0,0,0,3.883
+Fall 2024,USS,1101,35,16363,College Success,Jones,Amber R,4,3,2,2,4,0,1,2.067
+Fall 2024,USS,1101,38,16365,College Success,Reed,Erin A,2,3,1,0,0,0,1,3.277
+Fall 2024,USS,1101,42,16366,College Success,Thomas,Trever LeAnn,2,1,1,0,1,0,2,2.6
+Fall 2024,CHEE,8598,13,16368,Doctoral Research,Orman,Mehmet,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8598,14,16369,Doctoral Research,Palmer,Jeremy,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8598,15,16370,Doctoral Research,Rimer,Jeffrey,0,0,0,0,0,11,0,
+Fall 2024,CHEE,8598,17,16372,Doctoral Research,Varadarajan,Navin,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8598,18,16373,Doctoral Research,Vekilov,Peter,0,0,0,0,0,4,0,
+Fall 2024,HDCS,1300,6,16375,Human Ecosystems & Tech Change,Vercher,Michelle Taylor,25,20,4,0,0,0,1,3.341
+Fall 2024,HDCS,1300,7,16376,Human Ecosystems & Tech Change,Rifai,Rana Ihsan,36,8,2,0,2,0,2,3.57
+Fall 2024,ACCT,3368,3,16378,Intermediate Accounting II,Sun,Xue,12,18,9,0,0,0,1,3.128
+Fall 2024,SPAN,4343,1,16380,Health & Society in Hisp World,Zubiate,Maria Laura,4,1,1,0,0,0,1,3.61
+Fall 2024,LAW,5344,1,16381,Appellate Advocacy I,Giaccio,Danielle Ashley,8,14,1,0,0,0,0,3.39
+Fall 2024,ARTS,3370,1,16382,Traditional Photography,Casagranda,Madison Anne,11,4,1,0,0,0,0,3.666
+Fall 2024,MECT,3360,30,16383,Automated Manufacturing System,Zhu,Weihang,3,16,6,0,2,0,2,2.618
+Fall 2024,ENGL,3317,1,16385,The British Novel Before 1832,Mazella,David S,10,4,0,0,2,0,6,3.209
+Fall 2024,ENGL,4385,1,16387,Fiction Forms,Turchi,Peter D,14,5,0,0,0,0,1,3.737
+Fall 2024,MANA,4347,1,16390,Ethics and Corp Soc Respon.,Salaiz,Ashley,54,8,3,0,0,0,0,3.81
+Fall 2024,ENGL,7323,1,16391,Advncd Fiction Workshop,Turchi,Peter D,8,0,0,0,0,0,0,3.959
+Fall 2024,MANA,4336,1,16392,Legal Ethical Env of HR Mgt,Krylova,Ksenia O,2,24,7,1,1,0,1,2.658
+Fall 2024,MANA,4337,1,16393,Stress and Work,Sebastijanovic,Marina,52,4,3,0,1,0,0,3.728
+Fall 2024,MANA,4355,2,16394,Selection and Staffing,Zamanipour,Tina,36,11,3,2,2,0,1,3.426
+Fall 2024,MANA,4385,2,16396,Intro to Strategic Management,Tabesh,Pooya,30,24,3,3,1,0,0,3.3
+Fall 2024,ENGL,2330,3,16397,Writing Discipline English,Pogue,Donovan A,12,5,0,0,1,0,2,3.5
+Fall 2024,HRD,3346,1,16398,Performance Assessment & Eval,Del Grande,Lisa,43,3,1,0,0,0,1,3.844
+Fall 2024,HRD,4350,1,16399,Org Dev & Consulting,Clancy,James Patrick,20,4,1,0,0,0,0,3.734
+Fall 2024,ECE,3355,2,16400,Electronics,Shattuck,David P,5,6,14,0,0,0,0,2.574
+Fall 2024,SOCI,1301,14,16401,Introduction To Sociology,Dorsey,Patricia Lynne,22,25,7,3,1,0,1,3.035
+Fall 2024,MANA,6A25,6,16403,Ethical Leadrshp & Crit Reason,Carlin,Barbara A,23,6,0,0,0,0,1,3.725
+Fall 2024,GOVT,2306,13,16404,US and Texas Const/Politics,Littlepage,Kelley G,197,27,12,4,0,0,7,3.705
+Fall 2024,ARCH,6603,7,16405,Architecture Design Studio III,Johnson,Matthew W,9,2,0,0,0,0,0,3.668
+Fall 2024,ARCH,6603,9,16407,Architecture Design Studio III,Plauche',Roya,5,5,0,0,0,0,0,3.566
+Fall 2024,ARCH,6603,11,16409,Architecture Design Studio III,Woodfill,Celeste Ponce,2,7,1,0,0,0,0,2.935
+Fall 2024,LAW,6347,2,16411,Secured Financing,Hart,Matthew Olivier,5,9,0,0,0,0,0,3.286
+Fall 2024,LAW,6364,1,16412,Contract Drafting,Toedt III,Dell Charles,6,10,0,0,0,1,0,3.334
+Fall 2024,LAW,6364,2,16413,Contract Drafting,Toedt III,Dell Charles,3,6,0,0,0,2,0,3.37
+Fall 2024,LAW,5326,1,16414,Criminal Procedure,Braley,Timothy Shawn,16,38,0,0,0,8,0,3.211
+Fall 2024,LAW,5326,2,16415,Criminal Procedure,Bregant,Jessica Lynn,25,33,2,0,0,0,0,3.394
+Fall 2024,FINA,4330,5,16420,Corporate Finance,Berger,Elizabeth,24,28,3,1,0,0,0,3.351
+Fall 2024,FINA,4330,6,16421,Corporate Finance,De Angelis,David,18,22,7,5,1,0,4,2.937
+Fall 2024,FINA,4330,7,16422,Corporate Finance,De Angelis,David,21,17,8,1,3,0,3,3.04
+Fall 2024,MUSI,6120,1,16423,Percussion Ensemble,Wilkins,Blake M,2,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7336,1,16424,Strategic Human Resource Mgt,Fernandez,Alejandro,14,0,0,0,0,0,0,3.976
+Fall 2024,MANA,7356,1,16425,Inclusive Leadership,Fernandez,Alejandro,26,0,0,0,0,0,0,3.962
+Fall 2024,MUSI,4378,1,16426,History of Jazz I,Marmolejo,Noe J,7,0,0,0,0,0,0,4.0
+Fall 2024,MUED,3105,1,16427,Strings,Meitz,Penelope J,4,2,1,0,0,0,0,3.381
+Fall 2024,MUED,3103,1,16428,Brasses,Bell,Priscilla Garrett,15,1,3,0,0,0,0,3.545
+Fall 2024,ECE,6112,1,16429,Department Colloquium,Nguyen,Hien V,0,0,0,0,0,1,0,
+Fall 2024,ECE,6317,1,16430,Motor Drives,Rajashekara,Kaushik,3,0,3,1,0,0,0,2.761
+Fall 2024,ARCH,3500,33,16431,Architecture Design Studio V,Davis,Curtis M,4,6,5,0,0,0,0,2.801
+Fall 2024,ARCH,3500,35,16433,Architecture Design Studio V,Truitt,William C,9,6,0,0,0,0,1,3.622
+Fall 2024,ARCH,3500,37,16435,Architecture Design Studio V,Self,Ronnie L,3,7,5,0,0,0,0,2.823
+Fall 2024,ARCH,3500,41,16439,Architecture Design Studio V,Sen,Ozan,13,2,0,0,1,0,0,3.584
+Fall 2024,ARCH,3500,43,16441,Architecture Design Studio V,Jacobs,Daniel,3,9,2,0,0,0,1,3.119
+Fall 2024,OPTO,7230,1,16443,Glaucoma,Marrelli,Danica J,22,46,30,0,0,0,0,2.898
+Fall 2024,OPTO,7375,1,16444,Contact Lens II,Gostovic,Anita Ticak,53,38,5,0,0,0,0,3.5
+Fall 2024,OPTO,7336,1,16445,Ocular Pathology III,Harrison,Wendy W,30,56,11,0,0,0,0,3.169
+Fall 2024,OPTO,7131,1,16446,Clinical Medicine,Pate Jr,Lloyd D,73,9,3,0,0,0,0,3.808
+Fall 2024,NURS,6301,1,16447,Adv Rsrch Intgrtd Evdnce Prctc,Varghese,Shainy B,2,1,2,0,0,0,3,3.0
+Fall 2024,NURS,6333,1,16448,Population Health,Varghese,Shainy B,2,1,0,0,0,0,1,3.667
+Fall 2024,OPTO,8696,1,16449,General Clinic IV,Herring,Ralph Jay,0,0,0,0,0,32,0,
+Fall 2024,OPTO,8338,1,16450,Recent Developments/Round,Wheat,Joe L,16,18,0,0,0,0,0,3.49
+Fall 2024,OPTO,8384,1,16451,Practice Management II,Davis,Mark K,1,34,1,0,0,0,0,3.018
+Fall 2024,LAW,6213,1,16452,Innocence Investigations,Dow,David R,0,3,0,0,0,0,0,3.33
+Fall 2024,LAW,6240,1,16453,Death Penalty & Crim Appeals,Dow,David R,1,4,0,0,0,1,0,3.332
+Fall 2024,NURS,3311,2,16454,Health Assess Across Life Span,Edwards-Maddox,Shermel Vinese,5,34,0,3,0,0,2,2.976
+Fall 2024,NURS,4314,1,16455,Nursing Research,Brohard,Cheryl L,11,18,0,0,0,0,0,3.379
+Fall 2024,PUBL,6345,3,16456,Budgeting for Public Agencies,Koelling,Peter,15,4,0,0,0,0,0,3.685
+Fall 2024,CIVE,4364,1,16457,Structural Steel Design,Herman,Reagan,8,23,12,0,0,0,2,2.838
+Fall 2024,THEA,2342,1,16458,Dramatic Structures & Genres,Coen,Elizabeth Manya,18,9,2,0,0,0,1,3.506
+Fall 2024,GENB,6350,1,16461,Business Communications,Vandaveer,Amy L,13,6,0,0,0,0,0,3.702
+Fall 2024,MIS,3376,2,16462,Busn Appls Database Mgmt I,Jiang,Lianlian,49,10,1,0,0,0,2,3.817
+Fall 2024,MARK,4332,2,16463,Social Media Marketing,Zahn,William J,16,42,5,1,1,0,2,3.087
+Fall 2024,PSYC,6336,5,16464,Directed Rsch in Social Psyc,Neighbors,Clayton T,0,0,0,0,0,3,0,
+Fall 2024,DANC,1103,1,16465,Freshman Seminar in Somatics,Valle,Toni Leago,9,2,0,0,0,0,0,3.758
+Fall 2024,MATH,1100,2,16466,Developmental Math,Chern,Haley Nicole,0,0,0,0,0,102,10,
+Fall 2024,MATH,1100,3,16467,Developmental Math,Chern,Haley Nicole,0,0,0,0,0,74,14,
+Fall 2024,MATH,1100,4,16468,Developmental Math,Chern,Haley Nicole,0,0,0,0,0,11,6,
+Fall 2024,ARCH,7600,13,16469,Architecture Design Studio V,Longoria,Rafael R,6,0,0,0,0,0,0,3.945
+Fall 2024,INDE,7340,1,16471,Integer Programming,Lim,Gino Jinho,4,1,0,0,0,0,0,3.734
+Fall 2024,HLT,2320,3,16472,Introduction to Public Health,Rafique,Kiran Sajid,56,19,3,0,2,0,0,3.526
+Fall 2024,CIS,2347,31,16473,IS Infrastructure & Networking,Peddoju,Suresh Kumar,46,6,4,0,2,0,1,3.621
+Fall 2024,HON,4355,1,16474,Engaged Data,Konstantinidis,Ioannis,5,0,0,0,0,0,0,4.0
+Fall 2024,BUSI,2305,3,16475,Business Statistics,Wiley,Briceon C,22,8,8,0,0,0,4,3.386
+Fall 2024,CIS,4375,31,16476,Information Systems Capstone,Martinez,Jose C,11,17,7,1,0,0,0,3.046
+Fall 2024,USS,1101,50,16479,College Success,Haywood,Dy'Rius La'Ron,20,3,0,0,0,0,0,3.87
+Fall 2024,LAW,5402,2,16481,Entrpr Community Dev Clinic I,Heard,Christopher D,1,6,0,0,0,0,0,3.379
+Fall 2024,HRD,6303,2,16483,Assessment & Evaluation in Hrd,Shin,Daeun,13,1,0,0,0,0,1,3.905
+Fall 2024,WGSS,2350,13,16484,Intro To Women's Studies,Bustillo,Anneliese Medellin,24,3,1,1,1,0,1,3.545
+Fall 2024,WGSS,2350,14,16485,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,2,2,0,0,0,1,3.811
+Fall 2024,TLIM,3330,31,16486,Innovation Principles,Crawley,David L,6,5,6,0,2,0,3,2.511
+Fall 2024,WGSS,2360,7,16487,Introduction to LGBT Studies,Boffone,Trevor James,21,6,2,0,0,0,1,3.678
+Fall 2024,WGSS,2360,8,16488,Introduction to LGBT Studies,Boffone,Trevor James,27,2,0,0,0,0,1,3.931
+Fall 2024,BUSI,2305,4,16490,Business Statistics,Wiley,Briceon C,26,30,32,36,6,0,36,2.216
+Fall 2024,TLIM,3331,20,16491,Innovation Development,Crawley,David L,3,1,3,0,1,0,0,2.543
+Fall 2024,LAW,5342,1,16493,Prof Writing Strategies,Bray,Simone Rene,3,7,0,0,0,0,0,3.333
+Fall 2024,CIVE,6111,2,16494,Graduate Seminar,Momen,Mostafa,0,0,0,0,0,4,0,
+Fall 2024,MUSI,4100,2,16495,Chamber Music,Dokshansky,Yevgeny,18,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4100,3,16496,Chamber Music,Reed,Gavin Davis,10,1,0,0,0,0,0,3.849
+Fall 2024,TLIM,3371,30,16497,Budgeting and Financial Princ,Burns,Maria,65,3,2,2,2,0,1,3.698
+Fall 2024,AAMS,4300,1,16498,Asian Amer Culture/Community,Nguyen,An,10,2,2,1,0,0,0,3.29
+Fall 2024,MARK,4379,2,16499,Personal Branding,Muschalik,Monica Harper,18,4,1,0,0,0,1,3.71
+Fall 2024,RELS,2360,1,16500,Buddhist Traditions: An Intro,Huynh,Trung,9,7,4,6,1,0,2,2.605
+Fall 2024,LAW,5321,1,16502,Law Office Management,Brown,Charles D,7,26,0,0,0,17,0,3.402
+Fall 2024,ARCH,2327,3,16503,Technology I,Diehl,Tom,25,77,45,2,7,0,6,2.743
+Fall 2024,CUIN,4325,1,16505,Teach Science in Grades 4-8 I,Varnado,Jakarda Wiltz,2,0,1,0,0,0,0,3.223
+Fall 2024,HLT,4303,2,16506,The Obesity Epidemic,Olvera,Norma E,21,23,3,3,1,0,0,3.151
+Fall 2024,ANTH,2302,1,16508,Introduction to Archeology,Chase,Arlen F,39,21,4,1,2,0,8,3.349
+Fall 2024,ANTH,2346,1,16509,Introduction to Anthropology,McNeal,Keith E.,21,44,25,4,3,0,6,2.763
+Fall 2024,ARCH,6393,5,16513,Master's Project Preparation,Froehlich,Dietmar,6,1,0,0,0,0,0,3.763
+Fall 2024,PHLS,8348,1,16514,Evidence-Based Practice,Smith,Bradley,5,0,0,0,0,0,0,3.802
+Fall 2024,INDE,8699,5,16515,Doctoral Dissertation,Lin,Ying,2,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6393,7,16517,Master's Project Preparation,Zweig,Peter J,3,0,0,0,0,0,0,4.0
+Fall 2024,MIS,8398,1,16518,Special Problems in MIS,Hossain,Md Mahbub,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,5368,1,16519,Intermediate Accounting II,Muslu,Volkan,4,5,5,1,0,0,0,2.712
+Fall 2024,CIS,4355,30,16520,Information Systems Operations,Peddoju,Suresh Kumar,42,11,4,2,2,0,1,3.459
+Fall 2024,MANA,4350,1,16522,International Management,Celly,Nikhil,50,7,1,1,0,0,0,3.713
+Fall 2024,FINA,4328,2,16523,Principles of Personal Finance,Coleman,Alfred G,51,1,2,0,0,0,1,3.901
+Fall 2024,FINA,6A35,5,16524,Managerial Finance,De Angelis,David,12,8,5,0,3,0,2,2.929
+Fall 2024,ACCT,4332,1,16525,Corporate Taxation,Mangano,Clifford A,3,1,0,0,0,0,0,3.75
+Fall 2024,ACCT,5332,3,16526,Taxation of Business Entities,Mangano,Clifford A,0,3,0,0,0,0,0,3.11
+Fall 2024,GENB,6350,2,16527,Business Communications,Vandaveer,Amy L,7,1,0,0,0,0,0,3.751
+Fall 2024,ARCH,4367,1,16528,Case Studies in Sustain Design,Taylor,Rives,10,1,0,0,0,0,0,3.789
+Fall 2024,SCM,6A01,4,16531,SCM Concepts,Sahin,Funda,9,4,2,0,0,0,1,3.467
+Fall 2024,SCM,7A01,1,16532,Project Management,Tibodeau,Dale,6,3,0,0,0,0,0,3.63
+Fall 2024,BIOE,6320,1,16533,Tissue Engineering,Horton,Renita Elillian,5,6,0,1,0,0,0,3.223
+Fall 2024,ARTS,3300,1,16534,Advanced Drawing,Meza,Edgar,18,2,0,0,0,0,1,3.884
+Fall 2024,ARTS,3300,2,16535,Advanced Drawing,Sampy,Chayse Joilen,12,6,2,0,0,0,0,3.451
+Fall 2024,NSS,4345,1,16538,Capstone - Nat. Sec. Studies,Curiel,Ernesto F,4,4,2,0,0,0,0,3.035
+Fall 2024,FINA,7A10,1,16539,Valuation,Povel,Paul,5,3,0,0,0,0,1,3.543
+Fall 2024,FINA,4335,1,16540,Brainstorming to Bankrolling,Khumawala,Saleha B,13,5,1,0,0,0,1,3.562
+Fall 2024,MUSA,8320,5,16541,Doctoral Applied Music,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8199,3,16543,Dissertation,Margulis,Milena A,0,0,0,0,0,2,0,
+Fall 2024,BUSI,4396,2,16544,Business Internship,Wortzel,Zachary,0,0,0,0,0,9,0,
+Fall 2024,GEOL,8998,1,16546,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,4,0,
+Fall 2024,GEOL,8399,1,16548,Doctoral Dissertation,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8698,1,16551,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2024,PHLS,8199,4,16552,Dissertation,de Dios,Marcel A,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8698,3,16556,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8998,3,16559,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8998,4,16560,Doctoral Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2024,ACCT,5335,1,16562,Financial Statement Auditing,Kuruvilla,Mohan,1,3,2,0,0,0,2,2.778
+Fall 2024,ACCT,4335,2,16563,Financial Statement Auditing,Kuruvilla,Mohan,3,5,3,1,1,0,1,2.641
+Fall 2024,ACCT,5377,1,16564,Govt & Non-Profit Accounting,Bailey-Rihawi,Esther Elizabeth,6,1,1,1,0,0,0,3.333
+Fall 2024,SPAN,2311,6,16565,Intermediate Spanish I,Carrion Rivera,Lydiette,9,9,5,0,0,0,1,3.131
+Fall 2024,SPAN,2311,8,16566,Intermediate Spanish I,Lumbierres Pallas,Maria Pilar,2,12,6,0,3,0,2,2.478
+Fall 2024,SPAN,2312,6,16567,Intermediate Spanish II,Malacara Sanchez,Jonathan Jorge,4,12,7,1,0,0,0,2.86
+Fall 2024,SPAN,2312,7,16568,Intermediate Spanish II,Falahasl,Hamideh,8,9,5,3,1,0,0,2.655
+Fall 2024,COSC,6360,1,16569,Operating Systems,Cheng,Albert M K,7,5,1,0,0,0,0,3.462
+Fall 2024,BIOE,4115,3,16574,Intro Bioinstrumentation Lab,Akay,Yasemin M,6,0,0,0,0,0,0,4.0
+Fall 2024,INDS,6330,1,16577,Comp Aided Industr Design II,Chow,George K,0,1,0,0,0,0,0,3.33
+Fall 2024,PHAR,5675,4,16580,Disease State Management,Rosario,Natalie,5,1,0,0,0,0,0,3.833
+Fall 2024,GEOL,8999,2,16586,Doctoral Dissertation,Choi,Yunsoo,2,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8698,5,16587,Doctoral Research,Castagna,John P,0,0,0,0,0,2,0,
+Fall 2024,GEOL,8998,8,16593,Doctoral Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Fall 2024,SPAN,2311,9,16595,Intermediate Spanish I,Carrion Rivera,Lydiette,4,7,10,1,1,0,1,2.507
+Fall 2024,SPAN,2312,3,16596,Intermediate Spanish II,Said,Erika,6,15,4,0,0,0,0,3.093
+Fall 2024,BUSI,4396,3,16597,Business Internship,Newman,Michael Ray,0,0,0,0,0,4,0,
+Fall 2024,GEOL,8998,10,16599,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,3,16601,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,1,0,
+Fall 2024,CHEM,3333,1,16604,Inorganic Chemistry I,Brgoch,Jakoah,4,36,16,0,0,0,4,2.762
+Fall 2024,BZAN,7320,1,16605,Bus Modeling For Comp Adv,Murray,Michael J,7,3,0,0,0,0,0,3.568
+Fall 2024,PETR,6350,2,16609,Natural Gas Engineering,Farouq-Ali,Syed,1,1,0,0,0,0,0,3.5
+Fall 2024,PETR,6352,2,16610,Shale Reservoirs,Hathon,Lori A,3,0,0,0,0,0,0,4.0
+Fall 2024,PETR,6368,2,16612,Well Drilling and Completion I,Samuel,Robello,1,2,2,0,0,0,0,2.932
+Fall 2024,PETR,6372,2,16613,Petroleum Production Operation,Wong,George K,2,2,0,0,1,0,0,2.866
+Fall 2024,PETR,6332,2,16614,Deterministic Reserves Estimat,Zargar,Zeinab,0,3,0,0,0,0,0,3.11
+Fall 2024,ENGL,7398,3,16615,Special Problems,Boswell,Robert L,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7398,4,16616,Special Problems,Flynn,Nicholas,2,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8998,13,16618,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,4,0,
+Fall 2024,GEOL,7399,5,16626,Masters Thesis,Khan,Shuhab D,1,0,0,0,0,0,0,4.0
+Fall 2024,WGSS,2350,17,16627,Intro To Women's Studies,Fernandes,Bridget Yvonne Diggs,26,3,0,1,0,0,0,3.767
+Fall 2024,PHCA,7316,1,16633,Pharmacoepidemiology,Chen,Hua,1,2,0,0,0,0,0,3.333
+Fall 2024,PHCA,7306,1,16634,Health Outcomes and Quality,Aparasu,Rajender R,1,2,0,0,0,0,0,3.333
+Fall 2024,MATH,6380,2,16636,Programming for Data Analytics,Shastri,Dvijesh J,5,5,1,2,0,0,1,2.975
+Fall 2024,MATH,6358,3,16637,Probability & Stat. Computing,Poliak,Cathy Dawn,6,1,0,0,0,0,1,3.857
+Fall 2024,GEOL,8698,7,16638,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,2,0,
+Fall 2024,MECE,8399,19,16639,Doctoral Dissertation,Ardebili,Haleh,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,6387,5,16641,Managerial Analysis,Basu,Swati,12,3,0,0,0,0,1,3.844
+Fall 2024,ENGR,2301,3,16644,Mechanics I (Statics),Zamiran,Siavash,8,8,3,1,0,0,1,3.15
+Fall 2024,MIS,7373,1,16647,Bus Appls Database Mgt Sys I,Scamell,Richard W,10,5,0,0,1,0,0,3.314
+Fall 2024,GEOL,8998,14,16652,Doctoral Research,Rappenglueck,Bernhard,0,0,0,0,0,5,0,
+Fall 2024,GEOL,8998,15,16654,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,9,0,
+Fall 2024,HIST,1302,53,16656,The U.S. Since 1877,Vale,Timothy Eli,24,1,0,0,0,0,0,3.894
+Fall 2024,TMTH,3360,1,16659,Applied Technical Statistics,Thornton,Brandon Latroy,23,13,5,1,1,0,4,3.364
+Fall 2024,PHLS,8699,5,16661,Doctoral Dissertation,Margulis,Milena A,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6326,1,16664,Applied Double Bass,Larson,Eric Amery,2,0,0,0,0,0,0,4.0
+Fall 2024,ARTH,6399,4,16666,Master's Thesis,Harren,Natilee O,2,0,0,0,0,0,0,3.835
+Fall 2024,GEOL,8998,16,16667,Doctoral Research,Mann,Paul,0,0,0,0,0,2,0,
+Fall 2024,GEOL,8998,17,16668,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2024,ENGL,6311,1,16670,Research Methods,Voskuil,Lynn M,8,3,0,0,0,0,0,3.607
+Fall 2024,PUBL,6346,1,16673,Seminar Emergency Mgt,Sanchez,Francisco,6,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6305,2,16674,Power Electronics,Krishnamoorthy,Harish Sarma,4,8,0,0,0,0,2,3.361
+Fall 2024,CIS,6324,30,16675,Cybersecurity Risk Management,Conklin,William A,6,0,0,0,0,0,0,3.89
+Fall 2024,COSC,4370,1,16676,Interactive Computer Graphics,Deng,Zhigang,62,9,1,0,1,0,2,3.772
+Fall 2024,MECE,8298,25,16677,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,4,0,
+Fall 2024,BZAN,6350,1,16678,Quant Found for Busi Analytics,Wang,Cheng,15,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,29,16679,First Year Writing I,Moore,Kelly L,5,7,3,0,2,0,0,2.668
+Fall 2024,ENGL,1301,104,16680,First Year Writing I,Horton,Lara,4,4,7,1,4,0,0,2.018
+Fall 2024,ENGL,1301,107,16681,First Year Writing I,Horton,Lara,7,6,5,0,3,0,0,2.62
+Fall 2024,ENGL,1301,108,16682,First Year Writing I,Moore,Kelly L,11,4,1,1,1,0,1,3.168
+Fall 2024,ENGL,1301,114,16683,First Year Writing I,Moore,Kelly L,12,6,1,2,2,0,0,3.043
+Fall 2024,ENGL,1301,116,16684,First Year Writing I,McAlister,Susan Barbara,14,3,5,0,0,0,0,3.349
+Fall 2024,ENGL,1301,117,16685,First Year Writing I,Edens,Jenifer,10,6,3,3,0,0,0,2.97
+Fall 2024,ENGL,1301,118,16686,First Year Writing I,Edens,Jenifer,19,3,0,0,0,0,0,3.774
+Fall 2024,ENGL,1301,126,16687,First Year Writing I,Bass,Kasey Dawn,20,2,1,0,0,0,0,3.826
+Fall 2024,GEOL,7399,6,16691,Masters Thesis,Sun,Jiajia,0,0,0,0,0,0,0,
+Fall 2024,PHLA,6206,1,16692,Lean Six Sigma,Garey,Kevin W,8,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6337,2,16695,Stochastic Processes,Prasad,Saurabh,1,0,0,0,0,0,0,3.67
+Fall 2024,HRD,6353,30,16698,Methods of Adult Learning,Shirmohammadi,Melika,12,0,0,0,0,0,0,3.973
+Fall 2024,GEOL,7399,7,16699,Masters Thesis,Mann,Paul,1,0,0,0,0,0,0,3.67
+Fall 2024,GEOL,7399,8,16702,Masters Thesis,Murphy,Michael,0,0,0,0,0,1,0,
+Fall 2024,FINA,6A35,6,16703,Managerial Finance,De Angelis,David,11,5,2,1,0,0,0,3.282
+Fall 2024,FINA,6A35,7,16704,Managerial Finance,Berger,Elizabeth,19,15,8,1,0,0,1,3.163
+Fall 2024,PUBL,6332,1,16705,Administrative Law,Abbott Jr,Kenneth Wayne,10,2,0,0,1,0,0,3.538
+Fall 2024,ENGI,4198,1,16708,Independent Study,Luna Singh,Jennifer Austin,0,0,0,0,0,2,0,
+Fall 2024,MECE,8298,26,16709,Doctoral Research,Chen,Zheng,0,0,0,0,0,3,0,
+Fall 2024,COSC,4377,1,16713,Intro To Computer Networks,Gnawali,Omprakash D,36,42,24,1,4,0,6,3.0
+Fall 2024,BIOL,6398,8,16718,Special Problems,Chung,Sanghyuk,0,0,0,0,0,5,0,
+Fall 2024,GEOL,8698,8,16720,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6498,3,16725,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2024,BZAN,6351,2,16732,Basic Prog for Busi Analytics,Wang,Cheng,57,0,0,0,0,0,0,4.0
+Fall 2024,ANTH,4310,1,16733,Theories of Culture,Sen,Debarati,1,0,0,0,0,0,0,3.67
+Fall 2024,BCHS,6398,4,16736,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2024,IRW,1300,2,16742,Integrated Reading and Writing,Matlock,Rachel Elaine,0,0,0,0,0,33,0,
+Fall 2024,ENGL,1301,14,16743,First Year Writing I,Braniger,Leslie,5,13,2,1,1,0,1,2.879
+Fall 2024,ENGL,1301,38,16744,First Year Writing I,Mandia,Christopher Peter,12,7,2,1,2,0,1,3.015
+Fall 2024,MECE,8298,29,16749,Doctoral Research,Song,Gangbing,0,0,0,0,0,2,0,
+Fall 2024,MECE,8298,30,16751,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,3,0,
+Fall 2024,MECE,8699,21,16753,Doctoral Dissertation,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2024,MECE,8398,3,16755,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2024,MECE,8598,26,16757,Doctoral Research,Ryou,Jae-Hyun,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8699,10,16759,Doctoral Dissertation,Chatterjee,Sreya,0,0,0,0,0,1,0,
+Fall 2024,ENGL,2330,4,16760,Writing Discipline English,Gonzalez,Maria C,14,3,1,0,1,0,0,3.283
+Fall 2024,ENGL,2330,5,16761,Writing Discipline English,Yang,Sunny Chen,7,5,2,0,1,0,5,3.045
+Fall 2024,DANC,2202,1,16762,Sophomore Technique,Lockett,KeyAira,5,5,0,0,0,0,0,3.5
+Fall 2024,PHLS,8699,6,16764,Doctoral Dissertation,Arbona,Consuelo,0,0,0,0,0,1,0,
+Fall 2024,OPTO,5198,3,16767,Spec Prob - Clerkship,Berntsen,David A,0,0,0,0,0,15,0,
+Fall 2024,BCHS,6498,3,16773,Special Problems,Yeo,Hye-Jeong,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6498,4,16774,Special Problems,Widger,William R,0,0,0,0,0,2,0,
+Fall 2024,BCHS,6498,5,16775,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,1,0,
+Fall 2024,PHOP,6667,11,16788,Research Practicum A,Yoon,Geunyoung,2,0,0,0,0,0,0,3.67
+Fall 2024,PHOP,6767,3,16789,Research Practicum A,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,6298,2,16792,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Fall 2024,CIVE,7342,3,16793,Engineer Geographic Info. Syst,Xie,Surui,2,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8699,7,16795,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,7,16796,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2024,BIOE,6350,2,16798,Genomic and Proteomic Engr,Wu,Tianfu,23,5,0,0,0,0,0,3.774
+Fall 2024,BIOL,6598,4,16802,Special Problems,Chung,Sanghyuk,0,0,0,0,0,2,0,
+Fall 2024,CHEE,6331,2,16818,Math Mtds in Chem Engr,Balakotaiah,Vemuri,0,1,0,0,1,0,0,1.335
+Fall 2024,CHEE,6333,2,16819,Transport Processes,Conrad,Jacinta C,1,1,0,0,0,0,0,3.335
+Fall 2024,ECE,2201,3,16821,Circuit Analysis I,Ruchhoeft,Paul,21,16,24,8,2,0,16,2.592
+Fall 2024,BIOL,6298,4,16825,Special Problems,Pennings,Steven C,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,8,16829,Doctoral Research,Castagna,John P,0,0,0,0,0,2,0,
+Fall 2024,OPTO,5198,1,16831,Spec Prob - Clerkship,Kemp,Andrew P,0,0,0,0,0,16,0,
+Fall 2024,PHLS,8999,3,16834,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Fall 2024,PSYC,2305,23,16837,Intro to Methods in Psychology,Babalola,Olusegun,49,13,2,3,2,0,1,3.45
+Fall 2024,HDCS,1300,8,16839,Human Ecosystems & Tech Change,Ginwright,Alexis Jordan,19,17,9,0,0,0,4,3.215
+Fall 2024,PETR,8298,5,16842,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,6,0,
+Fall 2024,FINA,8338,2,16845,Sem in Financial Management I,Kumar,Praveen,4,0,0,0,0,0,0,3.835
+Fall 2024,DIGM,1376,30,16846,User Experience (UX)Principles,Rodwell,Elizabeth Ann,79,23,5,2,6,0,1,3.363
+Fall 2024,MECE,8298,31,16847,Doctoral Research,Yang,Di,0,0,0,0,0,3,0,
+Fall 2024,ECE,2201,5,16849,Circuit Analysis I,Ramachandran,Deepa,1,1,3,0,0,0,0,2.6
+Fall 2024,MECE,8699,22,16850,Doctoral Dissertation,Yang,Di,0,0,0,0,0,1,0,
+Fall 2024,ACCT,4379,1,16851,Enterprise Risk Management,Neely,Gregory Wayne,5,3,0,0,0,0,0,3.749
+Fall 2024,PHYS,2126,1,16852,University Physics Lab II,Wood,Lowell T,8,67,40,3,0,0,0,2.731
+Fall 2024,ENGI,1331,8,16858,Computing for Engineers,Burleson,Daniel W,27,31,4,0,4,0,5,3.197
+Fall 2024,ENGI,1100,26,16861,Introduction To Engineering,Kota,Venkata Krishna Tulasi,5,7,5,0,3,0,4,2.55
+Fall 2024,GEOL,6399,6,16864,Masters Thesis,Mann,Paul,0,0,0,0,0,1,0,
+Fall 2024,PSYC,2305,25,16865,Intro to Methods in Psychology,Babalola,Olusegun,37,20,3,3,4,0,2,3.219
+Fall 2024,MECE,8399,27,16868,Doctoral Dissertation,Liu,Dong,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8398,5,16869,Doctoral Research,Yang,Di,0,0,0,0,0,1,0,
+Fall 2024,MECE,8298,32,16870,Doctoral Research,Franchek,Matthew,0,0,0,0,0,4,0,
+Fall 2024,MECE,8399,28,16871,Doctoral Dissertation,Franchek,Matthew,2,0,0,0,0,2,0,4.0
+Fall 2024,ANTH,7399,4,16877,Masters Thesis,Ghazali,Marwa,0,0,0,0,0,1,0,
+Fall 2024,ACCT,2302,1,16879,Prin of Managerial Accounting,Weber,Catherine K,35,49,57,8,2,0,4,2.794
+Fall 2024,ACCT,2302,2,16880,Prin of Managerial Accounting,Seltz,Joe D,21,25,7,7,1,0,4,3.01
+Fall 2024,ACCT,3371,2,16881,Accounting Information Systems,Seijas,Nuria S,28,24,3,0,0,0,1,3.431
+Fall 2024,ACCT,5371,1,16882,Accounting Information Systems,Miles,Carolyn A,5,8,2,0,0,0,3,3.244
+Fall 2024,MECE,8598,27,16895,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2024,MANA,6A32,3,16906,Organizational Behavior & Mgt,Krylova,Ksenia O,11,5,1,0,0,0,0,3.491
+Fall 2024,MECE,8398,6,16908,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,3,0,
+Fall 2024,MECE,8598,28,16910,Doctoral Research,Selvamanickam,Venkat,0,0,0,0,0,5,0,
+Fall 2024,MECE,8399,32,16911,Doctoral Dissertation,Selvamanickam,Venkat,0,0,0,0,0,3,0,
+Fall 2024,MECE,8398,8,16914,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,1,0,
+Fall 2024,MECE,8198,17,16915,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2024,MECE,8398,9,16916,Doctoral Research,Song,Gangbing,0,0,0,0,0,3,0,
+Fall 2024,MECE,8399,33,16917,Doctoral Dissertation,Song,Gangbing,0,0,0,0,0,2,0,
+Fall 2024,HLT,1353,3,16918,Personal Health,Shamblin,Angel Ann,107,9,1,0,0,0,0,3.878
+Fall 2024,HLT,3304,2,16936,Child and Adolescent Health,Drenner,Kelli Linn,37,22,13,1,1,0,3,3.23
+Fall 2024,MECE,8398,10,16938,Doctoral Research,Chen,Zheng,0,0,0,0,0,3,0,
+Fall 2024,MECE,8399,34,16939,Doctoral Dissertation,Chen,Zheng,0,0,0,0,0,2,0,
+Fall 2024,RELS,2350,1,16944,Introduction to Islam,Ghazali,Marwa,26,7,1,0,1,0,0,3.572
+Fall 2024,MECE,8598,29,16946,Doctoral Research,Joshi,Shailendra Pramod,0,0,0,0,0,2,0,
+Fall 2024,ENGI,1100,27,16951,Introduction To Engineering,Luna Singh,Jennifer Austin,20,3,2,0,1,0,0,3.577
+Fall 2024,FINA,3332,1,16952,Prin of Financial Management,Suleymanov,Masim,19,7,0,0,0,0,0,3.68
+Fall 2024,SCM,7A01,3,16954,Project Management,Tibodeau,Dale,13,4,0,1,0,0,0,3.556
+Fall 2024,ENTR,7335,1,16955,Entreprnl Profit & Cash Mgt,Becker,Charles D,27,2,2,0,1,0,0,3.605
+Fall 2024,MECE,8598,30,16958,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Fall 2024,MECE,7399,20,16961,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2024,MECE,6399,18,16962,Masters Thesis,Song,Gangbing,0,0,0,0,0,2,0,
+Fall 2024,GEOL,8998,23,16967,Doctoral Research,Castagna,John P,0,0,0,0,0,2,0,
+Fall 2024,MANA,8999,2,16968,Doctoral Dissertation,Avery,Derek Reynold,0,0,0,0,0,2,0,
+Fall 2024,MECE,8598,33,16970,Doctoral Research,Baxevanis,Theocharis,0,0,0,0,0,1,0,
+Fall 2024,MECE,8298,34,16975,Doctoral Research,Sun,Li,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,11,16979,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Fall 2024,WGSS,2350,18,16988,Intro To Women's Studies,Ford,Devan,30,1,0,0,0,0,0,3.978
+Fall 2024,GEOL,8698,12,16989,Doctoral Research,Mann,Paul,0,0,0,0,0,2,0,
+Fall 2024,MECE,8398,16,16991,Doctoral Research,Wang,Su Su,0,0,0,0,0,1,0,
+Fall 2024,MECE,8699,29,16994,Doctoral Dissertation,Franchek,Matthew,0,0,0,0,0,2,0,
+Fall 2024,POLS,6398,2,16995,Special Problems,Zhu,Ling,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8398,12,16997,Doctoral Research,Choi,Yunsoo,0,0,0,0,0,1,0,
+Fall 2024,PHCA,6397,1,16998,Selected Topics,Varisco,Tyler J,0,0,0,0,0,0,0,
+Fall 2024,GEOL,8398,13,17002,Doctoral Research,Capuano,Regina M,0,0,0,0,0,1,0,
+Fall 2024,MARK,8999,2,17004,Doctoral Dissertation,Ahearne,Michael,0,0,0,0,0,0,0,
+Fall 2024,MIS,7373,2,17007,Bus Appls Database Mgt Sys I,Grimes,George M,16,12,4,0,1,0,1,3.273
+Fall 2024,COMM,1303,4,17008,Writing for Communicators,Lyn,Robyn,59,8,5,1,5,0,14,3.479
+Fall 2024,BCHS,8399,4,17009,Doctoral Dissertation,Gunaratne,Preethi H,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8398,14,17011,Doctoral Research,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2024,PHYS,2326,7,17015,University Physics II(lecture),Chen,Shuo,69,134,51,7,4,0,0,2.956
+Fall 2024,MARK,6A98,1,17020,Research,Belinne,Jamie King,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,8699,1,17026,Doctoral Dissertation,Ruggs,Enrica N,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,8999,2,17027,Doctoral Dissertation,Crawford,Steven,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2319,5,17031,Intro to Social Psychology,Weinstein,Andrew Phillip,23,30,11,5,4,0,5,2.858
+Fall 2024,FINA,8398,2,17032,Special Problems,Jacobs,Kris,1,0,0,0,0,0,0,4.0
+Fall 2024,WGSS,2350,19,17034,Intro To Women's Studies,Ford,Devan,30,0,0,1,0,0,0,3.893
+Fall 2024,ACCT,8999,3,17036,Doctoral Dissertation,Muslu,Volkan,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,8398,3,17039,Special Problems,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,8368,2,17040,Seminar in Investments,Jacobs,Kris,3,1,0,0,0,0,0,3.585
+Fall 2024,HIST,6380,2,17043,Public History Internship,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6198,11,17044,Spec Prob-Physio Optics,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6434,2,17048,Applied Clarinet,Potiomkin,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2024,ELET,4198,1,17052,Independent Study,Shireen,Wajiha,1,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,3198,2,17054,Independent Study,Phan,Trang Anh Thuc,15,0,0,0,0,0,0,4.0
+Fall 2024,MECE,7399,22,17055,Masters Thesis,Chen,Yi-Chao,0,0,0,0,0,1,0,
+Fall 2024,CHEM,6398,37,17057,Special Problems,May,Jeremy A,0,0,0,0,0,1,0,
+Fall 2024,PCEU,8998,4,17058,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,2,0,
+Fall 2024,MECE,8298,37,17060,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,16,17066,Doctoral Research,Khan,Shuhab D,0,0,0,0,0,1,0,
+Fall 2024,MECE,8298,38,17082,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,2,0,
+Fall 2024,CHEM,8999,29,17085,Doctoral Dissertation,Baldelli,Steve,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8998,27,17090,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8998,29,17093,Doctoral Research,Sager,William W,0,0,0,0,0,1,0,
+Fall 2024,PSYC,8390,2,17095,Clinical Neuropsyc Internship,Woods,Steven Paul,0,0,0,0,0,1,0,
+Fall 2024,HON,4398,9,17096,Independent Study,Rhoden,Brenda,0,0,0,0,0,0,0,
+Fall 2024,ECON,3363,1,17101,Environmental Economics,Kohlhase,Janet E,8,16,5,0,2,0,3,2.882
+Fall 2024,BIOL,3311,1,17104,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,119,31,5,0,1,0,1,3.68
+Fall 2024,SPAN,2311,2,17105,Intermediate Spanish I,Javierre Londono,Juliana,11,5,6,0,1,0,3,3.044
+Fall 2024,LAW,5116,1,17106,Advocacy Board ONE,Lawrence,Jim E,0,0,0,0,0,2,0,
+Fall 2024,LAW,5117,1,17107,Advocacy Board TWO,Lawrence,Jim E,0,0,0,0,0,1,0,
+Fall 2024,CLAS,3345,1,17108,Myth&Performance in Greek Trag,Due Hackney,Casey L,29,4,2,0,0,0,1,3.743
+Fall 2024,LAW,5125,1,17109,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,6,0,
+Fall 2024,LAW,5128,1,17110,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,56,0,
+Fall 2024,LAW,5129,1,17111,Advocacy Competition THREE,Lawrence,Jim E,0,0,0,0,0,9,0,
+Fall 2024,GERM,3350,1,17112,20Th C Thru German Culture,Kleinheider,Julia D,13,15,1,1,0,0,3,3.201
+Fall 2024,CUIN,4361,5,17114,Second Language Methodology,Latiolais,Cheryl S,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,1147,3,17115,Introductory Meteorology Lab,Jiang,Xun,2,11,2,0,0,0,1,2.868
+Fall 2024,CUIN,7383,1,17116,Early Chld Curr,Li,Xin,9,0,0,0,0,0,0,3.963
+Fall 2024,ARED,2310,2,17117,Intro Critical Visual Culture,Chung,Sheng Kuan,20,1,2,0,0,0,2,3.783
+Fall 2024,WCL,3385,1,17118,Cultures and Capitalisms,Majumder,Sarasij,1,1,0,0,0,0,1,3.665
+Fall 2024,MATH,2305,2,17119,Discrete Mathematics,Xhabli,Blerina,14,21,15,5,4,0,21,2.61
+Fall 2024,JWST,2380,1,17120,Jewish Civilization,Tamber-Rosenau,Caryn M,5,5,2,0,0,0,0,3.223
+Fall 2024,JWST,3380,1,17121,American Jewish Culture,Weiss,Kenneth Scott,2,3,1,2,0,0,1,2.79
+Fall 2024,WCL,2380,1,17122,Jewish Civilization,Tamber-Rosenau,Caryn M,1,0,0,1,0,0,0,2.665
+Fall 2024,WCL,3380,1,17123,American Jewish Culture,Weiss,Kenneth Scott,9,1,1,0,0,0,2,3.667
+Fall 2024,FINA,3332,2,17125,Prin of Financial Management,Suleymanov,Masim,99,72,37,12,1,0,1,3.179
+Fall 2024,JAPN,1501,1,17126,Elementary Japanese I,Ji,Fang,24,1,0,1,1,0,3,3.63
+Fall 2024,JAPN,1501,3,17128,Elementary Japanese I,Ji,Fang,18,6,0,1,3,0,2,3.262
+Fall 2024,HISP,2375,1,17131,US Hispanic Culture & Civ,Sisk,Christina L,8,11,3,3,1,0,0,2.77
+Fall 2024,SPAN,1501,23,17132,Elementary Spanish I,Torres-Calle,Maria Jose,8,9,5,0,1,0,1,2.986
+Fall 2024,SPAN,3301,1,17136,Span Oral Comm for Crit Think,Sisk,Christina L,13,8,0,0,0,0,1,3.635
+Fall 2024,SPAN,3331,1,17137,Mexican American Literature,Ventura,Gabriela Baeza,7,6,3,1,2,0,1,2.894
+Fall 2024,POLC,1311,1,17138,Public Policy Laboratory,Francis,Sara Sands,14,11,1,0,1,0,2,3.321
+Fall 2024,POLC,2312,1,17139,Intro to Econ Policy Analysis,Gilbert,Justin Valentine,6,10,6,0,6,0,2,2.286
+Fall 2024,POLC,3313,1,17140,Contemporary Poli Phil Policy,Reikosky,Nora,16,11,6,0,1,0,1,3.196
+Fall 2024,POLC,3314,1,17141,Leadership and Public Policy,Witt,Lawrence A,20,2,1,0,3,0,1,3.385
+Fall 2024,POLC,3315,1,17142,Policy Res Methods Stat & Reg,Gottlieb,Jessica Anne,5,7,2,0,1,0,2,2.934
+Fall 2024,POLC,3322,1,17143,Public Policy Analysis,Gilbert,Justin Valentine,13,5,2,0,0,0,3,3.468
+Fall 2024,POLC,3341,1,17144,State Authority and Freedom,Bronk,Robert C,9,1,0,0,1,0,1,3.455
+Fall 2024,MARK,3338,1,17145,Intro to Marketing Analytics,Hu,Ye,123,61,7,4,0,0,2,3.52
+Fall 2024,MARK,3338,2,17146,Intro to Marketing Analytics,Hu,Ye,75,50,11,5,2,0,3,3.322
+Fall 2024,MANA,4346,3,17148,Leadership Development,Lozano Garcia,Miguel Angel,32,2,3,0,0,0,0,3.766
+Fall 2024,MANA,6A83,2,17150,Strategic Analysis,Wesley Jr,Curtis LEONUS,27,4,2,0,0,0,0,3.608
+Fall 2024,MANA,6A83,3,17151,Strategic Analysis,Wesley Jr,Curtis LEONUS,14,10,2,0,0,0,3,3.347
+Fall 2024,PHIL,1361,5,17153,Philosophy and the Arts,Drapela,Nick Gerard,12,12,12,1,2,0,10,2.753
+Fall 2024,ARCH,4376,1,17154,Community Design Workshop,Rogers,Susan,7,2,0,0,0,0,0,3.668
+Fall 2024,MANA,7357,1,17155,Fund of Diversity Equity & Inc,Baldwin,Cheryl,16,1,0,0,0,0,0,3.805
+Fall 2024,CUIN,3317,11,17156,Kindergarten/Elem Curr & Instr,Christensen,Caroline,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,4315,11,17157,Assessment of Children,Christensen,Caroline,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,3316,11,17158,Prekindergarten Curr & Instr,Christensen,Caroline,1,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,3358,1,17159,Classics in Hist of Ethics,Phillips,David K,17,12,5,0,1,0,1,3.295
+Fall 2024,BUSI,2305,5,17160,Business Statistics,Patterson,Staci A,12,10,10,12,2,0,22,2.348
+Fall 2024,ENGI,1100,29,17163,Introduction To Engineering,Claydon,Frank J,34,8,1,0,1,0,0,3.682
+Fall 2024,BIOL,4342,50,17164,Introduction to Marine Biology,Hanke,Marc H,10,13,7,0,0,0,4,3.078
+Fall 2024,CHEM,1321,1,17166,Honors Fund. of Chem 1,Halasyamani,P Shiv,10,11,9,3,3,0,9,2.574
+Fall 2024,STAT,3331,2,17169,Statistical Anal Bus Appl I,Wiley,Briceon C,3,15,19,8,4,0,5,2.028
+Fall 2024,BIOL,3301,1,17174,Mendelian and Pop Genetics,Lin,Chin-Yo,96,45,15,4,0,0,5,3.411
+Fall 2024,BIOL,3301,2,17175,Mendelian and Pop Genetics,Lin,Chin-Yo,93,44,18,5,0,0,4,3.39
+Fall 2024,BIOL,3301,3,17176,Mendelian and Pop Genetics,Dauwalder,Brigitte,82,35,21,15,5,0,6,3.07
+Fall 2024,PSYC,4363,1,17180,Abnormal Child Psych,Perkovich,Elizabeth Susan,54,17,6,0,2,0,0,3.465
+Fall 2024,HIST,3310,1,17181,"Jacksonian America, 1820-1850",Deyle,Steven H,19,13,0,1,1,0,0,3.421
+Fall 2024,CHEM,6115,2,17184,Sem in Chm Lab Instruct,Bean,Mary B,0,0,0,0,0,3,0,
+Fall 2024,POLS,3340,50,17185,Ancient/Medieval Pol Thought,Gish,Dustin,13,7,1,0,1,0,1,3.319
+Fall 2024,GEOL,1103,13,17186,Physical Geology Lab,Hauptvogel,Daniel William,19,1,1,0,0,0,2,3.826
+Fall 2024,SCM,7390,1,17187,Global Supply Chain Strategy,Smith,Gordon D,4,3,5,0,1,0,0,2.718
+Fall 2024,GEOL,1302,1,17188,Intro To Global Climate Change,Zhang,Honghai,206,141,48,11,6,0,11,3.246
+Fall 2024,HON,3376,1,17189,Constitutional Cases & Controv,Erwing,Douglas A,19,0,0,0,0,0,3,3.965
+Fall 2024,GEOL,1303,1,17190,Physical Geology,Sisson,Virginia B,50,77,21,1,5,0,3,3.048
+Fall 2024,POLS,3352,50,17191,Immigration: Politics/Policy,Belco,Michelle Helene,23,1,0,0,0,0,1,3.945
+Fall 2024,GEOL,1303,6,17192,Physical Geology,Murphy,Michael,203,195,55,3,4,0,9,3.268
+Fall 2024,MIS,3371,2,17194,Transaction Processing Sys I,Messinger,Jacob Nelson,8,7,3,0,1,0,2,3.105
+Fall 2024,SOCI,1301,16,17195,Introduction To Sociology,Davis,Mary A,30,13,3,2,3,0,3,3.216
+Fall 2024,SGNL,1301,9,17196,Elementary Sign Language I,Brittain,Terrell,9,5,3,0,1,0,2,3.075
+Fall 2024,ACCT,2301,9,17198,Prin of Financial Accounting,Sykes,Mary Reeves,20,26,4,5,2,0,3,3.104
+Fall 2024,BUSI,4305,1,17200,Business Ethics for Accountant,Brant Jr,Robert Edward,9,5,1,0,0,0,0,3.621
+Fall 2024,ACCT,2302,3,17201,Prin of Managerial Accounting,Weber,Catherine K,13,28,28,4,0,0,3,2.775
+Fall 2024,ACCT,2302,4,17202,Prin of Managerial Accounting,Seltz,Joe D,18,15,5,3,1,0,2,3.182
+Fall 2024,ACCT,2302,5,17203,Prin of Managerial Accounting,Seltz,Joe D,35,27,14,3,0,0,1,3.244
+Fall 2024,HISP,2374,4,17205,Spanish American Culture & Civ,De Los Reyes Heredia,Jose Guillermo,23,5,0,1,5,0,1,3.147
+Fall 2024,ACCT,3366,5,17206,Financial Reporting Frameworks,Parthasarathy,Kiran M,19,12,15,2,3,0,6,2.798
+Fall 2024,ACCT,3367,3,17207,Intermediate Accounting I,Kilic,Emre,21,18,13,3,1,0,9,3.006
+Fall 2024,ACCT,3368,4,17209,Intermediate Accounting II,Muslu,Volkan,14,17,20,3,1,0,1,2.655
+Fall 2024,ACCT,7379,1,17210,Current Issues in Taxation,Evetts,Nancy Zalmanek,25,3,0,0,0,0,0,3.905
+Fall 2024,ACCT,7384,1,17211,Enterprise Risk Management,Neely,Gregory Wayne,14,1,0,0,0,0,0,3.955
+Fall 2024,ACCT,7320,1,17212,Intro to Data Analytics-Acct,Erdem,Ozer,20,4,0,0,0,0,0,3.723
+Fall 2024,ACCT,5301,1,17213,Financial and Managerial Acct,Serrato,Darlene Marie  Bohac,4,3,3,1,2,0,4,2.462
+Fall 2024,ELED,4311,1,17214,Science in Elementary School I,Domjan,Heather N,21,2,0,0,0,0,0,3.927
+Fall 2024,ELED,4311,5,17215,Science in Elementary School I,Wong,Sissy S,24,2,2,0,0,0,0,3.703
+Fall 2024,ELED,4311,4,17216,Science in Elementary School I,Domjan,Heather N,20,1,0,0,0,0,1,3.952
+Fall 2024,MATH,5333,1,17217,Analysis,Ji,Shanyu,4,3,1,0,0,0,1,3.375
+Fall 2024,MATH,6322,1,17218,Func Complex Variable,Nicol,Matthew J,15,0,0,0,0,0,0,3.934
+Fall 2024,MATH,5310,1,17219,History of Mathematics,Ji,Shanyu,5,5,0,0,0,0,1,3.467
+Fall 2024,ARTS,3304,3,17220,Intermediate Painting,Willis,William H,20,0,0,0,0,0,0,4.0
+Fall 2024,COMD,3321,1,17221,Multicultural Consid -- COMD,Castilla-Earls,Anny,9,2,0,0,1,0,0,3.363
+Fall 2024,COMD,3371,1,17222,Speech Devel & Dis in Children,Schaff,Carrie Allyson,33,25,1,0,0,0,0,3.481
+Fall 2024,COMD,3385,1,17223,Speech Science,Hein Machado,Sofia,26,8,3,0,0,0,1,3.577
+Fall 2024,BCHS,3304,50,17224,General Biochemistry I,Yeo,Hye-Jeong,13,16,4,0,0,0,4,3.223
+Fall 2024,ENTR,3310,6,17225,Entrepreneurship,Boles,James Read,15,8,0,0,0,0,1,3.537
+Fall 2024,BIOL,3311,2,17226,Adv Mthds/Writing in Gen Lab,Ibrahim,Abdalla Zanouny,60,14,2,1,0,0,2,3.684
+Fall 2024,ENTR,4330,1,17231,Entrepreneurial Costs/Budgets,Becker,Charles D,13,10,6,1,0,0,0,3.167
+Fall 2024,MARK,6A61,5,17240,Marketing Administration,Lish,Alan D,5,19,6,0,3,0,2,2.677
+Fall 2024,ARTS,3330,3,17241,Intermediate Graphic Design,Kim,Yoonkyung,5,16,1,0,0,0,2,3.197
+Fall 2024,GEOL,1103,14,17242,Physical Geology Lab,Hauptvogel,Daniel William,12,4,0,0,0,0,2,3.729
+Fall 2024,GEOL,1103,15,17243,Physical Geology Lab,Hauptvogel,Daniel William,14,3,0,2,0,0,1,3.578
+Fall 2024,ARCH,3311,1,17244,Topics in Design History,Kacmar,Donna,9,4,2,0,0,0,0,3.445
+Fall 2024,AAS,2320,6,17245,Intro To African American Stdy,Poindexter-Sylvers,Carole Jean,28,6,4,0,0,0,1,3.606
+Fall 2024,AAS,2330,1,17246,Black Liberation Theology,Johnson,Alexander Emmitt Maurice,14,10,3,2,5,0,1,2.745
+Fall 2024,ARCH,4510,9,17247,Integrated Arch Solutions,Hager,Jesse,15,4,0,0,0,0,0,3.72
+Fall 2024,LAW,5390,2,17251,Environmental Law,Anozie,Chinonso Tansi,7,6,0,0,0,0,0,3.412
+Fall 2024,LAW,6326,1,17252,Diplomacy for Oil and Gas,Cardenas Garcia,Julian Jose,11,21,0,0,0,3,0,3.426
+Fall 2024,KIN,4370,1,17255,Exercise Testing,Markofski,Melissa,36,50,42,3,0,0,0,2.893
+Fall 2024,COMM,3374,2,17257,Strategic Social Media,Choi,Ho Joon,29,0,0,0,0,0,1,3.989
+Fall 2024,COMM,4355,1,17258,Organizational Comm,Graham,Catherine Burch,20,7,0,1,1,0,0,3.494
+Fall 2024,IDNS,2114,3,17259,Calculus II SEP Workshop,Pattison,Donna,18,3,3,5,0,0,4,3.172
+Fall 2024,COMM,4357,1,17260,Intercultural Communication,Vaughn,Ginger Koto,11,15,0,0,1,0,1,3.321
+Fall 2024,ARTS,3350,1,17262,Intermediate Ceramics,Oloshove,Angel,15,0,0,0,0,0,1,3.956
+Fall 2024,SCLT,4386,30,17263,Project Logistics,Poisler,Marco A,15,0,0,0,0,0,1,3.956
+Fall 2024,COMM,3315,2,17264,News and Social Media,Lee,Taeyoung,9,9,6,0,0,0,0,3.084
+Fall 2024,LST,3354,1,17266,Law and Society,Watts,Jeffrey Allen,23,11,2,0,1,0,1,3.415
+Fall 2024,SCLT,6316,2,17268,Global Supply Chain Logistics,Wang,Kailai,21,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7339,2,17271,Leadership Development,Atwater,Leanne E,23,5,2,0,0,0,0,3.7
+Fall 2024,MUSI,1116,2,17272,Aural Skills I,Guez,Jonathan Charles,9,6,1,0,0,0,1,3.521
+Fall 2024,NUTR,3330,2,17273,Mgmt in Food & Nutr Systems,Haubrick,Kevin,2,6,0,0,0,0,0,3.25
+Fall 2024,NUTR,4352,1,17274,Child and Adolescent Nutrition,Vollrath,Kirstin,21,45,8,0,0,0,1,3.118
+Fall 2024,HIST,1301,3,17275,The U.S. to 1877,Goldberg,Mark A,188,59,12,8,8,0,8,3.475
+Fall 2024,HIST,1301,4,17276,The U.S. to 1877,Johnson,Michele R,214,57,13,10,6,0,8,3.542
+Fall 2024,HIST,1301,5,17277,The U.S. to 1877,Johnson,Michele R,223,42,17,8,9,0,7,3.542
+Fall 2024,HIST,1301,6,17278,The U.S. to 1877,Romero,Todd,209,63,15,9,7,0,2,3.455
+Fall 2024,HIST,1301,7,17279,The U.S. to 1877,Romero,Todd,201,55,20,11,17,0,3,3.304
+Fall 2024,MUSI,1181,4,17280,Group Piano I,Van Kekerix,Todd Evan,11,0,0,0,1,0,0,3.557
+Fall 2024,HIST,1302,1,17282,The U.S. Since 1877,Rector,Josiah John,198,59,20,7,12,0,2,3.413
+Fall 2024,HIST,1302,2,17283,The U.S. Since 1877,Reed,Linda,151,54,41,15,14,0,7,3.141
+Fall 2024,HIST,1302,3,17284,The U.S. Since 1877,Amaral,Lindsay Nicole,192,72,8,5,9,0,15,3.482
+Fall 2024,HIST,1302,4,17285,The U.S. Since 1877,Buzzanco,Robert,174,77,10,5,14,0,12,3.303
+Fall 2024,HIST,1302,5,17286,The U.S. Since 1877,Buzzanco,Robert,192,49,12,7,18,0,13,3.321
+Fall 2024,HIST,1302,6,17287,The U.S. Since 1877,Deyle,Steven H,64,36,26,5,9,0,6,3.01
+Fall 2024,MUSI,1311,2,17288,Music Theory I,Guez,Jonathan Charles,9,4,6,0,0,0,2,3.158
+Fall 2024,POLS,3344,1,17289,Inter'l Law & Law of War,Littlepage,Kelley G,9,13,9,2,3,0,8,2.639
+Fall 2024,POLS,3387,1,17290,Politics of the Qur'an,Contractor,Cyrus Ali,27,3,3,0,2,0,1,3.429
+Fall 2024,LST,3356,1,17291,Intro to Constitutional Law,Abbott Jr,Kenneth Wayne,32,11,0,0,0,0,0,3.713
+Fall 2024,POLS,3392,1,17292,Nuclear Weapons and Security,Zwald,Zachary J,13,17,9,1,1,0,0,2.968
+Fall 2024,GHL,3153,1,17293,Htl Mrktng New York Style,Boger Jr,Carl A,14,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6153,1,17294,Hotel Marketing-New York Style,Boger Jr,Carl A,4,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,3354,1,17295,Medical Ethics,Determeyer,Peggy Lee,7,0,0,0,0,0,1,4.0
+Fall 2024,ACCT,3366,6,17296,Financial Reporting Frameworks,Parthasarathy,Kiran M,60,37,32,9,4,0,10,2.935
+Fall 2024,CHEE,8298,20,17297,Doctoral Research,Zerze,Gul,0,0,0,0,0,4,0,
+Fall 2024,CHEE,8298,21,17298,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Fall 2024,GHL,7369,1,17299,Hospitality Financial Assets,Koh,Yoon,6,0,0,0,0,0,0,3.945
+Fall 2024,CHEE,8598,20,17304,Doctoral Research,Zerze,Gul,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8399,20,17306,Doctoral Dissertation,Zerze,Gul,4,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7368,1,17309,CSA Theories and Methods,Berger,Jason,10,0,0,0,0,0,0,4.0
+Fall 2024,TECH,1301,2,17310,Intro to Data Analytics Tools,Roberts,Phyllis Rayburn,13,9,4,2,1,0,4,3.023
+Fall 2024,ELCS,7392,1,17312,Internship in Superintendent,Klussmann,Duncan Foster,5,0,0,0,0,0,0,4.0
+Fall 2024,RELS,1301,2,17314,Intro To Religious Studies,Eberhart,Christian,21,24,6,3,2,0,5,3.065
+Fall 2024,RELS,3330,1,17315,Christianity,Eberhart,Christian,42,3,1,0,1,0,2,3.717
+Fall 2024,RELS,2380,1,17316,Religion and Film,Clark,Laura B,13,4,2,1,2,0,2,3.091
+Fall 2024,ANTH,2304,1,17317,Intro To Language and Culture,Majumder,Sarasij,34,6,1,1,0,0,3,3.722
+Fall 2024,PSYC,2330,5,17318,Biological Psychology,Rech,Megan Elizabeth,39,26,5,2,4,0,2,3.159
+Fall 2024,PSYC,3310,3,17319,Indstrl-Orgnztnl Psy,Ng,Vincent,29,9,4,1,1,0,2,3.492
+Fall 2024,PSYC,2301,4,17320,Introduction to Psychology,Silva,Karina,46,22,9,1,2,0,0,3.309
+Fall 2024,PSYC,2301,5,17321,Introduction to Psychology,Liu,Tingshu,52,10,7,3,3,0,2,3.356
+Fall 2024,COMM,4303,6,17327,Communication Law and Ethics,Bundage Juvane,Stephanie,70,9,2,0,0,0,0,3.807
+Fall 2024,ENGL,1370,3,17329,Composition II-Honors,Cooper,Carol B,3,2,1,1,1,0,0,2.46
+Fall 2024,ENGL,1370,4,17330,Composition II-Honors,Cooper,Carol B,3,4,0,0,1,0,0,2.835
+Fall 2024,ENGL,1370,5,17331,Composition II-Honors,Cremins,Robert Paul,8,1,1,0,0,0,0,3.535
+Fall 2024,ENGL,1370,6,17332,Composition II-Honors,Cremins,Robert Paul,5,2,0,0,0,0,0,3.62
+Fall 2024,ENGL,1370,7,17333,Composition II-Honors,Garner,Richard A,2,4,0,0,0,0,0,3.333
+Fall 2024,ENGL,1370,8,17334,Composition II-Honors,Garner,Richard A,2,3,1,0,0,0,0,3.002
+Fall 2024,ENGL,1370,9,17335,Composition II-Honors,Lyke,Larry,1,3,0,0,0,0,0,3.333
+Fall 2024,ENGL,1370,10,17336,Composition II-Honors,Morrison,Iain P D,6,2,0,0,0,0,0,3.668
+Fall 2024,ENGL,1370,11,17337,Composition II-Honors,Rayneard,Max James Anthony,2,3,0,0,0,0,0,3.466
+Fall 2024,ENGL,1370,12,17338,Composition II-Honors,Rayneard,Max James Anthony,0,2,0,0,0,0,0,3.165
+Fall 2024,ENGL,1370,13,17339,Composition II-Honors,Vollrath,Lesli A,2,3,0,0,0,0,0,3.466
+Fall 2024,ENGL,1370,37,17340,Composition II-Honors,Trninic,Marina,4,3,0,0,0,0,0,3.477
+Fall 2024,ARCH,3112,3,17342,Topics in Design Media,Noldt,Peter,14,1,0,0,0,0,0,3.845
+Fall 2024,MECT,3345,30,17343,Fund Power Generation Tech,Bose,Anima B,5,7,2,0,0,0,0,3.214
+Fall 2024,BUSI,1301,6,17344,Business Principles,Carvalho,Diogo,193,31,11,6,4,0,4,3.607
+Fall 2024,ENGL,1370,21,17345,Composition II-Honors,Bland,Laura Elizabeth,2,1,0,0,0,0,0,3.777
+Fall 2024,ENGL,1370,22,17346,Composition II-Honors,Bland,Laura Elizabeth,3,1,0,0,0,0,0,3.668
+Fall 2024,ENGL,1370,23,17347,Composition II-Honors,Charara,Hayan S,1,4,0,0,0,0,0,3.2
+Fall 2024,ENGL,1370,24,17348,Composition II-Honors,Charara,Hayan S,1,4,0,0,0,0,0,3.398
+Fall 2024,ENGL,1370,25,17349,Composition II-Honors,Ferguson,Jamie H,2,1,0,0,0,0,0,3.667
+Fall 2024,ENGL,1370,26,17350,Composition II-Honors,Gish,Dustin,4,1,0,0,0,0,0,3.602
+Fall 2024,ENGL,1370,27,17351,Composition II-Honors,Gish,Dustin,5,0,0,0,0,0,0,3.802
+Fall 2024,ENGL,1370,28,17352,Composition II-Honors,Hallmark,Terrell L,4,2,0,0,0,0,0,3.612
+Fall 2024,ENGL,1370,29,17353,Composition II-Honors,Hallmark,Terrell L,1,3,2,0,0,0,0,2.778
+Fall 2024,ENGL,1370,30,17354,Composition II-Honors,Ford,Bryn Eames,6,1,0,0,0,0,0,3.669
+Fall 2024,ENGL,1370,31,17355,Composition II-Honors,Ford,Bryn Eames,2,2,0,0,0,0,1,3.5
+Fall 2024,ENGL,1370,32,17356,Composition II-Honors,Rainbow,Jesse J,6,2,0,0,0,0,0,3.668
+Fall 2024,ENGL,1370,33,17357,Composition II-Honors,Rainbow,Jesse J,3,1,2,0,0,0,0,3.167
+Fall 2024,ENGL,1370,34,17358,Composition II-Honors,Sisman,Cengiz,2,1,0,0,1,0,0,2.75
+Fall 2024,ENGL,1370,35,17359,Composition II-Honors,Sisman,Cengiz,4,1,0,0,0,0,0,3.668
+Fall 2024,ENGL,1370,36,17360,Composition II-Honors,Trninic,Marina,3,2,0,1,0,0,0,3.167
+Fall 2024,ENGL,2360,3,17361,Western World Lit I--Honors,Cooper,Carol B,9,0,0,0,1,0,0,3.435
+Fall 2024,ENGL,2360,4,17362,Western World Lit I--Honors,Cooper,Carol B,7,1,0,0,0,0,0,3.751
+Fall 2024,ENGL,2360,5,17363,Western World Lit I--Honors,Cremins,Robert Paul,4,1,0,1,0,0,0,3.278
+Fall 2024,ENGL,2360,6,17364,Western World Lit I--Honors,Cremins,Robert Paul,5,5,0,0,0,0,0,3.533
+Fall 2024,ENGL,2360,7,17365,Western World Lit I--Honors,Garner,Richard A,6,4,0,0,0,0,0,3.633
+Fall 2024,ENGL,2360,8,17366,Western World Lit I--Honors,Garner,Richard A,8,3,0,0,0,0,0,3.667
+Fall 2024,ENGL,2360,9,17367,Western World Lit I--Honors,Lyke,Larry,6,7,0,0,0,0,0,3.487
+Fall 2024,ENGL,2360,10,17368,Western World Lit I--Honors,Morrison,Iain P D,6,4,0,0,0,0,0,3.6
+Fall 2024,ENGL,2360,11,17369,Western World Lit I--Honors,Rayneard,Max James Anthony,7,3,0,0,0,0,0,3.7
+Fall 2024,ENGL,2360,12,17370,Western World Lit I--Honors,Rayneard,Max James Anthony,8,7,0,0,0,0,0,3.577
+Fall 2024,ENGL,2360,13,17371,Western World Lit I--Honors,Vollrath,Lesli A,6,6,0,0,0,0,0,3.5
+Fall 2024,ENGL,2360,14,17372,Western World Lit I--Honors,Vollrath,Lesli A,10,5,0,0,0,0,0,3.645
+Fall 2024,ENGL,2360,15,17373,Western World Lit I--Honors,Werner,Andrew Timothy,5,3,0,1,0,0,0,3.333
+Fall 2024,ENGL,2360,16,17374,Western World Lit I--Honors,Werner,Andrew Timothy,10,1,0,0,0,0,0,3.699
+Fall 2024,ENGL,2360,37,17375,Western World Lit I--Honors,Trninic,Marina,7,2,0,0,0,0,1,3.631
+Fall 2024,ENGL,2360,21,17376,Western World Lit I--Honors,Bland,Laura Elizabeth,10,4,0,0,0,0,0,3.62
+Fall 2024,ENGL,2360,22,17377,Western World Lit I--Honors,Bland,Laura Elizabeth,7,4,0,0,0,0,0,3.546
+Fall 2024,ENGL,2360,23,17378,Western World Lit I--Honors,Charara,Hayan S,2,9,0,0,0,0,0,3.302
+Fall 2024,ENGL,2360,24,17379,Western World Lit I--Honors,Charara,Hayan S,5,6,0,0,0,0,0,3.545
+Fall 2024,ENGL,2360,25,17380,Western World Lit I--Honors,Ferguson,Jamie H,7,4,0,0,0,0,0,3.696
+Fall 2024,ENGL,2360,26,17381,Western World Lit I--Honors,Gish,Dustin,4,3,0,0,0,0,1,3.619
+Fall 2024,ENGL,2360,27,17382,Western World Lit I--Honors,Gish,Dustin,6,5,0,0,0,0,0,3.425
+Fall 2024,ENGL,2360,28,17383,Western World Lit I--Honors,Hallmark,Terrell L,6,3,1,0,0,0,0,3.368
+Fall 2024,ENGL,2360,29,17384,Western World Lit I--Honors,Hallmark,Terrell L,6,3,0,0,1,0,0,3.069
+Fall 2024,ENGL,2360,30,17385,Western World Lit I--Honors,Ford,Bryn Eames,5,4,0,0,0,0,0,3.592
+Fall 2024,ENGL,2360,31,17386,Western World Lit I--Honors,Ford,Bryn Eames,6,6,0,0,0,0,0,3.555
+Fall 2024,ENGL,2360,32,17387,Western World Lit I--Honors,Rainbow,Jesse J,4,5,0,0,0,0,0,3.554
+Fall 2024,ENGL,2360,33,17388,Western World Lit I--Honors,Rainbow,Jesse J,7,2,0,0,0,0,1,3.741
+Fall 2024,ENGL,2360,34,17389,Western World Lit I--Honors,Sisman,Cengiz,7,5,0,0,0,0,0,3.556
+Fall 2024,ENGL,2360,35,17390,Western World Lit I--Honors,Sisman,Cengiz,4,6,0,0,0,0,1,3.433
+Fall 2024,ENGL,2360,36,17391,Western World Lit I--Honors,Trninic,Marina,8,3,0,0,0,0,0,3.697
+Fall 2024,LAW,5310,1,17392,White Collar Crime,Kwok,David Y,4,7,0,0,0,3,0,3.364
+Fall 2024,ARCH,3112,4,17393,Topics in Design Media,Noldt,Peter,11,2,2,0,1,0,0,3.272
+Fall 2024,THEA,6359,1,17394,Flat Patterning,Niederer,Barbara,1,1,0,0,0,0,0,3.5
+Fall 2024,ARCH,3112,6,17395,Topics in Design Media,Noldt,Peter,10,3,0,0,1,0,0,3.359
+Fall 2024,ENGL,3361,1,17396,Mexican American Lit,Ellis,Amanda,12,15,1,0,1,0,1,3.128
+Fall 2024,ARCH,3112,9,17397,Topics in Design Media,Martinez,Marcus E,15,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,3312,3,17398,Topics in Design Media,Noldt,Peter,11,7,2,2,2,0,2,2.986
+Fall 2024,ARCH,3312,4,17399,Topics in Design Media,Smith,Joshua S,10,4,2,0,0,0,0,3.541
+Fall 2024,ARCH,3312,5,17401,Topics in Design Media,Tobar Martinez,Joaquin,13,0,0,0,0,0,0,3.898
+Fall 2024,ENGI,1100,30,17403,Introduction To Engineering,Metrovich,Brian,35,9,8,0,2,0,2,3.352
+Fall 2024,COSC,6335,1,17405,Data Mining,Eick,Christoph F,21,22,1,0,0,0,0,3.395
+Fall 2024,INDE,6333,1,17406,Probability Stat For Engineers,Chung,Christopher,10,1,0,0,0,0,0,3.909
+Fall 2024,KIN,4310,2,17407,Measurement Tech Human Perf,Parikh,Pranav J,93,5,1,0,1,0,0,3.784
+Fall 2024,COSC,1336,4,17408,Computer Science & Program,Yun,Changhoon,19,15,18,16,20,0,32,1.895
+Fall 2024,COSC,1336,3,17409,Computer Science & Program,Zhang,Chengming,22,14,12,1,2,0,0,2.994
+Fall 2024,COMD,3383,1,17410,Language Disorders in Children,Ivey,Michelle L,22,19,5,0,0,0,0,3.334
+Fall 2024,CUIN,4315,6,17411,Assessment of Children,Hernandez,Berky,15,1,0,0,0,0,0,3.938
+Fall 2024,LAW,5409,2,17412,Contracts,Fowler,Leah Robbins,18,19,1,0,0,0,0,3.369
+Fall 2024,LAW,5409,3,17413,Contracts,Hawkins,James R,15,23,2,0,0,0,0,3.399
+Fall 2024,LAW,5409,4,17414,Contracts,Gebru,Aman K,20,22,0,0,0,0,0,3.398
+Fall 2024,LAW,5387,1,17415,International Tax,Wells,Douglas,4,7,0,0,0,2,0,3.304
+Fall 2024,LAW,5374,1,17416,Legal History,Siegel,Martin Jonathan,18,24,0,0,0,0,0,3.35
+Fall 2024,HLT,1353,4,17417,Personal Health,Proctor,Robin Ann,102,10,2,0,1,0,3,3.823
+Fall 2024,BZAN,6354,2,17419,DB Mgt Tools Bus Analytics,Grimes,George M,10,3,1,0,0,0,1,3.643
+Fall 2024,CIVE,6378,2,17421,Principles Enviromntl Modeling,Louie,Stacey M,1,0,0,0,0,0,1,4.0
+Fall 2024,CIVE,2332,1,17422,Mechanics of Solids,Nakshatrala,Kalyana,3,15,11,4,2,0,1,2.334
+Fall 2024,ACCT,3371,3,17423,Accounting Information Systems,Miles,Carolyn A,9,14,2,0,0,0,0,3.254
+Fall 2024,ACCT,3377,4,17424,Cost Accounting,Serrato,Darlene Marie  Bohac,27,13,0,1,0,0,5,3.537
+Fall 2024,CIVE,6393,1,17425,Geostatistics,Lee,Hyongki,5,4,1,0,0,0,0,3.301
+Fall 2024,CIVE,6393,2,17426,Geostatistics,Lee,Hyongki,1,1,0,0,0,0,0,3.335
+Fall 2024,MECT,4326,30,17427,Fundamentals Offshore Systems,Al-Jamal,Helmi,1,8,5,1,0,0,0,2.622
+Fall 2024,SOCI,1301,18,17429,Introduction To Sociology,Adams,Jennifer Lauren,43,3,3,1,2,0,3,3.571
+Fall 2024,SOCI,1301,20,17430,Introduction To Sociology,Colbert,Sharla Stettnisch,35,10,5,2,0,0,1,3.487
+Fall 2024,SOCI,1301,26,17431,Introduction To Sociology,Adams,Jennifer Lauren,41,8,4,0,2,0,0,3.564
+Fall 2024,MANA,6A83,4,17433,Strategic Analysis,Celly,Nikhil,19,0,0,0,0,0,0,3.913
+Fall 2024,SCM,6A01,5,17435,SCM Concepts,Sahin,Funda,3,1,2,0,0,0,0,3.112
+Fall 2024,FINA,7381,1,17436,Principles of Real Estate,Disch,Kathryn Annette,6,0,0,0,0,0,0,3.89
+Fall 2024,CNST,2360,1,17437,Communication in Construction,Sheppard,Travis,35,3,1,0,0,0,0,3.872
+Fall 2024,BTEC,2322,20,17438,Introduction to Biopython,Chitrala,Kumaraswamy Naidu,36,1,2,0,1,0,1,3.742
+Fall 2024,BTEC,4100,30,17439,Principles Bioinformatics Lab,Balan,Venkatesh,6,7,2,0,0,0,0,3.355
+Fall 2024,BIOE,6301,2,17441,Statistical Methods in BME,Gifford,Howard,3,12,1,0,0,0,2,3.104
+Fall 2024,CHEE,3321,3,17443,Analytical Methods Chem Engr,Grabow,Lars C,1,2,2,0,0,0,2,2.734
+Fall 2024,CHEE,3333,2,17444,Chem Engr Thermodyn II,Zerze,Gul,5,1,0,0,0,0,1,3.778
+Fall 2024,CHEE,3363,2,17445,Fluid Mechanics for Chem Engrs,Wen,Mingjian,1,1,0,0,0,0,1,3.665
+Fall 2024,CHEE,3367,2,17446,Process Modeling and Control,Kaspar,Michael,1,1,0,0,0,0,1,3.5
+Fall 2024,CHEE,3369,2,17447,Chemical Engr Transport Proc,Harold,Michael P,1,1,0,0,0,0,0,3.5
+Fall 2024,CHEE,4367,2,17449,Chemical Reaction Engineering,Bollini,Praveen P,1,0,0,0,0,0,0,3.67
+Fall 2024,MAS,3346,1,17450,Latinas in the United States,Pino,Diana,10,6,3,0,0,0,1,3.282
+Fall 2024,CHEE,3462,1,17451,Unit Operations,Zerze,Hasan,18,14,2,0,0,0,0,3.461
+Fall 2024,CHEE,3462,3,17453,Unit Operations,Zerze,Hasan,1,1,0,0,0,0,0,3.5
+Fall 2024,NAVY,3302,1,17455,Naval Operations,Davis,Danyelle,0,1,1,0,0,0,0,2.5
+Fall 2024,MARK,7366,1,17458,Digital Marketing Analytics,Tirunillai,Seshadri N,13,1,1,1,0,0,0,3.625
+Fall 2024,POLS,3349,1,17459,American Political Thought,Hunt,Bruce A,7,19,12,4,0,0,3,2.549
+Fall 2024,COMM,3318,3,17460,Multimedia Storytelling,Uhrick,Jan,29,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,4332,2,17461,Corporate Taxation,Fernandez,Ramon,3,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,7375,3,17463,Taxation of Business Entities,Fernandez,Ramon,4,6,1,0,0,0,1,3.363
+Fall 2024,ACCT,4335,4,17464,Financial Statement Auditing,Kuruvilla,Mohan,13,14,5,3,0,0,2,3.057
+Fall 2024,ACCT,7360,1,17465,Partnership Taxation,King,Sheldon,5,8,0,0,0,0,0,3.537
+Fall 2024,ACCT,7367,1,17466,Advanced Internal Auditing,Brant Jr,Robert Edward,9,5,0,0,0,0,0,3.714
+Fall 2024,GOVT,2305,7,17467,"US Govt: Congress,Pres & Crts",Clark,Jennifer H,576,215,39,39,59,0,15,3.273
+Fall 2024,WGSS,2350,20,17468,Intro To Women's Studies,Deremer,Melissa Gale,30,0,0,0,0,0,0,3.956
+Fall 2024,ACCT,7385,1,17469,Forensic Accounting,Ramey,Dan T,13,2,0,0,0,0,0,3.867
+Fall 2024,CHEM,1311,5,17470,Fundamentals of Chemistry,Carrasquillo M,Edwin,52,72,62,13,14,0,54,2.609
+Fall 2024,NURS,4312,1,17471,Ldership and Mgmt in Prof Nur,Simon-Campbell,E'Loria,16,24,0,2,0,0,2,3.286
+Fall 2024,ECE,6302,1,17472,Introductn To Neuroengineering,Sheth,Bhavin R,1,2,0,0,0,0,0,3.443
+Fall 2024,NURS,6345,1,17473,Mgmt of Hlth Dsordrs in Wom/Ch,Tahmasbi,Sherin,1,3,0,0,0,0,1,3.25
+Fall 2024,NURS,6346,1,17474,Mgmt of Hlth Dsordrs in Wo/Ch,Tahmasbi,Sherin,0,0,0,0,0,4,1,
+Fall 2024,MATH,1300,1,17475,Fundamentals of Mathematics,Hollyer,Virginia Leigh,0,0,0,0,0,36,0,
+Fall 2024,ENGL,7399,6,17476,Essay,Ellis,Amanda,0,0,0,0,0,0,1,
+Fall 2024,HDCS,3384,1,17477,Consumer Sales,Mudd,Blake Stevens,52,0,0,0,0,0,0,4.0
+Fall 2024,CIS,2334,20,17478,Information Systems Applicatns,Ratner,Edward,61,34,21,6,6,0,13,3.016
+Fall 2024,CIS,1348,31,17479,Info Systems Appl Development,Lindner,Peggy,26,7,3,1,3,0,2,3.242
+Fall 2024,CIS,3320,20,17480,Information Visualization,Ratner,Edward,53,24,7,0,5,0,3,3.293
+Fall 2024,CNST,3210,1,17481,Safety for Industrial Projects,Zayas,Frederick A,7,18,1,0,1,0,1,3.136
+Fall 2024,GOVT,2305,2,17482,"US Govt: Congress,Pres & Crts",Casellas,Jason,80,139,16,0,7,0,4,3.174
+Fall 2024,ACCT,7340,2,17483,Financial Statement Analysis,Lu,Tong,6,1,0,0,0,0,0,3.857
+Fall 2024,GENB,7303,3,17485,Prof Accounting Communication,Newman,Michael Ray,12,6,0,0,0,0,0,3.74
+Fall 2024,MUSA,2300,9,17486,Applied Voice,Averyt,Zachary Benjamin,3,0,0,0,0,0,0,3.89
+Fall 2024,BIOE,4303,2,17487,Biomaterials,Abidian,Mohammad Reza,15,1,0,0,0,0,0,3.731
+Fall 2024,BIOE,6303,2,17488,Biomaterials,Abidian,Mohammad Reza,8,2,0,0,0,0,0,3.734
+Fall 2024,ENGL,1301,150,17489,First Year Writing I,Yates,Kaitlyn,18,2,1,1,0,0,0,3.607
+Fall 2024,ENGL,1301,151,17490,First Year Writing I,Yates,Kaitlyn,8,4,3,1,1,0,0,2.864
+Fall 2024,ENGL,1301,152,17491,First Year Writing I,Dykes,Justin,5,4,5,0,0,0,0,3.047
+Fall 2024,ENGL,1301,153,17492,First Year Writing I,Horton,Lara,2,2,5,4,2,0,0,1.867
+Fall 2024,ECON,2302,2,17493,Principles of Microeconomics,Hossain,Md Shahadath,246,161,68,4,3,0,20,3.318
+Fall 2024,GEOL,7333,1,17495,Seismic Wave & Ray Theory,Li,Aibing,4,12,2,0,0,0,0,3.166
+Fall 2024,BTEC,4301,30,17496,Principles of Bioprocessing,Lin,Yuheng,11,3,1,0,0,0,0,3.667
+Fall 2024,ACCT,4331,3,17497,Federal Income Tax,Fernandez,Ramon,9,40,15,0,1,0,3,2.958
+Fall 2024,MUSA,4440,1,17499,Applied Trumpet,Vassallo,Jim Cates,5,0,0,0,0,0,0,4.0
+Fall 2024,ECON,2301,3,17501,Principles of Macroeconomics,Maden,Bitaran Jang,16,36,24,6,2,0,5,2.651
+Fall 2024,SPAN,3384,3,17502,Intro To Hispanic Literature,Hasbun,Rodrigo,7,3,2,0,0,0,0,3.334
+Fall 2024,CHEM,8999,30,17504,Doctoral Dissertation,Brgoch,Jakoah,0,0,0,0,0,1,0,
+Fall 2024,FINA,3332,7,17505,Prin of Financial Management,Chisholm,Darla,26,37,23,20,3,0,12,2.569
+Fall 2024,CHEM,6698,36,17508,Special Problems,Lee,T Randall,0,0,0,0,0,1,0,
+Fall 2024,PHIL,3383,1,17512,His of Ancient Phi,Werner,Andrew Timothy,8,15,3,0,1,0,1,3.074
+Fall 2024,MUSA,2322,1,17513,Applied Viola,Archibald,Amber Cristina,3,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5130,1,17514,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,18,0,
+Fall 2024,ENGL,7399,7,17517,Essay,Harris,Francine Julia,0,0,0,0,0,1,0,
+Fall 2024,FINA,7326,1,17518,Private Equity & Invest Bankin,Stewart,Marcus,16,9,1,0,0,0,0,3.564
+Fall 2024,BIOE,6305,2,17521,Brain Machine Interfacing,Francis,Joseph Thachil,3,2,0,0,0,0,0,3.534
+Fall 2024,ENGL,8399,10,17522,Doctoral Dissertation,Berger,Jason,0,0,0,0,0,1,0,
+Fall 2024,PHOP,6257,18,17524,Research Practicum B,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7399,2,17526,Masters Thesis,Yoshida,Hanako,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,17,17527,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8698,14,17528,Doctoral Research,Jiang,Xun,0,0,0,0,0,1,0,
+Fall 2024,LAW,5232,1,17531,Trade Secrets,Beebe,James L,10,22,0,0,0,5,0,3.323
+Fall 2024,MARK,7366,2,17534,Digital Marketing Analytics,Tirunillai,Seshadri N,20,0,0,0,0,0,0,3.951
+Fall 2024,LAW,7314,1,17539,WRS: Antidiscrimination,Areheart,Bradley Allan,4,8,0,0,0,0,0,3.388
+Fall 2024,SGNL,2301,6,17541,Intermediate Sign Language I,Brittain,Terrell,5,8,6,0,0,0,0,2.93
+Fall 2024,BIOE,4319,2,17542,Mass Transport Biosystems,Majd,Sheereen,7,3,0,0,0,0,1,3.7
+Fall 2024,BIOE,6319,2,17543,Mass Transport Bio Systems,Majd,Sheereen,3,2,0,0,0,0,0,3.6
+Fall 2024,ENGR,2301,4,17544,Mechanics I (Statics),Zamiran,Siavash,5,9,5,5,0,0,0,2.583
+Fall 2024,PSYC,6393,9,17545,Clinical Research Practicum,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2024,FINA,7A40,2,17546,Fixed Income I,Doshi,Hitesh B,2,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8399,11,17547,Doctoral Dissertation,Majumder,Auritro,0,0,0,0,0,1,0,
+Fall 2024,POLC,6312,1,17549,Public Finance,Obregon,Alexander Wade,25,3,0,0,0,0,0,3.858
+Fall 2024,ENGL,8399,12,17551,Doctoral Dissertation,Stock,Lorraine K,0,0,0,0,0,1,0,
+Fall 2024,PHIL,4398,1,17552,Independent Study,Mag Uidhir,Christopher Domh,1,0,0,0,0,0,0,3.67
+Fall 2024,PSYC,6398,17,17553,Independent Studies,Reyes,Denise Lucia,0,0,0,0,0,4,0,
+Fall 2024,ECON,3347,1,17555,Capital Market Economics,Maden,Bitaran Jang,22,32,12,5,4,0,5,2.814
+Fall 2024,BZAN,7320,2,17557,Bus Modeling For Comp Adv,Murray,Michael J,8,2,1,0,0,0,1,3.636
+Fall 2024,HDFS,4325,3,17558,Theory to Practice in HDFS,Jordan,Erica F,18,1,0,0,0,0,0,3.913
+Fall 2024,MUSA,1300,4,17562,Applied Voice,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2024,SCM,7380,2,17567,Analytics & Enterprise Opertns,Murray,Michael J,7,5,0,0,0,0,0,3.583
+Fall 2024,SCM,7390,2,17568,Global Supply Chain Strategy,Smith,Gordon D,1,1,0,0,0,0,0,3.5
+Fall 2024,HRD,6396,1,17571,Internship in Human Res. Dev.,Greer,Tomika,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,7399,1,17574,Masters Thesis,Young,Nancy Beck,1,0,0,0,0,1,0,4.0
+Fall 2024,HIST,6399,1,17575,Masters Thesis,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,6111,3,17576,Graduate Seminar,Glennie,Craig Len,0,0,0,0,0,12,0,
+Fall 2024,FINA,4360,1,17578,International Financial Mgmt,Hitzemann,Steffen,7,16,1,0,0,0,0,3.25
+Fall 2024,PHLS,8199,9,17579,Dissertation,Allan,Blake A,1,0,0,0,0,2,0,4.0
+Fall 2024,FINA,7360,1,17581,International Finance,Hitzemann,Steffen,5,1,0,0,0,0,0,3.668
+Fall 2024,MUSA,8242,4,17583,Doctoral Recital III,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,3399,1,17584,Senior Honors Thesis,Sommers,Tamler S,0,0,0,0,0,0,0,
+Fall 2024,MUSA,8330,1,17586,Doctoral Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2024,CIS,2368,32,17587,Adv Info Systems Development,Peddoju,Suresh Kumar,13,7,4,0,0,0,2,3.32
+Fall 2024,MUSA,1310,4,17594,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3410,2,17596,Applied Piano,Norian,Gary,1,0,0,0,0,0,0,4.0
+Fall 2024,BUSI,3302,4,17600,Connecting Bauer to Business,Belinne,Jamie King,370,41,10,1,0,0,4,3.848
+Fall 2024,ENGL,8399,14,17601,Doctoral Dissertation,Davies,Daniel,0,0,0,0,0,1,0,
+Fall 2024,INDS,4380,1,17607,Design Internship,Wells,Adam C,11,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7699,6,17608,Thesis,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,12,17609,Doctoral Applied Music,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,13,17610,Doctoral Applied Music,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,7141,1,17611,Pharmacological Liter. Review,Bond,Richard A,0,0,0,0,0,13,0,
+Fall 2024,ECON,6693,1,17614,Master's Research Project,Zhivan,Natalia A,0,1,0,0,0,0,0,3.33
+Fall 2024,MATH,1324,8,17615,Finite Math with Applications,Hong,Yuqi,16,30,12,2,10,0,4,2.553
+Fall 2024,MUSA,6324,2,17616,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6306,4,17617,Social Work Practice Skills,White,Tamika Alonzo,25,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,3367,4,17618,Intermediate Accounting I,Kraten,Michael,49,19,8,3,2,0,7,3.334
+Fall 2024,ACCT,7320,2,17620,Intro to Data Analytics-Acct,Erdem,Ozer,21,3,0,0,0,0,0,3.793
+Fall 2024,ARTS,3300,3,17621,Advanced Drawing,Sampy,Chayse Joilen,11,6,3,0,0,0,0,3.301
+Fall 2024,ARTS,2316,4,17622,Fundamentals of Painting,Coulter,Crystal Lennette,16,2,2,0,0,0,0,3.7
+Fall 2024,MUSI,6351,1,17623,Applied Music Pedagogy,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,8296,1,17631,Doctoral Essay,Snyder,John L,0,0,0,0,0,0,0,
+Fall 2024,GEOL,6399,10,17635,Masters Thesis,Voarintsoa,Ny Riavo Gilbertinie,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6141,1,17637,Graduate Recital II,Hester,Timothy E,0,0,0,0,0,0,0,
+Fall 2024,MUSA,1332,1,17646,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6399,2,17648,Masters Thesis,Rector,Josiah John,0,0,0,0,0,1,0,
+Fall 2024,COSC,6398,132,17650,Special Problems,Yan,Feng,0,0,0,0,0,2,0,
+Fall 2024,COSC,8398,132,17653,Doctoral Research,Yan,Feng,0,0,0,0,0,2,0,
+Fall 2024,COSC,8698,132,17655,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Fall 2024,COSC,8998,132,17657,Doctoral Research,Yan,Feng,0,0,0,0,0,1,0,
+Fall 2024,ARTS,3301,2,17660,Life Drawing,Souvorova,Daria,14,4,1,0,0,0,1,3.615
+Fall 2024,MUSA,8320,14,17664,Doctoral Applied Music,Hughes,Mark Alan,0,0,0,0,0,0,0,
+Fall 2024,ARCH,3314,1,17674,Topics in Design Technology,Kyropoulou,Amygdalia,8,0,0,0,0,0,0,3.918
+Fall 2024,GHL,6172,1,17687,Mgmt Training Work Exp Prog I,Shepherd,Ashley,4,1,0,0,1,0,0,3.167
+Fall 2024,ANTH,4331,1,17688,Medical Anthropology,Ghazali,Marwa,20,1,0,0,0,0,1,3.968
+Fall 2024,ANTH,6322,1,17689,Seminar in Medical Anth,Ghazali,Marwa,5,0,0,0,0,0,0,4.0
+Fall 2024,ENTR,7336,2,17690,Entrepreneurship Overview,Wilbur,Stephen,12,2,0,0,0,0,0,3.763
+Fall 2024,PETR,3363,1,17691,Fluid Mechanics for PETR Engr,Qin,Guan,4,2,3,0,0,0,0,3.111
+Fall 2024,ARTS,3313,3,17698,Silkscreen,Bender,Hannah,12,1,0,0,0,0,0,3.898
+Fall 2024,MUSA,8320,28,17699,Doctoral Applied Music,Sonnenberg,Melanie,2,0,0,0,0,0,0,4.0
+Fall 2024,DIGM,4398,1,17700,Independent Study,Liao,Tony Chung-Li,5,0,0,0,0,0,0,4.0
+Fall 2024,MIS,6A41,3,17701,Information Systems,Silva,Leiser O,15,1,0,0,0,0,0,3.917
+Fall 2024,CIS,2337,31,17704,Fund of Information Security,Lee,Kyu In,73,50,13,0,1,0,2,3.385
+Fall 2024,CNST,3205,2,17705,Construction Safety Management,Hart,Lee J,19,2,0,0,0,0,0,3.905
+Fall 2024,SCM,3301,3,17715,SCM Fundamentals,Anderson Fletcher,Elizabeth,16,5,0,0,0,0,0,3.809
+Fall 2024,SCM,3301,4,17716,SCM Fundamentals,Anderson Fletcher,Elizabeth,16,3,1,0,0,0,0,3.684
+Fall 2024,PCEU,7142,1,17717,Pharmaceutic Literature Review,Bond,Richard A,0,0,0,0,0,3,0,
+Fall 2024,CIVE,3331,2,17719,Environmental Engineering,Saladi,Krishna Rishi Vijay,22,56,16,0,1,0,0,2.976
+Fall 2024,INDE,6372,2,17720,Advanced Linear Optimization,Diaz Martinez,Neil Orlando,7,30,2,0,1,0,1,3.058
+Fall 2024,CIVE,3337,2,17721,Structural Analysis,Phatak,Tejasree Mohan,9,18,10,0,0,0,0,2.973
+Fall 2024,CIVE,3339,3,17722,Geotechnical Engineering,Phatak,Tejasree Mohan,13,13,10,0,0,0,0,3.074
+Fall 2024,ECE,3317,3,17725,Applied Electromagnetic Waves,Chen,Jiefu,41,35,17,0,1,0,0,3.195
+Fall 2024,MECE,3369,2,17728,Solid Mechanics,Baxevanis,Theocharis,7,26,23,4,0,0,0,2.595
+Fall 2024,ECE,2201,7,17729,Circuit Analysis I,Ramachandran,Deepa,65,30,16,1,2,0,0,3.313
+Fall 2024,ANTH,4398,1,17733,Independent Study,Hannaford,Dinah Rebecca,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8398,21,17735,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2024,MECE,8298,1,17736,Doctoral Research,Song,Gangbing,0,0,0,0,0,5,0,
+Fall 2024,EDS,6333,1,17738,Probability and Statistics,Nwosu,Lucy,50,20,1,0,1,0,0,3.639
+Fall 2024,EDS,6342,1,17739,Intro to Machine Learning,Jegdic,Katarina Svetislav,17,24,10,4,0,0,0,2.982
+Fall 2024,MUSA,6430,1,17740,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,28,17741,Doctoral Dissertation,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,3321,6,17742,Engineering Mathematics,West,James David,141,55,39,17,24,0,0,2.983
+Fall 2024,MATH,3363,6,17743,Introduction To PDE,Morgan,Jeffrey,28,29,10,1,0,0,0,3.255
+Fall 2024,MECE,8298,40,17746,Doctoral Research,Cescon,Marzia,0,0,0,0,0,3,0,
+Fall 2024,COMD,7392,6,17747,Adv Pract Sp & Lang Dis,Guerra,Teresa Evangelina,5,0,0,0,0,0,0,3.736
+Fall 2024,COMD,7392,7,17748,Adv Pract Sp & Lang Dis,Oicata de Torres,Nancy,4,1,0,0,0,0,0,3.668
+Fall 2024,MUSA,2350,2,17751,Applied Percussion,Wilkins,Blake M,1,0,0,0,0,0,0,3.67
+Fall 2024,MIS,3376,4,17753,Busn Appls Database Mgmt I,Jiang,Lianlian,52,6,1,0,0,0,1,3.887
+Fall 2024,CIS,6321,40,17755,Principles of Cybersecurity,Lee,Kyu In,18,4,0,0,0,0,0,3.833
+Fall 2024,CHEM,1112,25,17756,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,17,1,0,0,0,0,3.182
+Fall 2024,CHEM,1112,26,17757,Fundamentals of Chm Lab,Zaitsev,Vladimir G,8,9,2,0,0,0,1,3.229
+Fall 2024,MUSA,1320,1,17761,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2024,CIS,6325,40,17762,Network Security,Banerjee,Tania,20,1,0,0,0,0,0,3.921
+Fall 2024,MATH,8999,1,17765,Doctoral Dissertation,Azencott,Robert Guy,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,2425,3,17766,Computer Org & Architecture,Johnsson,Lennart,28,51,10,1,1,0,28,3.103
+Fall 2024,COSC,2425,5,17768,Computer Org & Architecture,Mantini,Pranav,72,32,10,3,2,0,11,3.398
+Fall 2024,COSC,2425,801,17770,Computer Org & Architecture,Long,Kevin B,24,27,22,0,2,0,4,2.947
+Fall 2024,PCOL,6198,7,17772,Special Problems,Zhang,Yang,0,0,0,0,0,3,0,
+Fall 2024,TEPM,6301,40,17773,Project Management Principles,Sherman,Dennis Louis,16,6,1,0,0,0,0,3.667
+Fall 2024,TEPM,6302,40,17774,Leadership and Team Building,Hopkins,Ronald K,6,0,0,0,0,0,0,3.945
+Fall 2024,TEPM,6304,40,17775,Quality Improvemnt in Proj Mgt,Kovach,Jamison,5,0,0,0,0,0,1,4.0
+Fall 2024,MATH,1324,9,17781,Finite Math with Applications,Caglar,Atife,204,154,54,44,38,0,46,2.829
+Fall 2024,BIOE,8198,2,17782,Doctoral Research,Larin,Kirill,0,0,0,0,0,2,0,
+Fall 2024,PHOP,6767,6,17791,Research Practicum A,Yoon,Geunyoung,1,0,0,0,0,0,0,3.67
+Fall 2024,OPTO,5198,8,17798,Spec Prob - Clerkship,Berntsen,David A,0,0,0,0,0,24,0,
+Fall 2024,CIVE,8298,2,17800,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Fall 2024,CIVE,8498,2,17801,Doctoral Research,Li,Hongyi,0,0,0,0,0,4,0,
+Fall 2024,FORE,6311,40,17802,Introduction to Foresight,Rush,Julie,20,1,0,0,0,0,0,3.89
+Fall 2024,FORE,6331,40,17803,Social Change,Mudge,James Thomas,5,2,0,1,0,0,2,3.293
+Fall 2024,FORE,6351,40,17805,Futures Research,Cowart,Adam David,10,0,0,0,0,0,2,3.967
+Fall 2024,MARK,6A61,6,17806,Marketing Administration,Krishnamurthy,Parthasarathy,17,2,0,0,0,0,0,3.877
+Fall 2024,ENGL,1301,154,17807,First Year Writing I,Worley,Sharon J,11,12,0,0,1,0,1,3.32
+Fall 2024,ENGL,1301,155,17808,First Year Writing I,Worley,Sharon J,19,3,1,1,0,0,1,3.46
+Fall 2024,ENGL,1301,156,17809,First Year Writing I,Worley,Sharon J,11,6,1,1,1,0,5,3.234
+Fall 2024,ENGL,1301,157,17810,First Year Writing I,Bass,Kasey Dawn,14,3,5,0,1,0,2,3.218
+Fall 2024,ENGL,1301,158,17811,First Year Writing I,Presswood,Phillip Hilliard,23,0,0,0,1,0,0,3.82
+Fall 2024,ENGL,1301,159,17812,First Year Writing I,Presswood,Phillip Hilliard,20,0,3,0,2,0,0,3.414
+Fall 2024,ENGL,1301,160,17813,First Year Writing I,Pogue,Donovan A,5,4,8,2,2,0,2,2.365
+Fall 2024,ENGL,1301,161,17815,First Year Writing I,Lee,Nathanael D,17,3,2,0,2,0,0,3.306
+Fall 2024,ENGL,1301,162,17816,First Year Writing I,Ahern,John Michael,13,2,2,0,2,0,0,3.107
+Fall 2024,ENGL,1301,163,17817,First Year Writing I,Soullier,Anastasia Constance,4,9,6,1,4,0,1,2.347
+Fall 2024,ENGL,1302,62,17819,First Year Writing II,Sahi,Aishwarya,4,4,3,1,4,0,3,2.208
+Fall 2024,ENGL,1302,63,17820,First Year Writing II,Sahi,Aishwarya,8,7,1,1,0,0,2,3.197
+Fall 2024,PCOL,6298,3,17833,Special Problems,Wu,Mingfu,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,6198,4,17834,Special Problems,Wu,Mingfu,0,1,1,0,0,0,0,2.5
+Fall 2024,PSYC,7399,8,17836,Masters Thesis,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7399,12,17837,Masters Thesis,Reyes,Denise Lucia,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,1112,27,17838,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,3,0,0,0,1,3.069
+Fall 2024,SCM,4362,2,17840,Demand and Supply Integration,Khumawala,Basheer M,26,15,9,0,0,0,0,3.3
+Fall 2024,ENGL,8698,13,17842,Graduate Research,Tejada,Roberto Jose,0,0,0,0,0,2,0,
+Fall 2024,BTEC,6101,40,17844,Biotechnology Techniques Metho,Ibrahim,Eman Refaat,2,0,0,0,0,0,0,3.835
+Fall 2024,HIST,1302,51,17845,The U.S. Since 1877,Vale,Timothy Eli,23,1,0,0,1,0,0,3.8
+Fall 2024,TLIM,3363,33,17854,Technical Communications,Bracken II,William Terry,35,0,0,0,1,0,0,3.871
+Fall 2024,TLIM,3363,23,17855,Technical Communications,Piercy,Penelope Junker,17,8,9,1,0,0,0,3.096
+Fall 2024,EDS,6340,1,17856,Introduction to Data Science,Loganantharaj,Rasiah,61,13,0,0,0,0,0,3.882
+Fall 2024,CIVE,8298,4,17858,Doctoral Research,Lee,Hyongki,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8498,4,17859,Doctoral Research,Lee,Hyongki,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8398,5,17860,Doctoral Research,Lee,Hyongki,0,0,0,0,0,3,0,
+Fall 2024,BIOE,4350,2,17863,Genomic & Proteomic Engr,Wu,Tianfu,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8698,16,17864,Doctoral Research,Wang,Guoquan,0,0,0,0,0,0,0,
+Fall 2024,GEOL,8698,17,17865,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8298,5,17866,Doctoral Research,Glennie,Craig Len,0,0,0,0,0,3,0,
+Fall 2024,CIVE,8298,6,17867,Doctoral Research,Shaffer,Devin,0,0,0,0,0,1,0,
+Fall 2024,ECE,7399,6,17870,Masters Thesis,Mayerich,David Matthew,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,164,17872,First Year Writing I,Penzien,Eugene Norman,14,4,1,2,2,0,2,3.087
+Fall 2024,CIVE,8398,6,17873,Doctoral Research,Mo,Larry Yi-Lung,0,0,0,0,0,2,0,
+Fall 2024,GEOL,8398,21,17877,Doctoral Research,Wang,Guoquan,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8698,18,17878,Doctoral Research,Wang,Yuxuan,0,0,0,0,0,2,0,
+Fall 2024,COSC,6308,3,17880,Computer Architecture,Johnsson,Lennart,1,0,0,0,0,0,0,4.0
+Fall 2024,POLS,8999,12,17883,Doctoral Dissertation,Tiede,Lydia B,0,0,0,0,0,1,0,
+Fall 2024,ENGL,1301,166,17886,First Year Writing I,Story,Anna Elizabeth,9,4,4,2,0,0,0,2.948
+Fall 2024,ENGL,1301,167,17887,First Year Writing I,Ahern,John Michael,19,0,0,0,0,0,0,3.948
+Fall 2024,ENGL,1301,169,17888,First Year Writing I,Bass,Kasey Dawn,14,2,0,0,4,0,3,3.067
+Fall 2024,ENGL,1301,170,17889,First Year Writing I,Story,Anna Elizabeth,15,2,1,0,1,0,0,3.562
+Fall 2024,ENGL,1301,171,17890,First Year Writing I,Pogue,Donovan A,20,1,1,1,0,0,2,3.739
+Fall 2024,ENGL,1301,172,17891,First Year Writing I,Wei,Weixiao,10,4,0,1,1,0,3,3.189
+Fall 2024,ENGL,1301,173,17892,First Year Writing I,Wei,Weixiao,13,2,1,1,1,0,0,3.297
+Fall 2024,ENGL,1301,174,17893,First Year Writing I,Cervantes,Kimberly Ann,13,5,0,1,0,0,0,3.509
+Fall 2024,ENGL,1301,175,17894,First Year Writing I,Bernardi,Muriel,16,6,1,1,0,0,0,3.487
+Fall 2024,ENGL,1301,176,17895,First Year Writing I,Bernardi,Muriel,17,3,2,1,1,0,1,3.389
+Fall 2024,ENGL,1301,177,17896,First Year Writing I,Shepley,Nathan,15,10,0,0,0,0,0,3.494
+Fall 2024,ENGL,1302,66,17897,First Year Writing II,Hiers,Maria,22,0,0,2,0,0,0,3.723
+Fall 2024,ENGL,1302,67,17898,First Year Writing II,Coleman,Quintin,11,9,0,0,5,0,0,2.774
+Fall 2024,TECH,4310,1,17900,Future of Energy & Environment,Breaux,James William,38,0,0,0,1,0,1,3.889
+Fall 2024,ENGL,7699,7,17903,Thesis,Turchi,Peter D,0,0,0,0,0,0,0,
+Fall 2024,GEOL,8698,19,17905,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2024,PSYC,8399,29,17906,Doctoral Dissertation,Reyes,Denise Lucia,1,0,0,0,0,2,0,4.0
+Fall 2024,MECE,6399,5,17907,Masters Thesis,Grigoriadis,Karolos,0,0,0,0,0,1,0,
+Fall 2024,CIS,6325,20,17909,Network Security,Banerjee,Tania,75,0,0,0,1,0,1,3.917
+Fall 2024,PSYC,6398,21,17910,Independent Studies,Francis,David J,0,1,0,0,0,0,0,3.0
+Fall 2024,MECE,8598,1,17911,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Fall 2024,MECE,8699,1,17912,Doctoral Dissertation,Cescon,Marzia,0,0,0,0,0,2,0,
+Fall 2024,ENGL,8399,15,17913,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,2,0,
+Fall 2024,AAS,2320,7,17914,Intro To African American Stdy,Shakir,Ameenah,20,14,2,0,0,0,0,3.463
+Fall 2024,ENGL,8399,16,17915,Doctoral Dissertation,Lee,Eunjeong,0,0,0,0,0,1,0,
+Fall 2024,ENGL,7398,7,17916,Special Problems,Turchi,Peter D,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8598,2,17917,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,2,0,
+Fall 2024,OPTO,5198,11,17919,Spec Prob - Clerkship,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6410,1,17921,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8298,2,17922,Doctoral Research,Floryan,Daniel,0,0,0,0,0,2,0,
+Fall 2024,HLT,4320,3,17928,Admin of Health Services,Haq,Arooba A,35,5,1,0,0,0,1,3.741
+Fall 2024,PHCA,8698,1,17929,Doctoral Dissertation Research,Thornton,James D,2,0,0,0,0,0,0,4.0
+Fall 2024,INTB,3355,5,17930,Global Environment of Business,Carvalho,Emilia Barreto,132,91,13,5,3,0,4,3.385
+Fall 2024,CIVE,8298,7,17931,Doctoral Research,Louie,Stacey M,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8398,7,17933,Doctoral Research,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Fall 2024,SCM,4302,1,17935,Energy Supply Chain,Kamal,Saiyid Zafar,42,32,3,1,0,0,0,3.432
+Fall 2024,PSYC,8699,2,17940,Doctoral Dissertation,Neighbors,Clayton T,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8198,3,17943,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8398,8,17946,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8298,8,17947,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8498,7,17948,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Fall 2024,CIS,2336,33,17949,Web Application Development,Wu,Xuqing,36,17,7,0,3,0,1,3.26
+Fall 2024,ELET,1400,1,17950,Circuit Theory and Lab I,Lin,Qin,7,12,15,6,4,0,3,2.355
+Fall 2024,GEOL,8998,30,17953,Doctoral Research,Copeland,Peter,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8398,9,17956,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,2,0,
+Fall 2024,CNST,4302,30,17958,Construction Law and Ethics,Escobar,C Mauricio,19,11,2,0,0,0,0,3.459
+Fall 2024,MECE,8298,10,17959,Doctoral Research,Zhao,Bo,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8398,10,17960,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,3,0,
+Fall 2024,MUSA,8243,5,17961,Doctoral Lecture Recital,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,7399,14,17963,Masters Thesis,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,6398,6,17964,Special Problems,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8598,10,17965,Doctoral Research,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2024,PSYC,7399,15,17966,Masters Thesis,Alfano,Candice A,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8298,41,17967,Doctoral Research,Chen,Tian,0,0,0,0,0,0,0,
+Fall 2024,CIVE,8398,11,17968,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,3,0,
+Fall 2024,ECE,2100,3,17976,Circuit Analysis Laboratory,Meh Chu,Chu,21,2,0,0,0,0,0,3.884
+Fall 2024,GEOL,6399,13,17977,Masters Thesis,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8399,2,17978,Doctoral Dissertation,Glennie,Craig Len,0,0,0,0,0,3,0,
+Fall 2024,PEP,8699,5,17979,Doctoral Dissertation,Hawkins,Billy J,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8220,6,17984,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6399,3,17985,Masters Thesis,Reed,Linda,0,0,0,0,0,1,0,
+Fall 2024,PSYC,8999,2,17987,Doctoral Dissertation,Alfano,Candice A,0,0,0,0,0,0,0,
+Fall 2024,INDE,8398,7,17990,Doctoral Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2024,DRAM,1310,4,17995,Introduction to Theatre,Young,Courtney Leigh,43,3,1,0,0,0,0,3.866
+Fall 2024,MARK,7A43,2,17999,Digital and Inside Sales,Herman,Carl,8,0,0,0,0,0,0,3.959
+Fall 2024,MARK,7A44,2,18000,Customer Relationship Mgt,Herman,Carl,7,0,0,0,0,0,0,3.953
+Fall 2024,HIST,8399,6,18006,Doctoral Dissertation,Romero,Todd,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8999,7,18008,Doctoral Dissertation,Clavin,Matthew J,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8399,3,18018,Doctoral Dissertation,Wang,Keh-Han,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8396,3,18024,Doctoral Research,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2024,MECE,8698,1,18025,Doctoral Research,Liu,Dong,0,0,0,0,0,1,0,
+Fall 2024,MECE,7399,11,18027,Masters Thesis,Wang,Su Su,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8398,13,18029,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Fall 2024,COMD,7391,12,18031,Clinic in Speech Lang Disorder,Chapman,Amanda,0,1,0,0,0,0,0,3.33
+Fall 2024,COMD,7392,8,18032,Adv Pract Sp & Lang Dis,Townsend,Alayna,4,1,0,0,0,0,0,3.734
+Fall 2024,COMD,7392,9,18033,Adv Pract Sp & Lang Dis,Guerra,Teresa Evangelina,3,0,0,0,0,0,0,3.89
+Fall 2024,COMD,7392,10,18034,Adv Pract Sp & Lang Dis,Walker,Dionne A,3,1,0,0,0,0,0,3.833
+Fall 2024,CIVE,8298,10,18035,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Fall 2024,CIVE,8498,8,18036,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,4,0,
+Fall 2024,FINA,8398,4,18046,Special Problems,Yerramilli,Vijay,0,1,0,0,0,0,0,3.33
+Fall 2024,ECE,8398,33,18053,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8398,14,18054,Doctoral Research,Zhang,Ruda,0,0,0,0,0,2,0,
+Fall 2024,PSYC,7399,17,18055,Masters Thesis,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8399,7,18056,Doctoral Dissertation,Carales,Vincent D,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8298,11,18057,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,0,1,
+Fall 2024,CIVE,8498,9,18058,Doctoral Research,Rifai,Hanadi S,0,0,0,0,0,0,1,
+Fall 2024,FINA,7354,1,18061,Financial Econometrics,Susmel,Raul,3,0,0,0,0,0,1,4.0
+Fall 2024,FINA,7354,2,18062,Financial Econometrics,Susmel,Raul,1,0,0,0,1,0,0,2.0
+Fall 2024,DIGM,4398,2,18065,Independent Study,Liao,Pamara F,4,0,0,0,0,0,0,4.0
+Fall 2024,INDE,8598,7,18071,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,4,0,
+Fall 2024,MUSI,8296,2,18072,Doctoral Essay,Dirst,Matthew C,0,0,0,0,0,0,0,
+Fall 2024,MUSA,8320,32,18073,Doctoral Applied Music,Belcher,Daniel,2,0,0,0,0,0,0,4.0
+Fall 2024,INDE,8398,8,18074,Doctoral Research,Lim,Gino Jinho,0,0,0,0,0,3,0,
+Fall 2024,COSC,8298,122,18078,Doctoral Research,Pavlidis,Ioannis T,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8298,12,18081,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6424,2,18088,Applied Violoncello,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,8998,5,18089,Doctoral Research,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6100,4,18096,Chamber Music,Hester,Timothy E,14,0,0,0,0,0,0,3.953
+Fall 2024,ENTR,6398,1,18100,Research,Gonzalez,Liana,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8243,6,18101,Doctoral Lecture Recital,Pollack,Howard J,1,0,0,0,0,0,0,4.0
+Fall 2024,DRAM,1310,21,18106,Introduction to Theatre,Egging,Jon Leo,30,6,3,3,3,0,0,3.296
+Fall 2024,GEOL,8398,27,18114,Doctoral Research,Murphy,Michael,0,0,0,0,0,1,0,
+Fall 2024,ECON,3365,1,18128,Labor Economics,Hossain,Md Shahadath,22,32,11,0,1,0,1,3.066
+Fall 2024,ECON,3362,1,18129,Mathematics for Economics,Wang,Fan,7,10,5,0,0,0,4,3.076
+Fall 2024,GEOL,1104,2,18130,Historical Geology Lab,Hauptvogel,Daniel William,11,1,2,0,0,0,1,3.596
+Fall 2024,GEOL,1302,2,18131,Intro To Global Climate Change,Choi,Yunsoo,336,125,12,11,0,0,9,3.568
+Fall 2024,GEOL,6378,1,18155,Basin Analysis for Petrol Expl,Mann,Paul,2,5,0,0,0,0,0,3.191
+Fall 2024,FINA,4376,1,18157,Energy Trading Systems,Pena,Juan F,93,30,4,0,2,0,0,3.677
+Fall 2024,PUBL,6325,1,18158,Public Administration Capstone,Koelling,Peter,2,0,0,0,0,0,0,4.0
+Fall 2024,BZAN,6360,1,18160,Capstone Practicum in BZAN I,Abbott,Jeanna L,3,1,1,0,0,0,0,3.4
+Fall 2024,BZAN,6361,1,18161,Capstone Practicum in BZAN II,Abbott,Jeanna L,8,0,0,0,0,0,0,4.0
+Fall 2024,ECON,3334,5,18163,Intermediate Macroeconomics,Troncoso,Pablo A,13,14,7,3,0,0,4,2.973
+Fall 2024,MATH,2305,1,18171,Discrete Mathematics,Winkle,James J,2,17,32,14,7,0,8,1.962
+Fall 2024,MATH,1314,7,18172,College Algebra,Hafeez,Shahinda,80,48,77,29,27,0,36,2.413
+Fall 2024,MATH,2318,7,18173,Linear Algebra,Vershynina,Anna,6,5,4,1,2,0,7,2.557
+Fall 2024,ELCS,6370,3,18178,Research for Educatnal Leaders,Johnson,Detra DeVerne,18,0,0,0,0,0,0,3.982
+Fall 2024,MANA,7359,1,18186,Diversity Equity & Inc Strat,Avery,Derek Reynold,8,4,0,0,0,0,0,3.612
+Fall 2024,PHIL,3388,1,18189,Hist of 20Th Cent Phi,Morrison,Iain P D,6,9,1,0,1,0,1,3.04
+Fall 2024,PHIL,3335,1,18190,Theory of Knowledge,Vesga Plazas,Alejandro Jose,14,10,1,0,2,0,2,3.161
+Fall 2024,MIS,7375,2,18197,Transaction Processing Systems,Messinger,Jacob Nelson,10,5,0,0,0,0,0,3.601
+Fall 2024,POLC,6391,1,18198,Public Policy Internship,Bronk,Robert C,1,0,0,0,0,0,0,4.0
+Fall 2024,IDNS,2136,1,18199,Data Structures SEP Workshop,Pattison,Donna,20,4,4,1,1,0,1,3.356
+Fall 2024,POLC,4390,1,18201,Public Policy Internship,Cross,Renee Danielle,20,2,1,0,0,0,1,3.683
+Fall 2024,BCHS,4361,1,18202,Clinical Biochemistry,Bawa-Khalfe,Tasneem,23,14,5,3,0,0,2,3.355
+Fall 2024,BIOL,6301,1,18205,Conservation Biology,Crawford,Kerri M,1,0,0,0,0,0,0,4.0
+Fall 2024,POLC,4325,1,18206,Adv Policy Research Methods,Atsusaka,Yuki,4,1,2,0,2,0,1,2.556
+Fall 2024,MARK,3336,5,18207,Introduction to Marketing,Kraemer,Martin,44,23,7,2,0,0,2,3.426
+Fall 2024,MIS,3376,1,18209,Busn Appls Database Mgmt I,Scamell,Richard W,16,18,10,0,0,0,1,3.106
+Fall 2024,BIOL,4301,1,18210,Conservation Biology,Crawford,Kerri M,25,6,1,0,0,0,2,3.75
+Fall 2024,PEP,8350,1,18212,HHP Candidacy Project Research,Layne,Charles S,6,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,3367,5,18215,Intermediate Accounting I,Kraten,Michael,26,34,7,2,0,0,1,3.208
+Fall 2024,MATH,5331,1,18216,Linear Algebra W/ Applications,Etgen,Garret J,8,8,0,0,0,0,1,3.5
+Fall 2024,CUIN,4361,2,18217,Second Language Methodology,Burgess,Miguel,24,1,0,0,0,0,0,3.947
+Fall 2024,MATH,6374,1,18218,Num Part Diff Equations,Cappanera,Loic,11,1,0,0,0,0,0,3.917
+Fall 2024,CUIN,3345,1,18219,Writing & Grammar Tch English,Ortiz,Elizabeth Carter,8,1,1,1,0,0,0,3.485
+Fall 2024,CUIN,4349,1,18220,Teaching Geometry and Algebra,Chauvot,Jennifer B,20,3,0,0,0,0,0,3.841
+Fall 2024,CHEE,8598,22,18230,Doctoral Research,Wen,Mingjian,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8399,22,18231,Doctoral Dissertation,Wen,Mingjian,0,0,0,0,0,1,0,
+Fall 2024,SCLT,3381,33,18232,Industrial and Consumer Sales,Cassler,Daniel,4,2,2,0,0,0,0,3.044
+Fall 2024,AAS,3375,1,18233,Black Women in the U.S.,Shakir,Ameenah,6,6,2,0,2,0,3,2.875
+Fall 2024,SCLT,2362,34,18234,Intro To Logistics Technology,Cassler,Daniel,11,25,5,4,0,0,1,2.904
+Fall 2024,SOCW,7356,6,18235,Groups: Adv Clinical Practice,Lucas,Virginia,23,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7356,7,18236,Groups: Adv Clinical Practice,Carter,Cynthia J,19,1,0,0,0,0,0,3.95
+Fall 2024,SOCW,7356,8,18237,Groups: Adv Clinical Practice,Carter,Cynthia J,17,3,0,0,1,0,0,3.667
+Fall 2024,MATH,6326,1,18238,Partial Diff Equations,Jaramillo,Gabriela T,8,0,0,0,0,0,1,3.959
+Fall 2024,ARCH,4510,23,18241,Integrated Arch Solutions,Ayala,Jose Luis,16,2,0,0,0,0,0,3.742
+Fall 2024,PSYC,3347,2,18243,Problems of Normal Life,Anderson,Jill Annette,35,18,2,0,0,0,0,3.558
+Fall 2024,PHIL,1361,6,18244,Philosophy and the Arts,Mag Uidhir,Christopher Domh,118,63,38,11,15,0,13,3.038
+Fall 2024,NUTR,6304,1,18245,Adv Nutr Counseling & Educ,Ledoux,Tracey A,19,6,0,0,0,0,0,3.615
+Fall 2024,CIS,3330,30,18250,Info Systems in Organizations,Detillier,Bret James,7,38,18,2,0,0,1,2.688
+Fall 2024,PUBL,6312,1,18251,Public Finance,Obregon,Alexander Wade,6,0,0,0,0,0,0,4.0
+Fall 2024,JAPN,2311,1,18253,Intermediate Japanese I,Ji,Fang,21,1,0,0,0,0,0,3.865
+Fall 2024,KORE,1501,1,18254,Beginning Korean I,Back,Eunkyung Lee,14,7,0,0,0,0,1,3.667
+Fall 2024,KORE,1501,3,18256,Beginning Korean I,Back,Eunkyung Lee,17,2,3,1,1,0,3,3.32
+Fall 2024,CHEM,6314,1,18258,Spectroscopy,Baldelli,Steve,1,4,0,0,0,0,0,3.2
+Fall 2024,CHEM,6333,1,18259,Fund-Chemical Analysis,Baldelli,Steve,2,4,0,0,0,0,0,3.278
+Fall 2024,CHEM,6377,1,18260,Solid State Chemistry,Bocarsly,Joshua David,6,5,0,0,0,0,0,3.635
+Fall 2024,KORE,2311,1,18261,Intermediate Korean I,Back,Eunkyung Lee,3,3,2,0,0,0,0,3.249
+Fall 2024,ENGL,1370,14,18265,Composition II-Honors,Vollrath,Lesli A,1,0,0,0,0,0,1,4.0
+Fall 2024,ENGL,1370,15,18266,Composition II-Honors,Werner,Andrew Timothy,6,2,0,0,0,0,0,3.668
+Fall 2024,ENGL,1370,16,18267,Composition II-Honors,Werner,Andrew Timothy,2,2,0,0,0,0,0,3.418
+Fall 2024,ENRG,3310,2,18268,Intro to Energy & Sustainblty,Jacobsen,Nicolas Fisher,22,2,0,0,0,0,0,3.875
+Fall 2024,CNST,2360,2,18269,Communication in Construction,Escobar,C Mauricio,21,8,3,2,0,0,1,3.402
+Fall 2024,POLS,3310,2,18273,Intro to Political Theory,Cheng,Eric,30,11,1,0,0,0,2,3.612
+Fall 2024,HON,3308,1,18274,Lyric Medicine,Lambeth,Laurie Regine Clements,15,3,0,0,0,0,0,3.833
+Fall 2024,TECH,1301,3,18275,Intro to Data Analytics Tools,Thornton,Brandon Latroy,19,3,0,0,0,0,2,3.864
+Fall 2024,SOC,3390,2,18276,Sociology of Gender,Haltom,Trenton Matthews,29,7,4,3,2,0,0,3.274
+Fall 2024,SOC,3357,1,18277,Urban Sociology,Brailey,Carla,34,7,1,0,2,0,4,3.621
+Fall 2024,SOC,3314,1,18278,Juvenille Delinquency,Gallo,Joseph Ralph,35,8,1,4,0,0,0,3.542
+Fall 2024,FREN,3364,1,18280,Writing Holocausts,Glass,Hildegard,1,2,1,0,1,0,0,2.466
+Fall 2024,TMTH,3360,5,18284,Applied Technical Statistics,Telles,John E,26,12,5,0,0,0,3,3.519
+Fall 2024,ARCH,1500,15,18285,Design Studio I,Lee,Seo Hee,3,5,3,1,0,0,2,2.888
+Fall 2024,SOC,3300,4,18287,Intro to Sociological Theory,Grigorian,Stella,17,15,7,1,0,0,0,3.151
+Fall 2024,ARCH,1500,21,18288,Design Studio I,Smith,Joshua S,10,5,0,0,1,0,0,3.458
+Fall 2024,SOC,3300,5,18289,Intro to Sociological Theory,Grigorian,Stella,14,9,3,1,0,0,2,3.272
+Fall 2024,SOC,3335,1,18291,Sociology of Punishment,Adams,Jennifer Lauren,37,6,3,1,0,0,1,3.667
+Fall 2024,SOC,3336,1,18292,Aggression and Violence,Colbert,Sharla Stettnisch,32,11,2,1,1,0,2,3.539
+Fall 2024,POPH,2300,1,18293,Intro to Population Health,Bruce,Marino A,8,9,1,0,1,0,1,3.263
+Fall 2024,SOC,3326,1,18294,Immigration in US Society,Lee,Shayne,33,13,3,0,0,0,0,3.612
+Fall 2024,ARCH,2500,37,18295,Arc/Int Arc Design Studio III,Perez Villarreal,Felipe,5,11,1,0,0,0,1,3.235
+Fall 2024,SOC,3350,1,18297,Sociology of the Body,Kwan,Samantha S,16,18,5,1,0,0,0,3.242
+Fall 2024,SOC,3380,1,18298,Intro/Soc Health Care,Monserud,Maria Aleksandrovna,31,13,2,0,1,0,0,3.553
+Fall 2024,GERM,3381,1,18302,German Cinema,Kleinheider,Julia D,8,13,8,0,0,0,3,3.0
+Fall 2024,GERM,3364,1,18303,Writing Holocausts,Glass,Hildegard,3,2,0,0,0,0,0,3.468
+Fall 2024,INDS,7300,1,18304,Design Thesis I,Morshedzadeh,Elham,1,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6303,40,18306,Risk Assessment in Project Mgm,Rypien,David V,1,5,0,0,0,0,0,3.277
+Fall 2024,TEPM,6305,40,18307,Project Manager Tools,Sherman,Dennis Louis,2,2,0,0,0,0,0,3.583
+Fall 2024,TEPM,6306,40,18308,Project Management Office,Rypien,David V,3,3,0,0,0,0,0,3.5
+Fall 2024,TEPM,6307,40,18309,Advanced Project Management,Sherman,Dennis Louis,4,1,0,0,0,0,0,3.8
+Fall 2024,TEPM,6308,40,18310,Project Procurement Practices,Conover,Sharon Cecilia,2,0,0,0,0,0,0,4.0
+Fall 2024,TEPM,6391,40,18311,Project Management Seminar,Carden,Lila L,3,1,0,0,0,0,0,3.833
+Fall 2024,PHYS,6319,1,18312,Advanced Mechanics I,Su,Wu-Pei,3,11,3,1,0,0,2,2.962
+Fall 2024,PHYS,6313,1,18313,Methods of Math Physics I,Weglein,Arthur B,13,5,0,0,0,0,0,3.777
+Fall 2024,CHIN,3343,1,18319,Chinese Popular Culture,Li,Melody Yunzi,15,4,1,1,0,0,0,3.556
+Fall 2024,ARCH,5500,21,18322,Architecture Design Studio IX,Froehlich,Dietmar,12,1,0,0,0,0,0,3.771
+Fall 2024,ARCH,5500,23,18326,Architecture Design Studio IX,Race,Bruce Alan,3,13,1,0,0,0,0,3.254
+Fall 2024,ARCH,7600,15,18330,Architecture Design Studio V,Froehlich,Dietmar,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,2321,2,18334,Study of Early Civilizations,Neumann,Kristina Marie,9,11,11,2,0,0,1,2.758
+Fall 2024,HIST,2327,1,18336,Chicano History to 1910,Patterson,Catherine F,32,0,0,0,0,0,0,3.959
+Fall 2024,HIST,2367,1,18337,History of Mexico,Patterson,Catherine F,38,1,0,0,1,0,1,3.817
+Fall 2024,HIST,2371,1,18338,Latin America 1492-1820,Gharala,Norah Linda Andrews,22,13,2,0,1,0,2,3.369
+Fall 2024,HIST,6300,1,18340,Rdgs in Global History,McNally,David Joseph,13,1,0,0,0,0,0,3.952
+Fall 2024,HIST,4386,1,18342,Africa 1945 To Present,Chery,Tshepo Morongwa,9,18,2,0,3,0,3,2.948
+Fall 2024,HIST,3333,1,18349,Global Health Care History,Chakrabarti,Pratik,12,12,1,0,1,0,0,3.32
+Fall 2024,WCL,2370,1,18353,Cultures of India,Tiwari,Bhavya,10,9,5,1,0,0,11,3.08
+Fall 2024,PSYC,3334,1,18356,Psychology & Law,Capuozzo,Kristen Irene,23,35,6,5,4,0,6,2.954
+Fall 2024,POLS,3309,1,18372,Democratization,Pineda,Paula C,31,6,5,0,1,0,1,3.45
+Fall 2024,ARCH,4324,1,18373,High-Rise Structures,Colaco,Joseph P,2,6,7,0,0,0,0,2.579
+Fall 2024,DIGM,3357,30,18375,Social Media Apps & Analytics,Liao,Pamara F,36,27,4,0,1,0,1,3.373
+Fall 2024,DIGM,4379,20,18376,Transmedia Marketing,Lee,Seo Yoon,27,15,2,0,0,0,0,3.516
+Fall 2024,POLS,3311,2,18379,Intro Compar Politics,Cichock,Mark A,9,16,8,1,6,0,3,2.459
+Fall 2024,SPAN,3373,1,18381,Spanish Culture & Civilization,Gutierrez,Pedro Revuelta,6,7,2,0,1,0,1,3.021
+Fall 2024,SPAN,3386,1,18382,Spanish Culture Through Film,Solino,Maria Elena,26,7,1,0,1,0,0,3.619
+Fall 2024,ARCH,3112,7,18385,Topics in Design Media,Noldt,Peter,9,5,1,0,0,0,0,3.511
+Fall 2024,ARCH,3112,8,18386,Topics in Design Media,Noldt,Peter,9,5,0,0,0,0,0,3.525
+Fall 2024,PHYS,2325,5,18389,University Physics I (lecture),Chen,Xiaojia,16,25,84,1,8,0,21,2.168
+Fall 2024,POLS,4340,1,18395,Intelligence Analysis,Lubotzky,Asher,24,6,1,1,0,0,0,3.605
+Fall 2024,MECE,3336,2,18396,Mechanics II,Kulkarni,Yashashree,7,22,20,1,0,0,4,2.773
+Fall 2024,POLS,3345,1,18402,National Security Law,Abbott Jr,Kenneth Wayne,31,3,0,1,0,0,4,3.725
+Fall 2024,GOVT,2305,1,18403,"US Govt: Congress,Pres & Crts",Abbott Jr,Kenneth Wayne,72,97,47,19,5,0,9,2.857
+Fall 2024,GOVT,2305,6,18404,"US Govt: Congress,Pres & Crts",Cortina,Jeronimo,194,33,8,3,4,0,3,3.687
+Fall 2024,COSC,1336,5,18407,Computer Science & Program,Yun,Changhoon,42,23,13,7,16,0,15,2.611
+Fall 2024,COSC,3337,2,18408,Data Science I,Eick,Christoph F,17,73,22,2,1,0,5,2.904
+Fall 2024,COSC,3380,3,18410,Database Systems,Ramamurthy,Uma,22,30,11,2,5,0,3,2.806
+Fall 2024,COMD,4382,1,18414,Aural Rehabilitation,Andrews,Chereece N,27,7,0,1,0,0,1,3.658
+Fall 2024,GOVT,2306,4,18415,US and Texas Const/Politics,Davis,Jenna,14,54,63,46,39,0,32,1.795
+Fall 2024,GOVT,2306,14,18416,US and Texas Const/Politics,Littlepage,Kelley G,187,40,7,7,3,0,3,3.646
+Fall 2024,GOVT,2305,5,18417,"US Govt: Congress,Pres & Crts",Kistner,Michael,116,80,30,4,5,0,9,3.284
+Fall 2024,LST,3386,1,18418,Criminal Law,Wright,Andrew Alexander,10,19,7,1,0,0,2,3.036
+Fall 2024,BIOL,4324,1,18422,Bioinformatics,Stuckert,Adam,2,8,5,1,0,0,2,2.667
+Fall 2024,LAW,5416,1,18423,Civil Justice Clinic I,Marquez,Ryan Michael,3,9,0,0,0,0,0,3.388
+Fall 2024,PSYC,3338,1,18424,Psychology of Older Adults,Mustafa,Andrea Iman,72,3,2,0,1,0,2,3.829
+Fall 2024,ACCT,4335,5,18428,Financial Statement Auditing,Zhao,Yuping,36,29,5,0,0,0,0,3.405
+Fall 2024,ACCT,5372,3,18430,Intro-Data Analytics in ACCT,Erdem,Ozer,1,1,0,0,0,0,0,3.665
+Fall 2024,SOC,3400,4,18431,Intro To Social Statistics,Hwang,Hyunseok,8,10,2,1,2,0,5,2.97
+Fall 2024,PSYC,2319,7,18436,Intro to Social Psychology,Boada,Cristina Elise,65,8,3,1,2,0,1,3.663
+Fall 2024,ENGL,2315,2,18437,Literature and Film,Sicinski,Michael J,22,2,0,0,0,0,1,3.834
+Fall 2024,ANTH,3306,1,18440,Sex & Culture,Hannaford,Dinah Rebecca,28,5,1,0,1,0,1,3.639
+Fall 2024,SOCW,7367,3,18442,Social Policy Analysis,Byers,Katherine Howard,17,4,2,0,0,0,1,3.652
+Fall 2024,ENGL,4311,1,18444,Language Socialization,Zentz,Lauren R,10,2,2,0,2,0,1,3.146
+Fall 2024,SOCW,7302,1,18445,SW in Health Care Settings,Charles,Janea Nicole Adams,27,1,0,0,0,0,0,3.964
+Fall 2024,ENGL,4387,1,18446,SR Writing Proj CW: Fiction,Divakaruni,Chitra B,9,4,1,0,0,0,0,3.548
+Fall 2024,SOCW,7309,1,18447,Contemporary Issues in MH,Ross,Tiffany Monique,19,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,5372,1,18449,Intro-Data Analytics in ACCT,Erdem,Ozer,0,1,0,0,0,0,0,3.33
+Fall 2024,ENGL,8323,1,18451,Master Workshop: Narrative,Parsons,Alexander M,4,0,0,0,0,0,0,4.0
+Fall 2024,POLS,3319,1,18459,Politics of Social Policy,Shor,Boris,11,7,6,4,0,0,3,2.775
+Fall 2024,SOCI,1301,17,18460,Introduction To Sociology,Cooper,Chelsey Wells,45,9,3,0,0,0,2,3.748
+Fall 2024,BTEC,4350,30,18461,Biotechnology Capstone II,Khan,Abdul Latif,28,2,0,0,0,0,0,3.856
+Fall 2024,ARAB,1501,1,18464,Beginning Arabic I,Hefter,Thomas H,1,5,0,0,0,0,6,3.112
+Fall 2024,ARAB,1501,3,18466,Beginning Arabic I,Hefter,Thomas H,5,7,5,2,0,0,5,2.911
+Fall 2024,HRD,4396,20,18469,Internship in HRD,Polesello,Daiane,13,8,0,0,1,0,0,3.41
+Fall 2024,HRD,3340,1,18472,Principles of HRD,Hattier,Beth,33,11,2,0,1,0,3,3.533
+Fall 2024,GHL,1337,3,18476,Intro To Hospitality Industry,Barth,Stephen C,38,11,3,1,0,0,2,3.573
+Fall 2024,GHL,3155,1,18477,Event Planning,Haskell,Rebecca Erin,18,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,7320,3,18480,Intro to Data Analytics-Acct,Erdem,Ozer,13,3,0,0,0,0,0,3.689
+Fall 2024,ACCT,7360,2,18481,Partnership Taxation,King,Sheldon,4,1,0,0,0,0,0,3.734
+Fall 2024,ACCT,7373,2,18483,Data Analytics Tools Acct,Miles,Carolyn A,2,6,0,0,0,0,0,3.333
+Fall 2024,ACCT,7374,1,18484,Data Analytics Comp Tech Acct,Seijas,Nuria S,8,0,0,0,0,0,0,3.959
+Fall 2024,CIS,4375,32,18486,Information Systems Capstone,Martinez,Jose C,10,23,6,1,0,0,0,3.083
+Fall 2024,EDUC,4314,2,18487,Clinical Teaching 1-Secondary,Evans,Paige K,7,1,0,0,1,0,0,3.298
+Fall 2024,ANTH,2301,2,18488,Intro to Physical Anthropology,McElvaney,Katherine Anne,24,25,25,10,0,0,7,2.774
+Fall 2024,HDCS,3304,2,18489,Visual Merchandising,Mudd,Blake Stevens,11,4,0,0,0,0,0,3.711
+Fall 2024,GENB,7393,1,18490,Business Consulting Lab I,Galvani,Paul,1,0,0,0,0,0,0,3.67
+Fall 2024,GENB,7394,1,18491,Business Consulting Lab II,Galvani,Paul,1,0,0,0,0,0,0,3.67
+Fall 2024,MARK,4367,1,18492,Advertising and Promotion Mgt,Noriega,Jaime L,22,19,7,1,0,0,0,3.184
+Fall 2024,MARK,7393,1,18493,Business Consulting Lab I,Galvani,Paul,4,0,0,0,0,0,0,3.67
+Fall 2024,MARK,7394,1,18495,Business Consulting Lab II,Galvani,Paul,4,0,0,0,0,0,0,3.67
+Fall 2024,ARLD,6373,1,18497,Leadership in Public Art,Guidry,Michael Stack,5,2,0,0,0,0,0,3.667
+Fall 2024,ARLD,6380,1,18498,Introduction to Arts in Health,Docwra,Caroline Nicole,6,0,0,0,0,0,0,4.0
+Fall 2024,MATH,3333,4,18499,Intermediate Analysis,Ott,William R,14,6,0,0,1,0,9,3.398
+Fall 2024,MIS,4374,5,18500,Info Technology Project Mgmt,Jagtap,Pankaj,13,12,1,0,0,0,1,3.423
+Fall 2024,MIS,4378,4,18501,Admin of Computer-Based MIS,Knighton,William B,46,5,0,0,0,0,0,3.902
+Fall 2024,GHL,6329,1,18502,Negotiations for Services Ind.,Abbott,Jeanna L,7,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6364,1,18503,Hosp. Managerial Accounting,Johnson,Tucker A,4,0,0,0,0,0,0,3.918
+Fall 2024,GHL,8188,1,18505,Ph.D. Colloquium,Back,KiJoon,0,0,0,0,0,4,0,
+Fall 2024,GHL,6364,2,18506,Hosp. Managerial Accounting,Johnson,Tucker A,4,2,1,0,0,0,0,3.381
+Fall 2024,IRW,1100,1,18508,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,27,2,
+Fall 2024,IRW,1100,2,18509,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,25,1,
+Fall 2024,IRW,1100,3,18510,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,27,1,
+Fall 2024,IRW,1100,4,18511,Integrated Reading and Writing,Ebersole,John Ira,1,0,0,0,0,21,2,4.0
+Fall 2024,ANTH,4372,1,18513,Maya Archaeology,Chase,Arlen F,12,4,3,0,0,0,2,3.456
+Fall 2024,ACCT,4380,1,18514,Contro & Sec Intern Fin Inform,Brant Jr,Robert Edward,4,1,0,0,0,0,0,3.8
+Fall 2024,HDFS,3310,1,18515,Introduction to Child Life,Fraser,Camille,24,2,3,0,1,0,0,3.611
+Fall 2024,ACCT,2302,6,18517,Prin of Managerial Accounting,Weber,Catherine K,15,22,40,3,1,0,4,2.686
+Fall 2024,ARTH,2388,1,18520,"African, Oceania, Americas Art",Koontz,Rex A,50,4,2,2,0,0,1,3.747
+Fall 2024,PETR,3318,1,18521,Drilling Engineering I,Hatzignatiou,Dimitrios Georgios,13,0,0,0,0,0,0,3.721
+Fall 2024,ELET,4353,1,18530,Statistics for ET,Pollonini,Luca,2,3,5,0,0,0,0,2.7
+Fall 2024,LAW,5238,1,18533,Mental Health Law,Brents,Melinda Heath,7,9,2,0,0,1,0,3.369
+Fall 2024,LAW,5314,30,18534,Lawyering Skills & Strategy I,Brown,Maleaha L,4,13,0,0,0,0,0,3.391
+Fall 2024,GEOL,3373,1,18535,Igneous & Met. Petrogenesis,Turner,Stephen,10,4,1,0,0,0,1,3.446
+Fall 2024,GEOL,3130,1,18537,Paleobiology Laboratory,Maddocks,Rosalie F,1,2,3,5,0,0,0,1.819
+Fall 2024,GEOL,3130,2,18538,Paleobiology Laboratory,Maddocks,Rosalie F,1,2,2,4,0,0,3,2.037
+Fall 2024,LAW,6344,1,18544,U.S. Import Regulation,Hanson,Lawrence W,4,5,0,0,0,0,0,3.371
+Fall 2024,LAW,5120,1,18546,Texas Legal Research,Dykes,Christopher,8,12,0,0,0,0,0,3.384
+Fall 2024,LAW,6210,1,18550,Construction Law,LaPar,Kelly,9,10,1,0,0,0,0,3.4
+Fall 2024,ACCT,7337,2,18552,Oil & Gas Taxation,Wright,Denney L,2,2,0,0,0,0,0,3.5
+Fall 2024,ACCT,7337,3,18553,Oil & Gas Taxation,Wright,Denney L,3,1,0,0,0,0,0,3.585
+Fall 2024,ACCT,7390,1,18554,Contrl & Secur of Finan Inform,Brant Jr,Robert Edward,11,9,0,0,0,0,0,3.633
+Fall 2024,ARTH,3334,2,18557,History of Graphic Design,Orto,Luisa,16,25,0,0,0,0,4,3.398
+Fall 2024,ARTH,6334,2,18558,History of Graphic Design,Orto,Luisa,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,2305,3,18559,Discrete Mathematics,Winkle,James J,11,18,17,18,5,0,11,2.227
+Fall 2024,MATH,1332,3,18560,Contemporary Mathematics,Hafeez,Shahinda,17,23,17,14,6,0,3,2.381
+Fall 2024,SOCW,7337,1,18562,Crit Cinical Case Form & Diag,Viverette,April C,29,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7337,2,18563,Crit Cinical Case Form & Diag,Jacobs,Alexandra L,23,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7337,3,18564,Crit Cinical Case Form & Diag,Parks,Steven Lee,16,6,2,0,1,0,0,3.44
+Fall 2024,SOCW,7337,4,18565,Crit Cinical Case Form & Diag,Taylor,Patricia G,15,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7337,5,18566,Crit Cinical Case Form & Diag,Mayes,Kimberly,19,3,0,0,0,0,0,3.864
+Fall 2024,SOCW,7337,6,18567,Crit Cinical Case Form & Diag,Parks,Steven Lee,15,2,0,0,0,0,0,3.882
+Fall 2024,SOCW,7343,1,18568,Families: Adv Clinical Practic,Walton,Quenette,27,2,0,0,0,0,0,3.931
+Fall 2024,SOCW,7343,2,18569,Families: Adv Clinical Practic,Walton,Quenette,24,2,0,0,0,0,0,3.923
+Fall 2024,SOCW,7343,3,18570,Families: Adv Clinical Practic,Amtsberg,Donna K,30,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7343,4,18571,Families: Adv Clinical Practic,Amtsberg,Donna K,20,2,0,0,0,0,0,3.909
+Fall 2024,SOCW,7343,5,18572,Families: Adv Clinical Practic,Viverette,April C,11,1,0,0,0,0,0,3.917
+Fall 2024,BTEC,6302,40,18577,Intro to Regulatory Affairs,Flavier,Albert B,1,2,0,0,0,0,0,3.333
+Fall 2024,BTEC,6304,40,18578,Computational Methods in BTEC,Chitrala,Kumaraswamy Naidu,6,1,0,0,0,0,0,3.81
+Fall 2024,CIS,6323,40,18579,Applied Cryptography,Zhang,Yunpeng,21,0,0,0,1,0,0,3.818
+Fall 2024,CIS,6324,40,18580,Cybersecurity Risk Management,Conklin,William A,7,1,0,0,1,0,0,3.444
+Fall 2024,PSYC,2317,9,18582,Intro to Psychology Statistics,Vahedi,Meisam,64,6,4,0,4,0,2,3.624
+Fall 2024,ELET,6325,40,18584,Practicum in Engineering Tech,Yuan,Xiaojing,1,0,0,0,0,0,0,4.0
+Fall 2024,ELET,6350,40,18585,Overview Com Health Informatic,Pollonini,Luca,2,0,0,0,0,0,0,4.0
+Fall 2024,ELET,6352,40,18586,Matlab Engineering Technology,Zouridakis,George,3,2,0,0,0,0,0,3.666
+Fall 2024,GRET,6332,40,18587,Consumer Issues and Apps.,Johnson,Olivia,1,1,2,0,0,0,0,2.75
+Fall 2024,GRET,6334,40,18588,Global E-Tailing Systems,Ezell,Shirley D,5,0,0,0,0,0,0,4.0
+Fall 2024,GRET,6336,40,18589,Global Retail Analysis,Robinson,Ebony M,2,2,0,0,0,0,0,3.5
+Fall 2024,SCLT,6318,40,18591,Supply Chain Strategies,Bian,Zheyong,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3347,3,18592,Problems of Normal Life,Anderson,Jill Annette,29,19,6,0,1,0,0,3.316
+Fall 2024,TEPM,6395,40,18593,Integration Project,Carden,Lila L,3,0,0,0,0,0,0,3.89
+Fall 2024,MUED,6312,1,18594,History & Philosophy of Mus Ed,Wilkinson,Loneka,6,0,0,0,0,0,0,4.0
+Fall 2024,SCM,4330,4,18595,Bus Modeling and Dec Analysis,Cossick,Kathy L,5,3,0,1,2,0,0,2.727
+Fall 2024,SCM,4367,3,18596,Process and Quality Management,Miller,Bradley D,2,3,3,0,0,0,0,2.834
+Fall 2024,SCM,4390,4,18597,Supply Chain Strategy,Smith,Gordon D,2,5,3,0,0,0,0,2.834
+Fall 2024,MUSI,1102,3,18599,Wind Ensemble,Bertman,David Garry,15,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,1116,3,18600,Aural Skills I,Guez,Jonathan Charles,11,6,1,0,0,0,2,3.519
+Fall 2024,SCM,4350,2,18601,Strategic Supply Management,Wayhan,Victor Brian,3,2,0,0,0,0,0,3.6
+Fall 2024,MUSI,1311,3,18602,Music Theory I,Guez,Jonathan Charles,12,2,4,0,0,0,2,3.371
+Fall 2024,MUSI,6340,2,18606,Graduate Music History Review,Caton,Kathryn L.,13,2,3,0,0,0,0,3.482
+Fall 2024,PHLS,8393,2,18607,Doctoral Practicum in Psy,Arbona,Consuelo,0,0,0,0,0,7,0,
+Fall 2024,MUSI,8301,1,18608,Seminar in Perform Pedagogy,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,7375,1,18610,Intro To Family Counsl,Whitaker,Rachael Gwin,9,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,7375,2,18611,Intro To Family Counsl,Whitaker,Rachael Gwin,7,0,0,0,0,0,0,4.0
+Fall 2024,DANC,3203,1,18612,Contact Improvisation,Lockett,KeyAira,4,1,0,0,0,0,0,3.8
+Fall 2024,RELS,2336,1,18615,Jewish Civilization,Tamber-Rosenau,Caryn M,2,3,1,0,0,0,1,3.112
+Fall 2024,HLT,4317,2,18616,Found of Epi in Public Health,Drenner,Kelli Linn,12,12,11,5,1,0,6,2.643
+Fall 2024,THEA,6306,1,18617,Rigging,Vlahos,Kalliope,0,1,0,0,0,0,0,3.33
+Fall 2024,MUSI,2116,3,18624,Aural Skills III,Snyder,John L,9,11,1,0,0,0,0,3.287
+Fall 2024,MUSI,2210,3,18625,Theory III,Snyder,John L,11,9,0,0,1,0,1,3.287
+Fall 2024,INDE,2333,1,18626,Engineering Statistics I,Wang,Yaping,34,22,20,9,3,0,5,2.83
+Fall 2024,MUSI,4230,2,18627,Instrumental Conducting I,Bertman,David Garry,18,1,1,0,0,0,0,3.834
+Fall 2024,LAW,5365,1,18630,Bankrptcy&Creditrs Rgts,Lee,Kyung Shik,8,16,0,0,0,0,0,3.402
+Fall 2024,MECT,4323,30,18631,Application in Stress Analysis,Basaran,Burak,1,6,12,2,0,0,5,2.317
+Fall 2024,TLIM,4378,30,18632,Senior Project,Feriante,Chris,30,0,0,0,0,0,0,4.0
+Fall 2024,AAS,3366,1,18635,AAS Community Internship,Odewale,Alicia D,4,2,0,0,0,0,0,3.667
+Fall 2024,PSYC,4355,1,18636,Psychology of PM&R,Williams,Michael W,17,9,4,0,0,0,0,3.433
+Fall 2024,ELET,4356,1,18637,Info Visualization in ET,Merchant,Fatima Aziz,4,21,3,1,0,0,1,3.011
+Fall 2024,ELET,6356,1,18638,Health Analytics Visualization,Merchant,Fatima Aziz,12,7,0,0,0,0,0,3.545
+Fall 2024,BTEC,4101,30,18639,Principle of Bioprocessing Lab,Lin,Yuheng,10,5,0,0,0,0,0,3.557
+Fall 2024,FINA,7360,2,18640,International Finance,Hitzemann,Steffen,8,6,0,0,0,0,1,3.501
+Fall 2024,MANA,6A25,2,18642,Ethical Leadrshp & Crit Reason,Krylova,Ksenia O,9,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,2301,10,18643,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,16,24,14,9,8,0,9,2.525
+Fall 2024,ACCT,2301,11,18644,Prin of Financial Accounting,Zhu,Limin,12,29,22,12,2,0,3,2.583
+Fall 2024,ACCT,3368,5,18649,Intermediate Accounting II,Kraten,Michael,26,33,9,1,1,0,0,3.195
+Fall 2024,ACCT,2301,12,18650,Prin of Financial Accounting,Parthasarathy,Kiran M,54,55,22,6,4,0,6,3.146
+Fall 2024,ACCT,2301,14,18652,Prin of Financial Accounting,Serrato,Darlene Marie  Bohac,14,16,10,5,0,0,6,2.962
+Fall 2024,POLC,4323,1,18653,Data Analytics and Visual,Yuasa,Toshiyuki,3,0,0,0,0,0,0,3.67
+Fall 2024,FORE,6359,20,18654,Design Futures,Sweeney,John Arthur,5,0,0,0,0,0,0,4.0
+Fall 2024,FORE,6359,40,18655,Design Futures,Sweeney,John Arthur,9,0,0,0,0,0,0,4.0
+Fall 2024,PETR,6354,1,18656,Reservoir Engineering Fund,Thakur,Ganesh Chandra,2,7,0,0,0,0,0,3.076
+Fall 2024,HDCS,6331,40,18657,Adv Strat For Futures Planning,Hines,Andrew Lewis,8,1,0,0,0,0,0,3.816
+Fall 2024,ELCS,6370,2,18666,Research for Educatnal Leaders,Wilson,Alison Shelby Page,14,0,0,0,0,0,0,3.976
+Fall 2024,SCM,3301,5,18667,SCM Fundamentals,Miller,Bradley D,32,15,1,0,1,0,0,3.524
+Fall 2024,WGSS,3322,1,18668,Intersectionalities,Pegoda,Andrew Joseph,8,8,9,0,1,0,5,2.872
+Fall 2024,CNE,3310,1,18669,Construction Engr Project Mgmt,Safa,Mahdi,2,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,3339,5,18670,Geotechnical Engineering,Zamiran,Siavash,2,2,1,0,0,0,0,3.2
+Fall 2024,ANTH,3382,1,18671,Cultures & Capital India Asia,Majumder,Sarasij,13,5,0,0,0,0,2,3.704
+Fall 2024,HLT,4393,1,18674,Field Work in Com Health,Farmer,Jennifer,1,0,0,0,0,0,0,4.0
+Fall 2024,HLT,4392,1,18675,Field Work in Community Health,Farmer,Jennifer,38,2,0,0,1,0,2,3.87
+Fall 2024,HLT,4392,2,18676,Field Work in Community Health,Farmer,Jennifer,41,0,1,0,0,0,1,3.952
+Fall 2024,COMM,3326,4,18685,Graphics Applications,Economou-Clarke,Ann M,17,10,2,0,1,0,1,3.433
+Fall 2024,ENGL,7322,1,18691,Advncd Poetry Workshop,Tejada,Roberto Jose,11,0,0,0,0,0,0,4.0
+Fall 2024,MARK,3337,5,18692,Professional Selling,Boehm-Miller,Elizabeth A,148,74,12,0,2,0,1,3.51
+Fall 2024,CNST,6308,40,18693,Data Analysis in Construc Mgmt,Gao,Lu,2,0,0,0,0,0,0,4.0
+Fall 2024,CNST,6310,40,18694,Construction Contract Administ,Ducran,Denis George,4,0,0,0,0,0,0,4.0
+Fall 2024,CNST,6340,40,18695,Best Practices in Construction,Kim,Kinam,2,1,1,0,1,0,0,2.666
+Fall 2024,CNST,6350,40,18696,Decision Making and Risk Mgmt,Gao,Lu,3,0,0,0,0,0,0,4.0
+Fall 2024,ECE,5346,1,18697,Vlsi Design,Joardar,Biresh Kumar,3,2,0,0,0,0,0,3.468
+Fall 2024,ECE,6346,1,18698,Vlsi Design,Joardar,Biresh Kumar,9,16,5,0,0,0,1,3.1
+Fall 2024,ECE,6379,1,18699,Power Syst Oper and Modeling,Li,Xingpeng,9,2,1,0,0,0,0,3.722
+Fall 2024,INDS,6398,4,18701,Independent Study,Jackson,Megan H,2,0,0,0,0,0,0,3.67
+Fall 2024,ARCH,3311,3,18704,Topics in Design History,Rodriguez Fernandez,Marta,13,1,0,0,0,0,1,3.952
+Fall 2024,MUSA,6204,3,18705,Conducting,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8390,2,18706,Dissertation in Practice,Hutchison,Laveria F,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8390,3,18707,Dissertation in Practice,McNeil,Sara G,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8390,5,18708,Dissertation in Practice,Hausmann,Robert Carl,1,0,0,0,0,4,0,4.0
+Fall 2024,MUSA,3434,3,18709,Applied Clarinet,Potiomkin,Alexander,4,0,0,0,0,0,0,3.918
+Fall 2024,MATH,2318,8,18712,Linear Algebra,Olshanskiy,Maxim Alexandrovich,9,16,14,3,3,0,4,2.468
+Fall 2024,DIGM,4398,3,18715,Independent Study,Rodwell,Elizabeth Ann,10,0,0,0,0,0,1,4.0
+Fall 2024,MECE,3399,3,18718,Senior Honors Thesis,Song,Gangbing,0,0,0,0,0,0,0,
+Fall 2024,MANA,7338,1,18720,Org Power Politics & Culture,Abbott,Jeanna L,34,1,0,0,0,0,0,3.962
+Fall 2024,ECE,4437,3,18721,Embedded Microcomputer Systems,Le,Hung Quang,39,0,0,0,0,0,0,3.949
+Fall 2024,HIST,3344,1,18722,Drug History in Latin America,Cedillo,Adela,10,15,7,0,1,0,0,3.03
+Fall 2024,ARCH,3311,4,18723,Topics in Design History,Diehl,Tom,6,6,3,0,0,0,1,3.112
+Fall 2024,MUSA,6210,1,18724,Applied Piano,Hester,Timothy E,4,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,6391,1,18727,Practicum in the Principalship,Klussmann,Duncan Foster,6,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,6391,2,18728,Practicum in the Principalship,Klussmann,Duncan Foster,14,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,7460,1,18732,Intro to Medicinal Chemistry,Das,Joydip,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,7370,1,18733,Scientific Writing,Trivedi,Meghana,6,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,3371,4,18735,Accounting Information Systems,Seijas,Nuria S,20,17,6,0,2,0,0,3.17
+Fall 2024,KIN,1304,1,18739,Public Hlt Issues in Phys/Obes,Johnston,Craig Allen,283,105,16,3,4,0,6,3.568
+Fall 2024,PHLS,6325,3,18740,Theories of Counseling,Lee,Jungeun,10,1,0,0,0,0,0,3.819
+Fall 2024,CEA,3201,1,18745,Comp Program for Engineers,Meh Chu,Chu,2,0,2,0,0,0,0,3.0
+Fall 2024,CEA,3337,1,18746,Digital Signals and Systems,Bopardikar,Ajit Shyamsunder,1,2,3,1,0,0,1,2.523
+Fall 2024,CEA,3338,1,18747,Microprocessor Systems,Ramachandran,Deepa,4,1,2,0,0,0,0,3.286
+Fall 2024,CUIN,8690,5,18748,Dissertation in Practice,Hutchison,Laveria F,3,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8690,7,18750,Dissertation in Practice,Hausmann,Robert Carl,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3310,4,18753,Indstrl-Orgnztnl Psy,Mehta,Nandini M,55,16,2,1,3,0,1,3.575
+Fall 2024,MARK,4379,4,18760,Personal Branding,Richards,Sean Wesley,22,6,0,0,0,0,0,3.691
+Fall 2024,BIOL,8399,6,18762,Doctoral Dissertation,Feng,Qin,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8699,3,18766,Doctoral Dissertation,Knee,Clifford R,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6345,3,18769,Fluid Dynamics 1,Yang,Di,1,1,0,0,0,0,1,3.335
+Fall 2024,MECE,6377,2,18772,Continuum Mechs I,Chen,Yi-Chao,1,2,0,0,0,0,0,3.333
+Fall 2024,MECE,6377,3,18773,Continuum Mechs I,Chen,Yi-Chao,0,0,0,0,0,0,1,
+Fall 2024,MECE,6384,3,18774,Methods of Applied Math I,Chen,Yi-Chao,0,2,0,0,1,0,0,2.11
+Fall 2024,DIGM,4378,30,18775,Senior Project,Alters,Monika Joanna,15,7,2,0,0,0,1,3.473
+Fall 2024,PSYC,7399,18,18777,Masters Thesis,Williams,Michael W,0,0,0,0,0,1,0,
+Fall 2024,SYSE,3315,1,18779,Systems Architecture & Design,Diaz Martinez,Neil Orlando,2,4,1,0,0,0,0,3.049
+Fall 2024,SYSE,3301,1,18780,Fundamentals of Systems Engr,Diaz Martinez,Neil Orlando,1,4,1,0,1,0,0,2.571
+Fall 2024,PSYC,6359,8,18789,Directed Rsch in Clinical Psyc,Walker,Rheeda L,0,0,0,0,0,0,0,
+Fall 2024,CIVE,6335,1,18791,Advanced Concrete Design,Belarbi,Abdeldjelil,5,2,5,0,0,0,0,2.89
+Fall 2024,CIVE,6355,1,18792,Intro-Dynamics of Structures,Zhang,Ruda,8,7,1,1,0,0,0,3.294
+Fall 2024,CIVE,7342,1,18793,Engineer Geographic Info. Syst,Xie,Surui,7,4,0,0,0,0,1,3.636
+Fall 2024,CIVE,6337,1,18796,Matrix Analysis of Structures,Krakowiak,Konrad,5,6,5,2,0,0,3,2.778
+Fall 2024,CIVE,6337,2,18797,Matrix Analysis of Structures,Krakowiak,Konrad,0,0,2,0,0,0,1,2.0
+Fall 2024,GEOL,8399,13,18813,Doctoral Dissertation,Lapen,Thomas J,1,0,0,0,0,2,0,4.0
+Fall 2024,MUSA,8320,33,18814,Doctoral Applied Music,Bertman,David Garry,3,0,0,0,0,0,0,4.0
+Fall 2024,SCM,7325,3,18815,Process Analysis and Design,Robinson Jr,Powell Ersell,5,4,1,0,0,0,1,3.4
+Fall 2024,GEOL,8999,13,18817,Doctoral Dissertation,Wang,Yuxuan,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3399,4,18818,Senior Honors Thesis,Damian,Rodica Ioana,0,0,0,0,0,0,0,
+Fall 2024,BZAN,6310,8,18827,Quant Analysis for Busn Dec,Wiley,Briceon C,15,22,5,0,1,0,1,3.163
+Fall 2024,THEA,3322,1,18828,Musical Theatre for Actors,Wetzel,Molly Elizabeth,11,2,0,0,0,0,0,3.821
+Fall 2024,COMD,8391,1,18830,COMD Research,Castilla-Earls,Anny,0,0,0,0,0,0,0,
+Fall 2024,NUTR,6218,1,18831,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,7,0,
+Fall 2024,ANTH,6399,7,18832,Masters Thesis,Hannaford,Dinah Rebecca,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2310,2,18840,Applied Piano,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,4380,1,18841,Professional Practices,Barrera,Debra,20,4,0,0,0,0,0,3.778
+Fall 2024,ARTS,6386,1,18842,Professional Practices,Barrera,Debra,1,1,0,0,0,0,0,3.335
+Fall 2024,PSYC,6399,20,18845,Masters Thesis,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3399,6,18846,Senior Honors Thesis,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7399,8,18848,Essay,Womble,David Avari Patrick,2,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,3317,3,18849,Prenatal and Infant Developmt,Storch,Jill Frenchman,31,15,3,0,0,0,0,3.45
+Fall 2024,PSYC,3399,7,18850,Senior Honors Thesis,Leasure,Jennifer Leigh,0,0,0,0,0,0,0,
+Fall 2024,POLS,8999,13,18855,Doctoral Dissertation,Casellas,Jason,0,0,0,0,0,2,0,
+Fall 2024,POLS,8999,14,18856,Doctoral Dissertation,Aleman,Eduardo,0,0,0,0,0,2,0,
+Fall 2024,USS,1101,9,18858,College Success,Osborn,Lori,4,1,0,0,1,0,0,3.057
+Fall 2024,POLS,8999,16,18859,Doctoral Dissertation,Church,Jeffrey,0,0,0,0,0,3,0,
+Fall 2024,USS,1101,19,18861,College Success,Yendell,Kialyn Beth,2,2,1,0,3,0,1,2.041
+Fall 2024,USS,1101,31,18864,College Success,Ware,Amanda Wynn,10,1,1,1,0,0,0,3.564
+Fall 2024,USS,1101,33,18865,College Success,Williams,Kimberly,5,0,0,0,0,0,1,4.0
+Fall 2024,ENGL,1301,178,18868,First Year Writing I,Worley,Sharon J,13,5,1,2,2,0,1,3.015
+Fall 2024,ENGL,1301,179,18869,First Year Writing I,Worley,Sharon J,10,8,0,1,3,0,2,2.865
+Fall 2024,ENGR,2301,5,18871,Mechanics I (Statics),Metrovich,Brian,4,5,2,0,0,0,0,3.182
+Fall 2024,ENGL,7399,9,18876,Essay,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6348,1,18877,Applied Euphonium,Fenske,Kevin,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8388,2,18878,Dissertation Proposal,Golubev,Alexey Valeryevich,0,0,0,0,0,0,0,
+Fall 2024,LAW,6226,1,18879,Advanced Oil & Gas Contracting,Borrego,Theodore R,3,3,0,0,0,0,1,3.555
+Fall 2024,PHCA,6198,3,18880,Special Problems,Varisco,Tyler J,0,0,0,0,0,1,0,
+Fall 2024,MUSA,2350,3,18882,Applied Percussion,Hubley,Robert L,3,2,0,0,0,0,1,3.402
+Fall 2024,NURS,4322,1,18888,Policy &Ethics in Prof Nursing,Smith,Deborah Ann,16,5,0,0,0,0,0,3.762
+Fall 2024,NURS,3312,1,18889,Fundamental Concepts of Care,Smith,Deborah Ann,3,17,0,0,0,0,1,3.15
+Fall 2024,NURS,3313,1,18890,Fundamental Clinical,Heath-Pena,Rosalyn L,8,12,0,0,0,0,1,3.4
+Fall 2024,NURS,4213,1,18891,Mental Health Clinical,Smith,Deborah Ann,37,1,0,0,0,0,0,3.974
+Fall 2024,NURS,4211,1,18892,Mental Health Concepts of Care,Smith,Deborah Ann,14,24,0,0,0,0,0,3.368
+Fall 2024,NURS,3314,1,18893,Pharmacology,Bayliss,Debra Lee,4,16,0,1,0,0,1,3.095
+Fall 2024,NURS,6330,1,18894,Adv Diagnostic Physicl Examntn,Ecby,Chanique,2,2,1,0,0,0,3,3.2
+Fall 2024,NURS,8301,1,18897,"Healthcare Project Design, Met",Hermis,Kimberly,4,0,0,0,0,0,0,4.0
+Fall 2024,NURS,8302,1,18898,Advanced Practice Finance,Brohard,Cheryl L,4,0,0,0,0,0,0,4.0
+Fall 2024,FINA,6A31,3,18901,Analyzing Financial Statements,Woods,James D,13,8,3,1,0,0,0,3.346
+Fall 2024,MUSA,6310,1,18902,Applied Piano,Hester,Timothy E,7,0,0,0,0,0,0,3.906
+Fall 2024,MUSA,6310,2,18903,Applied Piano,Morgulis,Tali,4,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,8398,45,18904,Doctoral Research,Vovchenko,Volodymyr,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8498,10,18906,Doctoral Research,Milillo,Pietro,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8598,6,18907,Doctoral Research,Milillo,Pietro,0,0,0,0,0,3,0,
+Fall 2024,MUSA,1300,6,18910,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6410,3,18911,Applied Piano,Hester,Timothy E,2,0,0,0,0,0,0,4.0
+Fall 2024,COSC,3340,1,18912,Intro. to Automata and Comp.,Das,Rathish,48,64,0,0,0,0,7,3.437
+Fall 2024,COSC,4368,1,18913,Artificial Intelligence,Lin,Sen,50,47,3,1,1,0,2,3.415
+Fall 2024,PSYC,3350,5,18930,Intro to Cognitive Psychology,Barry,Kelly,47,24,4,2,2,0,2,3.393
+Fall 2024,PSYC,3350,6,18931,Intro to Cognitive Psychology,Racioppo,Keith,50,25,1,1,3,0,0,3.43
+Fall 2024,ENGI,1331,4,18933,Computing for Engineers,Kota,Venkata Krishna Tulasi,7,4,0,0,0,0,3,3.576
+Fall 2024,ENGI,1331,5,18934,Computing for Engineers,Kota,Venkata Krishna Tulasi,2,1,1,0,0,0,0,3.168
+Fall 2024,CIVE,8198,6,18935,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Fall 2024,PSYC,6393,10,18936,Clinical Research Practicum,Venta,Amanda Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2301,9,18944,Introduction to Psychology,Babalola,Olusegun,36,26,6,3,5,0,2,3.179
+Fall 2024,PSYC,3310,5,18945,Indstrl-Orgnztnl Psy,Thomas,Kalifa Nailah,31,18,14,5,5,0,3,2.945
+Fall 2024,MUSA,8242,6,18946,Doctoral Recital III,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6399,8,18947,Masters Thesis,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8699,1,18949,Doctoral Dissertation,McKinney,Lonnie Lyle,0,0,0,0,0,3,0,
+Fall 2024,PCOL,6498,5,18950,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6498,6,18951,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Fall 2024,MUSI,1181,1,18953,Group Piano I,Van Kekerix,Todd Evan,7,3,1,0,1,0,0,3.278
+Fall 2024,PCEU,6298,4,18954,Special Problems,Hu,Ming,0,0,0,0,0,0,0,
+Fall 2024,PHCA,8298,7,18959,Doctoral Dissertation Research,Sansgiry,Sujit Sharad,0,0,0,0,0,1,0,
+Fall 2024,INDE,6361,1,18960,Prod Planning & Invent Control,Hu,Minxiang,13,1,0,0,0,0,0,3.905
+Fall 2024,ARTS,3300,4,18969,Advanced Drawing,Meza,Edgar,19,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,1102,9,18971,Intro to Climate Change Lab,Zhang,Honghai,14,6,2,0,0,0,1,3.5
+Fall 2024,ENGL,8399,19,18977,Doctoral Dissertation,Butler,Paul G,1,0,0,0,0,1,0,4.0
+Fall 2024,MUSA,1310,3,18979,Applied Piano,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,1507,5,18981,Intns Elem Span Heritage Learn,Ruiz,Eugenia Maria,4,7,4,0,1,0,3,2.833
+Fall 2024,SOCW,6193,1,18985,SW Generalist Practicum 1,Gonzales,Shelley A,0,0,0,0,0,130,0,
+Fall 2024,SOCW,7184,1,18986,SW Clinical Practicum 1,Gonzales,Shelley A,0,0,0,0,0,118,0,
+Fall 2024,SOCW,7188,1,18987,Social Work Macro Practicum 1,Gonzales,Shelley A,0,0,0,0,0,18,0,
+Fall 2024,SOCW,7185,1,18988,SW Clinical Practicum 2,Gonzales,Shelley A,0,0,0,0,0,17,0,
+Fall 2024,SOCW,7189,1,18989,Social Work Macro Practicum 2,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6398,10,18992,Special Problems,McConnell,Bradley K,0,0,0,0,0,2,0,
+Fall 2024,PSYC,7399,20,18994,Masters Thesis,Venta,Amanda Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,4198,1,18998,Independent Study,Chen,Yuhua,5,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8193,4,19005,Internship in Psychology,Smith,Bradley,0,0,0,0,0,5,0,
+Fall 2024,BIOE,8399,26,19008,Doctoral Dissertation,Contreras-Vidal,Jose Luis,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6356,1,19009,Clinical Assessment I,Cirino,Paul,8,4,0,0,0,0,0,3.667
+Fall 2024,MANA,7312,2,19010,Fundtls of Healthcare Business,Kroger,Edward John,6,2,0,0,0,0,0,3.833
+Fall 2024,HIST,1301,44,19011,The U.S. to 1877,McDonald,Eric John,208,69,21,5,10,0,5,3.408
+Fall 2024,MECE,7399,12,19012,Masters Thesis,Ryou,Jae-Hyun,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,4332,1,19017,Hydrology,Saladi,Krishna Rishi Vijay,8,24,1,0,0,0,0,3.262
+Fall 2024,CIVE,4333,1,19018,Water and Wastewater Treatment,Saladi,Krishna Rishi Vijay,16,16,1,0,0,0,0,3.435
+Fall 2024,PHYS,1301,4,19019,College Physics I (lecture),Portillo Vazquez,Israel,29,46,51,20,8,0,46,2.399
+Fall 2024,ECE,5330,2,19020,Introduction to Robotics,Becker,Aaron T,14,19,20,4,1,0,0,2.65
+Fall 2024,ECE,3337,3,19021,Signals and Systems Analysis,Shih,Wei-Chuan,29,45,19,0,1,0,0,3.039
+Fall 2024,PSYC,2317,11,19022,Intro to Psychology Statistics,Vahedi,Meisam,62,9,2,0,5,0,2,3.564
+Fall 2024,ECE,3436,5,19023,Microprocessor Systems,Chen,Yuhua,74,18,2,0,1,0,0,3.567
+Fall 2024,MECE,4364,2,19025,Heat Transfer,Liu,Dong,7,14,17,3,1,0,0,2.634
+Fall 2024,MECE,3345,3,19026,Materials Science,Nejad,Alireza Mahdavi,47,9,0,0,0,0,0,3.786
+Fall 2024,ENGR,1304,1,19030,Engineering Graphics,Ray,Kyle A,33,21,4,0,1,0,1,3.39
+Fall 2024,PCOL,6498,2,19035,Special Problems,Cuny,Gregory D,0,0,0,0,0,1,0,
+Fall 2024,SOCW,6194,1,19037,SW Generalist Practicum 2,Gonzales,Shelley A,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8398,15,19038,Doctoral Research,Milillo,Pietro,0,0,0,0,0,2,0,
+Fall 2024,MECE,6367,1,19039,Control System Analysis and De,Song,Gangbing,13,18,5,0,1,0,0,3.099
+Fall 2024,MECE,5367,1,19040,Control Systm Analysis & Desgn,Song,Gangbing,15,61,10,0,0,0,0,3.097
+Fall 2024,THEA,6180,1,19042,Applying Methods Acting/Voice,Ferrarone,Jessica,9,1,0,0,0,0,0,3.834
+Fall 2024,COMD,7391,11,19043,Clinic in Speech Lang Disorder,Fitch,Jennifer,2,1,0,0,0,0,0,3.557
+Fall 2024,COMD,7391,14,19045,Clinic in Speech Lang Disorder,Kazhuro,Katsiaryna,1,0,0,0,0,0,0,3.67
+Fall 2024,COMD,7391,15,19046,Clinic in Speech Lang Disorder,Walker,Dionne A,1,0,0,0,0,0,0,3.67
+Fall 2024,POLS,3310,3,19047,Intro to Political Theory,Fumurescu,Alin,34,54,35,18,9,0,9,2.606
+Fall 2024,PCOL,6498,7,19049,Special Problems,Wu,Mingfu,1,0,0,0,0,0,0,4.0
+Fall 2024,COMD,8391,2,19050,COMD Research,Thiessen,Amber L,0,0,0,0,0,1,0,
+Fall 2024,SGNL,2301,4,19051,Intermediate Sign Language I,Brittain,Terrell,4,6,7,1,0,0,0,2.704
+Fall 2024,HIST,2321,3,19052,Study of Early Civilizations,Cong,Xiaoping,11,13,8,0,2,0,1,2.873
+Fall 2024,INDE,6365,2,19054,Engineering Economy II,Govindu,Nirathi Keerthi,23,3,0,0,0,0,0,3.872
+Fall 2024,SYSE,3301,2,19055,Fundamentals of Systems Engr,Diaz Martinez,Neil Orlando,1,4,2,0,0,0,0,2.904
+Fall 2024,SYSE,3315,2,19056,Systems Architecture & Design,Diaz Martinez,Neil Orlando,0,4,1,0,0,0,0,2.932
+Fall 2024,INDE,6365,3,19057,Engineering Economy II,Govindu,Nirathi Keerthi,15,1,0,0,0,0,0,3.69
+Fall 2024,MUSA,6320,1,19058,Applied Violin,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2024,BCIS,1305,5,19059,Business Computer Applications,Felvegi,Emese,259,55,23,16,10,0,10,3.474
+Fall 2024,PSYC,6359,6,19069,Directed Rsch in Clinical Psyc,Gallagher,Matthew Ward,2,0,0,0,0,0,0,4.0
+Fall 2024,INDE,6365,4,19071,Engineering Economy II,Govindu,Nirathi Keerthi,25,0,0,0,0,0,0,3.855
+Fall 2024,PSYC,2319,8,19073,Intro to Social Psychology,Anderson,Jill Annette,23,22,0,0,0,0,0,3.489
+Fall 2024,PSYC,2317,12,19074,Intro to Psychology Statistics,Browne,Lindsay J,54,8,7,3,3,0,3,3.374
+Fall 2024,BTEC,6305,30,19078,Bioprocessing in Biotechnology,Lin,Yuheng,5,1,1,0,0,0,0,3.477
+Fall 2024,BTEC,6105,30,19079,Bioprocessing Laboratory,Lin,Yuheng,3,2,0,0,0,0,0,3.6
+Fall 2024,CHEM,1111,79,19081,Fundamentals of Chm Lab,Zaitsev,Vladimir G,6,8,3,1,0,0,0,3.074
+Fall 2024,PHOP,6198,16,19082,Spec Prob-Physio Optics,Rump,Rachel,1,0,0,0,0,0,0,3.67
+Fall 2024,CHEM,1111,80,19084,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,9,4,0,0,0,5,2.933
+Fall 2024,CHEM,1111,81,19086,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,8,6,0,0,0,3,2.882
+Fall 2024,PHLS,8393,4,19091,Doctoral Practicum in Psy,Racine,Madeline D,0,0,0,0,0,11,0,
+Fall 2024,COMD,7391,16,19092,Clinic in Speech Lang Disorder,Cizek,Laura S,0,1,0,0,0,0,0,3.0
+Fall 2024,COMD,7391,17,19093,Clinic in Speech Lang Disorder,Andrade,Michelle Lee,1,1,0,0,0,0,0,3.5
+Fall 2024,COMD,7391,19,19097,Clinic in Speech Lang Disorder,Lebrun,Nathalie,0,1,0,0,0,0,0,3.33
+Fall 2024,COMD,7391,21,19099,Clinic in Speech Lang Disorder,Schaff,Carrie Allyson,2,0,0,0,0,0,0,3.835
+Fall 2024,HDFS,4315,5,19103,Culture and Diversity,Conston,Toya,28,4,1,1,0,0,0,3.667
+Fall 2024,HDFS,4315,7,19105,Culture and Diversity,Conston,Toya,24,3,0,0,1,0,0,3.75
+Fall 2024,LAW,5314,31,19110,Lawyering Skills & Strategy I,Brem,Katherine B,8,8,1,0,0,0,0,3.392
+Fall 2024,ECE,6379,2,19111,Power Syst Oper and Modeling,Li,Xingpeng,6,1,2,0,0,0,1,3.408
+Fall 2024,MARK,4367,2,19112,Advertising and Promotion Mgt,Noriega,Jaime L,18,16,5,0,0,0,1,3.257
+Fall 2024,MARK,4389,8,19113,Marketing Strategy & Planning,Lish,Alan D,3,15,13,4,1,0,0,2.408
+Fall 2024,PHCA,8199,5,19117,Doctoral Dissertation Defense,Sansgiry,Sujit Sharad,0,0,0,0,0,1,0,
+Fall 2024,DANC,1107,1,19118,Beginning Hip Hop Dance,Aguilera,Joel,17,3,1,0,0,0,3,3.746
+Fall 2024,ARCH,4321,1,19119,Design of Construction Details,Story,Jon Kevin,7,12,2,0,0,0,0,3.128
+Fall 2024,PSYC,6399,21,19122,Masters Thesis,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8598,30,19126,Doctoral Research,Li,Zhengwei,0,0,0,0,0,3,0,
+Fall 2024,BIOE,8398,29,19127,Doctoral Research,Li,Zhengwei,0,0,0,0,0,3,0,
+Fall 2024,MUSA,1328,1,19129,Applied Harp,Cowan,Hope Kathleen,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,4343,2,19130,Credit Analysis,Dawson,Alan M,7,12,6,0,0,0,0,3.027
+Fall 2024,PSYC,4399,2,19131,Senior Honors Thesis,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Fall 2024,THEA,6182,1,19132,Applying Methods Light/Costume,Willson,Paige A,6,0,0,0,0,0,0,4.0
+Fall 2024,CHEM,1111,82,19133,Fundamentals of Chm Lab,Zaitsev,Vladimir G,1,16,0,0,0,0,3,2.981
+Fall 2024,CHEM,1111,83,19134,Fundamentals of Chm Lab,Zaitsev,Vladimir G,2,14,3,0,0,0,1,3.017
+Fall 2024,CUIN,3316,5,19135,Prekindergarten Curr & Instr,Katz,Denise Annette,22,1,0,0,0,0,0,3.928
+Fall 2024,ELED,3322,3,19136,Elem Reading Phonics Instructn,Alba,Celeste,21,3,0,0,0,0,0,3.834
+Fall 2024,COSC,3360,3,19137,Operating Systems,Rincon Castro,Carlos Alberto,46,33,28,3,12,0,13,2.746
+Fall 2024,MECE,8698,5,19140,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,3,0,
+Fall 2024,GEOL,8398,31,19148,Doctoral Research,Lapen,Thomas J,0,0,0,0,0,3,0,
+Fall 2024,CHEE,8298,23,19149,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2024,PSYC,2319,9,19150,Intro to Social Psychology,Anderson,Jill Annette,25,17,1,1,0,0,1,3.433
+Fall 2024,CIVE,6392,2,19152,Mass Transfer in Environ Syst,Rixey,William G,2,0,0,0,0,0,0,3.835
+Fall 2024,GEOL,6320,1,19154,Advanced Physical Geology,Sisson,Virginia B,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,1,19155,Senior Research Project,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,2,19156,Senior Research Project,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,2317,13,19157,Intro to Psychology Statistics,Browne,Lindsay J,47,19,5,3,4,0,1,3.274
+Fall 2024,MUSA,6332,1,19165,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,8698,1,19166,Doctoral Research,Ott,William R,0,0,0,0,0,4,0,
+Fall 2024,MECE,8298,9,19167,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,5,0,
+Fall 2024,CIVE,8498,11,19169,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,29,19170,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,30,19171,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8243,1,19173,Doctoral Lecture Recital,Koozin,Timothy,0,0,0,0,0,0,0,
+Fall 2024,MUSA,6310,4,19174,Applied Piano,Staupe,Andrew Paul,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3310,6,19175,Indstrl-Orgnztnl Psy,Harlan,Pamela Kay,58,16,2,1,2,0,0,3.541
+Fall 2024,BIOE,8298,28,19176,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Fall 2024,PSYC,3399,8,19177,Senior Honors Thesis,Babcock,Julia,0,0,0,0,0,0,0,
+Fall 2024,PSYC,6398,22,19179,Independent Studies,Woods,Steven Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,1311,3,19180,Personal Dev and College Succ,Sidwell,Jane Catherine,21,12,5,0,2,0,0,3.225
+Fall 2024,HDFS,1311,4,19181,Personal Dev and College Succ,Hall,Juanita J,28,8,3,0,0,0,0,3.658
+Fall 2024,ECE,8498,31,19183,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2024,ECE,8298,30,19184,Doctoral Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2024,MUSA,6204,5,19187,Conducting,Koppel,Alexander,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8298,11,19190,Doctoral Research,Chen,Tian,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8198,8,19191,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8598,8,19192,Doctoral Research,Kalliontzis,Dimitrios,0,0,0,0,0,2,0,
+Fall 2024,KIN,4398,2,19193,Independent Study,Cottingham,Michael,2,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8298,14,19198,Doctoral Research,Vipulanandan,Cumaraswamy,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8298,16,19202,Doctoral Research,Momen,Mostafa,0,0,0,0,0,4,0,
+Fall 2024,COSC,4355,801,19203,Intro to Ubiquitous Computing,Pavlidis,Ioannis T,2,9,1,0,1,0,1,2.821
+Fall 2024,CNST,4345,20,19204,Reinforced Concrete Structures,Chang,Chi Chung,35,27,0,0,0,0,1,3.517
+Fall 2024,ECON,8399,9,19205,Doctoral Dissertation,Nygaard,Vegard Mokleiv,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8198,9,19210,Doctoral Research,Krakowiak,Konrad,0,0,0,0,0,2,0,
+Fall 2024,PHAR,5675,5,19212,Disease State Management,Ononogbu,Onyebuchi J,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6220,1,19219,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8398,32,19220,Doctoral Research,Li,Aibing,0,0,0,0,0,2,0,
+Fall 2024,TLIM,3363,24,19222,Technical Communications,Tangeman,Anthony C,23,7,2,2,1,0,1,3.428
+Fall 2024,PHYS,8398,47,19227,Doctoral Research,Mondaini,Rubem,0,0,0,0,0,1,0,
+Fall 2024,BZAN,6360,2,19228,Capstone Practicum in BZAN I,Abbott,Jeanna L,13,9,3,0,0,0,0,3.558
+Fall 2024,BZAN,6361,2,19229,Capstone Practicum in BZAN II,Abbott,Jeanna L,17,0,0,0,0,0,0,4.0
+Fall 2024,EDS,6398,1,19237,Research,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2024,EDS,6342,2,19239,Intro to Machine Learning,Soibam,Benjamin Singh,51,0,0,0,1,0,0,3.923
+Fall 2024,MECE,8298,12,19247,Doctoral Research,Chen,Yi-Chao,0,0,0,0,0,1,0,
+Fall 2024,MECE,8399,42,19248,Doctoral Dissertation,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8598,11,19250,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,3,0,
+Fall 2024,MUSI,6103,1,19251,Advanced Lyric Diction,Averyt,Zachary Benjamin,3,0,0,0,0,0,0,3.78
+Fall 2024,CUIN,8699,2,19255,Doctoral Dissertation,Chung,Sheng Kuan,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8699,3,19256,Doctoral Dissertation,Gist,Conra D,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8398,4,19257,Independent Study,McNeil,Sara G,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8398,12,19258,Independent Study,Wong,Sissy S,2,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8311,12,19260,Lab of Practice-Lit Revw Devel,Shockley,Gerald,1,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8311,14,19261,Lab of Practice-Lit Revw Devel,Davis,Bradley,3,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8311,15,19263,Lab of Practice-Lit Revw Devel,Johnson,Detra DeVerne,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8311,16,19264,Lab of Practice-Lit Revw Devel,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8311,18,19265,Lab of Practice-Lit Revw Devel,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4.0
+Fall 2024,ECON,7390,1,19270,Research & Readings - Economic,Lee,Hyunju,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6399,2,19271,Masters Thesis,Song,Gangbing,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6324,1,19273,Bioinformatics,Stuckert,Adam,2,7,1,0,0,0,0,3.1
+Fall 2024,MECE,8398,24,19274,Doctoral Research,Floryan,Daniel,0,0,0,0,0,1,0,
+Fall 2024,PSYC,7392,2,19276,Psychology Practicum,Kosten,Therese A,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,8301,3,19277,Seminar in Perform Pedagogy,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,2304,17,19281,Technical Communications,Wilson,Chad A,4,0,1,0,0,0,0,3.468
+Fall 2024,MECE,7399,3,19282,Masters Thesis,Cescon,Marzia,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8699,6,19284,Doctoral Dissertation,Zvolensky,Michael J,0,0,0,0,0,1,0,
+Fall 2024,PSYC,7399,21,19285,Masters Thesis,Hernandez,Arturo E,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8699,7,19286,Doctoral Dissertation,Fetterman,Adam Kent,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6142,3,19298,Graduate Recital III,Yon,Kirsten A,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8598,32,19302,Doctoral Research,An,Ran,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8398,31,19304,Doctoral Research,An,Ran,0,0,0,0,0,2,0,
+Fall 2024,BIOL,2101,25,19309,Anatomy & Physiology Lab I,Gill,Tejendra,6,9,4,2,2,0,1,2.681
+Fall 2024,BIOL,2101,26,19310,Anatomy & Physiology Lab I,Gill,Tejendra,4,8,6,4,1,0,0,2.449
+Fall 2024,PSYC,8699,8,19314,Doctoral Dissertation,Ng,Vincent,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,1181,6,19316,Group Piano I,Van Kekerix,Todd Evan,9,3,0,0,0,0,0,3.64
+Fall 2024,MECE,8398,25,19319,Doctoral Research,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2024,COMM,6398,3,19331,Special Problems,Ni,Lan,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6393,12,19333,Clinical Research Practicum,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8399,4,19335,Doctoral Dissertation,Shaffer,Devin,1,0,0,0,0,1,0,4.0
+Fall 2024,BIOE,8298,29,19336,Doctoral Research,Li,Zhengwei,0,0,0,0,0,1,0,
+Fall 2024,COMD,7192,1,19342,Advanced Practicum,Eckert,Janet F,1,0,0,0,0,0,0,3.67
+Fall 2024,BIOL,6598,14,19343,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Fall 2024,HIST,8999,8,19344,Doctoral Dissertation,Mizelle Jr,Richard M,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8399,8,19347,Doctoral Dissertation,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Fall 2024,CNE,3310,3,19353,Construction Engr Project Mgmt,Safa,Mahdi,2,5,0,0,0,0,1,3.286
+Fall 2024,EDS,6398,2,19362,Research,Hoskere,Vedhus,0,0,0,0,0,2,0,
+Fall 2024,PHOP,6198,17,19366,Spec Prob-Physio Optics,Stevenson,Scott Bailli,2,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8999,1,19368,Dissertation,Gearing,Robin Edward,0,0,0,0,0,2,0,
+Fall 2024,GEOL,7399,14,19372,Masters Thesis,Fu,Qi,0,0,0,0,0,1,0,
+Fall 2024,MECE,8398,26,19375,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Fall 2024,MECE,8298,20,19376,Doctoral Research,Xu,Ben,0,0,0,0,0,1,0,
+Fall 2024,MECE,8598,4,19377,Doctoral Research,Xu,Ben,0,0,0,0,0,3,0,
+Fall 2024,GEOL,8398,33,19381,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2024,MECE,8399,44,19383,Doctoral Dissertation,Chen,Tian,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1322,2,19384,Applied Viola,Archibald,Amber Cristina,0,0,0,0,0,0,0,
+Fall 2024,GEOL,8698,24,19385,Doctoral Research,Robinson,Alexander C,0,0,0,0,0,1,0,
+Fall 2024,EDS,6399,1,19388,Masters Thesis,Hoskere,Vedhus,3,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,3,19389,Senior Research Project,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2024,TLIM,4396,30,19392,Internship in TLIM,Burns,Maria,2,0,0,0,0,0,1,4.0
+Fall 2024,PHLS,8396,5,19394,Doctoral Research,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8399,5,19395,Doctoral Dissertation,Lee,Hyongki,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2334,3,19397,Applied Clarinet,Potiomkin,Alexander,2,0,0,0,0,0,0,4.0
+Fall 2024,ANTH,6398,1,19398,Special Problems,Routon,Erin Danielle,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6340,2,19403,Applied Trumpet,Vassallo,Jim Cates,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6365,9,19404,Dir Rsch in Dev Cog Beh Neuro,Borjon,Jeremy Isaac,1,0,0,0,0,0,0,4.0
+Fall 2024,INDE,6372,3,19406,Advanced Linear Optimization,Diaz Martinez,Neil Orlando,1,6,2,0,0,0,0,2.889
+Fall 2024,CIVE,8398,18,19407,Doctoral Research,Nakshatrala,Kalyana,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6210,2,19408,Applied Piano,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8198,12,19410,Doctoral Research,Rahimi,Mohammad,0,0,0,0,0,2,0,
+Fall 2024,GEOL,8698,25,19412,Doctoral Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2024,ECE,8498,33,19423,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Fall 2024,ECE,8598,31,19424,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8390,1,19426,Dissertation in Practice,Hale,Margaret Ann,0,0,0,0,0,0,2,
+Fall 2024,ECE,8298,33,19430,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8198,13,19432,Doctoral Research,Li,Hongyi,0,0,0,0,0,1,0,
+Fall 2024,MIS,8399,1,19433,Doctoral Dissertation in MIS,Chin,Wynne W,0,0,0,0,0,1,0,
+Fall 2024,FORE,6398,40,19442,Special Problems in Foresight,Hines,Andrew Lewis,1,1,0,0,0,0,0,3.5
+Fall 2024,TECH,6360,40,19443,Exp Design & Data Analysis,Thornton,Brandon Latroy,5,0,0,0,0,0,0,3.934
+Fall 2024,ENGL,8698,14,19448,Graduate Research,Flynn,Nicholas,0,0,0,0,0,2,0,
+Fall 2024,LAW,5199,3,19449,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8198,5,19450,Doctoral Research,Pollonini,Luca,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,33,19454,Doctoral Research,Du,Yuncheng,0,0,0,0,0,1,0,
+Fall 2024,ELET,6350,2,19460,Overview Com Health Informatic,Pollonini,Luca,3,4,0,0,0,0,0,3.476
+Fall 2024,MUSA,1330,3,19462,Applied Flute,Martin,Tyler Craig,4,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3430,3,19463,Applied Flute,Martin,Tyler Craig,2,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,4398,5,19464,Independent Study,Barrera,Debra,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6100,2,19466,Chamber Music,Dokshansky,Yevgeny,6,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8999,2,19478,Doctoral Dissertation,Howard,Philip,0,0,0,0,0,1,0,
+Fall 2024,FINA,7A23,1,19483,Portfolio Theory and Practice,Wu,Guojun,9,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,4398,25,19494,Independent Study,Claydon,Frank J,0,0,0,0,0,1,0,
+Fall 2024,PSYC,8199,7,19500,Doctoral Dissertation,Medina,Luis Daniel,0,0,0,0,0,1,0,
+Fall 2024,GENB,7397,1,19850,Selected Topics,Webb,James R,12,2,0,0,0,0,0,3.881
+Fall 2024,FINA,6387,4,19851,Managerial Analysis,Berta,Dominique,10,3,0,0,0,0,0,3.465
+Fall 2024,NUTR,6319,1,19852,Supervised Practice,Ferrell,Carla Denise,0,0,0,0,0,11,0,
+Fall 2024,PEP,6397,1,19853,Selected Topics in Human Perf,Walsh,David W,8,3,0,0,0,0,0,3.727
+Fall 2024,PEP,8306,1,19854,Scientific Inquiry in Hlt Prof,Clarke,Mark S,3,6,0,0,0,0,0,3.443
+Fall 2024,KIN,3309,1,19855,Biomechanics,Lee,Beom Chan,46,47,12,0,0,0,6,3.343
+Fall 2024,PEP,7397,1,19856,Adv Selected Topic Human Perf,Lee,Beom Chan,0,1,0,0,0,0,0,3.33
+Fall 2024,POLS,3382,1,19857,Pols/Religion in South Asia,Vijayalakshmi,Thangavel,7,0,0,0,0,0,0,3.859
+Fall 2024,INDI,3397,1,19858,Topics in India Studies,Vijayalakshmi,Thangavel,1,0,0,0,0,0,0,4.0
+Fall 2024,INDI,3397,2,19860,Topics in India Studies,Majumder,Sarasij,1,0,0,0,0,0,0,3.67
+Fall 2024,CLAS,3374,1,19862,Women in the Ancient World,Behr,Francesca D,19,7,5,1,0,0,2,3.303
+Fall 2024,CLAS,3341,1,19863,The Roman Republic,Armstrong,Richard H,23,6,2,0,1,0,2,3.501
+Fall 2024,HIST,3395,1,19868,Sel Top-European Hist,Glass,Hildegard,2,3,2,0,1,0,2,2.46
+Fall 2024,GERM,3330,1,19870,Reading German Texts,Glass,Hildegard,0,2,1,1,1,0,0,1.668
+Fall 2024,GERM,6392,1,19872,Reading German/Non-Majors I,Bandmann,Tanya,9,1,0,0,0,0,0,3.867
+Fall 2024,FREN,4395,1,19873,Sel Tops-French Language & Civ,Vredenburgh,Amanda Jane,1,0,1,0,1,0,0,2.11
+Fall 2024,FREN,3351,1,19874,The Francophone World,Vredenburgh,Amanda Jane,4,3,2,1,0,0,1,2.868
+Fall 2024,FREN,4396,1,19875,Sel Topics-Fren-lang & culture,Giacchetti,Claudine A,2,0,1,1,0,0,0,2.833
+Fall 2024,FREN,3331,1,19876,The Life of Words,Giacchetti,Claudine A,2,4,1,2,0,0,0,2.593
+Fall 2024,CHIN,4301,1,19879,Public Speaking in Chinese,Wen,Xiaohong Sharon,11,1,0,0,0,0,0,3.834
+Fall 2024,CHIN,3344,1,19881,Global Chinese Literature,Li,Melody Yunzi,36,12,0,4,0,0,0,3.526
+Fall 2024,WCL,1101,1,19882,Introduction to Languages,Wang,Wei,16,6,6,2,2,0,2,2.969
+Fall 2024,PHIL,1301,6,19885,Intro To Philosophy,Vesga Plazas,Alejandro Jose,31,28,10,0,0,0,6,3.295
+Fall 2024,PHIL,3304,1,19888,History of 17Th Century Phil,Hattab,Helen,3,4,3,1,1,0,6,2.638
+Fall 2024,PHIL,3333,1,19889,Metaphysics,Loewenstein,Yael R,13,9,9,0,1,0,3,3.0
+Fall 2024,PHIL,6395,1,19890,Seminar Philos Problems,Coates,Daniel J,13,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,6395,2,19891,Seminar Philos Problems,Mag Uidhir,Christopher Domh,11,3,0,0,0,0,0,3.739
+Fall 2024,PHIL,6395,3,19892,Seminar Philos Problems,Oliveira,Luis RG,7,3,0,0,0,0,0,3.7
+Fall 2024,PHIL,3344,1,19893,Philosophy of Science,Weisberg,Joshua,10,12,6,0,3,0,0,2.722
+Fall 2024,WCL,3397,1,19894,Selected Topics in WCL,Choi,Jin Aeng,2,3,0,0,0,0,0,3.334
+Fall 2024,WCL,3376,1,19896,Photo & Visual Stories,Ramirez,Marie Theresa,5,0,0,0,0,0,0,4.0
+Fall 2024,WCL,3348,1,19897,Enlightenment Stories,Zaretsky,Robert D,4,1,2,1,1,0,0,2.703
+Fall 2024,WCL,3397,3,19899,Selected Topics in WCL,Behr,Francesca D,0,1,1,0,0,0,0,2.335
+Fall 2024,JAPN,2311,2,19900,Intermediate Japanese I,Ji,Fang,13,1,2,0,0,0,0,3.626
+Fall 2024,SPAN,2307,2,19901,Span for Heritage Learners I,Hernandez,Yanina,11,8,2,0,0,0,1,3.444
+Fall 2024,ENGL,4396,1,19903,SR Experience Seminar Topics,Yang,Sunny Chen,11,4,0,0,1,0,1,3.479
+Fall 2024,ENGL,4300,2,19905,Intro-Study of Language,Lee,Eunjeong,21,4,1,0,0,0,4,3.769
+Fall 2024,ENGL,3345,1,19907,Nobel Prize Winners in Lit,Aboul-Ela,Hosam,16,6,4,1,1,0,0,3.156
+Fall 2024,ENGL,3369,1,19908,Caribbean Literatures,Singh,Kavita Ashana,11,5,2,3,1,0,1,2.97
+Fall 2024,ENGL,3367,1,19909,Gay and Lesbian Literature,Gonzalez,Maria C,20,7,0,0,1,0,1,3.536
+Fall 2024,ENGL,3362,1,19910,Women in Literature,Chatterjee,Sreya,20,6,1,0,1,0,2,3.56
+Fall 2024,ENGL,3322,2,19913,Contemporary Novel,Zamora,Lois,7,7,5,4,2,0,5,2.414
+Fall 2024,ENGL,3315,1,19915,The Romantic Movement,Womble,David Avari Patrick,12,10,4,1,0,0,3,3.234
+Fall 2024,ENGL,3302,1,19916,Medieval Literature,Stock,Lorraine K,10,13,5,0,0,0,0,3.12
+Fall 2024,ENGL,7345,1,19919,Language Socialization,Zentz,Lauren R,11,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7325,1,19920,The British Empire,Lecourt,Sebastian Joseph,11,1,0,0,0,0,0,3.917
+Fall 2024,ENGL,8389,1,19923,Advanced Proj in Translation,Ferguson,Jamie H,6,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8395,1,19924,Sel Topics in Rhet and Comp,Butler,Paul G,11,2,0,0,0,0,0,3.821
+Fall 2024,ANTH,3313,1,19925,"Brown Girls, Brown Stories",Quinn,Rachel Afi,12,4,2,2,0,0,4,3.234
+Fall 2024,ANTH,3320,1,19926,Ritual and Performance,McNeal,Keith E.,10,14,5,0,0,0,0,3.172
+Fall 2024,ANTH,3324,1,19927,People & Culture of Latin Amer,Routon,Erin Danielle,16,9,0,1,1,0,2,3.395
+Fall 2024,ANTH,4330,1,19928,Applied Anthropology,Routon,Erin Danielle,23,3,2,1,4,0,1,3.202
+Fall 2024,ANTH,4338,1,19930,Visual Anthropology,Ramirez,Marie Theresa,8,0,0,1,0,0,0,3.667
+Fall 2024,ANTH,6330,1,19932,Applied Anthropology,Routon,Erin Danielle,8,1,0,0,0,0,0,3.926
+Fall 2024,ANTH,6372,1,19934,Mayan Archaeology,Chase,Arlen F,4,0,0,0,0,0,0,3.918
+Fall 2024,ANTH,6395,1,19936,Selected Topics in Ant,Quinn,Rachel Afi,2,0,0,0,0,0,0,4.0
+Fall 2024,ANTH,6395,2,19937,Selected Topics in Ant,Hannaford,Dinah Rebecca,1,1,0,0,0,0,0,3.665
+Fall 2024,ANTH,7399,6,19938,Masters Thesis,Hannaford,Dinah Rebecca,2,0,0,0,0,0,0,4.0
+Fall 2024,ANTH,7399,7,19939,Masters Thesis,Routon,Erin Danielle,4,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,1501,25,19942,Elementary Spanish I,Serrano,Paloma A,8,6,3,0,3,0,3,2.784
+Fall 2024,RELS,3380,1,19945,Asian Religions: An Overview,Huynh,Trung,3,2,2,2,0,0,1,2.63
+Fall 2024,SPEC,6395,1,20724,Clinical Teaching I,Castillo,Bernadette Marie,0,0,0,0,0,6,0,
+Fall 2024,CUIN,8361,1,20725,State of the Curriculum Field,Cutler,Carrie Sybil,16,0,0,0,0,0,1,4.0
+Fall 2024,NSS,2342,1,20770,Intro to Nat. Sec. Studies,Vardy,Ronald V,23,11,1,1,1,0,2,3.433
+Fall 2024,POLS,3318,1,20771,Intro To Public Policy,Cortina,Jeronimo,9,3,2,1,0,0,1,3.311
+Fall 2024,POLS,3335,1,20773,Political Terrorism,Soules,Michael,36,5,0,0,0,0,1,3.83
+Fall 2024,POLS,3336,1,20774,Globalization,Vardy,Ronald V,25,8,5,4,0,0,1,3.215
+Fall 2024,POLS,3372,1,20776,Latino Politics,Casellas,Jason,29,12,1,0,1,0,0,3.535
+Fall 2024,POLS,3393,1,20777,Model United Nations,Spranger,Avery,34,6,0,0,2,0,1,3.667
+Fall 2024,PHYS,6387,1,20779,Solid State Physics I,Ting,Chin Sen,7,3,0,0,0,0,0,3.7
+Fall 2024,PHYS,6366,1,20780,Quantum Field Theory,Ratti,Claudia,11,12,0,0,0,0,0,3.392
+Fall 2024,PHYS,7397,1,20782,Selected Topics in Phy,Gunaratne,Gemunu,11,0,1,0,0,0,0,3.778
+Fall 2024,PHYS,7397,2,20783,Selected Topics in Phy,Miller,John H,18,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,4397,1,20786,Selected Topics-Physics,Das,Mini,5,8,0,0,0,0,1,3.435
+Fall 2024,POLS,3313,1,20831,Intro Internatl Relatns,Chatagnier,John Tyson,24,15,2,2,0,0,1,3.35
+Fall 2024,LST,3359,1,20832,Criminal Justice,Guerra,Cristina,29,6,3,1,1,0,4,3.459
+Fall 2024,INDS,2500,3,20884,Industrial Design Studio III,Jackson,Megan H,13,1,0,0,0,0,0,3.74
+Fall 2024,INDS,4500,3,20886,Industrial Design Studio VII,Morshedzadeh,Elham,11,6,5,0,0,0,0,3.123
+Fall 2024,SPAC,6398,1,20892,Special Problems,Netti,Vittorio,12,2,1,1,0,0,0,3.418
+Fall 2024,SPAC,6298,1,20893,Special Problems,Bell,Larry S,5,4,0,0,0,0,0,3.666
+Fall 2024,MANA,7397,1,20959,Selected Topics in Management,Wesley Jr,Curtis LEONUS,3,1,0,0,0,0,1,3.75
+Fall 2024,MANA,7336,2,20961,Strategic Human Resource Mgt,Babalola,Olusegun,33,0,0,0,1,0,0,3.853
+Fall 2024,MANA,8336,1,20973,Seminar in OBM Theory,Madera,Juan Manuel,8,0,0,0,0,0,0,4.0
+Fall 2024,MANA,8331,1,20984,Seminar in Organization Theory,Sauerwald,Steve,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,8330,1,20985,Sem in Mgt Research,Avery,Derek Reynold,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7351,1,21037,Mgt of  Global Organizations,Farah,Elena,23,0,0,0,0,0,0,3.986
+Fall 2024,PHYS,8698,3,21040,Doctoral Research,Bellwied,Rene,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8698,5,21042,Doctoral Research,Bittner,Eric R,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8698,6,21043,Doctoral Research,Chen,Shuo,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8698,9,21046,Doctoral Research,Chu,Ching Wu,0,0,0,0,0,3,0,
+Fall 2024,PHYS,8698,15,21057,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8698,22,21073,Doctoral Research,Mondaini,Rubem,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8698,23,21075,Doctoral Research,Morrison,Gregory C,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8698,26,21083,Doctoral Research,Ratti,Claudia,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8698,27,21084,Doctoral Research,Ren,Zhifeng,0,0,0,0,0,5,0,
+Fall 2024,PHYS,8698,28,21086,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8698,31,21092,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8698,32,21094,Doctoral Research,Ting,Chin Sen,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8698,34,21100,Doctoral Research,Vovchenko,Volodymyr,0,0,0,0,0,1,0,
+Fall 2024,ELED,3320,3,21125,Survey Literature Child Adol,Tyson,Eleanore S,16,6,0,0,0,0,0,3.712
+Fall 2024,ELED,4310,1,21126,Reading/Language in Elementary,Tyson,Eleanore S,26,4,0,0,0,0,0,3.823
+Fall 2024,CUIN,3302,3,21127,Social Education,Thomas,Dustine J,29,1,0,0,0,0,0,3.956
+Fall 2024,CUIN,3302,5,21128,Social Education,Thomas,Dustine J,24,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,3316,1,21129,Prekindergarten Curr & Instr,Katz,Denise Annette,11,3,0,0,0,0,1,3.739
+Fall 2024,CUIN,3352,1,21131,Perspectives Math and Science,Wong,Sissy S,5,6,0,0,0,0,0,3.605
+Fall 2024,ARED,3305,2,21132,Art in Elementary Schools,Boyaki Wilson,Amanda R,11,4,2,0,0,0,0,3.452
+Fall 2024,CUIN,3111,3,21134,Educational Tech Elem Teachers,Davis,Kelly M,12,3,0,0,0,0,1,3.756
+Fall 2024,CUIN,4375,3,21138,Classroom Management,De Leon,Daniel,21,0,0,0,0,0,0,4.0
+Fall 2024,ELED,4311,2,21144,Science in Elementary School I,Domjan,Heather N,15,5,1,0,0,0,0,3.682
+Fall 2024,ELED,4314,3,21145,Mathematics in Elem School I,Cutler,Carrie Sybil,18,2,1,0,0,0,0,3.841
+Fall 2024,MATH,2305,6,21146,Discrete Mathematics,Papadakis,Emanuel Ioannis,59,13,2,0,2,0,4,3.68
+Fall 2024,MATH,2318,9,21147,Linear Algebra,He,Yunhui,4,6,5,3,3,0,5,2.207
+Fall 2024,PHYS,8998,1,21198,Doctoral Research,Cardoso Barato,Andre,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,2,21199,Doctoral Research,Bassler,Kevin E,0,0,0,0,0,3,0,
+Fall 2024,PHYS,8998,3,21200,Doctoral Research,Bellwied,Rene,0,0,0,0,0,3,0,
+Fall 2024,PHYS,8998,5,21202,Doctoral Research,Chen,Shuo,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,8,21205,Doctoral Research,Chu,Wei-Kan,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,11,21208,Doctoral Research,Freelon,Byron Kendall,0,0,0,0,0,3,0,
+Fall 2024,PHYS,8998,12,21209,Doctoral Research,Gunaratne,Gemunu,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,13,21210,Doctoral Research,Hosur,Pavan R,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8998,15,21212,Doctoral Research,Koerner,Lisa Whitehead,0,0,0,0,0,2,0,
+Fall 2024,PHYS,8998,16,21213,Doctoral Research,Li,Liming,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,19,21216,Doctoral Research,Miller,John H,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,23,21220,Doctoral Research,Ratti,Claudia,0,0,0,0,0,4,0,
+Fall 2024,PHYS,8998,25,21222,Doctoral Research,Renshaw,Andrew,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,28,21225,Doctoral Research,Timmins,Anthony Robert,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,30,21227,Doctoral Research,Varghese,Oomman K,0,0,0,0,0,1,0,
+Fall 2024,PHYS,8998,32,21229,Doctoral Research,Kakadiaris,Ioannis A,0,0,0,0,0,0,0,
+Fall 2024,PHYS,8998,34,21231,Doctoral Research,Bose,Anima B,0,0,0,0,0,1,0,
+Fall 2024,MATH,5397,1,21236,Selected Topics in Mathematics,Fitzgibbon,William E,2,2,0,0,0,0,0,3.5
+Fall 2024,SOCI,1301,2,21237,Introduction To Sociology,Colbert,Sharla Stettnisch,38,10,3,3,0,0,1,3.574
+Fall 2024,SOC,3311,2,21238,Sociology of Law,Nelson,Steven M,28,14,6,0,1,0,0,3.361
+Fall 2024,SOC,3349,1,21242,Sociology of Culture,Adams,Jennifer Lauren,31,7,1,2,0,0,0,3.594
+Fall 2024,SOC,3373,1,21245,Comparative Family Structures,Monserud,Maria Aleksandrovna,28,11,5,3,1,0,0,3.237
+Fall 2024,MATH,3338,3,21246,Probability,Papadakis,Emanuel Ioannis,34,7,1,1,1,0,4,3.651
+Fall 2024,SOC,3397,1,21247,Sel-Topics in Sociology,Purdum,Jordan Carlee,7,7,1,0,0,0,1,3.378
+Fall 2024,SOC,3316,1,21248,Sociology of Sport,Haltom,Trenton Matthews,24,13,6,2,2,0,2,3.198
+Fall 2024,MATH,3339,7,21250,Statistics for the Sciences,Deng,Xiaoxue,22,18,11,4,2,0,3,3.005
+Fall 2024,MATH,4315,1,21252,Graph Theory with Applications,Josic,Kresimir,3,7,4,6,1,0,3,2.175
+Fall 2024,MATH,7397,2,21253,Topics in Probability,Olshanskiy,Maxim Alexandrovich,11,0,0,0,0,0,0,3.91
+Fall 2024,MATH,7320,1,21254,Functional Analysis,Kalantar,Mehrdad,12,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6397,1,21255,Selected Topics in Math,Timofeyev,Ilya,22,5,0,0,0,0,0,3.839
+Fall 2024,MATH,6397,2,21256,Selected Topics in Math,Jun,Mikyoung,2,5,0,0,0,0,0,3.191
+Fall 2024,MATH,4366,1,21271,Numerical Linear Algebra,He,Jiwen,11,8,3,0,0,0,2,3.364
+Fall 2024,MATH,4350,1,21272,Differential Geometry I,Ru,Min,6,5,3,0,1,0,4,2.912
+Fall 2024,SOC,6375,1,21275,Seminar in Sociology of Law,Baumle,Amanda K,9,2,0,0,0,0,0,3.848
+Fall 2024,SOC,3378,1,21276,Sociology of Visual Culture,Karner,Tracy Xavia,12,9,5,1,1,0,0,3.083
+Fall 2024,COMD,2338,3,21278,Phonetics,Townsend,Alayna,25,4,0,1,0,0,0,3.778
+Fall 2024,CNST,6375,1,21281,BIM Applications for CM,Din,Zia Ud,33,1,1,0,0,0,0,3.914
+Fall 2024,CNST,6335,40,21282,Intro to Oil and Gas Industry,Beadle,Dwight D,2,1,0,0,0,0,0,3.667
+Fall 2024,CNST,6397,1,21283,Sel Tops-Construction Managemt,Chang,Chi Chung,12,0,0,0,0,0,0,4.0
+Fall 2024,CNST,6397,40,21284,Sel Tops-Construction Managemt,Chang,Chi Chung,1,0,0,0,0,0,0,3.67
+Fall 2024,CNST,6335,1,21289,Intro to Oil and Gas Industry,Beadle,Dwight D,16,4,0,0,0,0,0,3.8
+Fall 2024,CNST,6397,2,21290,Sel Tops-Construction Managemt,Chang,Chi Chung,4,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,2500,39,21291,Arc/Int Arc Design Studio III,Medina Vilela,Mario Andre,10,4,1,2,0,0,0,3.197
+Fall 2024,PSYC,6339,1,21299,Human Motivation,Knee,Clifford R,14,0,0,0,0,0,0,3.906
+Fall 2024,ARCH,7600,17,21300,Architecture Design Studio V,Logan,Jason,6,0,0,0,0,0,0,3.89
+Fall 2024,ARCH,7600,19,21302,Architecture Design Studio V,Olwi,Asmaa,5,0,0,0,0,0,0,4.0
+Fall 2024,WGSS,2350,25,21305,Intro To Women's Studies,Slatton,Brittany Chevon,23,3,2,0,1,0,0,3.621
+Fall 2024,PSYC,7397,1,21306,Selected Topics in Psychology,Sharp,Carla,2,0,0,0,0,0,0,4.0
+Fall 2024,ECON,2301,4,21308,Principles of Macroeconomics,Peru Durayalage,Dhanushka Arunasiri,12,9,1,0,1,0,0,3.219
+Fall 2024,ECON,3334,1,21311,Intermediate Macroeconomics,Troncoso,Pablo A,8,12,10,4,0,0,1,2.706
+Fall 2024,ELET,3300,1,21312,Applied Math in ET,Barbieri,Enrique,3,7,19,0,1,0,2,2.367
+Fall 2024,CHEM,1312,4,21313,Fundamentals of Chemistry 2,Zastrow,Melissa L,17,46,52,9,26,0,58,2.14
+Fall 2024,CHEM,2325,2,21315,Organic Chemistry II,Young,Crystal Ann,4,7,19,11,6,0,19,1.823
+Fall 2024,CHEM,2325,3,21317,Organic Chemistry II,Cai,Chengzhi,5,15,14,15,3,0,26,2.007
+Fall 2024,FINA,4330,3,21324,Corporate Finance,Medina Palma,Paolina del Carmen,8,1,3,0,0,0,1,3.279
+Fall 2024,PSYC,6370,1,21325,Fndtns-Indstrl Org Psyc,Reyes,Denise Lucia,6,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6300,1,21326,Stat for Psy,Lai,Keke,15,7,1,0,0,0,0,3.523
+Fall 2024,PSYC,6397,1,21327,Sel Top in Psychology,Fetterman,Adam Kent,8,0,0,0,0,0,0,3.918
+Fall 2024,FINA,4397,1,21328,Selected Topics in Finance,Susmel,Raul,1,3,0,0,1,0,1,2.798
+Fall 2024,PSYC,6351,1,21329,Research Methods-I/O,Brummel,Bradley James,11,1,0,0,0,0,0,3.917
+Fall 2024,FINA,4397,2,21330,Selected Topics in Finance,Susmel,Raul,1,4,0,0,0,0,0,3.134
+Fall 2024,FINA,7397,1,21331,Selected Topics in Finance,Khumawala,Saleha B,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,4397,3,21335,Selected Topics in Finance,Bean,Gregory S,6,0,0,0,0,0,2,4.0
+Fall 2024,FINA,8397,1,21336,Selected Topics in Finance,Jacobs,Kris,7,0,0,0,0,0,0,4.0
+Fall 2024,FINA,8354,1,21337,Econometrics I,Susmel,Raul,2,2,0,0,0,0,0,3.583
+Fall 2024,FINA,7397,3,21339,Selected Topics in Finance,Smith III,Edwin A,2,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7397,4,21340,Selected Topics in Finance,Bean,Gregory S,7,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7397,5,21341,Selected Topics in Finance,George,Thomas J,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7397,6,21342,Selected Topics in Finance,Hitzemann,Steffen,1,1,0,0,0,0,0,3.665
+Fall 2024,FINA,7397,7,21343,Selected Topics in Finance,Hitzemann,Steffen,4,1,0,0,0,0,0,3.734
+Fall 2024,ECON,3351,1,21345,The Economics of Development,Liu,Elaine Meichen,5,10,5,0,1,0,1,2.841
+Fall 2024,ECON,4338,1,21346,Social Science Data Mining,Zhivan,Natalia A,8,6,2,0,0,0,2,3.272
+Fall 2024,ECON,4374,1,21348,Behavioral Economics,Friedman,Willa H,13,26,5,0,0,0,1,3.144
+Fall 2024,ECON,7346,1,21349,Quantitative Macroeconomics,Paluszynski,Radoslaw,7,0,0,0,0,0,0,4.0
+Fall 2024,ECON,7351,1,21350,Develop Econ:Microecon Issues,Friedman,Willa H,8,0,0,0,0,0,0,4.0
+Fall 2024,ECON,7366,1,21351,Health Economics,Liu,Elaine Meichen,5,0,0,0,0,0,0,3.934
+Fall 2024,ECON,7380,1,21352,Macro Modeling & Forecasting,Papell,David H,6,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6302,1,21353,Expermental Dsgn,Litson,Kaylee,26,3,0,0,0,0,0,3.851
+Fall 2024,PSYC,7397,3,21355,Selected Topics in Psychology,Cirino,Paul,0,0,0,0,0,1,0,
+Fall 2024,LAW,5404,1,21361,Civil Justice Clinic II,Marquez,Ryan Michael,0,1,0,0,0,0,0,3.33
+Fall 2024,ECON,7395,1,21363,Selected Topics,Juhn,Chinhui,8,2,0,0,0,0,0,3.767
+Fall 2024,LAW,5350,1,21371,Mediation Clinic I,Willis,Tasha L,0,3,0,0,0,1,0,3.33
+Fall 2024,LAW,6317,1,21373,Mediation Clinic II,Willis,Tasha L,0,5,0,0,0,0,0,3.33
+Fall 2024,LAW,6335,1,21375,Entertainment Law Clinic,Barks,Justen S,0,3,0,0,0,0,0,3.33
+Fall 2024,LAW,5601,1,21377,Immigration Clinic I,Cabot,Jessica Anna,4,7,0,0,0,0,0,3.394
+Fall 2024,ITAL,3309,1,21378,Women Writers & Filmmakers,Behr,Francesca D,12,7,3,0,1,0,1,3.247
+Fall 2024,ECON,3377,1,21379,Economics of Public Finance,Craig,Steven G,14,25,8,0,0,0,1,3.071
+Fall 2024,LAW,5300,1,21380,Criminal Defense Clinic,Locascio,Erik Matthew,0,2,0,0,0,0,0,3.33
+Fall 2024,ELET,4325,20,21397,Advanced Microcomputer Netwrks,Velusamy,Gandhimathi,10,0,0,0,0,0,0,3.934
+Fall 2024,ENTR,3310,7,21448,Entrepreneurship,Wilbur,Stephen,141,131,17,4,4,0,0,3.319
+Fall 2024,ENTR,4340,2,21449,Entrepreneurial Capital,Rios,Eduardo Javier,11,5,1,0,1,0,0,3.316
+Fall 2024,ENTR,4397,1,21450,Sel Topics in Entrepreneurship,McCormick,Kelly,41,9,3,1,4,0,0,3.385
+Fall 2024,ENTR,4397,2,21451,Sel Topics in Entrepreneurship,McCormick,Kelly,23,10,4,1,1,0,0,3.351
+Fall 2024,ELET,6312,40,21452,Network Management,Lent,Marino Ricardo,2,0,0,0,0,0,0,4.0
+Fall 2024,ENTR,4397,3,21453,Sel Topics in Entrepreneurship,Boles,James Read,16,9,6,2,0,0,2,3.192
+Fall 2024,MARK,3337,6,21459,Professional Selling,Herman,Carl,98,112,26,7,1,0,6,3.19
+Fall 2024,MARK,4397,1,21462,Selected Topics in Mkt,Pogge,Joe M,15,15,2,0,0,0,0,3.406
+Fall 2024,MARK,7338,1,21463,Intro to Marketing Analytics,Hu,Ye,33,2,0,0,0,0,0,3.943
+Fall 2024,MARK,7399,1,21464,MS Marketing Prof Project,Koch,Steven F,1,0,0,0,0,0,0,3.67
+Fall 2024,MARK,7399,2,21465,MS Marketing Prof Project,Koch,Steven F,6,1,0,0,0,0,0,3.857
+Fall 2024,MARK,8335,1,21466,Marketing Models,Hui,Kachuen Sam,12,0,0,0,0,0,0,4.0
+Fall 2024,CNST,6399,5,21467,Thesis,Din,Zia Ud,0,0,0,0,0,1,0,
+Fall 2024,MATH,6397,3,21468,Selected Topics in Math,Jun,Mikyoung,2,3,0,0,0,0,0,3.268
+Fall 2024,KIN,3306,2,21470,Physiology-Human Performance,Paulson,Sally,37,60,17,2,2,0,2,3.029
+Fall 2024,FINA,4323,2,21472,Investment & Mutual Fund Mgt,Caire,Matthew,28,1,0,0,0,0,0,3.966
+Fall 2024,FINA,4323,3,21473,Investment & Mutual Fund Mgt,Caire,Matthew,19,0,0,1,0,0,0,3.834
+Fall 2024,ELCS,6338,1,21504,American Higher Education,McKinney,Lonnie Lyle,2,2,0,0,0,0,0,3.5
+Fall 2024,ELCS,6338,2,21505,American Higher Education,Carales,Vincent D,11,1,0,0,0,0,1,3.724
+Fall 2024,ELCS,6370,5,21508,Research for Educatnal Leaders,Hernandez,Belkis Pamela,10,3,1,0,1,0,0,3.356
+Fall 2024,ELCS,7330,1,21509,Admin of Higher Educ I,Messa,Emily Alice,3,0,0,0,0,0,0,4.0
+Fall 2024,MIS,7397,2,21517,Selected Topics in MIS,Wang,Cheng,21,0,0,0,0,0,0,3.984
+Fall 2024,MIS,7397,3,21520,Selected Topics in MIS,Pena,Juan F,27,5,0,0,1,0,0,3.737
+Fall 2024,MIS,7397,4,21524,Selected Topics in MIS,Campbell,Phillip James,8,4,0,0,0,0,0,3.667
+Fall 2024,MIS,7397,5,21529,Selected Topics in MIS,Cooper,Randolph B,10,4,6,3,1,0,0,2.792
+Fall 2024,COMM,3361,2,21530,Advertising Copywriting,Tinnel,Jason Wayne,5,16,5,2,0,0,0,2.822
+Fall 2024,MIS,7397,6,21532,Selected Topics in MIS,Messinger,Jacob Nelson,12,4,3,0,0,0,0,3.508
+Fall 2024,MIS,7397,7,21533,Selected Topics in MIS,Hosseini,Leila,7,8,3,1,1,0,0,2.95
+Fall 2024,COMM,4360,3,21534,Media Planning & Placement,Jin,Eunjoo,10,19,1,0,0,0,0,3.168
+Fall 2024,MIS,3360,5,21535,Systems Analysis and Design,Ruff,Eniscia R,62,6,0,0,0,0,3,3.917
+Fall 2024,MIS,3370,5,21536,Info Systems Development Tools,Adesanya,Bolanle Atinuke,8,12,7,8,0,0,9,2.571
+Fall 2024,MIS,3376,5,21537,Busn Appls Database Mgmt I,Grimes,George M,18,21,10,1,1,0,3,3.059
+Fall 2024,MIS,4378,5,21538,Admin of Computer-Based MIS,Knighton,William B,44,3,0,0,0,0,1,3.936
+Fall 2024,MIS,4397,1,21539,Selected Topics in MIS,Hosseini,Leila,5,11,4,0,0,0,0,2.935
+Fall 2024,MIS,4397,4,21542,Selected Topics in MIS,Wang,Cheng,48,1,0,0,0,0,1,3.966
+Fall 2024,MIS,4397,5,21543,Selected Topics in MIS,Messinger,Jacob Nelson,14,7,0,0,0,0,6,3.604
+Fall 2024,SCLT,4375,31,21548,Global Supply Chain,Velarde,Jose Manuel,15,18,4,0,1,0,0,3.245
+Fall 2024,SCLT,4380,30,21549,Quality Systems,Singh,Gulshan,8,19,9,1,2,0,1,2.718
+Fall 2024,COMM,3301,1,21879,Doctor-Patient Interaction,Yamasaki,Jill S,25,3,1,1,0,0,0,3.7
+Fall 2024,COMM,4313,1,21882,Investigative Reporting,Platenburg,Gheni Nicole,6,3,4,2,0,0,1,2.845
+Fall 2024,COMM,4354,1,21883,Organizational Crisis Comm.,Uhrick,Jan,22,2,0,0,0,0,0,3.875
+Fall 2024,COMM,4363,1,21884,Integrated Comm. Campaigns,Tinnel,Jason Wayne,8,10,3,0,0,0,0,3.175
+Fall 2024,COMM,4397,1,21887,Selected Topics Communication,Trupiano,Jerome,30,2,0,0,0,0,0,3.938
+Fall 2024,SCLT,4387,31,21888,Financial Evaluation For SCM,Reyes,Jorge,25,7,5,0,1,0,0,3.421
+Fall 2024,COMM,4312,1,21889,Feature Writing,Bhat,Nandikoor R Prashanth,15,3,0,0,1,0,0,3.632
+Fall 2024,COMM,3353,2,21890,Information & Comm Tech I,Liu,Youmei,36,4,5,0,0,0,3,3.689
+Fall 2024,EDBA,8301,1,21891,Grand Challenges in Business,Patrick-Ralhan,Vanessa M,21,0,0,0,0,0,1,3.984
+Fall 2024,CUIN,8340,1,21894,Suv/Rsch in Erly Ch Edu,Li,Xin,2,0,1,0,0,0,0,3.443
+Fall 2024,HRD,4301,1,21895,Global Leadership in HRD,Lopez,Johana,9,3,2,0,2,0,0,3.001
+Fall 2024,HIST,2303,1,21899,The Historian's Craft,Gharala,Norah Linda Andrews,6,6,2,0,3,0,1,2.667
+Fall 2024,HIST,2303,3,21901,The Historian's Craft,Cedillo,Adela,13,6,0,1,0,0,0,3.484
+Fall 2024,HIST,2357,1,21903,Modern South Asian History,Bhattacharya,Nandini Saradindu,13,5,0,0,0,0,1,3.667
+Fall 2024,HIST,3304,1,21907,Early American Republic,Clavin,Matthew J,12,13,7,2,2,0,1,2.879
+Fall 2024,IDNS,2197,1,21913,Top-Natrl Sci & Mth,Pattison,Donna,8,5,3,2,0,0,5,3.111
+Fall 2024,HIST,3355,1,21915,British Empire Since 1500,Ittmann,Karl,14,13,1,1,0,0,4,3.379
+Fall 2024,HIST,3372,1,21916,Environment since 1800,Rector,Josiah John,25,7,1,0,1,0,0,3.598
+Fall 2024,HON,3397,1,21917,Honors Selected Topics,Williamson,Jonathan Lyle,2,0,0,0,0,0,0,4.0
+Fall 2024,HIST,4347,1,21919,Stuart Britain Capstone,Patterson,Catherine F,7,7,1,0,0,0,0,3.378
+Fall 2024,HIST,4355,1,21920,Topics in Hist of Law and Soc,Zarnow,Leandra Ruth,5,8,1,0,0,0,1,3.333
+Fall 2024,HIST,4362,1,21921,Capstone in Asian History,Cong,Xiaoping,3,3,0,0,2,0,1,2.749
+Fall 2024,ENRG,4397,1,21922,Sel Topics-Enrgy & Sustainblty,Debrah,Akua Asamoah,14,3,0,0,0,0,2,3.843
+Fall 2024,HIST,4385,1,21924,Capstone in European History,Neumann,Kristina Marie,4,4,2,1,2,0,1,2.488
+Fall 2024,HON,3397,2,21925,Honors Selected Topics,Trninic,Marina,10,0,0,0,0,0,0,3.967
+Fall 2024,HON,3314,1,21926,Research & Writing Humanities,Rayneard,Max James Anthony,5,2,0,0,1,0,1,3.25
+Fall 2024,HON,4397,1,21927,Honors Selected Topics,Garner,Richard A,8,0,0,0,0,0,0,4.0
+Fall 2024,HON,3307,1,21928,Narrative Medicine,Vollrath,Lesli A,17,0,0,0,0,0,0,3.922
+Fall 2024,HON,3309,1,21929,Intro to Health Professions,Macdonald,Arlene,19,2,1,0,0,0,0,3.788
+Fall 2024,GEOL,1147,4,21973,Introductory Meteorology Lab,Jiang,Xun,5,5,3,0,1,0,3,2.834
+Fall 2024,MATH,3349,1,21974,Inferential Statistics,Cao,Jian,7,3,1,2,1,0,0,2.858
+Fall 2024,ACCT,4A06,1,22010,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,1,0,
+Fall 2024,ACCT,4A06,2,22011,PPA Colloquium 2,Newman,Michael Ray,0,0,0,0,0,47,0,
+Fall 2024,GEOL,1303,9,22012,Physical Geology,Robinson,Alexander C,27,24,33,7,3,0,6,2.618
+Fall 2024,HIST,3366,1,22016,Europe since 1900,Golubev,Alexey Valeryevich,15,10,3,3,2,0,4,2.92
+Fall 2024,HIST,3326,1,22017,Afr Am Women in Slavery & Frdm,Reed,Linda,26,5,1,1,0,0,2,3.657
+Fall 2024,HIST,6306,1,22018,Socialist Modernity,Golubev,Alexey Valeryevich,6,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6322,1,22019,Eur Historiog From 1600,Boyd,Sarah Fishman,7,0,0,0,1,0,0,3.459
+Fall 2024,HIST,6356,1,22020,U.S Historiography to 1877,Hopkins,Kelly Y,12,1,0,0,0,0,0,3.948
+Fall 2024,HIST,6381,1,22021,Readings in Public Hist,Young,Nancy Beck,13,1,0,0,1,0,0,3.689
+Fall 2024,ACCT,4A05,1,22023,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,5,0,
+Fall 2024,ACCT,4A05,2,22024,PPA Colloquium 1,Newman,Michael Ray,0,0,0,0,0,39,0,
+Fall 2024,IDNS,1101,3,22025,Physics 1301 Workshop,Pattison,Donna,25,3,1,0,0,0,4,3.759
+Fall 2024,IDNS,2113,5,22026,Calculus I SEP Workshop,Pattison,Donna,10,1,2,0,0,0,0,3.59
+Fall 2024,IDNS,2123,10,22027,Organic Chem I SEP Workshop,Pattison,Donna,18,7,3,2,1,0,1,3.279
+Fall 2024,SPEC,8301,1,22028,Professional Writing,Giles,Vickey M,7,5,0,0,1,0,1,3.257
+Fall 2024,SPEC,8301,2,22029,Professional Writing,Hale,Margaret Ann,20,3,1,0,0,0,1,3.792
+Fall 2024,ACCT,2305,1,22031,Found of Fina Acct for Non-bus,Sykes,Mary Reeves,11,15,5,4,3,0,0,2.789
+Fall 2024,ACCT,2305,3,22033,Found of Fina Acct for Non-bus,Sykes,Mary Reeves,2,5,1,0,2,0,5,2.566
+Fall 2024,ACCT,2306,1,24286,Found of Mana Acct for Non-bus,Seltz,Joe D,5,3,2,1,0,0,1,3.241
+Fall 2024,CUIN,7332,1,24290,Teaching and Learning Math,Chauvot,Jennifer B,7,1,0,0,0,0,0,3.875
+Fall 2024,CUIN,8383,1,24293,Action Research,Thomas,Dustine J,10,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8374,1,24294,Policy/Politics-Edu Governance,Hutchison,Laveria F,10,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,7331,1,24295,Supporting Striving Readers,Reis,Nancy,19,2,0,0,0,0,1,3.936
+Fall 2024,HDCS,2301,2,24326,Consumer Science,Mudd,Blake Stevens,24,10,1,0,0,0,0,3.667
+Fall 2024,HDCS,1300,9,24330,Human Ecosystems & Tech Change,Jones,Domenique Elizabeth,15,22,9,2,0,0,2,3.097
+Fall 2024,HDCS,1300,10,24331,Human Ecosystems & Tech Change,Gatterson,Beverly,31,12,4,1,1,0,1,3.469
+Fall 2024,GEOL,3344,1,24332,Paleoclimatology,Voarintsoa,Ny Riavo Gilbertinie,0,7,1,0,0,0,0,2.875
+Fall 2024,GEOL,6338,1,24334,Paleoclimate,Voarintsoa,Ny Riavo Gilbertinie,6,4,0,0,0,0,0,3.567
+Fall 2024,GEOL,4385,1,24344,Intro to Marine Geophysics,Sager,William W,1,1,0,1,0,0,0,2.557
+Fall 2024,GEOL,7327,1,24345,Principles of Marine Geophysic,Sager,William W,4,1,0,0,0,0,0,3.536
+Fall 2024,COMM,6309,1,24346,Propaganda,Turner,Taylor,15,0,0,0,0,0,1,3.956
+Fall 2024,GEOL,4340,1,24347,Aerosols and Climate,Rappenglueck,Bernhard,9,17,0,0,0,0,1,3.181
+Fall 2024,ELET,6312,20,24348,Network Management,Lent,Marino Ricardo,1,2,0,0,0,0,0,3.553
+Fall 2024,GEOL,6321,1,24349,Aerosols and Climate,Rappenglueck,Bernhard,4,1,0,0,0,0,0,3.734
+Fall 2024,ELET,6303,1,24352,Applied Neural Networks,Malki,Heidar A,8,0,0,0,0,0,0,3.876
+Fall 2024,ECON,4389,2,24354,Tops-Contemporary Economics II,Rana,Saumya,11,7,0,1,0,0,0,3.352
+Fall 2024,GEOL,4397,1,24358,Selected Topics-Geology,Zhang,Honghai,3,6,3,0,0,0,1,3.0
+Fall 2024,GEOL,6319,1,24361,Atm and Ocean Dynamics,Zhang,Honghai,2,0,0,0,0,0,1,3.835
+Fall 2024,ACCT,4331,4,24367,Federal Income Tax,Fernandez,Ramon,6,32,6,0,0,0,1,3.09
+Fall 2024,GEOL,4347,1,24368,Atmospheric Biogeochemistry,Wang,Yuxuan,6,2,0,0,0,0,0,3.791
+Fall 2024,GEOL,6370,1,24369,Atmospheric Biogeochemistry,Wang,Yuxuan,4,1,0,0,0,0,0,3.8
+Fall 2024,CUIN,7368,1,24372,Digital Imaging in Education,McNeil,Sara G,18,1,0,0,0,0,1,3.947
+Fall 2024,CUIN,7368,2,24373,Digital Imaging in Education,Ahlf,Michael,14,3,0,0,0,0,2,3.804
+Fall 2024,CUIN,7397,3,24374,Selected Topics in CUIN,McNeil,Sara G,6,1,0,0,0,0,0,3.904
+Fall 2024,CUIN,7347,2,24375,"Sem in Learning, Design & Tech",Dogan,Bulent,9,0,0,0,0,0,0,4.0
+Fall 2024,COMM,7397,1,24376,Selected Topics - Comm,Choi,Ho Joon,5,0,0,0,0,0,1,4.0
+Fall 2024,GEOL,6372,1,24377,Petroleum Geochemistry,Radovic,Jagos,13,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,6390,1,24378,3-D Seismic Exploration I,Zhou,Hua-Wei,6,1,0,0,0,0,0,3.763
+Fall 2024,GEOL,4365,1,24379,Environmental Geochemistry,Capuano,Regina M,15,11,10,0,0,0,1,3.093
+Fall 2024,ACCT,5331,3,24380,Federal Income Tax,Fernandez,Ramon,1,6,0,0,1,0,0,2.75
+Fall 2024,GEOL,6341,1,24381,Geochemistry,Capuano,Regina M,11,3,0,0,0,0,0,3.833
+Fall 2024,GEOL,3365,1,24382,Exploring the Planets,Stewart,Robert R,9,10,4,0,0,0,2,3.16
+Fall 2024,GEOL,6397,1,24383,Selected Topics in Geology,Stewart,Robert R,3,0,0,0,0,0,0,3.78
+Fall 2024,ACCT,5373,1,24385,Appl Data Analytics Tools-Acct,Miles,Carolyn A,1,1,0,0,0,0,0,3.335
+Fall 2024,ACCT,7337,1,24387,Oil & Gas Taxation,Wright,Denney L,4,4,0,0,0,0,0,3.418
+Fall 2024,CUIN,7358,2,24388,Educ Uses Digital Storytelling,Dogan,Bulent,11,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,7301,2,24394,Capstone Project,Van Nieuwenhuise,Donald S,3,1,0,0,0,0,0,3.75
+Fall 2024,GEOL,6397,2,24396,Selected Topics in Geology,Castagna,John P,10,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,6389,1,24397,Carbon Sequestration,Castagna,John P,8,1,0,0,0,0,0,3.889
+Fall 2024,GEOL,6352,1,24398,Microtectonics,Robinson,Alexander C,8,3,0,0,0,0,0,3.697
+Fall 2024,ECON,4390,1,24401,Economics Internship,Troncoso,Pablo A,7,0,0,0,0,0,0,3.764
+Fall 2024,PSYC,6397,2,24402,Sel Top in Psychology,Kosten,Therese A,7,0,0,0,0,0,0,3.859
+Fall 2024,SOC,3358,1,24404,Gender & Health Care in Africa,Langa,Neema Michael,9,7,1,3,0,0,0,3.166
+Fall 2024,SOC,6397,1,24405,Selected Topics in Sociology,Mabillard,Nicolas Dominique,10,0,0,0,0,0,0,3.934
+Fall 2024,EDS,6333,2,24410,Probability and Statistics,Nwosu,Lucy,32,17,3,0,0,0,0,3.558
+Fall 2024,EDS,6340,2,24413,Introduction to Data Science,Loganantharaj,Rasiah,43,3,0,0,0,0,0,3.956
+Fall 2024,EDS,6346,1,24415,Data Mining for Engineers,Nwosu,Lucy,73,6,0,0,0,0,0,3.853
+Fall 2024,ELCS,8356,1,24424,Program Policy Evaluation,Davis,Bradley,3,0,1,0,0,0,0,3.5
+Fall 2024,ELCS,6321,1,24426,Instructional Leadership II,Butcher,Keith,12,1,0,0,0,0,0,3.923
+Fall 2024,ELCS,6321,2,24427,Instructional Leadership II,Butcher,Keith,4,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8311,19,24428,Lab of Practice-Lit Revw Devel,Hawkins,Jacqueline McLean,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8311,21,24429,Lab of Practice-Lit Revw Devel,Butcher,Keith,0,0,0,0,0,0,0,
+Fall 2024,ELCS,8311,22,24430,Lab of Practice-Lit Revw Devel,Peters-Hawkins,April,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8313,1,24431,Issues for Urban Education Adm,Peters-Hawkins,April,7,1,0,0,1,0,0,3.298
+Fall 2024,ELCS,8395,1,24432,Dissertation in practice,Davis,Bradley,2,0,0,0,0,3,0,4.0
+Fall 2024,ELCS,8395,2,24433,Dissertation in practice,Butcher,Keith,2,0,0,0,0,5,0,4.0
+Fall 2024,ELCS,8395,3,24434,Dissertation in practice,Johnson,Detra DeVerne,0,0,0,0,0,4,0,
+Fall 2024,ELCS,8395,4,24435,Dissertation in practice,Klussmann,Duncan Foster,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8395,5,24436,Dissertation in practice,Peters-Hawkins,April,0,0,0,0,0,2,0,
+Fall 2024,ELCS,8395,6,24437,Dissertation in practice,Snodgrass Rangel,Virginia Walker,3,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8395,7,24438,Dissertation in practice,Shockley,Gerald,0,0,0,0,0,2,0,
+Fall 2024,ELCS,8695,1,24442,Dissertation in Practice,Davis,Bradley,1,0,0,0,0,3,0,4.0
+Fall 2024,ELCS,8695,3,24444,Dissertation in Practice,Johnson,Detra DeVerne,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8695,4,24445,Dissertation in Practice,Klussmann,Duncan Foster,0,0,0,0,0,0,0,
+Fall 2024,ELCS,8695,5,24446,Dissertation in Practice,Peters-Hawkins,April,1,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8695,6,24447,Dissertation in Practice,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4.0
+Fall 2024,BUSI,4336,1,24479,Consulting-Small Business Need,Becker,Charles D,12,2,3,1,0,0,0,3.297
+Fall 2024,CUIN,2300,3,24480,Introduction to STEM Teaching,Mateer,Ramona Caravella,2,0,1,0,0,0,0,3.333
+Fall 2024,IDNS,2197,2,24481,Top-Natrl Sci & Mth,Pattison,Donna,17,8,2,0,0,0,2,3.568
+Fall 2024,GEOL,6374,1,24482,Radiogenic Isotope Geochemisty,Copeland,Peter,3,3,0,0,0,0,0,3.5
+Fall 2024,IDNS,2197,3,24484,Top-Natrl Sci & Mth,Pattison,Donna,19,3,2,0,0,0,1,3.708
+Fall 2024,CUIN,3350,1,24485,Knowing/Learning Science-Math,Segura,Perri F,24,1,1,0,0,0,0,3.897
+Fall 2024,FINA,4336,1,24486,Consulting-Small Business Need,Becker,Charles D,18,3,0,0,0,0,0,3.731
+Fall 2024,GEOL,4397,2,24487,Selected Topics-Geology,Zheng,Youtong,7,7,1,1,1,0,0,3.02
+Fall 2024,GEOL,6397,3,24488,Selected Topics in Geology,Zheng,Youtong,5,2,0,0,0,0,0,3.62
+Fall 2024,LAW,6224,1,24498,Remedies,Edison,Andrew,10,24,0,1,0,8,0,3.285
+Fall 2024,LAW,7328,1,24506,WRC: Writing Criminal Defense,Maselli,Jani,6,6,0,0,0,0,0,3.39
+Fall 2024,LAW,5391,1,24511,Immigration and Family Law,Heppard,Janet M,4,8,0,0,0,0,0,3.306
+Fall 2024,LAW,6315,1,24524,Entrepreneurship,Wickliff,Cortlan James,7,6,1,0,0,0,0,3.381
+Fall 2024,CUIN,7301,1,24529,CUIN Capstone Seminar,Hausmann,Robert Carl,13,0,0,0,0,0,0,4.0
+Fall 2024,LAW,7303,1,24530,WRC: Texas Consumer Law,Marquez,Ryan Michael,3,9,0,0,0,0,0,3.388
+Fall 2024,CUIN,4397,1,24532,Selected Topics in C&I,Manuel,Mariam A,5,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5204,1,24533,Commercial Finance Transaction,Ransom,Robert Todd,5,5,1,0,0,0,0,3.394
+Fall 2024,GHL,1301,3,24541,Hospitality Technology,Morosan,Cristian,11,23,5,4,1,0,5,2.909
+Fall 2024,GHL,3349,2,24550,Hosp Procurement & Purchasing,Ginapp,Kathrine,16,17,7,1,0,0,0,3.155
+Fall 2024,BCHS,4322,1,24552,Biochemistry of Organelles,Widger,William R,15,4,1,0,0,0,1,3.717
+Fall 2024,BCHS,4355,1,24553,Eukaryotic Gene Regulation,Schwartz,Robert J,2,0,0,0,0,0,0,3.835
+Fall 2024,BCHS,6238,1,24554,Gene Regulation,Schwartz,Robert J,8,0,0,0,0,0,0,3.959
+Fall 2024,PSYC,4345,1,24556,Emotion & Motivation,Westmoreland,Kirsten E,20,24,6,3,0,0,4,3.045
+Fall 2024,GHL,4361,2,24557,Marketing Strategies,Mohamed,Mohamed Elsayed AbdElaziz,23,9,7,1,2,0,0,3.112
+Fall 2024,SOCW,7356,9,24558,Groups: Adv Clinical Practice,Robinson,Demetria,13,0,0,0,0,0,1,4.0
+Fall 2024,SOCW,7367,4,24559,Social Policy Analysis,Borja,Sharon G,29,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5284,1,24567,Energy Taxation,Matlock,Gregory Michael,4,2,0,0,0,0,0,3.502
+Fall 2024,GHL,2315,1,24573,Introduction to SPA Management,Doudna,Simone P,42,8,0,1,0,0,0,3.745
+Fall 2024,BIOL,4397,1,24597,Selected Topics in Biology,McKeon,Frank D,19,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,2397,1,24598,Selected Topics in Biology,Nunez,Martin A,22,2,0,0,1,0,1,3.76
+Fall 2024,BIOL,3340,1,24599,Invertebrate Zoology,Pennings,Steven C,7,8,12,0,2,0,5,2.587
+Fall 2024,HRD,3351,2,24619,Instructional Design for HRD,Pereira-Leon,Maura Josefina,29,15,5,0,0,0,0,3.389
+Fall 2024,BCHS,6227,1,24621,Membranes/Signal Transduction,Fujita,Masaya,15,8,0,0,0,0,0,3.638
+Fall 2024,GHL,7369,2,24690,Hospitality Financial Assets,Koh,Yoon,8,2,0,0,0,0,0,3.734
+Fall 2024,LAW,5459,2,24744,Federal Income Tax,Wells,Douglas,13,18,0,0,0,25,0,3.409
+Fall 2024,SCM,4362,3,24747,Demand and Supply Integration,Khumawala,Basheer M,2,6,0,1,0,0,0,2.927
+Fall 2024,BIOL,3301,4,24749,Mendelian and Pop Genetics,Dauwalder,Brigitte,51,46,40,11,2,0,12,2.834
+Fall 2024,KIN,4345,1,24750,Econ and Finc Aspects of Sport,Lee,Dong Hun,10,9,1,1,0,0,0,3.255
+Fall 2024,BIOL,3301,5,24751,Mendelian and Pop Genetics,Farmer,Lisa M,40,59,36,9,1,0,9,2.867
+Fall 2024,BIOL,4360,1,24755,Evol Basis of Hlth and Disease,Graur,Dan,13,5,1,1,0,0,0,3.418
+Fall 2024,GHL,4372,1,24779,Global Hosp Leadership: Asia,Glickman,Jennifer D,2,1,0,0,0,0,0,3.667
+Fall 2024,GHL,6372,1,24784,Global Hosp: Asian Community,Glickman,Jennifer D,4,0,0,0,0,0,0,4.0
+Fall 2024,GOVT,2306,50,24788,US and Texas Const/Politics,Belco,Michelle Helene,25,0,0,0,0,0,0,4.0
+Fall 2024,GOVT,2306,52,24790,US and Texas Const/Politics,Leland,Alison W,14,10,1,0,0,0,0,3.467
+Fall 2024,GOVT,2306,53,24791,US and Texas Const/Politics,LeVeaux,Christine,18,7,0,0,0,0,0,3.628
+Fall 2024,GOVT,2306,54,24792,US and Texas Const/Politics,LeVeaux,Christine,17,4,4,0,0,0,0,3.494
+Fall 2024,GOVT,2305,51,24795,"US Govt: Congress,Pres & Crts",LeVeaux,Christine,13,8,3,0,0,0,0,3.375
+Fall 2024,HON,3374,1,24796,Hist & Pol of the Hebrew Bible,Rainbow,Jesse J,8,0,0,0,0,0,0,3.835
+Fall 2024,HON,4390,1,24797,Antiquity Revisited,Barnes,Michael,16,0,0,0,0,0,0,4.0
+Fall 2024,HON,4397,2,24798,Honors Selected Topics,Liddell,Robert B,12,0,0,0,0,0,0,4.0
+Fall 2024,POLS,4347,50,24799,Religion and Politics,Cooper,Carol B,13,9,1,0,0,0,1,3.493
+Fall 2024,HON,3397,3,24801,Honors Selected Topics,Konstantinidis,Ioannis,24,0,0,0,0,0,1,4.0
+Fall 2024,HON,3397,4,24802,Honors Selected Topics,Leland,Alison W,5,10,0,0,0,0,0,3.355
+Fall 2024,HON,4330,1,24803,Narratives in the Professions,Reynolds,Aaron E,24,1,0,0,0,0,0,3.934
+Fall 2024,POLS,3310,50,24804,Intro to Political Theory,Hallmark,Terrell L,9,10,2,0,1,0,4,3.182
+Fall 2024,GEOL,4379,1,24805,Groundwater/Eng Geophys,Wiley,Robert W,2,2,0,0,0,0,0,3.5
+Fall 2024,LAW,5397,1,24808,Selected Topics,Abramson,Brian Dean,2,7,0,0,0,7,0,3.332
+Fall 2024,COMM,4375,1,24814,Propaganda & Mass Comm,Turner,Taylor,13,6,0,0,2,0,0,3.333
+Fall 2024,LAW,5397,2,24841,Selected Topics,Moulton,Cynthia,6,10,0,0,0,0,0,3.396
+Fall 2024,IDNS,3121,2,24851,Engineering Math SEP Workshop,Pattison,Donna,8,4,2,1,0,0,1,3.201
+Fall 2024,PSYC,4397,3,24854,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,0,0,
+Fall 2024,LAW,5343,1,24860,Employment Law,Taylor,John A,10,28,0,0,0,0,0,3.307
+Fall 2024,MATH,1314,10,24862,College Algebra,Krzywon,Lukasz J,36,29,35,19,25,0,20,2.179
+Fall 2024,HLT,3301,5,24864,Health Behavior Theories,Ripperger-Suhler,Ken,53,11,1,1,0,0,1,3.688
+Fall 2024,HLT,3301,6,24865,Health Behavior Theories,Haq,Arooba A,40,20,3,1,0,0,0,3.48
+Fall 2024,HLT,4307,6,24866,Research and Eval in Health,Adams,Monica Nichole,8,16,9,1,0,0,0,2.795
+Fall 2024,HLT,4307,7,24867,Research and Eval in Health,Adams,Monica Nichole,11,6,1,0,0,0,1,3.372
+Fall 2024,HLT,4307,8,24868,Research and Eval in Health,Ripperger-Suhler,Ken,9,8,3,2,0,0,2,3.001
+Fall 2024,HLT,4310,7,24869,Program Planning for Hlt Prof,Behjat,Amirmohsen,13,19,2,1,0,0,1,3.191
+Fall 2024,HLT,4310,8,24870,Program Planning for Hlt Prof,Behjat,Amirmohsen,16,17,1,0,0,0,0,3.402
+Fall 2024,HLT,4310,9,24871,Program Planning for Hlt Prof,Farmer,Jennifer,35,1,0,0,0,0,0,3.936
+Fall 2024,HLT,4310,10,24872,Program Planning for Hlt Prof,Farmer,Jennifer,37,0,0,0,0,0,0,3.946
+Fall 2024,PHLS,8324,1,24931,Multivar Analy in Psy/Educ Res,Wiesner,Margit F,14,4,0,0,0,0,0,3.704
+Fall 2024,PHLS,8350,1,24932,Educational Psychology,Master,Allison,10,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,6311,2,24940,Introduction to Counseling,Hurt,Kara Marie,5,1,0,0,0,0,0,3.833
+Fall 2024,PHLS,6324,2,24943,Addictions Counseling,Lukingbeal,Patrick Livingston,15,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,6343,2,24945,Ethical Legal Issues in Counsl,Smith,Nathaniel Lewis,5,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,6343,3,24946,Ethical Legal Issues in Counsl,Smith,Nathaniel Lewis,10,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6197,2,24962,Selected Topics,Padilla,Magdalena Manzano,10,1,0,0,0,0,0,3.939
+Fall 2024,POLS,3311,3,24967,Intro Compar Politics,Bagashka,Tanya G,7,21,5,6,1,0,0,2.634
+Fall 2024,SOCW,7337,7,24969,Crit Cinical Case Form & Diag,McMorris,Saralyn Dionne,18,1,0,0,0,0,0,3.947
+Fall 2024,PSYC,3331,1,24995,Psychology of Gender,Jaramillo,Kristen,70,6,0,1,0,0,1,3.845
+Fall 2024,PSYC,3331,2,24996,Psychology of Gender,Pathak,Neha,24,42,9,2,3,0,0,3.091
+Fall 2024,PSYC,4363,2,24997,Abnormal Child Psych,Salentine,Cassidy,45,24,6,0,1,0,3,3.426
+Fall 2024,ECE,6384,1,24998,MEMS and Nano Devices,Shih,Wei-Chuan,12,0,0,0,0,0,0,3.918
+Fall 2024,ECE,6345,1,24999,Microstrip Antennas,Jackson,David R,10,1,0,0,0,0,0,3.819
+Fall 2024,ECE,6360,1,25000,GPU/Heterogeneous Programming,Mayerich,David Matthew,16,4,0,0,1,0,0,3.603
+Fall 2024,DIGM,3358,30,25001,Augmented and Virtual Reality,Liao,Tony Chung-Li,104,21,2,1,2,0,2,3.652
+Fall 2024,PSYC,4363,3,25002,Abnormal Child Psych,Cervantes,Breana Rachelle,72,4,1,2,0,0,1,3.815
+Fall 2024,CIS,1348,32,25003,Info Systems Appl Development,Lindner,Peggy,39,6,1,0,0,0,3,3.718
+Fall 2024,CIS,1348,33,25004,Info Systems Appl Development,Albayrak,Levent,31,4,1,0,2,0,5,3.606
+Fall 2024,CIS,3320,30,25006,Information Visualization,Ratner,Edward,42,16,4,1,9,0,4,3.056
+Fall 2024,CIS,4355,31,25007,Information Systems Operations,Peddoju,Suresh Kumar,38,14,4,2,0,0,2,3.517
+Fall 2024,HON,3397,5,25009,Honors Selected Topics,Rayder,Benjamin Taylor,9,2,0,0,0,0,0,3.668
+Fall 2024,PSYC,2330,6,25010,Biological Psychology,Little,Kaitlyn Marie,53,21,2,4,0,0,0,3.542
+Fall 2024,PSYC,4363,4,25011,Abnormal Child Psych,Vieira,Alyssa Marie,49,23,7,0,0,0,1,3.465
+Fall 2024,CIS,1376,30,25015,User Experience (UX) Principle,Rodwell,Elizabeth Ann,51,4,4,0,1,0,1,3.651
+Fall 2024,LAW,5242,1,25016,Intermediate Legal Research,Watson,Amanda,6,6,0,0,0,2,0,3.39
+Fall 2024,LAW,5197,1,25019,Selected Topics,Brownell,Robert Bruce Anthony,4,9,0,0,0,0,0,3.384
+Fall 2024,GOVT,2306,10,25021,US and Texas Const/Politics,Church,Jeffrey,70,102,60,2,4,0,6,2.91
+Fall 2024,GOVT,2306,11,25022,US and Texas Const/Politics,Church,Jeffrey,44,120,47,9,15,0,12,2.662
+Fall 2024,POLS,4396,1,25023,Sel Top-Comp & Intl Pol,Lubotzky,Asher,10,3,2,1,0,0,0,3.313
+Fall 2024,COSC,4353,802,25024,Software Design,Subramaniam,Venkat,6,12,1,0,0,0,2,3.315
+Fall 2024,LST,4392,1,25025,Internship in Public Law,Tiede,Lydia B,10,0,0,0,0,0,0,4.0
+Fall 2024,COSC,3371,1,25026,Cybersecurity,Shi,Weidong,21,20,13,1,3,0,9,2.886
+Fall 2024,COSC,4394,1,25028,Physical Computing,Kakadiaris,Ioannis A,9,17,2,1,0,0,1,3.195
+Fall 2024,COSC,6370,1,25034,Fundamental of Medical Imaging,Tsekos,Nikolaos V,16,8,0,0,0,0,0,3.722
+Fall 2024,ARCH,5508,1,25037,Professional-Level Studio,Diehl,Tom,4,12,0,0,0,0,0,3.312
+Fall 2024,ARCH,6320,1,25039,Materials and Assemblies,Mantz,Ophelia,4,9,1,0,0,0,0,3.214
+Fall 2024,ARCH,5508,3,25042,Professional-Level Studio,Brune,Geoffrey,10,6,0,0,0,0,0,3.584
+Fall 2024,ARCH,5508,5,25044,Professional-Level Studio,Kacmar,Donna,7,6,2,0,0,0,0,3.311
+Fall 2024,JWST,3397,1,25294,Selected Topics Jewish Studies,Lubotzky,Asher,1,0,0,0,0,0,1,4.0
+Fall 2024,ARTH,3317,1,25295,Ancient Near Eastern Art,Rodriguez,Leticia Rios,5,6,6,1,2,0,0,2.402
+Fall 2024,ARTH,4320,1,25296,Rdng in 20th & 21st Cent Photo,Volpe,Lisa Marie,8,1,0,0,0,0,0,3.779
+Fall 2024,ARTH,4394,1,25297,Sel Tops in Art History,Tejada,Roberto Jose,5,0,0,0,0,0,1,3.934
+Fall 2024,ARTH,4394,2,25298,Sel Tops in Art History,Nevitt Jr,Hugh R,11,0,0,0,0,0,1,4.0
+Fall 2024,ARTH,4394,3,25299,Sel Tops in Art History,Rodriguez,Leticia Rios,2,2,3,0,0,0,0,2.904
+Fall 2024,HISP,2373,1,25300,Spanish Culture and Civ,Solino,Maria Elena,11,7,2,1,1,0,3,3.167
+Fall 2024,ARTH,6312,1,25301,Ancient Near Eastern Art,Rodriguez,Leticia Rios,1,1,1,0,0,0,0,2.89
+Fall 2024,ARTH,6320,1,25302,Reading 20th & 21st Cent Photo,Volpe,Lisa Marie,9,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,4367,1,25303,US Hispanics and Language,Gutierrez,Manuel J,2,3,1,0,0,0,0,3.167
+Fall 2024,ARTH,6394,1,25304,Sel Top in Art History,Tejada,Roberto Jose,11,0,0,0,0,0,0,3.91
+Fall 2024,ARTH,6394,2,25305,Sel Top in Art History,Nevitt Jr,Hugh R,3,0,0,0,0,0,0,4.0
+Fall 2024,ARTH,6394,3,25306,Sel Top in Art History,Rodriguez,Leticia Rios,2,1,1,0,0,0,0,3.168
+Fall 2024,ARTH,6399,3,25307,Master's Thesis,Zalman,Sandra,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,1316,2,25310,Fundamentals of Drawing,Herndon,Ashley Anika,14,2,2,0,1,0,1,3.439
+Fall 2024,LAW,5197,2,25312,Selected Topics,Kwok,David Y,1,1,0,0,0,0,1,3.5
+Fall 2024,LAW,5397,5,25313,Selected Topics,Levine,Aaron Michael,14,15,2,0,0,9,0,3.366
+Fall 2024,LAW,5397,6,25314,Selected Topics,Locascio,Erik Matthew,0,2,0,0,0,0,0,3.33
+Fall 2024,CUIN,6313,1,25316,Foundations of Bilingual Ed,Cole,Mikel Walker,15,4,0,0,1,0,2,3.584
+Fall 2024,CUIN,6318,1,25317,Approaches in 2nd Lang Teach,Burgess,Miguel,18,1,0,0,0,0,0,3.947
+Fall 2024,CUIN,7311,1,25318,Lang&Lit to Bilingual Learners,Cole,Mikel Walker,12,0,0,0,0,0,0,3.973
+Fall 2024,CIS,2334,21,25319,Information Systems Applicatns,Ratner,Edward,48,20,19,4,1,0,8,3.092
+Fall 2024,LAW,5327,1,25320,Asylum Law,Pisano Goetz,Georgianna Marie,9,7,1,0,0,0,0,3.509
+Fall 2024,LAW,5397,7,25322,Selected Topics,Davidson,Peter,4,7,0,0,0,0,0,3.394
+Fall 2024,CEA,4321,1,25324,Database Principles and Apps,Bopardikar,Ajit Shyamsunder,4,3,1,0,0,0,0,3.334
+Fall 2024,CEA,4335,1,25325,Capstone Design I,Ramachandran,Deepa,8,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6311,1,25326,Topics in Design History,Rodriguez Fernandez,Marta,2,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6311,2,25327,Topics in Design History,Kacmar,Donna,4,1,0,0,0,0,0,3.8
+Fall 2024,ARCH,6311,3,25331,Topics in Design History,Diehl,Tom,0,0,0,0,0,0,0,
+Fall 2024,CEA,4339,1,25333,Engr Applications Graph Theory,Meh Chu,Chu,6,2,0,0,0,0,0,3.709
+Fall 2024,LAW,5421,1,25334,Business Organizations,Brantley,Maikieta Antoinette,22,28,0,0,0,0,0,3.42
+Fall 2024,ARCH,3397,1,25337,Selected Topics,Lander,Lawrence Farnham,85,3,1,1,1,0,0,3.854
+Fall 2024,ARTS,4397,1,25339,Sel Topics in Fine Arts,Willis,William H,19,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6397,1,25340,Sel Topics/Studio Arts,Willis,William H,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7348,1,25343,Estate Planning,Huang,Yonghui,2,7,1,1,0,0,0,2.999
+Fall 2024,FINA,7349,1,25344,Capstone Personal Fin Planning,Johnson,Nicholas A,2,2,2,0,0,0,0,3.055
+Fall 2024,MANA,4397,1,25345,Selected Topics in Mana,Houston,Lawrence,2,1,2,0,1,0,3,2.555
+Fall 2024,MANA,4397,4,25348,Selected Topics in Mana,Salaiz,Ashley,21,5,3,0,0,0,2,3.575
+Fall 2024,MATH,6398,15,25349,Special Problems,Quaini,Annalisa,0,0,0,0,0,2,0,
+Fall 2024,ARTS,3331,1,25350,Graphic Design Software,Rose,Sierra,22,2,0,0,0,0,0,3.889
+Fall 2024,CEA,4422,1,25353,Communications and Networking,Han,Zhu,6,2,0,0,0,0,0,3.75
+Fall 2024,CEA,4424,1,25355,Embedded Computing and IoT,Bopardikar,Ajit Shyamsunder,1,5,2,0,0,0,0,2.958
+Fall 2024,ECE,2197,1,25357,Selected Topics,De La Rosa-Pohl,Diana,18,1,0,0,0,0,0,3.93
+Fall 2024,SPAN,6354,1,25359,Span Phonetics and Variation,Goodin-Mayeda,Carrie Elizabeth,8,0,0,0,1,0,0,3.372
+Fall 2024,SPAN,6389,1,25360,Method Teach Span Heritage Lrn,Fairclough,Marta A,11,2,0,0,0,0,0,3.821
+Fall 2024,SPAN,7301,1,25361,Methods Hisp Lit & Lang,Rivera Garza,Cristina,11,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,6347,1,25362,Span Caribbean Women Rewrite,Cuesta,Mabel,12,0,1,0,0,0,0,3.846
+Fall 2024,SPAN,7304,1,25363,Critical Theory,Ruisanchez Serra,Jose Ramon,3,0,3,0,0,0,0,3.0
+Fall 2024,SPAN,7337,1,25364,Spanish-Language Immigrant Lit,Kanellos,Nicolas,8,1,0,1,0,0,0,3.567
+Fall 2024,POLS,3331,1,25365,American Foreign Policy,Heinrich,Tobias,12,9,5,3,3,0,12,2.74
+Fall 2024,GEOL,6350,1,25366,Advanced Structural Geology,Naruk,Stephen,5,2,0,0,0,0,0,3.667
+Fall 2024,GEOL,6380,1,25367,Sequence Stratigraphy,Bhattacharya,Janok P,1,6,0,0,0,0,0,3.237
+Fall 2024,GEOL,6381,1,25368,Petroleum Geology,Van Nieuwenhuise,Donald S,4,3,0,0,0,0,0,3.477
+Fall 2024,PSYC,4363,5,25373,Abnormal Child Psych,Gecha,Tess C,43,33,2,1,0,0,1,3.418
+Fall 2024,ECE,4371,1,25377,Advanced Telecommunications,Han,Zhu,20,2,1,0,0,0,0,3.797
+Fall 2024,ECE,5397,1,25379,Selected Topics,Mayerich,David Matthew,0,1,0,0,0,0,0,3.33
+Fall 2024,ARTS,6397,2,25385,Sel Topics/Studio Arts,Meza,Abinadi,4,0,0,0,0,0,0,4.0
+Fall 2024,ECE,5397,3,25386,Selected Topics,Shan,Xiaonan,3,0,0,0,0,0,0,3.89
+Fall 2024,ECE,5397,4,25389,Selected Topics,Nguyen,Hien V,23,1,0,0,0,0,0,3.766
+Fall 2024,ECE,6397,2,25391,Selected Topics,Shan,Xiaonan,50,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6397,3,25392,Selected Topics,Nguyen,Hien V,9,2,0,0,0,0,0,3.848
+Fall 2024,MATH,3321,1,25393,Engineering Mathematics,West,James David,30,25,40,19,39,0,27,1.926
+Fall 2024,HLT,4320,4,25397,Admin of Health Services,Behjat,Amirmohsen,6,23,7,1,0,0,1,2.856
+Fall 2024,HLT,4320,5,25398,Admin of Health Services,Behjat,Amirmohsen,4,18,11,3,1,0,1,2.568
+Fall 2024,MATH,2414,31,25400,Calculus II,May,Jennifer Ruhnow,110,72,56,36,27,0,34,2.652
+Fall 2024,HLT,3306,1,25401,Environmental Health,Fedor Amador,Theresa Marie,131,14,5,0,0,0,0,3.829
+Fall 2024,HLT,3306,2,25402,Environmental Health,Fedor Amador,Theresa Marie,95,15,6,2,1,0,0,3.656
+Fall 2024,HLT,3381,3,25410,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,75,10,1,0,0,0,0,3.811
+Fall 2024,HLT,3380,3,25411,Culture and Health,Markowitz,Eliz,35,13,6,0,0,0,5,3.525
+Fall 2024,HLT,3380,4,25412,Culture and Health,Markowitz,Eliz,38,10,7,2,2,0,0,3.306
+Fall 2024,HLT,4392,4,25413,Field Work in Community Health,Proctor,Robin Ann,36,4,1,0,0,0,2,3.821
+Fall 2024,HLT,4302,1,25414,Hlt Aspect Human Sexuality,Hinds,Josephine Taulbee,16,5,2,0,1,0,0,3.458
+Fall 2024,PHLS,7302,1,25415,Internship I,Lee,Jungeun,0,0,0,0,0,7,0,
+Fall 2024,PHLS,7302,2,25416,Internship I,Smith,Nathaniel Lewis,0,0,0,0,0,10,0,
+Fall 2024,PHLS,8349,1,25417,Advanced Psyc Assessment II,Blassingame,Jonathan C,9,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8369,1,25418,Program Evaluation,Gonzalez,Jorge E,16,0,0,0,0,0,0,4.0
+Fall 2024,HLT,3304,3,25425,Child and Adolescent Health,Shamblin,Angel Ann,59,11,4,2,1,0,0,3.602
+Fall 2024,ARCH,6312,1,25433,Topics in Design Media,Noldt,Peter,1,0,0,0,2,0,0,1.223
+Fall 2024,ARTS,6396,1,25443,Sel Topics in Fine Arts Media,Giampietro,Francis A,4,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,3396,1,25446,Selected Tops Studio Practice,Giampietro,Francis A,8,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6396,2,25449,Sel Topics in Fine Arts Media,Giampietro,Francis A,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6302,2,25450,Introductn To Neuroengineering,Sheth,Bhavin R,2,1,0,0,0,0,0,3.557
+Fall 2024,ARLD,3300,1,25454,Intro to Arts Administration,McWilliams,Emily,24,0,1,0,0,0,0,3.907
+Fall 2024,ECE,6397,4,25455,Selected Topics,Brankovic,Stanko R,5,2,0,0,0,0,0,3.62
+Fall 2024,ECE,6397,5,25456,Selected Topics,Nguyen,Hien V,8,1,0,0,0,0,0,3.816
+Fall 2024,ARLD,6335,1,25462,Leading Change in the Arts,Cachia,Amanda,14,0,0,0,0,0,1,4.0
+Fall 2024,ARLD,6360,1,25463,Arts & Community Engagement,Richardo,Nicole D,6,0,0,0,0,0,0,3.945
+Fall 2024,ECE,5197,1,25464,Selected Topics,Nguyen,Hien V,10,0,0,0,0,0,0,4.0
+Fall 2024,ARLD,6395,1,25467,Sel Topics in Arts Leadership,Holum,Erika Mei Chua,7,0,0,0,0,0,0,4.0
+Fall 2024,ARLD,6398,1,25471,Special Prob in Arts Leadrshp,Fernando,Fleurette S,2,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5316,1,25476,Entertainment Law Clinic II,Barks,Justen S,1,0,0,0,0,0,0,3.67
+Fall 2024,DRAM,1310,3,25478,Introduction to Theatre,Egging,Jon Leo,38,3,4,0,3,0,1,3.521
+Fall 2024,ECE,5319,1,25479,Introduction to Nanotechnology,Canepa,Pieremanuele,2,3,0,0,0,0,0,3.466
+Fall 2024,LAW,5342,2,25481,Prof Writing Strategies,Nieuwveld,Lisa Bench,4,6,0,0,0,2,0,3.367
+Fall 2024,LAW,5342,3,25483,Prof Writing Strategies,Warren,Jill,5,6,1,0,0,0,0,3.306
+Fall 2024,INDE,2333,2,25484,Engineering Statistics I,Govindu,Nirathi Keerthi,9,11,3,0,0,0,2,3.132
+Fall 2024,INDE,2333,3,25485,Engineering Statistics I,Govindu,Nirathi Keerthi,10,11,3,0,0,0,1,3.223
+Fall 2024,INDE,2333,4,25486,Engineering Statistics I,Govindu,Nirathi Keerthi,23,14,4,0,0,0,1,3.383
+Fall 2024,HIST,3320,1,25487,US Women's History Since 1840,Johnson,Michele R,18,16,1,2,0,0,2,3.36
+Fall 2024,HIST,3361,1,25488,Sports in American History,Lira,Karla Aisen,23,10,2,1,5,0,2,3.138
+Fall 2024,ARCH,6112,1,25489,Topics in Design Media,Noldt,Peter,3,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6112,2,25490,Topics in Design Media,Noldt,Peter,2,3,0,0,0,0,0,3.268
+Fall 2024,ARCH,6112,3,25491,Topics in Design Media,Noldt,Peter,4,1,0,0,0,0,0,3.602
+Fall 2024,ARCH,6112,5,25493,Topics in Design Media,Noldt,Peter,3,2,0,0,0,0,0,3.534
+Fall 2024,ARCH,6112,6,25494,Topics in Design Media,Noldt,Peter,4,1,0,0,0,0,0,3.536
+Fall 2024,THEA,3303,1,25501,Playwriting: Non-Realism,Romero,Gregory John,17,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7340,1,25502,Clinical Practice with Child,Rivera,Jaime,27,2,0,0,0,0,0,3.931
+Fall 2024,SOCW,7339,1,25504,Prof. Grant Writing for SW,Stagg,Helen Ruth,28,0,1,0,0,0,0,3.931
+Fall 2024,SOCW,7371,1,25505,Trauma & SW Practice,O'Neal,Vaughn,28,1,0,0,0,0,0,3.966
+Fall 2024,SOCW,7340,2,25506,Clinical Practice with Child,Cheung,Monit,13,4,0,0,0,0,0,3.765
+Fall 2024,PHIL,1301,7,25517,Intro To Philosophy,Haaga,Curtis W,88,58,12,1,1,0,1,3.431
+Fall 2024,THEA,6304,1,25523,Mask Theory and Practice,Willson,Paige A,0,1,0,0,0,0,0,3.33
+Fall 2024,LAW,5338,1,25524,Legal writing,Davis,Megan Leigh-Wilson,10,9,2,2,0,0,0,3.131
+Fall 2024,LAW,5338,2,25525,Legal writing,Simmons,Laurel Ellis Parker,2,20,0,0,0,0,0,3.016
+Fall 2024,THEA,6396,1,25528,Selected Topics Theatre,Romero,Gregory John,1,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5342,4,25530,Prof Writing Strategies,Swift,Kenneth Richard,6,5,1,0,0,0,0,3.362
+Fall 2024,HLT,1353,6,25531,Personal Health,Vercher,Michelle Taylor,90,19,8,2,0,0,0,3.617
+Fall 2024,HLT,3300,3,25532,Social Health and Wellness,Hudson-Gillan,Gail,90,8,0,0,0,0,0,3.891
+Fall 2024,HLT,3300,4,25533,Social Health and Wellness,Hudson-Gillan,Gail,87,10,0,1,2,0,0,3.77
+Fall 2024,AAS,3325,1,25534,AFAM Studies Theory and Method,Wright,Kelechi Chinyere,12,2,0,1,0,0,0,3.645
+Fall 2024,AAS,3390,1,25536,Harlem Renaissance,Green,Tara T,2,3,2,0,0,0,0,3.0
+Fall 2024,AAS,3394,1,25537,Selected Topics Afr Am Stdy,Singh,Kavita Ashana,0,1,1,0,0,0,0,2.665
+Fall 2024,MECE,5397,1,25538,Selected Topics,Chen,Tian,9,14,4,0,0,0,1,3.271
+Fall 2024,MECE,5397,2,25539,Selected Topics,Huang,Yi-Chun,28,11,1,0,0,0,1,3.593
+Fall 2024,MECE,5397,3,25540,Selected Topics,Franchek,Matthew,5,9,5,1,0,0,0,2.933
+Fall 2024,MECE,5397,4,25541,Selected Topics,Joshi,Shailendra Pramod,2,8,0,0,0,0,1,3.299
+Fall 2024,MECE,6333,1,25542,Conduction and Radiation,Zhao,Bo,2,1,0,0,0,0,0,3.667
+Fall 2024,MECE,6333,2,25543,Conduction and Radiation,Zhao,Bo,1,3,1,0,0,0,2,3.264
+Fall 2024,MECE,6333,3,25544,Conduction and Radiation,Zhao,Bo,1,1,1,0,0,0,0,3.22
+Fall 2024,MECE,6363,1,25545,Physical Metallurgy,Selvamanickam,Venkat,5,15,0,0,0,0,1,3.333
+Fall 2024,LAW,5277,1,25547,Records Sealing Expunction I,Cepeda Hendrickson,Grecia,0,4,0,0,0,0,0,3.33
+Fall 2024,LAW,5297,2,25548,Selected Topics,Prasad,Priya,4,6,0,0,0,0,0,3.4
+Fall 2024,MECE,6397,1,25549,Selected Topics,Lee,Myoungkyu,10,5,1,0,0,0,0,3.542
+Fall 2024,MECE,6397,2,25550,Selected Topics,Lee,Myoungkyu,1,0,2,0,0,0,1,2.667
+Fall 2024,MECE,6397,3,25551,Selected Topics,Lee,Myoungkyu,0,0,0,0,0,0,1,
+Fall 2024,IDNS,1141,7,25552,Chemistry I SEP Workshop,Pattison,Donna,18,4,1,2,0,0,2,3.454
+Fall 2024,MECE,6397,4,25553,Selected Topics,Xu,Ben,12,0,1,0,0,0,0,3.694
+Fall 2024,MECE,6397,5,25554,Selected Topics,Xu,Ben,1,0,1,0,0,0,1,2.835
+Fall 2024,MECE,6397,6,25555,Selected Topics,Xu,Ben,5,1,0,0,0,0,0,3.723
+Fall 2024,MECE,6397,7,25556,Selected Topics,Huang,Yi-Chun,7,0,0,0,0,0,1,4.0
+Fall 2024,MECE,6397,8,25557,Selected Topics,Franchek,Matthew,5,2,1,1,0,0,0,3.039
+Fall 2024,MECE,6397,9,25558,Selected Topics,Chen,Tian,7,0,0,0,0,0,0,3.859
+Fall 2024,ARTS,6397,3,25559,Sel Topics/Studio Arts,Clarke,Chelsea,4,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,4397,1,25569,Selected Topics,Race,Bruce Alan,7,6,0,0,0,0,0,3.564
+Fall 2024,LAW,5390,1,25570,Environmental Law,Hester,Tracy,11,10,1,0,0,1,1,3.41
+Fall 2024,ARCH,6397,1,25571,Sel Tpcs-Arc/Urbn Desgn,Race,Bruce Alan,2,4,1,0,0,0,2,3.284
+Fall 2024,GEOL,6380,2,25572,Sequence Stratigraphy,Bhattacharya,Janok P,0,1,0,0,0,0,0,3.33
+Fall 2024,GEOL,6381,2,25573,Petroleum Geology,Van Nieuwenhuise,Donald S,1,0,0,0,0,0,0,3.67
+Fall 2024,DANC,2323,1,25576,Dance in Film,Estrada,Maria Gabriela,30,4,0,1,0,0,0,3.791
+Fall 2024,DANC,4110,2,25577,Dance Ensemble,Lockett,KeyAira,19,1,0,0,0,0,0,3.95
+Fall 2024,DANC,4197,1,25578,Selected Topics,Valle,Toni Leago,11,0,0,0,0,0,0,3.94
+Fall 2024,ECE,3441,3,25581,Digital Logic Design,Viswanath,Padmavati Aparna,17,9,7,0,0,0,2,3.243
+Fall 2024,MIS,4397,6,25585,Selected Topics in MIS,Eierdam,Richard R,15,8,4,1,0,0,1,3.321
+Fall 2024,MIS,4397,7,25586,Selected Topics in MIS,Gonzalez Jr,Frederick,29,0,0,0,0,0,1,4.0
+Fall 2024,MIS,4397,9,25588,Selected Topics in MIS,Jagtap,Pankaj,1,0,0,0,0,0,0,3.67
+Fall 2024,MIS,7376,2,25589,Systems Analysis and Design,Ruff,Eniscia R,31,2,0,0,0,0,0,3.959
+Fall 2024,MIS,7397,8,25590,Selected Topics in MIS,Jagtap,Pankaj,10,4,0,0,0,0,0,3.738
+Fall 2024,MIS,7397,10,25592,Selected Topics in MIS,Gonzalez Jr,Frederick,30,0,0,0,0,0,0,4.0
+Fall 2024,MIS,7397,11,25593,Selected Topics in MIS,Jagtap,Pankaj,5,0,0,0,0,0,0,3.868
+Fall 2024,DANC,1202,1,25602,Open Level Ballet,Ozsoy,Firat Kazbek,17,2,0,0,0,0,0,3.86
+Fall 2024,ARCH,6201,1,25603,Visual Studies I,Clovis,Sam,9,3,1,0,0,0,1,3.488
+Fall 2024,IART,3395,2,25620,Sel Topics in Interdis Arts,Meza,Abinadi,3,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,8377,2,25637,Qualitative Inquiry in Educ I,Burgess,Miguel,12,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3331,3,25647,Psychology of Gender,Martinez,Anjelica M,23,12,5,0,0,0,0,3.458
+Fall 2024,PSYC,2330,8,25652,Biological Psychology,Jackson,Lillian Reed,44,29,5,0,1,0,1,3.426
+Fall 2024,POLS,6350,1,25656,Seminar in Media and Politics,Archer,Allison Michelle Nam,7,2,0,0,0,0,0,3.668
+Fall 2024,POLS,6357,1,25657,Comparative Judicial Systems,Tiede,Lydia B,3,1,0,0,0,4,0,3.75
+Fall 2024,POLS,6315,1,25658,Health Care Policy,Shor,Boris,4,2,0,0,0,0,0,3.667
+Fall 2024,POLS,6364,1,25659,Seminar in Legislative Process,Kistner,Michael,6,1,0,0,0,0,0,3.669
+Fall 2024,POLS,6396,1,25660,Selected Topics in Compar IR,Jung,Jae Hee,11,0,0,0,0,0,0,3.82
+Fall 2024,POLS,6348,1,25661,Contemporary Political Theory,Church,Jeffrey,7,0,0,0,0,0,0,3.953
+Fall 2024,POLS,6396,2,25662,Selected Topics in Compar IR,Heinrich,Tobias,3,5,0,0,0,0,0,3.334
+Fall 2024,MECE,6388,1,25663,Optimal Control Theory,Chen,Zheng,8,0,2,0,0,0,1,3.435
+Fall 2024,MECE,6388,2,25665,Optimal Control Theory,Chen,Zheng,0,2,0,0,0,0,0,3.0
+Fall 2024,MECE,6388,3,25666,Optimal Control Theory,Chen,Zheng,0,0,1,0,0,0,2,2.0
+Fall 2024,ACCT,4380,2,25718,Contro & Sec Intern Fin Inform,Brant Jr,Robert Edward,1,1,0,0,0,0,0,3.665
+Fall 2024,ACCT,5378,2,25720,Control & Security of Fin Info,Brant Jr,Robert Edward,0,1,0,0,0,0,0,3.33
+Fall 2024,ACCT,7390,2,25725,Contrl & Secur of Finan Inform,Brant Jr,Robert Edward,3,4,0,0,0,0,0,3.523
+Fall 2024,BUSI,4305,2,25727,Business Ethics for Accountant,Brant Jr,Robert Edward,1,2,0,0,0,0,0,3.443
+Fall 2024,GENB,5304,2,25728,Business Ethics for Accountant,Brant Jr,Robert Edward,0,1,0,0,0,0,0,3.0
+Fall 2024,GENB,7304,2,25729,Bus Ethics for Accountants,Brant Jr,Robert Edward,0,3,0,0,0,0,0,3.11
+Fall 2024,HDFS,2314,6,25740,Human Dev and Interventions,Dunsmore,Julie C,68,17,12,6,8,0,14,3.112
+Fall 2024,HDFS,2314,1,25742,Human Dev and Interventions,Dunsmore,Julie C,104,29,10,6,5,0,9,3.392
+Fall 2024,HDFS,2314,5,25746,Human Dev and Interventions,Dunsmore,Julie C,20,17,15,5,16,0,6,2.238
+Fall 2024,HDFS,4318,5,25747,Parent-Child Relationships,Frankel,Leslie Ann,11,2,0,0,0,0,0,3.795
+Fall 2024,HDFS,4318,6,25748,Parent-Child Relationships,Kamdar-Sharif,Amber,35,4,0,0,0,0,0,3.762
+Fall 2024,PHLS,6330,3,25749,Human Growth-Developmnt,Whitaker,Rachael Gwin,10,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,6330,4,25750,Human Growth-Developmnt,Whitaker,Rachael Gwin,10,1,0,0,1,0,0,3.583
+Fall 2024,MUSA,3160,1,25754,Applied Music,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,MUED,6301,1,25757,Intro to Research in Music Edu,Meals,Cory Dewitt,5,2,0,0,0,0,0,3.809
+Fall 2024,MUSI,1110,3,25758,Jazz Orchestra,Marmolejo,Noe J,6,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,1150,3,25762,Mariachi Ensemble,Longoria,Jose Isabel,2,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7397,2,25764,Selected Topics in Management,Kumar,Sanjiv,17,0,1,0,0,0,0,3.761
+Fall 2024,MUSI,2181,4,25765,Group Piano III,Van Kekerix,Todd Evan,8,3,0,0,0,0,0,3.697
+Fall 2024,MUSI,2181,5,25766,Group Piano III,Van Kekerix,Todd Evan,9,5,0,0,0,0,0,3.619
+Fall 2024,MUSI,1303,1,25767,Fundamentals of Music,Brake,Austin S,10,10,3,0,0,0,0,3.204
+Fall 2024,MUSI,4100,1,25768,Chamber Music,Archibald,Amber Cristina,24,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4100,4,25769,Chamber Music,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4160,1,25770,Internship in Piano Teaching I,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4197,1,25771,Selected Topics in Music,Suits,Brian J,1,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,3300,3,25773,Educational Psychology,Conston,Toya,141,11,8,1,2,0,0,3.718
+Fall 2024,MUSI,4250,1,25774,Performance Pedagogy,Reed,Gavin Davis,6,2,0,0,0,0,0,3.709
+Fall 2024,HDFS,2320,5,25775,Research Methods in HDFS,Brown,Deon,19,8,4,2,0,0,1,3.313
+Fall 2024,HDFS,2320,6,25776,Research Methods in HDFS,Kamdar-Sharif,Amber,19,11,2,0,1,0,1,3.384
+Fall 2024,MUSI,6397,1,25779,Selected Topics-Music,Pollack,Howard J,8,1,1,0,0,0,1,3.535
+Fall 2024,MUSI,4358,1,25780,Music of Bach and Handel,Dirst,Matthew C,2,3,0,0,0,0,0,3.136
+Fall 2024,MUSI,6358,1,25781,Music of Bach and Handel,Dirst,Matthew C,4,2,0,0,0,0,0,3.667
+Fall 2024,MUSI,4317,1,25784,Anal of Jazz and Popular Music,Koozin,Timothy,5,2,0,0,0,0,1,3.714
+Fall 2024,MUSI,6317,1,25785,Analysis of Jazz & Pop Music,Koozin,Timothy,4,1,0,0,0,0,1,3.8
+Fall 2024,MUSI,6100,3,25786,Chamber Music,Reed,Gavin Davis,4,0,0,0,0,0,0,4.0
+Fall 2024,BTEC,4249,30,25791,Biotechnology Capstone I,Khan,Abdul Latif,15,0,0,0,0,0,0,3.934
+Fall 2024,BTEC,6100,30,25793,Seminar in Biotechnology,Khan,Abdul Latif,3,0,0,0,0,0,0,4.0
+Fall 2024,BTEC,6399,41,25795,Thesis,Lin,Yuheng,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6327,1,25798,Collab Skills for Organists I,Robinson,Daryl Allen,3,0,0,0,0,0,0,3.89
+Fall 2024,MUSI,6397,2,25800,Selected Topics-Music,Dirst,Matthew C,2,6,0,0,0,0,0,3.333
+Fall 2024,MUSI,6397,3,25801,Selected Topics-Music,Lee,Ji Yeon,7,2,0,0,0,0,0,3.814
+Fall 2024,BUSI,4397,1,25804,Selected Topics in GENB,Bean,Gregory S,4,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7397,9,25805,Selected Topics in Finance,Bean,Gregory S,6,0,0,0,0,0,0,4.0
+Fall 2024,THEA,1220,1,25807,Intro to Voice and Movement,Majkowski,Vivian,6,1,2,0,0,0,2,3.298
+Fall 2024,LAW,5197,3,25808,Selected Topics,Brem,Katherine B,0,0,0,0,0,38,0,
+Fall 2024,PHLS,6345,2,25810,Atypical Growth & Behavior,Hurt,Kara Marie,5,1,1,0,0,0,0,3.666
+Fall 2024,PHLS,8397,1,25811,Selected Topics,Allan,Blake A,11,1,0,0,0,0,0,3.834
+Fall 2024,ARCH,3397,2,25813,Selected Topics,Kudless,Andrew Justin,128,30,5,2,17,0,13,3.317
+Fall 2024,ENGL,4384,1,25814,SR Writing Proj CW: Poetry,Belieu,Erin Colleen,12,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5351,1,25815,Juvenile Law,Marrus,Ellen,3,13,0,0,0,0,0,3.394
+Fall 2024,PSYC,4308,1,25817,Psychopharmacology,Leasure,Jennifer Leigh,8,17,11,4,0,0,1,2.717
+Fall 2024,PETR,7322,1,25818,Advanced Formation Evaluation,Myers,Michael Tolbert,5,2,0,0,0,0,0,3.714
+Fall 2024,DIGM,2376,30,25820,UX Principles 2,Rodwell,Elizabeth Ann,47,12,1,1,1,0,0,3.539
+Fall 2024,DIGM,2351,30,25822,Web Design,Dawson,Michael John,18,12,1,0,3,0,0,3.206
+Fall 2024,LAW,6321,3,25824,Professional Responsibility,Murphy,Mary Ellen,23,34,3,0,0,0,0,3.322
+Fall 2024,ARTS,3397,1,25827,Sel Tops in Fine Arts,Winter,Shane Evan,16,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,8331,1,25828,Research Paradigms in Acct,Larson,Chad R,5,0,0,0,0,0,0,3.934
+Fall 2024,SOCW,8345,1,25831,Research Methods V,Borja,Sharon G,6,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8333,1,25832,Social Science Theories,Borja,Sharon G,6,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8298,24,25834,Doctoral Research,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,23,25835,Doctoral Research,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,2,0,
+Fall 2024,CHEE,8598,23,25837,Doctoral Research,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,4,0,
+Fall 2024,CHEE,8399,23,25838,Doctoral Dissertation,Abdelrahman,Omar Abdelrahman Ali,0,0,0,0,0,2,0,
+Fall 2024,LAW,7397,1,25839,Selected Topics,Ten Cate,Irene,6,5,0,0,0,0,0,3.395
+Fall 2024,ENGL,6363,1,25841,Early Modern Literature,Christensen,Ann C,4,7,0,0,0,0,0,3.514
+Fall 2024,LAW,5421,2,25842,Business Organizations,Ragazzo,Robert A,20,36,2,0,0,0,0,3.362
+Fall 2024,LAW,7304,1,25844,WRS: Bioethics,Koch,Valerie Gutmann,7,2,2,0,0,0,0,3.395
+Fall 2024,LAW,6372,1,25845,Analytic Methods,Chandler,Seth J,2,4,0,0,0,0,0,3.388
+Fall 2024,LAW,5397,8,25847,Selected Topics,Chandler,Seth J,5,10,0,0,0,0,0,3.377
+Fall 2024,LAW,7335,1,25848,WRS: Animal Law,Morath,Sarah,4,8,0,0,0,0,0,3.388
+Fall 2024,LAW,5335,1,25849,Land Use,Zale,Kellen B,11,20,3,0,0,9,0,3.196
+Fall 2024,MANA,4354,1,25853,EEO Commission Internship,Williams,John M,0,0,0,0,0,9,0,
+Fall 2024,MANA,4350,2,25855,International Management,Abgaryan,Natalia,10,1,1,0,0,0,0,3.668
+Fall 2024,MANA,3335,6,25857,Intro Org Behavior and Mgmt,Traylor,Horatio Deone,51,12,2,0,0,0,1,3.678
+Fall 2024,MANA,3335,7,25858,Intro Org Behavior and Mgmt,Garcia,Larissa Renee,34,15,1,0,0,0,0,3.686
+Fall 2024,LAW,6393,1,25861,Patent Remedies & Defenses,Janicke,Paul,7,10,0,0,0,0,0,3.392
+Fall 2024,TLIM,3360,32,25862,Law & Ethics-Tech & Innovation,Feriante,Chris,47,11,9,0,0,0,2,3.488
+Fall 2024,HISP,2374,5,25864,Spanish American Culture & Civ,Ruisanchez Serra,Jose Ramon,13,13,4,0,0,0,0,3.256
+Fall 2024,LAW,6336,1,25865,The Law and Theology,Buckles,Johnny R,2,6,0,0,0,5,0,3.333
+Fall 2024,MECE,7399,1,25866,Masters Thesis,Huang,Yi-Chun,1,0,0,0,0,0,0,4.0
+Fall 2024,LAW,7397,2,25870,Selected Topics,Portuondo,Laura,6,5,0,0,0,0,0,3.395
+Fall 2024,LAW,6392,1,25871,Privacy and Data Protection,Guggenberger,Nikolas,10,14,1,0,0,0,0,3.36
+Fall 2024,LAW,5118,1,25872,EENR Research,Pittman,Aimee Self,4,1,1,0,0,0,1,3.5
+Fall 2024,ARCH,6397,2,25873,Sel Tpcs-Arc/Urbn Desgn,Rogers,Susan,3,0,0,0,0,0,0,3.67
+Fall 2024,SPAN,6358,1,25874,Spanish Sociolinguistics,Gutierrez,Manuel J,6,0,0,0,0,0,0,3.89
+Fall 2024,LAW,5397,9,25875,Selected Topics,Warren,Gina S,15,22,1,0,0,3,0,3.386
+Fall 2024,LAW,7397,3,25876,Selected Topics,Zale,Kellen B,6,1,2,0,0,0,0,3.408
+Fall 2024,LAW,5389,1,25877,Immigration Law,Morales,Daniel I,9,16,1,0,0,4,0,3.257
+Fall 2024,ARCH,6367,1,25878,Case Studies Sustainable Arch,Taylor,Rives,1,1,0,0,0,0,0,3.665
+Fall 2024,INAR,4393,1,25879,Senior Project Preparation,Gonzales,Michael A,8,11,0,0,0,0,0,3.334
+Fall 2024,MECT,4350,30,25880,Principles of Mechatronics,Fan,Zheng,14,9,0,0,0,0,0,3.738
+Fall 2024,LAW,6342,1,25882,Climate Intervention Policy,Hester,Tracy,8,12,0,0,0,10,0,3.4
+Fall 2024,WGSS,3395,1,25887,Sel Tops in Women's Studies,Green,Tara T,0,0,1,0,0,0,0,2.33
+Fall 2024,WGSS,3395,2,25888,Sel Tops in Women's Studies,Shakir,Ameenah,2,2,0,0,0,0,0,3.418
+Fall 2024,WGSS,3319,1,25889,"Gender, Sexuality, and Health",Langa,Neema Michael,2,1,0,0,0,0,1,3.447
+Fall 2024,ACCT,7397,1,25890,Selected Topics in Accounting,Kraten,Michael,7,6,1,0,0,0,0,3.476
+Fall 2024,PSYC,7397,4,25892,Selected Topics in Psychology,Grigorenko,Elena L,0,0,0,0,0,1,0,
+Fall 2024,PSYC,7397,5,25893,Selected Topics in Psychology,Yoshida,Hanako,5,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5396,1,25896,Elections and Law of Democracy,Froomkin,David,12,13,3,0,0,0,0,3.404
+Fall 2024,JWST,3397,2,25897,Selected Topics Jewish Studies,Rainbow,Jesse J,1,0,0,0,0,0,0,4.0
+Fall 2024,GHL,3197,1,25899,Selected Topics in Hospitality,Koh,Yoon,7,1,0,0,0,0,0,3.793
+Fall 2024,GHL,6197,3,25901,Selected Topics,Koh,Yoon,5,0,0,0,0,0,0,4.0
+Fall 2024,MANA,4397,6,25906,Selected Topics in Mana,Thompson,Joseph Lee,50,5,2,1,0,0,2,3.782
+Fall 2024,LAW,5297,3,25912,Selected Topics,Hebbar,Rohan A,4,9,0,0,0,0,0,3.358
+Fall 2024,MUSA,4426,1,25913,Applied Double Bass,Larson,Eric Amery,1,1,0,0,0,0,0,3.665
+Fall 2024,INDI,3397,3,25915,Topics in India Studies,Vijayalakshmi,Thangavel,3,0,0,0,0,0,0,4.0
+Fall 2024,COMD,3381,2,25920,Audiology,Vijayan,Vijaya Varshaa,10,4,0,0,0,0,2,3.714
+Fall 2024,COMD,8397,1,25921,Selected Topics in COMD,Wynn,Camille Jane,4,2,0,0,0,0,0,3.722
+Fall 2024,NAVY,3310,1,25922,Fund of Maneuver Warfare,Collins,Daniel W,5,1,0,0,0,0,0,3.558
+Fall 2024,WGSS,3354,1,25924,Social Justice & Health Equity,Tuthill,Zelma,10,0,0,0,1,0,0,3.636
+Fall 2024,SOC,3354,1,25925,Social Justice & Health Equity,Tuthill,Zelma,14,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6112,8,25928,Topics in Design Media,Martinez,Marcus E,1,0,0,0,0,0,0,4.0
+Fall 2024,USS,1101,11,25932,College Success,Young,Carrie Reid,8,4,0,2,0,0,0,3.168
+Fall 2024,ARCH,6312,2,25938,Topics in Design Media,Smith,Joshua S,1,1,0,0,0,0,0,3.5
+Fall 2024,COMD,8193,1,25947,COMD Proseminar,Blake,Margaret T,0,0,0,0,0,6,0,
+Fall 2024,PHLS,8699,11,25955,Doctoral Dissertation,Correa-Fernandez,Virmarie,0,0,0,0,0,1,0,
+Fall 2024,INDE,7397,1,25957,Selected Topics,Zou,Na,24,7,3,0,0,0,0,3.618
+Fall 2024,PHLS,7398,1,25958,Candidacy Research,Correa-Fernandez,Virmarie,0,0,0,0,0,2,0,
+Fall 2024,ARCH,6312,3,25969,Topics in Design Media,Tobar Martinez,Joaquin,6,0,1,0,0,0,0,3.667
+Fall 2024,FINA,4397,5,25979,Selected Topics in Finance,Richards,Keith Allen,63,29,5,0,0,0,3,3.591
+Fall 2024,COSC,4397,1,25980,Sel Top-Computer Science,Mukherjee,Arjun,31,18,11,0,0,0,3,3.289
+Fall 2024,MUSA,3420,1,25981,Applied Violin,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,7398,2,25986,Candidacy Research,Arbona,Consuelo,1,0,0,0,0,0,0,4.0
+Fall 2024,HDFS,4398,1,25988,Independent Study,Dunsmore,Julie C,1,0,0,0,0,0,0,4.0
+Fall 2024,INDS,3365,1,25989,Design Research Methods,Akalou,Yared,14,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6330,1,25991,Power Systems Stability,Yellajosula,Jaya Raghavendra Arun Kumar,0,1,0,0,0,0,0,2.67
+Fall 2024,PSYC,7397,6,25993,Selected Topics in Psychology,Woods,Steven Paul,0,0,0,0,0,3,0,
+Fall 2024,ARCH,6201,2,25995,Visual Studies I,Olwi,Asmaa,11,8,0,0,0,0,1,3.492
+Fall 2024,MARK,4376,2,25997,Sales CRM,Suki,Yara D,23,5,0,0,1,0,0,3.69
+Fall 2024,MARK,4380,3,25998,Digital Selling,Suki,Yara D,44,17,0,0,0,0,1,3.694
+Fall 2024,HIST,1301,8,25999,The U.S. to 1877,McDonald,Eric John,250,42,11,6,7,0,1,3.612
+Fall 2024,HIST,4319,1,26000,Medicine in the Global South,Bhattacharya,Nandini Saradindu,14,5,0,0,0,0,0,3.615
+Fall 2024,PUBL,6314,1,26011,Pub Admin Res I: Intro to Stat,Vallejo,Agustin,11,0,1,0,1,0,0,3.513
+Fall 2024,COSC,6324,1,26012,Rndmzd Algo Prob Tchnqs Cmptng,Pandurangan,Gopal,8,4,0,0,0,0,0,3.667
+Fall 2024,ENGR,2301,6,26015,Mechanics I (Statics),Ballarini,Roberto,6,22,28,8,15,0,14,1.92
+Fall 2024,CIVE,3331,3,26016,Environmental Engineering,Louie,Stacey M,16,13,7,1,0,0,4,3.145
+Fall 2024,ENTR,4340,3,26017,Entrepreneurial Capital,Rios,Eduardo Javier,18,7,1,0,2,0,0,3.275
+Fall 2024,CIVE,3337,3,26018,Structural Analysis,Belarbi,Abdeldjelil,9,13,5,1,2,0,1,2.856
+Fall 2024,CIVE,4311,3,26019,Prof Practice in Civil Engr,Herman,Reagan,28,19,2,0,0,0,0,3.463
+Fall 2024,PETR,7397,1,26021,Selected Topics,Dindoruk,Birol,6,0,0,0,0,0,0,3.945
+Fall 2024,CIVE,4312,3,26022,Civil Engineering Capstone,Mo,Larry Yi-Lung,11,6,0,0,0,0,0,3.647
+Fall 2024,CIVE,3332,3,26024,Engineering Materials,Krakowiak,Konrad,5,16,10,0,0,0,1,2.86
+Fall 2024,MIS,7397,12,26026,Selected Topics in MIS,Messinger,Jacob Nelson,4,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,4332,3,26027,Hydrology,Li,Hongyi,43,22,2,0,0,0,0,3.622
+Fall 2024,CIVE,4333,3,26028,Water and Wastewater Treatment,Rixey,William G,31,26,13,0,0,0,0,3.234
+Fall 2024,CIVE,5362,2,26029,Water Quality Engineering,Shaffer,Devin,2,13,10,2,0,0,0,2.556
+Fall 2024,CIVE,6358,3,26030,Deep Learning for Engineers,Hoskere,Vedhus,24,15,2,0,0,0,2,3.488
+Fall 2024,CIVE,6377,5,26031,Environmental Chemistry,Rahimi,Mohammad,7,0,1,0,0,0,0,3.791
+Fall 2024,CIVE,6378,3,26033,Principles Enviromntl Modeling,Louie,Stacey M,3,1,0,0,0,0,1,3.585
+Fall 2024,CIVE,6392,3,26034,Mass Transfer in Environ Syst,Rixey,William G,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,6323,1,26035,Advanced Foundation Design,Vipulanandan,Cumaraswamy,10,0,0,0,0,0,0,3.967
+Fall 2024,CIVE,6323,2,26036,Advanced Foundation Design,Vipulanandan,Cumaraswamy,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,6359,1,26037,SAR Remote Sensing,Milillo,Pietro,5,6,0,0,0,0,0,3.365
+Fall 2024,CIVE,6387,1,26039,Physicochem Treatment Process,Shaffer,Devin,2,0,1,0,0,0,0,3.333
+Fall 2024,CIVE,6387,2,26040,Physicochem Treatment Process,Shaffer,Devin,0,0,1,0,0,0,0,2.33
+Fall 2024,CIVE,5397,1,26041,Selected Topics,Ferdowsi,Behrooz,2,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,7397,1,26042,Selected Topics,Ferdowsi,Behrooz,4,0,0,0,0,0,0,3.918
+Fall 2024,CIVE,7397,2,26043,Selected Topics,Ferdowsi,Behrooz,2,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,7397,3,26044,Selected Topics,Li,Hongyi,12,0,0,0,0,0,0,3.89
+Fall 2024,CIVE,7397,4,26045,Selected Topics,Li,Hongyi,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,7397,5,26046,Selected Topics,Lee,Hyongki,9,0,0,0,0,0,1,3.817
+Fall 2024,CIVE,7397,6,26047,Selected Topics,Lee,Hyongki,2,0,0,0,0,0,0,3.67
+Fall 2024,ACCT,5397,3,26050,Selected Topics in Accounting,Kraten,Michael,2,0,0,0,0,0,0,3.67
+Fall 2024,CIVE,7397,9,26051,Selected Topics,Mo,Larry Yi-Lung,7,0,0,0,0,0,0,3.906
+Fall 2024,CIVE,7397,10,26052,Selected Topics,Mo,Larry Yi-Lung,4,1,0,0,0,0,0,3.866
+Fall 2024,CIVE,7397,11,26053,Selected Topics,Momen,Mostafa,3,2,0,0,0,0,0,3.6
+Fall 2024,CIVE,7397,12,26054,Selected Topics,Momen,Mostafa,0,1,0,0,0,0,0,3.33
+Fall 2024,ENTR,4397,4,26055,Sel Topics in Entrepreneurship,McCormick,Kelly,44,12,3,2,0,0,0,3.585
+Fall 2024,ELET,2307,1,26062,Electrical-Electronic Circuits,Abraham,Yonas B,5,4,11,0,0,0,3,2.816
+Fall 2024,CUIN,7342,1,26065,Designing PD,Worthington,Stephanie A,15,1,3,0,0,0,0,3.632
+Fall 2024,CIS,6362,20,26066,Advanced SOC Analysis,Burke,Ross,24,1,1,0,0,0,0,3.834
+Fall 2024,CIS,6362,40,26067,Advanced SOC Analysis,Burke,Ross,12,2,1,0,0,0,0,3.755
+Fall 2024,CIS,6367,1,26068,Adv Control System Security,Conklin,William A,2,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7381,1,26069,Narrative and Narrative Theory,Aboul-Ela,Hosam,12,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,4198,1,26073,Independent Study,Newman,Michael Ray,9,0,0,0,0,0,1,4.0
+Fall 2024,AAS,3358,1,26074,Gender & Health Care in Africa,Langa,Neema Michael,1,3,0,0,1,0,0,2.6
+Fall 2024,ECE,3331,2,26076,Program Appl in Elec Comp Engr,Meh Chu,Chu,9,2,0,0,0,0,0,3.878
+Fall 2024,ECE,6330,2,26077,Power Systems Stability,Yellajosula,Jaya Raghavendra Arun Kumar,12,1,0,0,0,0,0,3.898
+Fall 2024,INDS,4361,1,26078,E-Portfolio,Wells,Adam C,23,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,6397,1,26079,Selected Topics,Varadarajan,Navin,10,0,0,0,0,0,0,3.835
+Fall 2024,PSYC,4398,1,26080,Independent Study,Damian,Rodica Ioana,0,0,0,0,0,1,0,
+Fall 2024,GHL,4132,1,26081,Bev Mgmt & Mktg Internship,Taylor,David C,2,0,0,0,0,0,0,4.0
+Fall 2024,IEEM,6360,2,26084,Data Analytics for Engr. Mgt,Tan,Zhuo,52,15,2,0,0,0,0,3.653
+Fall 2024,ITAL,4398,1,26087,Independent Study,Behr,Francesca D,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,6397,2,26088,Selected Topics,Robertson,Megan L,10,1,0,0,0,0,0,3.849
+Fall 2024,MATH,8399,13,26090,Doctoral Dissertation,Fitzgibbon,William E,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8397,1,26091,Sem Top Ed Ldshp&Cul St,Messa,Emily Alice,10,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,7371,1,26092,Higher Educ Law,Louis,Dave A,10,0,0,0,0,0,0,4.0
+Fall 2024,SAER,8320,1,26093,Ethnog Mthds Educ,Louis,Dave A,5,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,3370,1,26094,Foundations of ABA,Carp,Charlotte Lynn,4,1,1,0,0,0,0,3.335
+Fall 2024,BIOE,2201,1,26102,BioCircuit Analysis,Li,Zhengwei,2,15,2,0,0,0,0,2.913
+Fall 2024,BIOE,3341,1,26103,Biothermodynamics,Aglyamov,Salavat,9,5,0,0,0,0,0,3.643
+Fall 2024,MUSA,4438,1,26110,Applied Saxophone,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,8998,1,26128,Doctoral Research,Tam,Vincent H,0,0,0,0,0,1,0,
+Fall 2024,PHLS,8399,1,26129,Doctoral Dissertation,Master,Allison,0,0,0,0,0,1,0,
+Fall 2024,ENTR,4398,1,26130,Independent Study,Gonzalez,Liana,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,4398,1,26134,Independent Study,Zerze,Gul,2,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,8398,2,26135,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2024,PCEU,8498,1,26136,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2024,MUSA,2332,2,26137,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6300,1,26138,Applied Voice,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6300,2,26139,Applied Voice,Belcher,Daniel,4,0,0,0,0,0,0,3.918
+Fall 2024,MUSA,6300,3,26140,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6300,4,26141,Applied Voice,Jones,Timothy J,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6300,5,26142,Applied Voice,Sonnenberg,Melanie,7,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6300,6,26143,Applied Voice,Vasquez,Hector A,0,0,0,0,0,0,1,
+Fall 2024,FINA,4326,2,26144,Private Equity & Inv. Banking,Stewart,Marcus,18,12,1,0,0,0,0,3.527
+Fall 2024,SOCW,8995,1,26146,Pre-Dissertation Research,Robbins,Susan P,0,0,0,0,0,1,0,
+Fall 2024,SOCW,8995,2,26151,Pre-Dissertation Research,Walton,Quenette,0,0,0,0,0,2,0,
+Fall 2024,THEA,6175,1,26155,Perf Lab / Ensemble Training,Young,John M,0,15,0,0,0,0,0,3.044
+Fall 2024,BIOE,6311,1,26157,Advances in Vision Research,Naash,Muna,3,2,0,0,0,0,0,3.666
+Fall 2024,CIVE,8399,6,26158,Doctoral Dissertation,Nakshatrala,Kalyana,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,4396,3,26159,Senior Research Project,Yi,Ping,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8699,12,26160,Doctoral Dissertation,Aboul-Ela,Hosam,0,0,0,0,0,1,0,
+Fall 2024,SCLT,3341,30,26163,GIS & Geospatial Tech,Henson,Alfred Bernard,11,6,0,0,1,0,0,3.298
+Fall 2024,DANC,4398,1,26164,Independent Study,Chapman,Teresa Lynn,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,6397,4,26165,Sel Topics/Studio Arts,Kokoladze,Salome,2,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7699,10,26169,Thesis,Parsons,Alexander M,0,0,0,0,0,3,0,
+Fall 2024,MUSA,4422,1,26172,Applied Viola,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8241,4,26173,Doctoral Recital II,Hester,Timothy E,1,0,0,0,0,0,0,3.67
+Fall 2024,PHCA,8698,2,26177,Doctoral Dissertation Research,Abughosh,Susan M,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8995,3,26178,Pre-Dissertation Research,Ali,Samira Bano,0,0,0,0,0,5,0,
+Fall 2024,MIS,4379,1,26182,MIS Consulting,Scott,Carl P,16,4,0,0,0,0,0,3.751
+Fall 2024,GEOL,7399,16,26183,Masters Thesis,Carlson,Brandee Nicole,2,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,8298,1,26185,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6290,1,26186,Professional Paper I,Shin,Min Jung,1,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,6398,1,26187,Special Problems,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2024,DIGM,2325,32,26188,Info Tech Applications,Dawson,Michael John,21,15,5,2,2,0,1,3.053
+Fall 2024,ENGL,8393,1,26190,Research Colloquium-Doctoral,Majumder,Auritro,0,0,0,0,0,4,0,
+Fall 2024,PSYC,4398,2,26193,Independent Study,Zvolensky,Michael J,12,0,0,0,0,0,0,4.0
+Fall 2024,PETR,2313,1,26195,Reservoir Fluids,Dindoruk,Birol,5,4,0,0,0,0,0,3.372
+Fall 2024,CNE,3311,1,26197,Const Engr Cost Estimating,Wu,Yuntian,1,0,0,0,0,0,0,3.67
+Fall 2024,POLS,4334,1,26198,Strategy in IR,Fox,Amos Carl,7,12,5,2,2,0,2,2.679
+Fall 2024,CNE,3311,3,26206,Const Engr Cost Estimating,Wu,Yuntian,4,0,0,1,0,0,0,3.07
+Fall 2024,ENGL,6398,1,26208,Rd&Research in Lang&Lit,Nelson,Antonya,0,0,0,0,0,1,0,
+Fall 2024,CIVE,3332,5,26209,Engineering Materials,Zamiran,Siavash,7,4,0,0,0,0,0,3.636
+Fall 2024,CIVE,3337,4,26211,Structural Analysis,Wu,Yuntian,0,2,1,0,0,0,0,2.447
+Fall 2024,CIVE,3380,3,26212,Plane Surveying Fundamentals,Wu,Yuntian,3,2,0,0,0,0,0,3.534
+Fall 2024,SOCW,7343,9,26226,Families: Adv Clinical Practic,Lucas,Virginia,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,7301,6,26231,Confronting Oppression & Injus,Shepherd,Donisha Shanice,18,1,0,0,1,0,0,3.75
+Fall 2024,SOCW,7301,7,26232,Confronting Oppression & Injus,Shepherd,Donisha Shanice,22,0,0,0,0,0,0,4.0
+Fall 2024,PHIL,3395,1,26234,Selected Topics in Phil,Zaretsky,Robert D,6,2,0,0,0,0,0,3.585
+Fall 2024,MUTX,3331,1,26246,Music Therapy Techniques I,Roth,Edward A,4,0,0,0,0,0,0,4.0
+Fall 2024,HLT,4397,1,26248,Selected Topics in Health,Carmack,Chakema,16,3,0,0,0,0,0,3.859
+Fall 2024,INTN,3360,1,26250,ASL Intensive I,Gietz,Merrilee Ruth,2,6,0,0,0,0,0,3.168
+Fall 2024,MUSI,6329,1,26251,Seminar in Organ Literature,Robinson,Daryl Allen,2,0,0,0,0,0,0,3.835
+Fall 2024,MUSI,4397,2,26252,Selected Topics in Music,Desouza,Chelsea Anne,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6397,4,26254,Selected Topics-Music,Desouza,Chelsea Anne,6,2,0,0,0,0,0,3.709
+Fall 2024,GHL,8699,1,26255,Dissertation II in Hosp. Admin,Lee,Minwoo,0,0,0,0,0,1,0,
+Fall 2024,GHL,8699,2,26259,Dissertation II in Hosp. Admin,Shin,Min Jung,0,0,0,0,0,1,0,
+Fall 2024,GHL,8699,3,26260,Dissertation II in Hosp. Admin,Taylor,David C,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6498,1,26261,Special Problems,Das,Joydip,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8999,5,26262,Doctoral Dissertation,Momen,Mostafa,0,0,0,0,0,1,0,
+Fall 2024,GHL,8398,1,26263,Research Proposal in Hosp Adm,Lee,Minwoo,0,0,0,0,0,1,0,
+Fall 2024,GHL,8398,2,26264,Research Proposal in Hosp Adm,Shin,Min Jung,0,0,0,0,0,1,0,
+Fall 2024,GHL,8398,3,26265,Research Proposal in Hosp Adm,Taylor,David C,0,0,0,0,0,1,0,
+Fall 2024,GHL,6398,1,26266,Special Problems,Boger Jr,Carl A,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,7399,11,26267,Essay,Flynn,Nicholas,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,6350,2,26268,Advanced Structural Geology,Naruk,Stephen,0,1,0,0,0,0,0,3.0
+Fall 2024,ARTS,7398,1,26271,Independent Graduate Study,Giampietro,Francis A,2,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,7398,2,26272,Independent Graduate Study,Hagmann,Sibylle,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8698,27,26273,Doctoral Research,Stewart,Robert R,0,0,0,0,0,1,0,
+Fall 2024,ECON,6394,1,26275,Tpcs-Eco of Socl Issue,Obrizan,Maksym,1,2,0,0,0,0,0,3.223
+Fall 2024,ECON,6390,1,26277,Workshop Research Methods I,Prokopovych,Pavlo,4,5,0,0,0,0,0,3.481
+Fall 2024,ENGL,4385,2,26278,Fiction Forms,Stockwell,Patrick Edward,18,0,0,0,0,0,0,3.927
+Fall 2024,ECE,8498,35,26298,Doctoral Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Fall 2024,ECE,8298,35,26299,Doctoral Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Fall 2024,PHCA,6498,1,26300,Special Problems,Varisco,Tyler J,0,0,0,0,0,1,0,
+Fall 2024,PHCA,6398,2,26301,Special Problems,Varisco,Tyler J,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6200,1,26303,Applied Voice,Jones,Timothy J,1,0,0,0,0,0,0,4.0
+Fall 2024,USS,1301,1,26308,College Success,Price,Chelsea T,9,4,2,1,1,0,3,3.098
+Fall 2024,MATH,2305,7,26310,Discrete Mathematics,Xu,Zhihang,35,20,7,0,0,0,17,3.43
+Fall 2024,CHEM,8999,32,26311,Doctoral Dissertation,Bao,Jiming,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6397,5,26312,Selected Topics-Music,Maroney,Marcus K,3,8,4,0,0,0,0,2.999
+Fall 2024,GEOL,8998,34,26316,Doctoral Research,Murphy,Michael,0,0,0,0,0,2,0,
+Fall 2024,MUSA,6142,1,26318,Graduate Recital III,Cho,Eunghee,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,2324,1,26319,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3424,1,26320,Applied Violoncello,Kitai,Anthony T,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,4398,3,26321,Independent Study,Babcock,Julia,4,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,7333,3,26329,Developing Algebraic Thinking,Chauvot,Jennifer B,1,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,8395,1,26331,Dissertation in Practice,Hawkins,Jacqueline McLean,4,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,8695,1,26333,Dissertation in Practice,Hawkins,Jacqueline McLean,2,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,8695,2,26334,Dissertation in Practice,Santi,Kristi L,1,0,0,0,0,1,0,4.0
+Fall 2024,ELCS,8399,6,26341,Doctoral Dissertation,Snodgrass Rangel,Virginia Walker,1,0,0,0,0,0,0,4.0
+Fall 2024,DIGM,4375,30,26342,Package Design,De Vega,Jaime M,26,0,0,0,0,0,0,3.962
+Fall 2024,CUIN,8329,1,26346,Academic Publishing/ Presentin,Qiu,Tairan,7,0,0,0,0,0,0,3.953
+Fall 2024,ENGL,8398,1,26347,Graduate English Resrch,Shepley,Nathan,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8398,2,26348,Graduate English Resrch,Aboul-Ela,Hosam,0,0,0,0,0,2,0,
+Fall 2024,HDFS,3310,2,26349,Introduction to Child Life,Fraser,Camille,23,5,1,1,0,0,0,3.634
+Fall 2024,MECE,7399,4,26350,Masters Thesis,Song,Gangbing,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,3371,6,26351,Accounting Information Systems,Miles,Carolyn A,3,13,5,0,1,0,5,2.698
+Fall 2024,ENGL,8398,3,26352,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8398,4,26353,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6404,1,26354,Conducting,DeSpain,Kaitlin Elizabeth,1,0,0,0,0,0,0,4.0
+Fall 2024,GHL,3362,1,26355,Mgt Training Work Experience I,Kenyan,Erin Oeser,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8398,5,26356,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2024,MUSA,4400,1,26359,Applied Voice,Averyt,Zachary Benjamin,1,1,0,0,0,0,0,3.5
+Fall 2024,ENGL,8398,6,26360,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2024,EDBA,8307,1,26362,Creation of Business Knowledge,Habel,Johannes,25,1,0,0,0,0,0,3.949
+Fall 2024,EDBA,8303,1,26364,Principles of Research Methods,Johnson,Norman A,20,1,0,0,1,0,1,3.683
+Fall 2024,EDBA,8309,1,26366,Qualitative Analysis,Silva,Leiser O,26,0,0,0,0,0,0,3.987
+Fall 2024,PCEU,6498,2,26368,Special Problems,Hu,Ming,0,0,0,0,0,0,0,
+Fall 2024,MUSA,6314,1,26370,Applied Harpsichord,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,8698,4,26378,Doctoral Dissertation Research,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8398,7,26379,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6100,5,26380,Chamber Music,Robinson,Daryl Allen,2,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,2301,15,26381,Prin of Financial Accounting,Sykes,Mary Reeves,25,18,11,9,1,0,5,2.963
+Fall 2024,ACCT,2302,7,26382,Prin of Managerial Accounting,Weber,Catherine K,3,8,11,4,0,0,1,2.524
+Fall 2024,HIST,6651,1,26387,Public History Internship,Young,Nancy Beck,3,0,0,0,0,0,0,4.0
+Fall 2024,ELET,6399,1,26389,Master's Thesis,Yuan,Xiaojing,0,0,0,0,0,1,0,
+Fall 2024,HIST,8388,4,26391,Dissertation Proposal,Young,Nancy Beck,0,0,0,0,0,0,0,
+Fall 2024,HIST,6394,1,26392,Res Seminar in US History,Young,Nancy Beck,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6398,1,26393,Special Problems,Rector,Josiah John,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6398,2,26394,Special Problems,Patterson,Catherine F,2,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8388,5,26395,Dissertation Proposal,Bhattacharya,Nandini Saradindu,0,0,0,0,0,0,0,
+Fall 2024,HIST,8388,6,26396,Dissertation Proposal,Goldberg,Mark A,0,0,0,0,0,0,0,
+Fall 2024,HIST,6398,3,26398,Special Problems,Chakrabarti,Pratik,3,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6374,1,26399,Readings in Latina/O History,Goldberg,Mark A,11,0,0,0,0,0,0,3.88
+Fall 2024,PCOL,8998,1,26400,Doctoral Research,Statsyuk,Alexander V,2,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,6399,3,26401,Master's Thesis,Belarbi,Abdeldjelil,0,0,0,0,0,1,0,
+Fall 2024,CHEE,4398,2,26402,Independent Study,Henderson,Jerrod A,1,0,0,0,0,0,0,4.0
+Fall 2024,MTLS,6319,1,26407,Introductn to Nanoengineering,Canepa,Pieremanuele,8,18,0,0,1,0,0,3.307
+Fall 2024,GHL,6190,2,26409,Hospitality Research Proposal,Shin,Min Jung,0,0,0,0,0,1,0,
+Fall 2024,GHL,6198,1,26410,Special Problems,Shin,Min Jung,1,0,0,0,0,0,0,4.0
+Fall 2024,ANTH,4393,1,26413,Research Practicum,Hannaford,Dinah Rebecca,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,4338,3,26414,Performance Management Systems,Sullivan,David Walter,36,20,2,1,1,0,0,3.555
+Fall 2024,HRD,6397,1,26415,Selected Topics in Hrd,Charmchian Langroudi,Maryam,3,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,6398,3,26416,Rd&Research in Lang&Lit,Ellis,Amanda,0,0,0,0,0,1,0,
+Fall 2024,CHEM,1311,7,26419,Fundamentals of Chemistry,Larsen,Russell Gene,3,0,1,1,0,0,0,2.934
+Fall 2024,ARTS,7398,3,26425,Independent Graduate Study,Masterson,Patrick D,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,6398,4,26427,Rd&Research in Lang&Lit,Turchi,Peter D,0,0,0,0,0,1,0,
+Fall 2024,PCOL,8998,2,26428,Doctoral Research,Boini,Krishna M,0,0,0,0,0,2,0,
+Fall 2024,ENGL,3363,1,26429,African-American Fiction,Green,Tara T,2,5,0,0,1,0,1,2.834
+Fall 2024,GEOL,7399,17,26437,Masters Thesis,Voarintsoa,Ny Riavo Gilbertinie,3,0,0,0,0,0,0,4.0
+Fall 2024,WCL,3397,4,26438,Selected Topics in WCL,Singh,Kavita Ashana,1,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6198,2,26439,Special Problems,Guchait,Priyanko,1,0,0,0,0,0,0,4.0
+Fall 2024,GHL,6190,3,26440,Hospitality Research Proposal,Guchait,Priyanko,0,0,0,0,0,1,0,
+Fall 2024,PSYC,2305,27,26441,Intro to Methods in Psychology,Anderson,Jill Annette,31,10,2,2,1,0,0,3.45
+Fall 2024,PSYC,4398,5,26446,Independent Study,Neighbors,Clayton T,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,2197,2,26448,Selected Topics,Chang,Christiana,20,12,1,0,0,0,0,3.576
+Fall 2024,ELCS,8398,1,26451,Independent Study,Carales,Vincent D,0,0,0,0,0,1,0,
+Fall 2024,WCL,3399,1,26453,Senior Honors Thesis,Ramirez,Marie Theresa,0,1,0,0,0,0,0,3.0
+Fall 2024,ENGL,8398,8,26454,Graduate English Resrch,Snediker,Michael,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6160,1,26455,Internship in Piano Pedagogy,Van Kekerix,Todd Evan,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6252,1,26456,Group & Adult Piano Pedagogy,Van Kekerix,Todd Evan,4,0,0,0,0,0,0,3.918
+Fall 2024,CIS,3330,31,26457,Info Systems in Organizations,Detillier,Bret James,6,42,27,1,0,0,3,2.663
+Fall 2024,LAW,5397,3,26458,Selected Topics,Nguyen,Hung T,4,17,7,0,0,0,0,2.858
+Fall 2024,MUSA,8241,5,26461,Doctoral Recital II,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8398,9,26465,Graduate English Resrch,Ellis,Amanda,0,0,0,0,0,1,0,
+Fall 2024,MANA,3335,11,26466,Intro Org Behavior and Mgmt,Owens,Tiffany,16,13,5,0,0,0,0,3.362
+Fall 2024,MUSA,8241,6,26467,Doctoral Recital II,Sonnenberg,Melanie,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,7398,3,26469,Candidacy Research,de Dios,Marcel A,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8330,1,26470,Literacy Trends and Concerns,Qiu,Tairan,6,0,0,0,0,0,1,4.0
+Fall 2024,LAW,5140,1,26472,Legal Methods,Simmons,Laurel Ellis Parker,0,0,0,0,0,6,0,
+Fall 2024,LAW,7397,4,26473,Selected Topics,Frank,Demetria,4,4,2,0,0,0,0,3.233
+Fall 2024,CIVE,8699,4,26475,Doctoral Dissertation,Nakshatrala,Kalyana,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6198,20,26476,Research,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2024,ARTS,3384,2,26484,Sound Art,Cone,Marcus Andrew,12,0,0,0,0,0,1,4.0
+Fall 2024,ARTS,6397,5,26485,Sel Topics/Studio Arts,Cone,Marcus Andrew,1,0,0,0,0,0,0,4.0
+Fall 2024,IART,3395,5,26486,Sel Topics in Interdis Arts,Cone,Marcus Andrew,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,6368,1,26497,Artificial Intelligence,Yang,Jianyi,42,6,0,0,0,0,0,3.854
+Fall 2024,ENGI,4198,1,26498,Independent Study,Landon,Alexandra Maley,0,0,0,0,0,14,0,
+Fall 2024,DIGM,4382,30,26499,Simulation and Gaming,Bennett,Spencer McLain,14,2,0,0,0,0,0,3.834
+Fall 2024,MUSI,8499,1,26501,Doctoral Document,Pollack,Howard J,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,6340,1,26502,Database Systems,Ordonez,Carlos,5,9,0,0,0,0,0,3.428
+Fall 2024,ECE,5377,2,26503,Power System Analysis,Viswanath,Padmavati Aparna,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6377,2,26504,Power Systems Analysis,Viswanath,Padmavati Aparna,2,3,0,0,1,0,0,2.943
+Fall 2024,PHLS,8399,2,26505,Doctoral Dissertation,Smith,Bradley,0,0,0,0,0,2,0,
+Fall 2024,SCM,8999,1,26506,Dissertation,Li,Meng,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8398,10,26507,Graduate English Resrch,Christensen,Ann C,0,0,0,0,0,1,0,
+Fall 2024,ENGL,8398,11,26508,Graduate English Resrch,Tejada,Roberto Jose,0,0,0,0,0,3,0,
+Fall 2024,INTB,7371,1,26509,Energy Value Chain,Slaughter,Andrew Jeremy,0,3,0,0,0,0,0,3.0
+Fall 2024,ACCT,2302,8,26518,Prin of Managerial Accounting,Seltz,Joe D,25,21,19,6,4,0,5,2.848
+Fall 2024,HLT,1353,7,26519,Personal Health,Vercher,Michelle Taylor,95,16,4,1,2,0,0,3.667
+Fall 2024,HLT,3301,7,26520,Health Behavior Theories,Haq,Arooba A,25,30,4,2,0,0,3,3.241
+Fall 2024,HLT,3381,4,26521,Hlt Promotn & Disease Preventn,Fedor Amador,Theresa Marie,70,12,1,1,1,0,0,3.726
+Fall 2024,HLT,4310,11,26522,Program Planning for Hlt Prof,Bennett,Kristin C,27,7,0,0,0,0,1,3.784
+Fall 2024,GHL,8399,1,26526,Dissertation I in Hosp. Admin,Back,KiJoon,0,0,0,0,0,1,0,
+Fall 2024,POLC,4398,1,26529,Independent Study,Cross,Renee Danielle,1,0,1,0,0,0,0,3.0
+Fall 2024,HLT,2320,5,26534,Introduction to Public Health,Proctor,Robin Ann,65,13,1,0,0,0,0,3.76
+Fall 2024,HLT,2320,6,26535,Introduction to Public Health,Rafique,Kiran Sajid,56,22,2,0,1,0,0,3.528
+Fall 2024,HLT,4306,3,26538,Women's Health Issues,Adams,Monica Nichole,60,15,2,2,0,0,0,3.604
+Fall 2024,HLT,4306,4,26539,Women's Health Issues,Adams,Monica Nichole,65,14,0,0,0,0,1,3.806
+Fall 2024,ECE,4198,2,26540,Independent Study,Meh Chu,Chu,6,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6399,1,26541,Masters Thesis,Chen,Tian,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,3396,1,26545,Senior Research Project,Ott,William R,0,0,0,0,0,1,0,
+Fall 2024,KIN,3309,3,26546,Biomechanics,Park,Seoung Hoon,34,3,2,0,0,0,0,3.846
+Fall 2024,BTEC,6399,43,26547,Thesis,Chitrala,Kumaraswamy Naidu,0,0,0,0,0,1,0,
+Fall 2024,INDS,6350,1,26552,Design Studies,Morshedzadeh,Elham,6,0,0,0,0,0,0,4.0
+Fall 2024,GRET,6398,1,26561,Special Problems in GRET,Robinson,Ebony M,1,0,0,0,0,0,0,4.0
+Fall 2024,GRET,6399,1,26562,Thesis in Global Retailing,Johnson,Olivia,1,0,0,0,0,0,0,4.0
+Fall 2024,POLC,4399,1,26564,Senior Thesis,Francis,Sara Sands,0,0,0,0,0,0,1,
+Fall 2024,MUSA,6312,1,26568,Applied Organ,Robinson,Daryl Allen,1,0,0,0,0,0,0,4.0
+Fall 2024,LAW,6331,1,26570,Military Justice Clinic II,Marquez,Jason R,0,1,0,0,0,0,0,3.0
+Fall 2024,POLS,3399,1,26574,Senior Honors Thesis,Rottinghaus,Brandon J,0,0,0,0,0,0,0,
+Fall 2024,CUIN,7381,2,26576,Instructional Evaluation,Gronseth,Susie L B,16,1,0,0,0,0,0,3.961
+Fall 2024,ARTS,2366,1,26580,Watercolor,Forse,John,17,2,0,0,0,0,0,3.895
+Fall 2024,THEA,3362,1,26581,Costume Design for the Stage,Willson,Paige A,5,4,0,0,1,0,1,3.266
+Fall 2024,THEA,4398,1,26582,Independent Study,Willson,Paige A,4,3,0,0,1,0,0,3.043
+Fall 2024,HON,3399,5,26585,Senior Honors Thesis,Ghazali,Marwa,0,0,0,0,0,0,0,
+Fall 2024,NURS,4312,2,26588,Ldership and Mgmt in Prof Nur,Edwards-Maddox,Shermel Vinese,2,13,0,0,0,0,2,3.133
+Fall 2024,INDE,6370,1,26589,Operation Research-Digital Sim,Khator,Suresh K,2,0,1,0,0,0,0,3.223
+Fall 2024,NURS,8225,1,26592,Complex Health Deviations Sem,Tahmasbi,Sherin,0,0,0,0,0,1,0,
+Fall 2024,NURS,8326,1,26593,Complex Health Deviations Prac,Tahmasbi,Sherin,0,0,0,0,0,1,0,
+Fall 2024,NURS,4221,1,26594,Pediatric Clinical,Kleinhans,Alicia Diane,9,3,0,0,0,0,1,3.75
+Fall 2024,NURS,4219,1,26595,Pediatric Concepts of Care,Kleinhans,Alicia Diane,0,12,0,0,0,0,1,3.0
+Fall 2024,NURS,4419,1,26596,High Acuity Clinical,Joseph,Beena Roby,4,11,0,0,0,0,2,3.267
+Fall 2024,NURS,4318,1,26597,High Acuity Concepts of Care,Kleinhans,Alicia Diane,1,13,0,1,0,0,2,2.933
+Fall 2024,NURS,4521,1,26598,Community Health Nursing,Barta,Kelsie R,11,10,0,0,0,0,1,3.524
+Fall 2024,BIOL,8898,1,26602,Doctoral Research,Dauwalder,Brigitte,0,0,0,0,0,2,0,
+Fall 2024,ELCS,7392,2,26603,Internship in Superintendent,Klussmann,Duncan Foster,2,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8310,1,26604,The Superintendency,Butcher,Keith,2,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8356,2,26605,Program Policy Evaluation,Davis,Bradley,5,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8398,12,26606,Graduate English Resrch,Backus,Margot Gayle,0,0,0,0,0,1,0,
+Fall 2024,ARTS,3397,2,26607,Sel Tops in Fine Arts,Dupre,Roslyn M,11,0,0,0,1,0,0,3.584
+Fall 2024,MANA,4312,2,26608,Fundamtls Healthcare Business,Kroger,Edward John,23,15,4,0,0,0,3,3.429
+Fall 2024,GEOL,8698,28,26609,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6106,7,26617,Grad Large Ensemble,Koppel,Alexander,2,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,6322,2,26625,Dimensions in Women's Health,Adams,Monica Nichole,4,0,0,0,0,0,0,3.835
+Fall 2024,ARCH,3343,1,26626,Latin American Architecture,Longoria,Rafael R,3,1,0,0,0,0,0,3.75
+Fall 2024,HIST,6398,4,26627,Special Problems,Romero,Todd,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6398,5,26628,Special Problems,McNally,David Joseph,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3402,2,26634,Applied Composition,Smith,Robert Thomas,3,1,0,0,0,0,1,3.75
+Fall 2024,NURS,6314,1,26635,Development of Nur Curriculum,Schrader,Patricia K,5,0,0,0,0,0,0,4.0
+Fall 2024,NURS,6331,1,26637,Advanced Pharmacotherapy,Bayliss,Debra Lee,2,3,0,0,0,0,0,3.4
+Fall 2024,BIOL,8399,9,26638,Doctoral Dissertation,Lin,Chin-Yo,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,8399,6,26639,Doctoral Dissertation,Liu,Yu,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,3399,6,26643,Senior Honors Thesis,Christensen,Ann C,0,0,0,0,0,0,0,
+Fall 2024,PHLS,6320,1,26644,Sexual Counseling,Smith,Nathaniel Lewis,10,0,0,0,0,0,0,4.0
+Fall 2024,MANA,7372,2,26645,Leading Change in Healthcare,Kroger,Edward John,7,1,0,0,0,0,0,3.916
+Fall 2024,MUSA,4189,1,26646,Senior Recital,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2024,THEA,4398,2,26648,Independent Study,Vintu,Tatiana,1,0,0,0,0,0,0,3.67
+Fall 2024,CHEM,3396,1,26651,Senior Research Project,Teets,Thomas,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6257,20,26654,Research Practicum B,Sayah,Diane Noel,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,5397,5,26655,Selected Topics,Rahman,Muhammad Maksudur,14,7,0,0,0,0,0,3.604
+Fall 2024,MECE,6397,10,26656,Selected Topics,Rahman,Muhammad Maksudur,8,7,0,0,0,0,0,3.489
+Fall 2024,ECE,6399,30,26657,Masters Thesis,Joardar,Biresh Kumar,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8220,1,26662,Doctoral Applied Music,Yon,Kirsten A,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,6399,3,26664,Masters Thesis,Chen,Yi-Chao,0,0,0,0,0,1,0,
+Fall 2024,FINA,7372,2,26665,Upstream Economics,Berta,Dominique,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,4372,3,26668,Upstream Economics,Berta,Dominique,1,1,0,0,0,0,0,3.5
+Fall 2024,ARCH,6343,1,26670,Latin America Architecture,Longoria,Rafael R,5,2,0,0,0,0,0,3.714
+Fall 2024,ARCH,6398,1,26671,Special Problems,Longoria,Rafael R,1,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6398,2,26672,Special Problems,Longoria,Rafael R,1,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,3397,3,26673,Selected Topics,Bell,Larry S,7,0,2,0,0,0,0,3.556
+Fall 2024,ARCH,6397,4,26674,Sel Tpcs-Arc/Urbn Desgn,Bell,Larry S,2,0,0,0,0,0,0,4.0
+Fall 2024,ARCH,6398,3,26675,Special Problems,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3347,4,26676,Problems of Normal Life,Anderson,Jill Annette,16,34,4,0,1,0,0,3.182
+Fall 2024,HIST,2303,4,26682,The Historian's Craft,Chery,Tshepo Morongwa,10,5,1,0,0,0,0,3.48
+Fall 2024,GENB,7397,2,26689,Selected Topics,Wilbur,Stephen,6,0,0,0,0,0,0,3.89
+Fall 2024,FINA,7A97,2,26690,Selected Topics in Finance,George,Thomas J,2,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8995,4,26693,Pre-Dissertation Research,Pritzker,Suzanne,0,0,0,0,0,1,0,
+Fall 2024,FINA,4372,4,26695,Upstream Economics,Berta,Dominique,4,2,0,0,0,0,0,3.612
+Fall 2024,THEA,6198,21,26710,Independent Study,Fernando,Fleurette S,0,0,0,0,0,0,1,
+Fall 2024,INTB,3355,6,26718,Global Environment of Business,Wengelnik,Dorothee-Catherine,46,11,1,1,1,0,0,3.645
+Fall 2024,INTB,3355,7,26720,Global Environment of Business,Wengelnik,Dorothee-Catherine,47,9,1,0,2,0,1,3.588
+Fall 2024,MANA,4397,7,26721,Selected Topics in Mana,Wengelnik,Dorothee-Catherine,14,4,0,0,0,0,1,3.741
+Fall 2024,MUSA,2310,4,26734,Applied Piano,Hester,Timothy E,1,0,0,0,0,0,0,3.67
+Fall 2024,BTEC,6105,40,26741,Bioprocessing Laboratory,Lin,Yuheng,1,1,0,0,0,0,0,3.5
+Fall 2024,BTEC,6305,40,26742,Bioprocessing in Biotechnology,Lin,Yuheng,2,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,4344,9,26752,Cultural Psychology,Haddad,Sana,51,19,8,0,1,0,1,3.477
+Fall 2024,MECT,4331,31,26753,Heat Transfer Applications,Mohan,Gowtham,21,5,1,1,1,0,0,3.426
+Fall 2024,POLS,3395,1,26754,Selected Topics Am Gov,Chapa,Samantha,6,0,0,0,0,0,0,4.0
+Fall 2024,MECT,4275,32,26755,Senior Design Project I,Mohan,Gowtham,15,6,0,0,0,0,0,3.651
+Fall 2024,SOCW,8999,5,26756,Dissertation,Pritzker,Suzanne,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3310,7,26757,Indstrl-Orgnztnl Psy,Harlan,Pamela Kay,46,26,3,1,2,0,2,3.364
+Fall 2024,HIST,3399,5,26766,Senior Honors Thesis,Cedillo,Adela,0,0,0,0,0,0,1,
+Fall 2024,IDNS,2197,4,26767,Top-Natrl Sci & Mth,Molnar,Kayla Ann,0,2,2,0,0,0,0,2.5
+Fall 2024,IDNS,2197,5,26768,Top-Natrl Sci & Mth,Molnar,Kayla Ann,5,1,0,0,0,0,0,3.723
+Fall 2024,PCOL,6498,10,26769,Special Problems,Garey,Kevin W,0,0,0,0,0,2,0,
+Fall 2024,SPAN,6399,1,26770,Masters Thesis,Fairclough,Marta A,1,0,0,0,0,0,0,4.0
+Fall 2024,SPAN,7399,1,26771,Masters Thesis,Fairclough,Marta A,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,4,26776,Senior Research Project,Morrison,Gregory C,0,0,0,0,0,0,0,
+Fall 2024,TLIM,3363,25,26777,Technical Communications,Peterson,Kathryn Marie,33,4,1,0,2,0,0,3.642
+Fall 2024,TLIM,3363,26,26779,Technical Communications,Peterson,Kathryn Marie,36,2,0,0,0,0,1,3.93
+Fall 2024,COSC,6386,1,26810,Prgrm Analys & Testing,Alipour,Mohammad Amin,25,2,0,0,0,0,0,3.84
+Fall 2024,GEOL,8399,15,26817,Doctoral Dissertation,Curiale,Joseph A,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6400,1,26819,Applied Voice,Belcher,Daniel,1,0,0,0,0,0,0,4.0
+Fall 2024,KIN,3325,1,26820,Sports Therapy/Athletic Trng,Knoblauch,Mark Alan,30,10,3,1,4,0,1,3.216
+Fall 2024,BCHS,6498,6,26826,Special Problems,Liu,Yu,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6498,2,26827,Special Problems,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2024,PSYC,6598,2,26828,Special Problems,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2024,MECT,4172,32,26830,Materials Tech Lab,Al Ibadi,Adnan,3,3,0,0,0,0,0,3.61
+Fall 2024,CIVE,8598,12,26835,Doctoral Research,Ballarini,Roberto,0,0,0,0,0,1,0,
+Fall 2024,NUTR,2332,4,26836,Intro To Human Nutrition,Hughes,Lindsay,44,29,13,4,0,0,7,3.219
+Fall 2024,MUSA,1300,12,26837,Applied Voice,Clayton Vasquez,Cynthia L,3,0,0,0,0,0,0,4.0
+Fall 2024,BTEC,6100,40,26839,Seminar in Biotechnology,Khan,Abdul Latif,3,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3442,1,26841,Applied French Horn,Johnson,Robert,0,1,0,0,0,0,0,3.0
+Fall 2024,CUIN,8398,11,26842,Independent Study,Li,Xin,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,8999,6,26856,Dissertation,Cheung,Monit,0,0,0,0,0,1,0,
+Fall 2024,MUSA,2260,1,26859,Applied Music,Garcia,Jeremy S,2,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,3367,7,26867,Intermediate Accounting I,Kuruvilla,Mohan,0,1,1,0,0,0,0,2.83
+Fall 2024,ACCT,5367,3,26868,Intermediate Accounting I,Kuruvilla,Mohan,4,1,0,1,0,0,7,3.223
+Fall 2024,BIOL,1125,1,26869,Survey of Health Professions,Ogletree-Hughes,Monique L,28,3,0,1,3,0,1,3.439
+Fall 2024,BIOL,1125,2,26870,Survey of Health Professions,Ogletree-Hughes,Monique L,17,5,0,2,0,0,1,3.569
+Fall 2024,INDS,3397,4,26871,Selected Topics,Kimbrough,Mark S,18,8,0,0,0,0,0,3.667
+Fall 2024,MUSA,4248,1,26872,Applied Euphonium,Fenske,Kevin,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3432,1,26873,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,8898,1,26875,Doctoral Research,Wang,Yuhong,0,0,0,0,0,3,0,
+Fall 2024,CUIN,7354,1,26879,Perspectives in Science & Math,Wong,Sissy S,2,1,0,0,0,0,0,3.777
+Fall 2024,BIOL,6998,1,26880,Special Problems,Pennings,Steven C,0,0,0,0,0,1,0,
+Fall 2024,IDNS,4397,1,26881,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,7,0,0,0,0,0,0,4.0
+Fall 2024,IDNS,4397,2,26882,Sel Tops-Natural Scien & Math,Ogletree-Hughes,Monique L,5,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,6390,1,26883,Supervised Exper in Spec Educ,Thompson,Amber M,0,0,0,0,0,1,0,
+Fall 2024,MUSA,2334,4,26889,Applied Clarinet,Dokshansky,Yevgeny,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,7398,1,26893,Masters Research,Mann,Paul,0,0,0,0,0,2,0,
+Fall 2024,MUSA,6422,1,26894,Applied Viola,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6143,1,26895,Graduate Recital IV,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,SGNL,1302,2,26896,Elementary Sign Language II,Brittain,Robyn Michelle,2,6,6,1,1,0,3,2.376
+Fall 2024,COMD,3385,2,26897,Speech Science,Bunta,Ferenc,8,14,5,0,0,0,1,3.111
+Fall 2024,MUSI,6398,2,26898,Research,Koozin,Timothy,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,8898,2,26903,Doctoral Research,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2024,SGNL,2301,7,26905,Intermediate Sign Language I,Gietz,Merrilee Ruth,5,7,3,0,0,0,0,3.045
+Fall 2024,SGNL,2301,8,26906,Intermediate Sign Language I,Brittain,Robyn Michelle,1,4,8,1,1,0,1,2.222
+Fall 2024,MUSA,8320,35,26907,Doctoral Applied Music,Cho,Eunghee,2,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,6301,1,26908,Fundamental Electrodynamics,Cherdack,Daniel David,0,1,0,0,0,0,0,3.33
+Fall 2024,CHEM,1112,28,26909,Fundamentals of Chm Lab,Zaitsev,Vladimir G,3,7,1,1,0,0,3,3.11
+Fall 2024,PHYS,8398,49,26911,Doctoral Research,Fan,Wenqing,0,0,0,0,0,1,0,
+Fall 2024,COSC,4398,11,26932,Independent Study,Bering,Edgar A,0,0,0,0,0,5,1,
+Fall 2024,COSC,6310,3,26935,Fundamentals of Operating Syst,Rincon Castro,Carlos Alberto,1,1,0,0,0,0,0,3.5
+Fall 2024,BIOL,6598,15,26946,Special Problems,Stuckert,Adam,0,0,0,0,0,2,0,
+Fall 2024,BIOL,8798,1,26947,Doctoral Research,Yi,Ping,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8898,3,26949,Doctoral Research,Kelleher Meisel,Erin S,0,0,0,0,0,2,0,
+Fall 2024,BCHS,8698,4,26951,Doctoral Research,Briggs,James M,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8998,4,26955,Doctoral Research,Peng,Weiyi,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8998,5,26956,Doctoral Research,Graur,Dan,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6998,3,26957,Special Problems,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6598,17,26958,Special Problems,Feng,Qin,0,0,0,0,0,1,0,
+Fall 2024,BCHS,8898,3,26960,Doctoral Research,Schwartz,Robert J,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6898,3,26961,Special Problems,Pennings,Steven C,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6998,4,26962,Special Problems,Daane,Jacob,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6898,4,26963,Special Problems,Yi,Ping,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6798,1,26965,Special Problems,Yi,Ping,0,0,0,0,0,1,0,
+Fall 2024,BCHS,8698,5,26966,Doctoral Research,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6498,8,26967,Special Problems,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2024,BCHS,8998,2,26971,Doctoral Research,Willson,Richard,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6798,2,26972,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6698,1,26973,Special Problems,Gunaratne,Preethi H,0,0,0,0,0,2,0,
+Fall 2024,CHEE,4398,3,26975,Independent Study,Bollini,Praveen P,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8698,29,26976,Doctoral Research,Zheng,Youtong,0,0,0,0,0,3,0,
+Fall 2024,BTEC,6399,1,26977,Thesis,Chitrala,Kumaraswamy Naidu,0,0,0,0,0,1,0,
+Fall 2024,PEP,8999,1,26979,Doctoral Dissertation,Hawkins,Billy J,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6998,6,26984,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2024,BCHS,8998,3,26987,Doctoral Research,Gunaratne,Preethi H,0,0,0,0,0,3,0,
+Fall 2024,BIOL,8698,7,26989,Doctoral Research,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6998,7,26992,Special Problems,O'Brien,John,0,0,0,0,0,2,0,
+Fall 2024,BIOL,8898,4,26993,Doctoral Research,Liu,Xinli,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6798,3,26994,Special Problems,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2024,BCHS,8698,6,26995,Doctoral Research,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6898,6,26996,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6798,4,26997,Special Problems,Crawford,Kerri M,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8898,5,26998,Doctoral Research,Peng,Weiyi,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8898,6,26999,Doctoral Research,Lin,Chin-Yo,0,0,0,0,0,1,0,
+Fall 2024,MATH,8698,23,27000,Doctoral Research,Ru,Min,0,0,0,0,0,2,0,
+Fall 2024,GEOL,6397,4,27001,Selected Topics in Geology,Turner,Stephen,1,1,0,0,0,0,0,3.5
+Fall 2024,BIOL,6898,7,27003,Special Problems,Azevedo,Ricardo,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6798,5,27005,Special Problems,Fujita,Masaya,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6898,9,27006,Special Problems,Dauwalder,Brigitte,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6798,6,27009,Special Problems,Khan,Abdul Latif,0,0,0,0,0,3,0,
+Fall 2024,BIOL,6998,8,27011,Special Problems,Dryer,Stuart E,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6698,3,27014,Special Problems,Wang,Yuhong,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6798,9,27017,Special Problems,Peng,Weiyi,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8998,6,27018,Doctoral Research,Zufall,Rebecca A,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8318,2,27029,Issues in Urban Education,Hale,Margaret Ann,16,1,0,0,0,0,1,3.922
+Fall 2024,BCHS,6398,8,27030,Special Problems,Bawa-Khalfe,Tasneem,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6898,10,27031,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8399,16,27040,Doctoral Dissertation,Suppe,John,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8698,30,27041,Doctoral Research,Li,Aibing,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8898,8,27042,Doctoral Research,Zhang,Shaun Xiaoliu,0,0,0,0,0,2,0,
+Fall 2024,BIOE,8198,6,27043,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,2,0,
+Fall 2024,BIOE,8298,32,27044,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,34,27045,Doctoral Research,Henderson,Jerrod A,0,0,0,0,0,2,0,
+Fall 2024,BIOL,8698,8,27046,Doctoral Research,Mohan,Chandra,0,0,0,0,0,1,0,
+Fall 2024,COMM,4398,1,27047,Independent Study,Uhrick,Jan,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6312,1,27048,Scientific Communication,Graur,Dan,8,0,0,0,0,0,0,4.0
+Fall 2024,INDE,3399,1,27049,Senior Honors Thesis,Wang,Yaping,2,0,0,0,0,0,0,4.0
+Fall 2024,INDE,3399,2,27050,Senior Honors Thesis,Lin,Ying,1,0,0,0,0,0,0,4.0
+Fall 2024,SCLT,6397,1,27053,Selected Topics,Bian,Zheyong,2,2,0,0,0,0,0,3.5
+Fall 2024,MUSA,8320,37,27066,Doctoral Applied Music,Koppel,Alexander,2,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,8398,13,27073,Graduate English Resrch,Yang,Sunny Chen,0,0,0,0,0,1,0,
+Fall 2024,PHLA,6250,1,27075,Research Methodology,Garey,Kevin W,7,1,0,0,0,0,0,3.793
+Fall 2024,PSYC,4398,6,27076,Independent Study,Sharp,Carla,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,8998,4,27077,Doctoral Research,Udugamasooriya,Damith Gomika,0,0,0,0,0,2,0,
+Fall 2024,GEOL,7398,2,27080,Masters Research,Lapen,Thomas J,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8243,8,27081,Doctoral Lecture Recital,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSI,8296,8,27082,Doctoral Essay,Caton,Kathryn L.,0,0,0,0,0,2,0,
+Fall 2024,PSYC,3310,8,27084,Indstrl-Orgnztnl Psy,Babalola,Olusegun,57,7,2,0,2,0,1,3.725
+Fall 2024,PSYC,4344,10,27085,Cultural Psychology,Haddad,Sana,63,5,7,3,0,0,2,3.611
+Fall 2024,PSYC,2301,10,27086,Introduction to Psychology,Snead,Alexandra L,28,34,11,1,1,0,2,3.169
+Fall 2024,PSYC,2316,7,27087,Psychology of Personality,Snead,Alexandra L,57,22,3,0,2,0,2,3.489
+Fall 2024,PSYC,3331,4,27088,Psychology of Gender,Snead,Alexandra L,26,39,10,1,1,0,3,3.151
+Fall 2024,GEOL,8998,35,27089,Doctoral Research,Voarintsoa,Ny Riavo Gilbertinie,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6698,1,27091,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2024,GEOL,7327,2,27092,Principles of Marine Geophysic,Sager,William W,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,2304,4,27093,Technical Communications,Smith-Irving,Brandi,16,2,2,1,2,0,2,3.146
+Fall 2024,COSC,3380,4,27096,Database Systems,Ramamurthy,Uma,8,16,23,6,8,0,9,2.11
+Fall 2024,CIVE,4311,5,27104,Prof Practice in Civil Engr,Phatak,Tejasree Mohan,11,21,3,0,0,0,1,3.163
+Fall 2024,CIVE,4381,1,27106,Satellite-based Geomatics,Lee,Hyongki,17,26,6,1,1,0,0,3.085
+Fall 2024,ECE,5357,1,27107,Intro to Cybersecurity,Pan,Miao,24,34,0,0,0,0,0,3.408
+Fall 2024,MECE,3338,2,27108,Dynamics & Controls Mech Syst,Nejad,Alireza Mahdavi,51,9,0,0,0,0,0,3.845
+Fall 2024,ELCS,8695,8,27110,Dissertation in Practice,Hassett,Kristen Spring,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3334,2,27111,Psychology & Law,Inman,Tonya N,34,23,10,2,1,0,7,3.186
+Fall 2024,TLIM,3363,34,27113,Technical Communications,Burgner,Rebecca,31,7,0,1,0,0,0,3.735
+Fall 2024,CHEE,6399,2,27114,Masters Thesis,Vekilov,Peter,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,7399,2,27115,Masters Thesis,Rimer,Jeffrey,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,1301,11,27117,The U.S. to 1877,McDonald,Eric John,39,3,2,0,0,0,0,3.811
+Fall 2024,HIST,1301,12,27118,The U.S. to 1877,McDonald,Eric John,91,13,10,0,2,0,0,3.624
+Fall 2024,INTB,3355,8,27119,Global Environment of Business,Miljanic,Andra Olivia,170,54,18,2,1,0,5,3.551
+Fall 2024,HIST,2313,2,27120,Global Civilization to 1500,Johnson,Michele R,35,65,14,0,1,0,0,3.142
+Fall 2024,BUSI,1301,7,27121,Business Principles,Thompson,Joseph Lee,222,11,2,0,7,0,8,3.811
+Fall 2024,PCOL,6398,2,27122,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6498,11,27123,Special Problems,Eriksen,Jason,0,0,0,0,0,1,0,
+Fall 2024,LAW,6369,2,27124,Legal Analysis and Writing,Campbell,Catherine,0,0,0,0,0,7,0,
+Fall 2024,SOCW,8995,5,27125,Pre-Dissertation Research,Acquati,Chiara,0,0,0,0,0,1,0,
+Fall 2024,PCOL,8998,5,27126,Doctoral Research,McConnell,Bradley K,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8320,38,27127,Doctoral Applied Music,Archibald,Amber Cristina,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,4390,1,27131,Professional Internship,Zentz,Lauren R,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8298,25,27133,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8398,24,27134,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8598,24,27136,Doctoral Research,Powell,Joseph Broun,0,0,0,0,0,1,0,
+Fall 2024,PHLA,7299,6,27138,Masters Thesis,Eubank,Taryn Ashley,0,0,0,0,0,1,0,
+Fall 2024,PHLA,7299,7,27139,Masters Thesis,Ononogbu,Onyebuchi J,0,0,0,0,0,1,0,
+Fall 2024,COSC,3360,1,27140,Operating Systems,Paris,Jehan-Francois,33,53,15,6,1,0,6,2.988
+Fall 2024,MUSA,6142,4,27141,Graduate Recital III,Hester,Timothy E,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6798,10,27142,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Fall 2024,MARK,4389,9,27143,Marketing Strategy & Planning,Agrawal,Arpit,38,2,0,0,0,0,0,3.892
+Fall 2024,USS,1301,2,27148,College Success,Floyd,Monica,13,4,2,0,0,0,1,3.631
+Fall 2024,SOC,3312,1,27149,Sociology of Deviance,Colbert,Sharla Stettnisch,19,13,3,3,2,0,4,3.125
+Fall 2024,SOC,3382,1,27150,Sociology of Drug Use & Recove,Adams,Jennifer Lauren,36,4,3,2,1,0,3,3.544
+Fall 2024,ELCS,8398,2,27151,Independent Study,Shockley,Gerald,0,0,0,0,1,0,0,0.0
+Fall 2024,PSYC,7392,7,27152,Psychology Practicum,Neighbors,Clayton T,0,0,0,0,0,2,0,
+Fall 2024,CHEE,6198,1,27156,Research,Karim,Alamgir,0,0,0,0,0,1,0,
+Fall 2024,CHEE,6298,1,27158,Research,Karim,Alamgir,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6498,16,27163,Special Problems,Stuckert,Adam,0,0,0,0,0,2,0,
+Fall 2024,BIOE,6298,5,27175,Research,Li,Zhengwei,0,0,0,0,0,1,0,
+Fall 2024,MECE,8699,2,27176,Doctoral Dissertation,Zhao,Bo,0,0,0,0,0,1,0,
+Fall 2024,GERM,4391,1,27181,Professional Practicum in Germ,Glass,Hildegard,1,0,0,0,0,0,0,4.0
+Fall 2024,MIS,3370,6,27182,Info Systems Development Tools,Cooper,Randolph B,4,11,12,4,7,0,19,2.026
+Fall 2024,BIOL,6898,11,27187,Special Problems,Meisel,Richard P,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6310,3,27189,Applied Piano,Van Kekerix,Todd Evan,1,0,0,0,0,0,0,4.0
+Fall 2024,ELET,6356,40,27195,Health Analytics Visualization,Merchant,Fatima Aziz,0,1,0,0,0,0,0,3.33
+Fall 2024,IART,2300,1,27196,The Arts in Houston,Hernandez-Vargas,Saul,13,2,3,0,0,0,2,3.501
+Fall 2024,ARTS,1316,5,27197,Fundamentals of Drawing,Hernandez-Vargas,Saul,14,3,0,0,0,0,1,3.765
+Fall 2024,ARTS,4397,2,27198,Sel Topics in Fine Arts,Hernandez-Vargas,Saul,7,2,0,0,0,0,0,3.741
+Fall 2024,ARTS,6397,6,27199,Sel Topics/Studio Arts,Hernandez-Vargas,Saul,1,0,0,0,0,0,0,4.0
+Fall 2024,DANC,2303,2,27200,Introduction to Dance,Bobet,Jacqueline A,50,12,6,12,8,0,10,2.932
+Fall 2024,MUSA,1260,1,27201,Applied Music,Garcia,Jeremy S,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3350,7,27203,Intro to Cognitive Psychology,Yoshida,Hanako,18,21,7,6,0,0,2,3.0
+Fall 2024,ECON,6394,3,27204,Tpcs-Eco of Socl Issue,Verchenko,Olesia,7,1,0,0,0,0,0,3.916
+Fall 2024,ECON,6394,4,27205,Tpcs-Eco of Socl Issue,Nivievskyi,Oleg,0,1,0,0,0,0,0,3.0
+Fall 2024,MUSA,1378,1,27207,Applied Jazz Guitar,Petito,Gregory Michael,0,1,0,0,0,0,0,2.67
+Fall 2024,MUSA,1334,4,27208,Applied Clarinet,Griffin,Randall S,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,7399,8,27209,Masters Thesis,Li,Xingpeng,1,0,0,0,0,0,0,4.0
+Fall 2024,COMD,8291,1,27210,COMD Research,Thiessen,Amber L,0,0,0,0,0,0,0,
+Fall 2024,HIST,1301,13,27212,The U.S. to 1877,Lira,Karla Aisen,149,58,31,21,39,0,20,2.849
+Fall 2024,MATH,8698,24,27214,Doctoral Research,Jaramillo,Gabriela T,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,34,27215,Doctoral Research,Turner,Stephen,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6298,1,27220,Special Problems,Liu,Xinli,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6498,12,27224,Special Problems,Zhang,Yang,0,0,0,0,0,2,0,
+Fall 2024,PCEU,8998,6,27225,Doctoral Research,Hao,Jiukuan,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6432,1,27226,Applied Oboe,Fischer,Jonathan,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6140,6,27227,Graduate Recital I,Fischer,Jonathan,0,0,0,0,0,0,0,
+Fall 2024,CIS,6371,30,27229,Design Data Analytic Solutions,Albayrak,Levent,15,1,0,0,0,0,0,3.938
+Fall 2024,SPEC,6397,1,27231,Selected Topics,Carp,Charlotte Lynn,0,0,1,0,0,0,0,2.33
+Fall 2024,MUSA,6140,7,27232,Graduate Recital I,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6442,1,27233,Applied French Horn,Johnson,Robert,1,0,0,0,0,0,0,4.0
+Fall 2024,TLIM,3363,35,27234,Technical Communications,Piercy,Penelope Junker,18,8,3,0,3,0,3,3.074
+Fall 2024,BIOE,8498,26,27236,Doctoral Research,Willson,Richard,0,0,0,0,0,1,0,
+Fall 2024,GEOL,7398,3,27241,Masters Research,Capuano,Regina M,0,0,0,0,0,1,0,
+Fall 2024,MUSA,1332,2,27242,Applied Oboe,Dinitz,Adam L,1,0,0,0,0,0,0,4.0
+Fall 2024,CHIN,6397,1,27243,Selected Topics,Wang,Wei,0,0,1,0,0,0,0,2.0
+Fall 2024,ECE,8398,34,27245,Doctoral Research,Zheng,Jianfeng,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,35,27247,Doctoral Research,Canepa,Pieremanuele,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6998,9,27249,Special Problems,Mohan,Chandra,0,0,0,0,0,1,0,
+Fall 2024,PHOP,8798,1,27250,Doctoral Research,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6498,18,27251,Special Problems,Pennings,Steven C,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6698,4,27255,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6398,3,27257,Special Problems,Trivedi,Meghana,0,0,0,0,0,1,0,
+Fall 2024,OPTO,5298,1,27258,Spec Prob Phys Optics,Archila,Andrew Mario,0,0,0,0,0,11,0,
+Fall 2024,PCOL,8998,6,27259,Doctoral Research,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2024,COMM,4398,2,27260,Independent Study,Yamasaki,Jill S,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,8998,8,27261,Doctoral Research,Wu,Mingfu,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,8898,4,27262,Doctoral Research,Lekven,Arne,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6198,1,27265,Special Problems,Tam,Vincent H,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6198,2,27266,Special Problems,Liu,Xinli,2,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,6198,3,27267,Special Problems,Hu,Ming,0,0,0,0,0,0,0,
+Fall 2024,PCEU,6198,4,27268,Special Problems,Hao,Jiukuan,2,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,6198,1,27269,Special Problems,Kumar,Ashok,0,0,0,0,0,1,0,
+Fall 2024,PCOL,6198,2,27270,Special Problems,Darabi,Radbod,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8598,35,27272,Doctoral Research,Nurminen,Lauri Oskari,0,0,0,0,0,1,0,
+Fall 2024,BIOE,6301,1,27276,Statistical Methods in BME,Gifford,Howard,7,16,0,0,0,0,0,3.347
+Fall 2024,MATH,8398,25,27277,Doctoral Research,Climenhaga,Vaughn,0,0,0,0,0,1,0,
+Fall 2024,DANC,3103,1,27279,Junior Seminar in Somatics,Chapman,Teresa Lynn,6,3,0,1,0,0,2,3.499
+Fall 2024,MUSA,2350,1,27283,Applied Percussion,Warren,Paul Alexander,4,1,0,0,0,0,0,3.734
+Fall 2024,CHEE,8399,25,27284,Doctoral Dissertation,Yao,Yan,2,0,0,0,0,1,0,4.0
+Fall 2024,CHEE,8598,25,27285,Doctoral Research,Yao,Yan,0,0,0,0,0,4,0,
+Fall 2024,CHEE,8398,25,27286,Doctoral Research,Yao,Yan,0,0,0,0,0,1,0,
+Fall 2024,PSYC,2301,11,27290,Introduction to Psychology,Babalola,Olusegun,44,10,3,2,11,0,5,3.067
+Fall 2024,BIOE,8298,33,27291,Doctoral Research,Chow,Diana Shu-Lian,0,0,0,0,0,1,0,
+Fall 2024,SPAN,6354,1,27293,Span Phonetics and Variation,Goodin-Mayeda,Carrie Elizabeth,3,1,0,0,0,0,0,3.833
+Fall 2024,MECE,8699,3,27294,Doctoral Dissertation,Ghasemi,Hadi,0,0,0,0,0,1,0,
+Fall 2024,ARTH,7399,1,27296,Master's Thesis,Harren,Natilee O,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGI,2197,3,27298,Selected Topics,Chang,Christiana,9,9,0,0,0,0,2,3.555
+Fall 2024,SCLT,4389,32,27299,Practicum in Supply Chain,Kennedy,Elizabeth Heyn,16,3,0,1,0,0,0,3.651
+Fall 2024,PHLS,7398,4,27300,Candidacy Research,Allan,Blake A,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8898,10,27305,Doctoral Research,Nunez,Martin A,0,0,0,0,0,1,0,
+Fall 2024,MUSI,6397,6,27309,Selected Topics-Music,Caton,Kathryn L.,11,0,0,0,0,0,0,3.97
+Fall 2024,PHOP,8498,6,27311,Doctoral Research,Coates,Daniel R,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8698,1,27312,Doctoral Research,Ostrin,Lisa,2,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8898,1,27313,Doctoral Research,Ribelayga,Christophe Pierre,2,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8998,1,27315,Doctoral Research,Twa,Michael D,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6198,19,27316,Spec Prob-Physio Optics,O'Brien,John,2,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6167,7,27317,Research Practicum A,Patel,Nimesh Bhikhu,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6657,3,27318,Research Practicum B,Das,Vallabh E,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8998,2,27319,Doctoral Research,Ritchey,Eric R,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8399,10,27320,Doctoral Dissertation,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,8698,2,27321,Doctoral Research,Walker,Maria Kelly,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,6398,30,27322,Research,Hoskere,Vedhus,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8699,2,27323,Doctoral Dissertation,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,1324,2,27324,Applied Violoncello,Cho,Eunghee,3,0,0,0,0,0,0,4.0
+Fall 2024,KIN,1304,5,27325,Public Hlt Issues in Phys/Obes,Betts,Charles Raphael,63,24,6,1,1,0,3,3.516
+Fall 2024,MUSA,3450,1,27326,Applied Percussion,Warren,Paul Alexander,2,1,0,0,0,0,0,3.667
+Fall 2024,PCOL,8998,9,27329,Doctoral Research,Trivedi,Meghana,0,0,0,0,0,1,0,
+Fall 2024,ECE,6298,29,27333,Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Fall 2024,ECE,6398,31,27334,Research,Joardar,Biresh Kumar,0,0,0,0,0,1,0,
+Fall 2024,KIN,3305,4,27337,Sport Sociology,Ogunrinde,Joyce,11,12,10,6,6,0,3,2.356
+Fall 2024,COMD,8299,1,27338,Dissertation,Castilla-Earls,Anny,0,0,0,0,0,2,0,
+Fall 2024,ENGL,1301,180,27340,First Year Writing I,Horton,Lara,2,5,8,0,4,0,5,2.001
+Fall 2024,ENGL,1302,25,27341,First Year Writing II,Coleman,Quintin,8,6,2,0,4,0,2,2.535
+Fall 2024,ENGL,1302,26,27342,First Year Writing II,Braniger,Leslie,4,13,4,0,2,0,1,2.768
+Fall 2024,ENGL,1301,181,27343,First Year Writing I,Horton,Lara,4,8,5,1,4,0,1,2.243
+Fall 2024,ENGL,1301,182,27344,First Year Writing I,Garcia,Serena Mari,8,5,3,3,2,0,3,2.588
+Fall 2024,HIST,1301,9,27345,The U.S. to 1877,Thompson,Joseph Lee,247,27,4,4,10,0,5,3.69
+Fall 2024,BIOE,8399,25,27346,Doctoral Dissertation,Du,Yuncheng,1,0,0,0,0,0,0,4.0
+Fall 2024,COMD,8299,2,27349,Dissertation,Joshi,Ashwini,0,0,0,0,0,2,0,
+Fall 2024,TLIM,3355,32,27350,Project Management Principles,Moore,George P,54,7,1,0,2,0,1,3.657
+Fall 2024,COMD,8299,3,27351,Dissertation,Dial,Heather Raye,0,0,0,0,0,1,0,
+Fall 2024,COMD,8399,1,27352,Dissertation,Castilla-Earls,Anny,0,0,0,0,0,2,0,
+Fall 2024,COMD,8399,2,27353,Dissertation,Joshi,Ashwini,0,0,0,0,0,1,0,
+Fall 2024,COMD,8699,1,27356,Dissertation,Joshi,Ashwini,0,0,0,0,0,1,0,
+Fall 2024,ELET,6353,40,27357,Applied Stats for Technology,Pollonini,Luca,1,0,0,0,0,0,0,3.67
+Fall 2024,QSS,4393,4,27373,QSS Research Project,Paluszynski,Radoslaw,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,5,27374,Senior Research Project,Crawford,Kerri M,0,1,0,0,0,0,0,3.0
+Fall 2024,BIOL,6698,3,27375,Special Problems,Albecker,Molly A,0,0,0,0,0,1,0,
+Fall 2024,HLT,3325,4,27376,Medical Terminology,Burk,Kelly Ann,123,7,12,3,2,0,2,3.638
+Fall 2024,PHOP,8598,8,27377,Doctoral Research,Marsack,Jason,1,0,0,0,0,0,0,4.0
+Fall 2024,HLT,3381,5,27378,Hlt Promotn & Disease Preventn,Markowitz,Eliz,69,10,4,0,1,0,1,3.679
+Fall 2024,PHOP,8698,3,27379,Doctoral Research,Rump,Rachel,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6198,20,27380,Spec Prob-Physio Optics,Schill,Alexander W,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,7177,1,27381,MATLAB programming,Stevenson,Scott Bailli,2,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8298,36,27384,Doctoral Research,Fan,Lei,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,37,27385,Doctoral Research,Fan,Lei,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8699,5,27387,Doctoral Dissertation,Lee,Hyongki,2,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,1,27388,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,2,27389,Adv Special Problem Human Perf,Gorniak,Stacey,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,39,27390,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2024,INDE,6398,2,27391,Research,Xiang,Yisha,0,0,0,0,0,1,0,
+Fall 2024,INDE,8298,7,27398,Doctoral Research,Zou,Na,0,0,0,0,0,3,0,
+Fall 2024,PHYS,4398,3,27402,Independent Study,Miller,John H,1,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,4298,1,27403,Independent Study,Varghese,Oomman K,1,2,0,0,0,0,0,3.333
+Fall 2024,PHYS,4498,1,27404,Independent Study,Freelon,Byron Kendall,5,1,0,0,0,0,1,3.778
+Fall 2024,ECE,8398,38,27407,Doctoral Research,Lin,Qin,0,0,0,0,0,1,0,
+Fall 2024,BIOL,6598,19,27410,Special Problems,Vicens,Quentin,0,0,0,0,0,1,0,
+Fall 2024,POLS,8999,1,27411,Doctoral Dissertation,Fumurescu,Alin,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8598,13,27412,Doctoral Research,Xie,Surui,0,0,0,0,0,1,0,
+Fall 2024,ECE,3317,4,27413,Applied Electromagnetic Waves,Jackson,David R,2,13,3,1,0,0,0,2.721
+Fall 2024,GEOL,7398,4,27414,Masters Research,Carlson,Brandee Nicole,0,0,0,0,0,2,0,
+Fall 2024,POLS,8999,17,27415,Doctoral Dissertation,Heinrich,Tobias,0,0,0,0,0,1,0,
+Fall 2024,POLS,8999,18,27416,Doctoral Dissertation,Bagashka,Tanya G,0,0,0,0,0,0,0,
+Fall 2024,SOCW,8999,7,27417,Dissertation,Ali,Samira Bano,0,0,0,0,0,0,0,
+Fall 2024,CIVE,8598,14,27418,Doctoral Research,Li,Hongyi,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8699,6,27419,Doctoral Dissertation,Glennie,Craig Len,0,0,0,0,0,1,0,
+Fall 2024,PHOP,6367,5,27420,Research Practicum A,Ribelayga,Christophe Pierre,1,0,0,0,0,0,0,4.0
+Fall 2024,MIS,8399,2,27421,Doctoral Dissertation in MIS,Aron,Ravi,0,0,0,0,0,1,0,
+Fall 2024,THEA,6398,1,27422,Independent Study,Vlahos,Kalliope,1,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8398,3,27423,Independent Study,Horn,Catherine Lynn,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,8698,25,27424,Doctoral Research,Charon,Nicolas,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8999,6,27426,Doctoral Dissertation,Rahimi,Mohammad,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8999,7,27427,Doctoral Dissertation,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8298,19,27428,Doctoral Research,Zhang,Ruda,0,0,0,0,0,1,0,
+Fall 2024,MUSA,3310,2,27429,Applied Piano,Norian,Gary,0,1,0,0,0,0,0,3.0
+Fall 2024,COSC,4398,2,27433,Independent Study,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2024,BCHS,6398,10,27434,Special Problems,Sen,Mehmet,0,0,0,0,0,1,0,
+Fall 2024,HON,3399,7,27435,Senior Honors Thesis,Khan,Abdul Latif,0,0,0,0,0,0,0,
+Fall 2024,HON,3399,8,27436,Senior Honors Thesis,Smith,Bradley,0,0,0,0,0,0,0,
+Fall 2024,ENGL,1301,183,27437,First Year Writing I,Murray,Christopher Brean,13,7,3,0,1,0,1,3.209
+Fall 2024,ENGL,1301,184,27438,First Year Writing I,Thran,Kimberley Anne,19,5,0,0,1,0,0,3.6
+Fall 2024,ENGL,1301,185,27439,First Year Writing I,Thran,Kimberley Anne,21,2,1,0,0,0,1,3.723
+Fall 2024,ENGL,1302,27,27440,First Year Writing II,Stewart-Steele,Heather Marie,11,3,1,0,0,0,8,3.623
+Fall 2024,ENGL,1302,28,27441,First Year Writing II,Campese,Kathleen Ann,20,3,0,0,1,0,1,3.667
+Fall 2024,MUSA,8243,9,27442,Doctoral Lecture Recital,Dirst,Matthew C,0,0,0,0,0,0,0,
+Fall 2024,POLS,8999,23,27447,Doctoral Dissertation,Kistner,Michael,0,0,0,0,0,1,0,
+Fall 2024,POLS,8999,26,27448,Doctoral Dissertation,Jenke,Elizabeth,0,0,0,0,0,0,0,
+Fall 2024,SOCW,8995,6,27450,Pre-Dissertation Research,Gearing,Robin Edward,0,0,0,0,0,3,0,
+Fall 2024,ELCS,8395,8,27451,Dissertation in practice,Hassett,Kristen Spring,0,0,0,0,0,1,0,
+Fall 2024,ECE,8399,32,27452,Doctoral Dissertation,Robles Hernandez,Francisco C,0,0,0,0,0,1,0,
+Fall 2024,INDS,4260,2,27453,Design Issues II,Jackson,Megan H,12,10,0,0,0,0,0,3.575
+Fall 2024,PEP,7398,3,27454,Adv Special Problem Human Perf,Johnston,Craig Allen,2,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,4,27455,Adv Special Problem Human Perf,Park,Seoung Hoon,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,5,27456,Adv Special Problem Human Perf,LaVoy,Emily Claire-Pyle,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6302,1,27457,Applied Composition,Smith,Robert Thomas,0,0,0,0,0,0,0,
+Fall 2024,PHCA,6398,1,27460,SP- Outcomes Research,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,6198,5,27461,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2024,SOCI,1301,9,27463,Introduction To Sociology,Davis,Mary A,31,11,7,2,3,0,1,3.143
+Fall 2024,PEP,7398,6,27465,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,3.67
+Fall 2024,IRW,1100,5,27468,Integrated Reading and Writing,Ebersole,John Ira,0,0,0,0,0,22,0,
+Fall 2024,BIOE,8198,8,27469,Doctoral Research,Roh,Jinsook,0,0,0,0,0,1,0,
+Fall 2024,SCLT,6399,30,27470,Master's Thesis,Bian,Zheyong,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,6309,1,27471,Intro Automata & Computability,Das,Rathish,3,0,0,0,0,0,0,3.78
+Fall 2024,CHEM,4396,1,27473,Senior Research Project,Daugulis,Olafs,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8399,7,27476,Doctoral Dissertation,Ballarini,Roberto,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6367,6,27477,Research Practicum A,Ferreira,Tarsis Gesteira,1,0,0,0,0,0,0,4.0
+Fall 2024,PHOP,6198,21,27478,Spec Prob-Physio Optics,Sapoznik,Kaitlyn Anne,1,0,0,0,0,0,0,4.0
+Fall 2024,COMM,4398,3,27480,Independent Study,Crowe,Craig Warren,2,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,2344,2,27484,Applied Trombone,Freeman,Phillip I,1,1,0,0,0,0,0,3.665
+Fall 2024,MUSA,6344,1,27485,Applied Trombone,Freeman,Phillip I,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6344,2,27486,Applied Trombone,Kauk,Brian Keith,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,6898,12,27488,Special Problems,Nunez,Martin A,0,0,0,0,0,1,0,
+Fall 2024,PHCA,7310,3,27495,Teaching Practicum,Chen,Hua,2,0,0,0,0,0,0,4.0
+Fall 2024,HRD,6399,2,27496,Master's Thesis,Greer,Tomika,1,0,0,0,0,0,0,4.0
+Fall 2024,PCOL,8998,11,27497,Doctoral Research,Garey,Kevin W,0,0,0,0,0,1,0,
+Fall 2024,CIVE,6396,1,27498,Master's Research Project,Li,Hongyi,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,6398,6,27499,Special Problems,Zarnow,Leandra Ruth,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,8399,2,27501,Doctoral Document,Meals,Cory Dewitt,1,0,0,0,0,0,0,4.0
+Fall 2024,AAS,2320,8,27502,Intro To African American Stdy,Muhammad Murphy,Wilma Denae,18,8,0,0,2,0,1,3.323
+Fall 2024,PHCA,8398,1,27503,Doctoral Dissertation Research,Thornton,James D,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3434,1,27505,Applied Clarinet,Griffin,Randall S,0,1,0,0,0,0,0,2.67
+Fall 2024,MATH,1324,11,27510,Finite Math with Applications,Besabe,Lander Yabut,76,76,32,24,36,0,26,2.468
+Fall 2024,CIVE,8699,7,27511,Doctoral Dissertation,Rodrigues,Debora Frigi,1,0,0,0,0,1,0,4.0
+Fall 2024,CIVE,8498,16,27512,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8598,15,27513,Doctoral Research,Ferdowsi,Behrooz,0,0,0,0,0,2,0,
+Fall 2024,BIOL,6198,2,27514,Special Problems,Chung,Sanghyuk,0,0,0,0,0,1,0,
+Fall 2024,ECE,8398,39,27515,Doctoral Research,Banerjee,Tania,0,0,0,0,0,1,0,
+Fall 2024,MECE,6399,4,27516,Masters Thesis,Xu,Ben,1,0,0,0,0,0,0,4.0
+Fall 2024,COMD,8398,1,27517,Special Problems,Dial,Heather Raye,1,0,0,0,0,0,0,4.0
+Fall 2024,CHIN,3398,1,27518,Independent Study,Wang,Wei,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8298,20,27519,Doctoral Research,Xie,Surui,0,0,0,0,0,2,0,
+Fall 2024,CIVE,8999,8,27521,Doctoral Dissertation,Hoskere,Vedhus,2,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,186,27522,First Year Writing I,Soullier,Anastasia Constance,11,4,4,0,3,0,2,2.789
+Fall 2024,ENGL,1301,187,27523,First Year Writing I,Dubois,Mary Elizabeth,14,5,0,0,2,0,2,3.271
+Fall 2024,ENGL,1301,188,27524,First Year Writing I,Dubois,Mary Elizabeth,15,4,0,2,3,0,1,2.973
+Fall 2024,PHCA,8298,6,27528,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Fall 2024,PHCA,8398,2,27529,Doctoral Dissertation Research,Essien,Ekere James,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8399,8,27530,Doctoral Dissertation,Krakowiak,Konrad,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8298,3,27531,Doctoral Research,Lee,Myoungkyu,0,0,0,0,0,1,0,
+Fall 2024,MECE,8598,5,27532,Doctoral Research,Alba,Kamran,0,0,0,0,0,1,0,
+Fall 2024,HIST,1302,13,27535,The U.S. Since 1877,Young,Nancy Beck,70,33,12,1,10,0,15,3.219
+Fall 2024,WGSS,2350,2,27538,Intro To Women's Studies,Martinez,Itzel Areli,19,5,1,1,2,0,1,3.298
+Fall 2024,ECE,3331,3,27542,Program Appl in Elec Comp Engr,Meh Chu,Chu,10,4,1,0,0,0,0,3.622
+Fall 2024,ECE,2202,3,27543,Circuit Analysis II,Trombetta,Leonard P,3,0,2,1,5,0,10,1.485
+Fall 2024,COMM,4398,4,27545,Independent Study,Houk,Keith R,3,0,0,0,0,0,0,3.78
+Fall 2024,ECON,2302,5,27546,Principles of Microeconomics,Nidhiri,Sebin Bapty,5,17,17,4,2,0,4,2.452
+Fall 2024,ENGL,1302,29,27547,First Year Writing II,Klopp,Chelsea Gordon,13,4,2,0,5,0,1,2.833
+Fall 2024,MATH,8398,26,27548,Doctoral Research,Zhong,Ming,0,0,0,0,0,1,0,
+Fall 2024,PSYC,3310,9,27550,Indstrl-Orgnztnl Psy,Harlan,Pamela Kay,51,20,1,1,1,0,1,3.541
+Fall 2024,PSYC,2316,8,27551,Psychology of Personality,Harlan,Pamela Kay,43,24,3,0,1,0,3,3.479
+Fall 2024,PSYC,2319,10,27552,Intro to Social Psychology,Anderson,Jill Annette,39,11,0,0,0,0,0,3.707
+Fall 2024,CIVE,8699,8,27553,Doctoral Dissertation,Momen,Mostafa,0,0,0,0,0,2,0,
+Fall 2024,PEP,7398,7,27556,Adv Special Problem Human Perf,Cottingham,Michael,1,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5672,4,27558,Clinical Pharmaceutical Resch,Varisco,Tyler J,1,0,0,0,0,0,0,4.0
+Fall 2024,PHAR,5672,5,27559,Clinical Pharmaceutical Resch,Garey,Kevin W,1,0,0,0,0,0,0,4.0
+Fall 2024,EDS,6399,2,27560,Masters Thesis,Prasad,Saurabh,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8399,9,27561,Doctoral Dissertation,Li,Hongyi,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8198,9,27563,Doctoral Research,Shevkoplyas,Sergey,0,0,0,0,0,1,0,
+Fall 2024,BIOE,8598,36,27566,Doctoral Research,Wang,Lu,0,0,0,0,0,2,0,
+Fall 2024,MUSA,6202,1,27571,Applied Composition,Smith,Robert Thomas,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,6399,3,27573,Masters Thesis,Robertson,Megan L,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,7399,3,27574,Masters Thesis,Robertson,Megan L,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,8,27575,Adv Special Problem Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6398,24,27576,Independent Studies,Borjon,Jeremy Isaac,2,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,7398,5,27577,Masters Research,Wellner,Julia S,0,0,0,0,0,1,0,
+Fall 2024,PSYC,2317,14,27578,Intro to Psychology Statistics,Vahedi,Meisam,48,7,5,4,7,0,1,3.183
+Fall 2024,GEOL,8699,5,27579,Doctoral Dissertation,Choi,Yunsoo,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,6399,4,27580,Master's Thesis,Wang,Keh-Han,0,0,0,0,0,1,0,
+Fall 2024,PHCA,7398,1,27581,SP in Pharmacy Admin Doctoral,Aparasu,Rajender R,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,9,27582,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,10,27583,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8399,4,27584,Doctoral Dissertation,Margulis,Milena A,1,0,0,0,0,1,0,4.0
+Fall 2024,MUSA,6204,6,27586,Conducting,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,4398,7,27587,Independent Study,Derrick,Jaye L,2,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,7380,1,27588,Advanced Research in SP,Margulis,Milena A,0,0,0,0,0,1,0,
+Fall 2024,HDCS,1300,11,27590,Human Ecosystems & Tech Change,Jones,Domenique Elizabeth,11,21,9,4,3,0,2,2.667
+Fall 2024,HDCS,1300,12,27592,Human Ecosystems & Tech Change,Gatterson,Beverly,31,8,2,2,4,0,3,3.185
+Fall 2024,MECE,8298,4,27598,Doctoral Research,Huang,Yi-Chun,0,0,0,0,0,1,0,
+Fall 2024,MECE,8598,6,27600,Doctoral Research,Ardebili,Haleh,0,0,0,0,0,1,0,
+Fall 2024,MUED,8398,1,27603,Research in Music Education,Derges,Julie D,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6198,21,27604,Research,Derges,Julie D,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8399,10,27607,Doctoral Dissertation,Louie,Stacey M,0,1,0,0,0,0,0,3.33
+Fall 2024,CIVE,8399,11,27608,Doctoral Dissertation,Kalliontzis,Dimitrios,0,0,0,0,0,1,0,
+Fall 2024,GEOL,4398,3,27609,Independent Study,Murphy,Michael,0,0,0,0,0,0,0,
+Fall 2024,DRAM,1310,9,27611,Introduction to Theatre,Hinkel,Heidi Anne,37,7,3,2,0,0,0,3.572
+Fall 2024,DRAM,1310,10,27612,Introduction to Theatre,Hinkel,Heidi Anne,38,10,1,2,0,0,0,3.602
+Fall 2024,DRAM,1310,11,27613,Introduction to Theatre,Young,Courtney Leigh,28,13,5,2,1,0,1,3.232
+Fall 2024,DRAM,1310,12,27614,Introduction to Theatre,Young,Courtney Leigh,33,11,5,0,0,0,0,3.531
+Fall 2024,HIST,4394,1,27615,Sel Top-United States History,Harwell,Debbie Z,1,0,0,0,0,0,0,4.0
+Fall 2024,DANC,2303,3,27616,Introduction to Dance,Bobet,Jacqueline A,42,18,2,6,8,0,6,3.027
+Fall 2024,GEOL,8398,35,27617,Doctoral Research,Sun,Jiajia,0,0,0,0,0,2,0,
+Fall 2024,MUSI,8399,3,27618,Doctoral Document,Derges,Julie D,0,0,0,0,0,0,0,
+Fall 2024,HDFS,4198,1,27619,Independent Study,Master,Allison,1,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,7399,2,27620,Masters Thesis,Meier,Mark Albert,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8420,2,27621,Doctoral Applied Music,Wilkins,Blake M,1,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,5198,4,27622,Spec Prob - Clerkship,Berntsen,David A,0,0,0,0,0,6,0,
+Fall 2024,OPTO,5198,5,27623,Spec Prob - Clerkship,Cheng,Han,0,0,0,0,0,9,0,
+Fall 2024,OPTO,5198,6,27624,Spec Prob - Clerkship,Garza,Janet,0,0,0,0,0,7,0,
+Fall 2024,ARCH,6398,5,27625,Special Problems,Noldt,Peter,1,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,6298,3,27626,Special Problems,Amaral Antunes,Dinler,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8198,1,27628,Independent Study,Horn,Catherine Lynn,3,1,0,0,0,0,0,3.75
+Fall 2024,OPTO,5198,7,27629,Spec Prob - Clerkship,Giannoni,Amber Gaume,0,0,0,0,0,1,0,
+Fall 2024,OPTO,5198,9,27630,Spec Prob - Clerkship,Tucker,Ashley,0,0,0,0,0,2,0,
+Fall 2024,OPTO,5198,10,27631,Spec Prob - Clerkship,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Fall 2024,OPTO,7495,1,27633,General Clinic IIIc,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Fall 2024,HON,3399,9,27647,Senior Honors Thesis,Majumder,Sarasij,1,0,0,0,0,0,0,4.0
+Fall 2024,PCEU,6498,5,27649,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6398,3,27650,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2024,PCEU,6298,2,27651,Special Problems,Guo,Bin,0,0,0,0,0,1,0,
+Fall 2024,LAW,5299,3,27652,Special Problems,Vetter,Greg R,0,0,0,0,0,1,0,
+Fall 2024,PHCA,6398,3,27653,Special Problems,Chen,Hua,1,0,0,0,0,0,0,4.0
+Fall 2024,EDS,6399,3,27654,Masters Thesis,Cescon,Marzia,0,0,0,0,0,1,0,
+Fall 2024,EDS,6398,3,27655,Research,Wu,Xuping,0,0,0,0,0,0,0,
+Fall 2024,EDS,6399,4,27656,Masters Thesis,Wu,Xuqing,1,0,0,0,0,0,0,4.0
+Fall 2024,OPTO,5198,12,27658,Spec Prob - Clerkship,Herring,Ralph Jay,0,0,0,0,0,1,0,
+Fall 2024,BIOL,8998,7,27659,Doctoral Research,Daane,Jacob,0,0,0,0,0,1,0,
+Fall 2024,MECE,7399,5,27666,Masters Thesis,Alba,Kamran,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8298,21,27667,Doctoral Research,Balan,Venkatesh,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8699,9,27668,Doctoral Dissertation,Balan,Venkatesh,0,0,0,0,0,1,0,
+Fall 2024,GEOL,8398,36,27671,Doctoral Research,Zhou,Hua-Wei,0,0,0,0,0,1,0,
+Fall 2024,PEP,8999,3,27672,Doctoral Dissertation,Park,Yoonjung,0,0,0,0,0,1,0,
+Fall 2024,PHIL,1301,8,27675,Intro To Philosophy,Aiman,Edwin E,36,11,1,2,5,0,2,3.249
+Fall 2024,INDE,4398,1,27677,Independent Study,Wang,Yaping,0,0,0,0,0,1,0,
+Fall 2024,MATH,8398,27,27679,Doctoral Research,Morgan,Jeffrey,0,0,0,0,0,1,0,
+Fall 2024,MUSA,4189,3,27680,Senior Recital,Kauk,Brian Keith,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6397,4,27687,Selected Topics in Math,Bodmann,Bernhard G,1,0,0,0,0,0,0,4.0
+Fall 2024,IDNS,2136,3,27688,Data Structures SEP Workshop,Pattison,Donna,17,8,3,2,0,0,0,3.377
+Fall 2024,BIOL,8898,11,27691,Doctoral Research,Cirino,Patrick C,0,0,0,0,0,1,0,
+Fall 2024,PHLS,8399,5,27697,Doctoral Dissertation,Smith,Nathan G,0,0,0,0,0,1,0,
+Fall 2024,MATH,8399,32,27698,Doctoral Dissertation,Nicol,Matthew J,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,6398,3,27699,Special Problems,Van Nieuwenhuise,Donald S,0,1,0,0,0,0,0,3.0
+Fall 2024,FINA,8396,1,27705,Research Practicum,George,Thomas J,0,0,0,0,0,1,0,
+Fall 2024,PSYC,4398,8,27707,Independent Study,Sabat,Isaac Emmanuel,1,0,0,0,0,0,0,4.0
+Fall 2024,MATH,6398,17,27709,Special Problems,He,Yunhui,0,0,0,0,0,1,0,
+Fall 2024,MECE,8698,7,27710,Doctoral Research,Franchek,Matthew,0,0,0,0,0,2,0,
+Fall 2024,GEOL,7399,18,27712,Masters Thesis,Wang,Yuxuan,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8398,27,27715,Doctoral Research,Sharma,Pradeep,0,0,0,0,0,1,0,
+Fall 2024,CIVE,8399,12,27716,Doctoral Dissertation,Rodrigues,Debora Frigi,0,0,0,0,0,1,0,
+Fall 2024,ARTS,7398,4,27717,Independent Graduate Study,Anderson-Staley,Keliy,1,0,0,0,0,0,0,4.0
+Fall 2024,BZAN,6350,3,27718,Quant Found for Busi Analytics,Johnson,Norman A,8,7,0,0,0,0,0,3.599
+Fall 2024,COMD,8198,1,27719,Independent Study,Cizek,Laura S,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,8396,2,27724,Research Practicum,Hitzemann,Steffen,0,1,0,0,0,0,0,3.33
+Fall 2024,FINA,8398,6,27725,Special Problems,Hitzemann,Steffen,1,1,0,0,0,0,0,3.665
+Fall 2024,EDS,6398,4,27736,Research,Vekilov,Peter,0,0,0,0,0,0,0,
+Fall 2024,EDS,6399,5,27737,Masters Thesis,Vekilov,Peter,0,0,0,0,0,0,0,
+Fall 2024,MUSI,8398,1,27738,Research in Pedagogy,Averyt,Zachary Benjamin,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8420,3,27739,Doctoral Applied Music,Morgulis,Tali,1,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,6367,1,27740,Special Education for Leaders,Hassett,Kristen Spring,1,0,0,0,0,0,0,3.67
+Fall 2024,BIOE,4115,4,27741,Intro Bioinstrumentation Lab,Akay,Yasemin M,2,0,0,0,0,0,0,3.835
+Fall 2024,EDS,6397,3,27743,Selected Topics,Ekhtari,Nima,39,5,0,0,0,0,0,3.744
+Fall 2024,EDS,6397,4,27745,Selected Topics,Joshuva,Justin K,59,4,0,0,0,0,0,3.937
+Fall 2024,HON,4396,1,27749,Senior Research Project,Rhoden,Brenda,1,0,0,0,0,0,0,4.0
+Fall 2024,CIVE,8198,14,27756,Doctoral Research,Lee,Hyongki,0,0,0,0,0,1,0,
+Fall 2024,MECE,8699,4,27757,Doctoral Dissertation,Floryan,Daniel,0,0,0,0,0,1,0,
+Fall 2024,FINA,8396,3,27758,Research Practicum,Kumar,Praveen,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,3400,9,27761,Applied Voice,Ceres,Emily Margaret,1,0,0,0,0,0,0,4.0
+Fall 2024,MANA,8999,3,27764,Doctoral Dissertation,Sauerwald,Steve,0,0,0,0,0,0,0,
+Fall 2024,BIOL,4398,1,27765,Independent Study,Albecker,Molly A,1,0,0,0,0,0,0,4.0
+Fall 2024,THEA,4398,4,27766,Independent Study,Niederer,Barbara,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,8699,4,27767,Doctoral Dissertation,Golubev,Alexey Valeryevich,0,0,0,0,0,0,0,
+Fall 2024,ELCS,8398,4,27768,Independent Study,Zou,Yali,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,8698,134,27770,Doctoral Research,Zhang,Chengming,0,0,0,0,0,1,0,
+Fall 2024,CUIN,8397,3,27773,Selected Topics in C&I,Wong,Sissy S,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6359,11,27774,Directed Rsch in Clinical Psyc,Bick,Johanna R,0,0,0,0,0,1,0,
+Fall 2024,MECE,8498,1,27779,Doctoral Research,Song,Gangbing,0,0,0,0,0,0,0,
+Fall 2024,HON,3396,6,27782,Senior Research Project,Mohan,Chandra,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8298,37,27785,Doctoral Research,Zhao,Lihong,0,0,0,0,0,1,0,
+Fall 2024,MECE,8699,5,27787,Doctoral Dissertation,Kulkarni,Yashashree,1,0,0,0,0,0,0,4.0
+Fall 2024,MECE,8298,5,27788,Doctoral Research,Kulkarni,Yashashree,0,0,0,0,0,1,0,
+Fall 2024,BIOL,2101,27,27790,Anatomy & Physiology Lab I,Gill,Tejendra,2,10,5,0,2,0,5,2.544
+Fall 2024,BIOL,2101,28,27791,Anatomy & Physiology Lab I,Gill,Tejendra,3,11,4,3,0,0,1,2.62
+Fall 2024,GEOL,8699,6,27793,Doctoral Dissertation,Sager,William W,1,0,0,0,0,0,0,4.0
+Fall 2024,COMM,4398,5,27794,Independent Study,Lee,Jaesub,1,0,0,0,0,0,0,4.0
+Fall 2024,EGRP,1130,2,27795,Engineering Applications I,Luna Singh,Jennifer Austin,6,1,2,0,0,0,1,3.371
+Fall 2024,PSYC,6399,24,27797,Masters Thesis,Zvolensky,Michael J,0,0,0,0,0,0,0,
+Fall 2024,THEA,4398,5,27798,Independent Study,Coen,Elizabeth Manya,1,0,0,0,0,0,0,4.0
+Fall 2024,HRD,6396,2,27801,Internship in Human Res. Dev.,Shirmohammadi,Melika,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,8398,26,27802,Doctoral Research,Dindoruk,Birol,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8398,5,27803,Independent Study,Snodgrass Rangel,Virginia Walker,5,1,0,0,0,0,0,3.778
+Fall 2024,CUIN,6318,2,27806,Approaches in 2nd Lang Teach,Burgess,Miguel,0,1,0,0,0,0,0,3.0
+Fall 2024,CUIN,7311,3,27807,Lang&Lit to Bilingual Learners,Cole,Mikel Walker,1,0,0,0,0,0,0,4.0
+Fall 2024,ACCT,8999,4,27808,Doctoral Dissertation,Lobo,Gerald,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,11,27809,Adv Special Problem Human Perf,Parikh,Pranav J,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,12,27810,Adv Special Problem Human Perf,Parikh,Pranav J,2,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,13,27811,Adv Special Problem Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,14,27812,Adv Special Problem Human Perf,Markofski,Melissa,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6204,7,27813,Conducting,Parodi,Jorge Luis,2,0,0,0,0,0,0,4.0
+Fall 2024,MANA,4353,3,27814,Mgmt Training and Career Devel,Shumate,Lisa T,7,2,0,0,0,0,0,3.814
+Fall 2024,THEA,3399,1,27815,Senior Honors Thesis,Coen,Elizabeth Manya,0,0,0,0,0,0,0,
+Fall 2024,MUSA,4260,2,27816,Applied Music,Marmolejo,Noe J,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,7398,6,27817,Masters Research,Sun,Jiajia,0,0,0,0,0,1,0,
+Fall 2024,MUSI,4198,1,27818,Independent Study,Bell,Priscilla Garrett,5,2,0,0,0,0,0,3.761
+Fall 2024,MECT,4198,1,27822,Independent Study,Zhu,Weihang,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSI,6198,1,27824,Research in Chamber Music,Archibald,Amber Cristina,2,0,0,0,0,0,0,4.0
+Fall 2024,COSC,7399,135,27825,Masters Thesis,Liu,Jinyang,0,0,0,0,0,1,0,
+Fall 2024,HON,3396,7,27826,Senior Research Project,Gilbertson,Scott R,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,6399,14,27827,Masters Thesis,Castagna,John P,0,0,0,0,0,2,0,
+Fall 2024,BIOL,3396,8,27830,Senior Research Project,Daane,Jacob,2,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8399,6,27831,Doctoral Dissertation,Wiesner,Margit F,0,0,0,0,0,1,0,
+Fall 2024,EGRP,1131,2,27834,Engineering Applications II,Luna Singh,Jennifer Austin,5,2,0,1,0,0,0,3.416
+Fall 2024,EGRP,1140,2,27835,Engineering Applications III,Luna Singh,Jennifer Austin,9,3,0,0,1,0,1,3.462
+Fall 2024,EGRP,1165,2,27838,Engineering Workshop,Luna Singh,Jennifer Austin,4,3,0,0,0,0,1,3.524
+Fall 2024,EGRP,1180,2,27839,Engineering Applications X,Luna Singh,Jennifer Austin,4,2,1,0,0,0,2,3.381
+Fall 2024,EGRP,1182,2,27840,Engineering Applications XII,Luna Singh,Jennifer Austin,10,2,0,0,0,0,0,3.751
+Fall 2024,GEOL,8698,31,27843,Doctoral Research,Carlson,Brandee Nicole,0,0,0,0,0,1,0,
+Fall 2024,PEP,6399,1,27851,Masters Thesis,Cottingham,Michael,0,0,0,0,0,1,0,
+Fall 2024,INDE,6333,3,27853,Probability Stat For Engineers,Feng,Qianmei,1,0,0,0,0,0,0,3.67
+Fall 2024,POLC,6398,1,27854,Special Problems,Holman,Mirya R,1,0,0,0,0,0,0,4.0
+Fall 2024,AAS,2320,9,27855,Intro To African American Stdy,Odewale,Alicia D,21,5,6,0,5,0,0,3.0
+Fall 2024,THEA,4398,6,27856,Independent Study,Webb,Matthew Clark,1,0,0,0,0,0,0,4.0
+Fall 2024,CUIN,7331,2,27858,Supporting Striving Readers,Reis,Nancy,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,8399,7,27859,Doctoral Dissertation,Fan,Weihua,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8240,6,27860,Doctoral Recital I,Cho,Eunghee,1,0,0,0,0,0,0,4.0
+Fall 2024,SCM,8399,1,27861,Dissertation,Aron,Ravi,0,0,0,0,0,1,0,
+Fall 2024,INDS,3198,1,27862,Independent Study,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Fall 2024,INDS,3398,1,27863,Independent Study,Feng,Jeff Feng,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,7399,19,27865,Masters Thesis,Castagna,John P,0,0,0,0,0,1,0,
+Fall 2024,CHEE,4398,4,27867,Independent Study,Abdelrahman,Omar Abdelrahman Ali,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,7A10,5,27870,Valuation,Yerramilli,Vijay,10,4,2,0,0,0,1,3.5
+Fall 2024,BIOL,8598,11,27871,Doctoral Research,Crawford,Kerri M,0,0,0,0,0,1,0,
+Fall 2024,MUSA,3410,4,27872,Applied Piano,Staupe,Andrew Paul,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6260,2,27875,Applied Music,Garcia,Jeremy S,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4198,3,27877,Independent Study,Warren,Paul Alexander,0,1,0,0,0,0,0,3.0
+Fall 2024,INDS,6297,1,27879,Selected Topics,Wells,Adam C,2,0,0,0,0,0,0,4.0
+Fall 2024,BIOE,8598,38,27885,Doctoral Research,Yousefi,Ali,0,0,0,0,0,0,0,
+Fall 2024,MUSA,2330,3,27887,Applied Flute,Dorough,Aralee,1,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1302,30,27893,First Year Writing II,Jones,Baylea,8,6,3,1,4,0,1,2.561
+Fall 2024,THEA,6198,1,27894,Independent Study,Noble,Adam S,7,0,0,0,0,0,0,4.0
+Fall 2024,ENGL,1301,189,27897,First Year Writing I,Worley,Sharon J,8,6,1,1,3,0,0,2.772
+Fall 2024,CIVE,7399,6,27899,Master's Thesis,Vipulanandan,Cumaraswamy,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,4398,2,27900,Independent Study,Contreras-Vidal,Jose Luis,0,0,1,0,0,0,0,2.0
+Fall 2024,HON,3399,10,27901,Senior Honors Thesis,Sen,Mehmet,0,0,0,0,0,0,0,
+Fall 2024,LST,3354,2,27902,Law and Society,Littlepage,Kelley G,26,14,3,2,1,0,0,3.283
+Fall 2024,FINA,8396,4,27903,Research Practicum,Yerramilli,Vijay,0,1,0,0,0,0,0,3.33
+Fall 2024,MUSI,8398,2,27904,Research in Pedagogy,Meals,Cory Dewitt,0,0,0,0,0,0,0,
+Fall 2024,GEOL,4398,4,27905,Independent Study,Stewart,Robert R,0,0,0,0,0,0,0,
+Fall 2024,MUSI,4399,1,27907,Senior Honors Thesis,Koozin,Timothy,1,0,0,0,0,0,0,3.67
+Fall 2024,MUSA,8241,9,27908,Doctoral Recital II,Clayton Vasquez,Cynthia L,1,0,0,0,0,0,0,4.0
+Fall 2024,FINA,8999,4,27909,Doctoral Dissertation,Liu,Zesong,0,0,0,0,0,1,0,
+Fall 2024,MUSA,6220,2,27911,Applied Violin,Austin,Alan S,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,7398,8,27912,Masters Research,Zheng,Yingcai,0,0,0,0,0,1,0,
+Fall 2024,MECE,4398,7,27914,Independent Study,Love,Holley Carole,0,0,0,0,0,0,0,
+Fall 2024,OPTO,5298,2,27915,Spec Prob Phys Optics,Lambreghts,Kimberly,0,0,0,0,0,1,0,
+Fall 2024,CHEE,8598,26,27919,Doctoral Research,Robles Hernandez,Francisco C,0,0,0,0,0,1,0,
+Fall 2024,COSC,6398,134,27933,Special Problems,Zhang,Chengming,0,0,0,0,0,1,0,
+Fall 2024,RELS,1301,3,27934,Intro To Religious Studies,Dawson,Cindy,28,9,5,1,3,0,1,3.254
+Fall 2024,GHL,6198,3,27935,Special Problems,Taylor,David C,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6106,8,27936,Grad Large Ensemble,Bertman,David Garry,1,0,0,0,0,0,0,4.0
+Fall 2024,HIST,4399,1,27937,Senior Honors Thesis,Patterson,Catherine F,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,8,27938,Senior Research Project,Kapral,Andrew J,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6434,3,27940,Applied Clarinet,Dokshansky,Yevgeny,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,8320,40,27941,Doctoral Applied Music,Maroney,Marcus K,0,0,0,0,0,0,0,
+Fall 2024,SPEC,8195,1,27942,Dissertation in Practice,Santi,Kristi L,0,0,0,0,0,1,0,
+Fall 2024,MIS,8399,3,27943,Doctoral Dissertation in MIS,Cooper,Randolph B,0,0,0,0,0,1,0,
+Fall 2024,SPAC,7410,3,27945,Master Thesis Proj: Spac Arch,Bell,Larry S,1,3,0,0,0,0,0,3.498
+Fall 2024,HDFS,4397,2,27946,Selected Topics in HDFS,Master,Allison,2,1,1,0,0,0,0,3.333
+Fall 2024,PEP,7398,15,27947,Adv Special Problem Human Perf,Layne,Charles S,1,0,0,0,0,0,0,4.0
+Fall 2024,ECE,8298,38,27951,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2024,ECE,8198,33,27952,Doctoral Research,Cheng,Albert M K,0,0,0,0,0,1,0,
+Fall 2024,MECT,4398,30,27962,Independent Study,El Nahas,Medhat A,1,0,0,0,0,0,0,4.0
+Fall 2024,EDBA,8308,2,27965,Appl of Quantitative Methods,Grimes,George M,24,0,0,0,0,0,0,4.0
+Fall 2024,BCHS,8998,4,27966,Doctoral Research,Sen,Mehmet,0,0,0,0,0,1,0,
+Fall 2024,MUSA,8243,10,27973,Doctoral Lecture Recital,Witt,Woodrow W,0,0,0,0,0,0,0,
+Fall 2024,MUSA,8220,7,27974,Doctoral Applied Music,Witt,Woodrow W,1,0,0,0,0,0,0,4.0
+Fall 2024,COSC,4398,3,27976,Independent Study,Eick,Christoph F,0,0,0,0,0,1,0,
+Fall 2024,EDBA,8302,2,27980,Global Strategic Leadership,Celly,Nikhil,21,0,0,0,0,0,1,4.0
+Fall 2024,PEP,8350,2,27982,HHP Candidacy Project Research,Ledoux,Tracey A,0,0,0,0,0,0,0,
+Fall 2024,PEP,7398,16,27983,Adv Special Problem Human Perf,Ogunrinde,Joyce,1,0,0,0,0,0,0,4.0
+Fall 2024,PEP,7398,17,27984,Adv Special Problem Human Perf,Gorniak,Stacey,0,0,0,0,0,0,0,
+Fall 2024,ELCS,8198,2,27991,Independent Study,Carales,Vincent D,0,0,0,0,0,1,0,
+Fall 2024,PCEU,8399,1,27993,Doctoral Dissertation,Chow,Diana Shu-Lian,1,0,0,0,0,0,0,4.0
+Fall 2024,PHYS,7398,1,27994,Master Research,Chu,Ching Wu,0,0,0,0,0,1,0,
+Fall 2024,ENGL,6398,5,27995,Rd&Research in Lang&Lit,Ferguson,Jamie H,0,0,0,0,0,1,0,
+Fall 2024,INDS,3398,2,27997,Independent Study,Kang,Chul Min,0,2,0,0,0,0,0,3.33
+Fall 2024,MUSA,8240,7,28001,Doctoral Recital I,DeSpain,Kaitlin Elizabeth,0,0,0,0,0,0,0,
+Fall 2024,MUSA,3440,3,28002,Applied Trumpet,Harris,Richard,1,1,0,0,0,0,0,3.665
+Fall 2024,MUSA,1340,3,28003,Applied Trumpet,Harris,Richard,1,0,0,0,0,0,0,4.0
+Fall 2024,COMM,4398,7,28004,Independent Study,Olson,Beth M,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSA,6340,3,28005,Applied Trumpet,Harris,Richard,0,1,0,0,0,0,0,3.33
+Fall 2024,MUSA,8320,41,28006,Doctoral Applied Music,Harris,Richard,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4398,1,28007,Independent Study,Rakonjac,Damjan,1,0,0,0,0,0,0,4.0
+Fall 2024,SOCW,6294,1,28010,Social Work Practicum II,Gonzales,Shelley A,0,0,0,0,0,1,0,
+Fall 2024,ELCS,8191,1,28015,Special Field Projects,McKinney,Lonnie Lyle,0,1,0,0,0,0,0,3.0
+Fall 2024,ELCS,6397,1,28029,Selected Topics in Elcs,Butcher,Keith,1,0,0,0,0,0,0,4.0
+Fall 2024,GEOL,8398,37,28032,Doctoral Research,Zheng,Youtong,0,0,0,0,0,1,0,
+Fall 2024,MUSI,4197,22,28035,Selected Topics in Music,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,4197,23,28037,Selected Topics in Music,Fernando,Fleurette S,3,0,0,0,0,0,0,4.0
+Fall 2024,THEA,6198,23,28038,Independent Study,Fernando,Fleurette S,1,0,0,0,0,0,0,4.0
+Fall 2024,INTN,1105,2,28040,Intro for Bilinguals,Sheneman,Naomi,6,4,2,0,0,0,0,3.278
+Fall 2024,COSC,8399,525,28041,Doctoral Dissertation,Shi,Weidong,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,8399,30,28043,Doctoral Dissertation,Gallagher,Matthew Ward,1,0,0,0,0,0,0,4.0
+Fall 2024,SOC,3398,1,28049,Ind Study in Soc,Tuthill,Zelma,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,4311,1,28053,Close Relationships,Derrick,Jaye L,34,12,0,1,0,0,1,3.561
+Fall 2024,CUIN,7398,5,28054,Independent Study,Alarcon,Jeannette Driscoll,0,0,0,0,0,0,0,
+Fall 2024,COMM,4398,8,28057,Independent Study,Uhrick,Jan,1,0,0,0,0,0,0,4.0
+Fall 2024,SPEC,8394,1,28061,University Teaching Practicum,Hassett,Kristen Spring,1,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8360,1,28062,Studies Post Secondary Educatn,Louis,Dave A,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,3350,8,28063,Intro to Cognitive Psychology,Sun,Lichao,13,18,2,0,1,0,1,3.129
+Fall 2024,PSYC,4363,6,28064,Abnormal Child Psych,Sun,Lichao,9,13,3,0,1,0,0,3.115
+Fall 2024,TLIM,4396,31,28066,Internship in TLIM,Burns,Maria,0,1,0,0,0,0,0,2.67
+Fall 2024,COMM,4398,9,28069,Independent Study,Crixell,Charles A,1,0,0,0,0,0,0,4.0
+Fall 2024,BIOL,4398,2,28070,Independent Study,Frankino,William A,3,0,0,0,0,0,0,4.0
+Fall 2024,THEA,4298,1,28071,Independent Study,Clark,Kyle Richard,1,0,0,0,0,0,0,4.0
+Fall 2024,PSYC,6359,12,28072,Directed Rsch in Clinical Psyc,Zvolensky,Michael J,1,0,0,0,0,0,0,4.0
+Fall 2024,DRAM,1310,22,28081,Introduction to Theatre,Egging,Jon Leo,20,0,0,0,2,0,0,3.621
+Fall 2024,ARCH,1198,2,28084,Special Problems,Phan,Trang Anh Thuc,1,0,0,0,0,0,0,4.0
+Fall 2024,PHLS,6398,2,28086,Special Problems,Whitaker,Rachael Gwin,1,0,0,0,0,0,0,4.0
+Fall 2024,CHEE,4398,1,28088,Independent Study,Malamataris,Nikolaos,1,0,0,0,0,0,0,4.0
+Fall 2024,LAW,5128,3,28089,Advocacy Competition ONE,Lawrence,Jim E,0,0,0,0,0,1,0,
+Fall 2024,THEA,6398,2,28090,Independent Study,Coen,Elizabeth Manya,1,0,0,0,0,0,1,3.67
+Fall 2024,ELCS,8311,30,28091,Lab of Practice-Lit Revw Devel,Johnson,Detra DeVerne,0,0,0,0,0,1,0,
+Fall 2024,POLC,4198,2,28103,Independent Study,Witt,Lawrence A,1,0,0,0,0,0,0,4.0
+Fall 2024,HON,3396,10,28104,Senior Research Project,McConnell,Bradley K,1,0,0,0,0,0,0,4.0
+Fall 2024,ELCS,8311,31,28108,Lab of Practice-Lit Revw Devel,Davis,Bradley,1,0,0,0,0,0,0,4.0
+Fall 2024,MUSI,6198,22,28110,Research,Parodi,Jorge Luis,0,0,0,0,0,0,1,
+Fall 2024,LAW,5125,2,28111,Advocacy Competition FOUR,Lawrence,Jim E,0,0,0,0,0,1,0,
+Fall 2024,LAW,5130,3,28112,Advocacy Competition TWO,Lawrence,Jim E,0,0,0,0,0,1,0,
+Fall 2024,CNST,3185,3,28113,Construction Experience,Senouci,Ahmed,0,1,0,0,0,0,0,3.33


### PR DESCRIPTION
This PR adds grade distribution data received from UH covering Summer 2022 through Spring 2024. The CSVs are not in their original format. The process converting the original CSV to their current format can be seen at https://github.com/adamnelsonarcher/CSV_Splitter_CG.IO/tree/main
